### PR TITLE
docs(cm): planificación SP2 — candidatas, specs Inc 2.1 y traceability

### DIFF
--- a/docs/plans/sp2/SP2-candidatas.md
+++ b/docs/plans/sp2/SP2-candidatas.md
@@ -1,0 +1,282 @@
+# SP2 — La Competencia: Incrementos y US Candidatas
+
+| Campo | Valor |
+|-------|-------|
+| **Subproyecto** | SP2 — La Competencia |
+| **Baseline objetivo** | BL-002 |
+| **BCs activos** | Competencia (completo — se agrega aggregate `Competencia`) + Resultados (núcleo) |
+| **DoD del SP2** | Ejecutar una disciplina STA y una DNF completas con 10 atletas cada una, incluyendo DNS y black-outs. Mostrar el ranking final de cada una. |
+| **Fecha** | 2026-03-24 |
+
+---
+
+## Resumen de Incrementos
+
+| Inc. | Nombre | Tipo | US candidatas | DoD observable |
+|------|--------|------|---------------|----------------|
+| **2.1** | La grilla de salida | Domain (aggregate Competencia) | US-2.1.1 a US-2.1.4 | Juez avanza por la grilla atleta a atleta · grilla generada con orden correcto |
+| **2.2** | Dos mecánicas, un modelo | Domain + API | US-2.2.1, US-2.2.2 | STA (tiempo) y DNF (distancia) funcionando · avance automático al siguiente atleta |
+| **2.3** | Andariveles simultáneos | Domain + API | US-2.3.1 | 2-3 andariveles activos sin conflicto · performances en andariveles distintos |
+| **2.4** | El ranking | Domain (BC Resultados) | US-2.4.1, US-2.4.2 | Ranking con podio generado automáticamente al cerrar disciplina |
+
+---
+
+## Deuda SOLID SP1→SP2 (alta prioridad — resolver en US-2.1.1)
+
+| Deuda | Tipo | Prioridad | Descripción |
+|-------|------|-----------|-------------|
+| DIP en `router.py` | SOLID | Alta | El router instancia dependencias directamente en lugar de recibirlas por inyección |
+| OCP en `_apply_stored` de `Performance` | SOLID | Media | Método con cadena if/elif que debe extenderse para nuevos eventos |
+
+Ambas se resuelven dentro de US-2.1.1 (primer US del SP2) antes de agregar código nuevo.
+
+---
+
+## Incremento 2.1 — La Grilla de Salida
+
+**Objetivo:** introducir el aggregate `Competencia` completo con su ciclo de vida hasta
+`IniciarCompetencia`. Reemplaza el stub `CompetenciaEstadoPort` con la implementación real.
+
+### US-2.1.1 — Scaffold Aggregate Competencia + ConfigurarIntervaloOT
+
+| Campo | Valor |
+|-------|-------|
+| **Comando** | `ConfigurarIntervaloOT` |
+| **Evento** | `IntervaloOTConfigurado` |
+| **Actor** | Organizador / Juez |
+| **Invariantes** | INV-C-01 |
+| **ES candidata** | US-C-01 |
+| **RFs** | RF-PR-08 |
+
+**Precondiciones:**
+- La Competencia existe y está en estado `Preparacion`
+- No existe aún un intervalo configurado, o bien existe y se está reconfigurando
+
+**Postcondición:** `IntervaloOTConfigurado` persiste en el stream `competencia-{id}`.
+Competencia mantiene estado `Preparacion`.
+
+**Invariante:**
+- `INV-C-01`: `intervaloDisciplina` debe estar configurado antes de `GenerarGrilla`
+
+**Incluye:** resolución de deuda SOLID (DIP en `router.py` + OCP en `_apply_stored`).
+
+---
+
+### US-2.1.2 — Generar / Regenerar Grilla
+
+| Campo | Valor |
+|-------|-------|
+| **Comando** | `GenerarGrilla` / `RegenerarGrilla` |
+| **Evento** | `GrillaDeSalidaGenerada` |
+| **Actor** | Organizador / Sistema |
+| **Invariantes** | INV-C-01, P-01, P-02 |
+| **ES candidata** | US-C-02 |
+| **RFs** | RF-PR-04, RF-PR-05 |
+
+**Precondiciones:**
+- `intervaloDisciplina` está configurado (INV-C-01)
+- La grilla no está confirmada (`GrillaConfirmada` no emitido) — regeneración permitida
+
+**Postcondición:** `GrillaDeSalidaGenerada` persiste. La lista ordenada de atletas con
+posición, andarivel y OT calculado queda proyectada en el Read Model.
+
+**Invariantes / Políticas:**
+- `INV-C-01`: intervalo configurado antes de generar
+- `P-01`: disciplinas de distancia → AP menor a mayor; tiempo → AP mayor a menor
+- `P-02`: OT de cada atleta = OT_inicio + (posición × intervaloDisciplina)
+- `RF-PR-04`: atletas sin AP no aparecen en la grilla
+- Regeneración permitida mientras `GrillaConfirmada` no fue emitido
+
+---
+
+### US-2.1.3 — Ajustar Grilla
+
+| Campo | Valor |
+|-------|-------|
+| **Comando** | `AjustarGrilla` |
+| **Evento** | `GrillaDeSalidaAjustada` |
+| **Actor** | Organizador |
+| **Invariantes** | INV-C-02 (parcial) |
+| **ES candidata** | US-C-03 |
+| **RFs** | RF-PR-07 |
+
+**Precondiciones:**
+- La grilla fue generada (`GrillaDeSalidaGenerada` emitido)
+- La grilla **no** está confirmada (INV-C-02 — parcial: antes de `GrillaConfirmada`)
+
+**Postcondición:** `GrillaDeSalidaAjustada` persiste con los cambios de posición/andarivel.
+Read Model actualizado.
+
+**Invariantes:**
+- `INV-C-02`: `AjustarGrilla` no permitido después de `GrillaConfirmada`
+
+---
+
+### US-2.1.4 — Confirmar Grilla + Iniciar Competencia
+
+| Campo | Valor |
+|-------|-------|
+| **Comandos** | `ConfirmarGrilla` · `IniciarCompetencia` |
+| **Eventos** | `GrillaConfirmada` · `CompetenciaIniciada` |
+| **Actor** | Organizador (confirmar) · Juez (iniciar) |
+| **Invariantes** | INV-C-02, INV-C-03 |
+| **ES candidatas** | US-C-04, US-C-05 |
+
+**ConfirmarGrilla:**
+- Precondición: grilla generada (`GrillaDeSalidaGenerada`)
+- Postcondición: `GrillaConfirmada` persiste. Grilla congelada — `GenerarGrilla`,
+  `RegenerarGrilla` y `AjustarGrilla` bloqueados (INV-C-02 completo)
+
+**IniciarCompetencia:**
+- Precondición: Competencia en estado `Confirmada` (INV-C-03)
+- Postcondición: `CompetenciaIniciada` persiste. Competencia en estado `EnEjecucion`.
+  Performances habilitadas para ejecución según grilla (P-06)
+
+**Incluye:** reemplazo del stub `CompetenciaEstadoPort` con la implementación real
+que consulta el stream de Competencia para verificar `GrillaConfirmada` e `is_en_ejecucion`.
+
+---
+
+## Incremento 2.2 — Dos Mecánicas, un Modelo
+
+**Objetivo:** soportar STA (tiempo en segundos) y DNF (distancia en metros con decimales)
+como disciplinas con descriptor propio. El juez ve el campo correcto según la disciplina.
+
+### US-2.2.1 — Descriptor de Disciplina
+
+| Campo | Valor |
+|-------|-------|
+| **Tipo** | Value Object + Port |
+| **Actor** | Sistema |
+| **RFs** | RF-EJ-08 |
+
+Value Object `DisciplinaDescriptor`: encapsula tipo de medición (tiempo / distancia),
+unidad (`Segundos` / `Metros`), y regla de ordenamiento de grilla.
+
+Introduce `DisciplinaDescriptorPort` en `domain/ports/` para que `GenerarGrilla` y
+`RegistrarResultado` consulten el descriptor sin acoplarse a una implementación concreta.
+
+---
+
+### US-2.2.2 — API Disciplina-Aware + Avance Automático
+
+| Campo | Valor |
+|-------|-------|
+| **Tipo** | Application + API |
+| **Actor** | Juez |
+| **RFs** | RF-EJ-08 |
+
+- Endpoint `POST /competencia/{id}/performance/{pid}/resultado` valida la unidad
+  según el descriptor de la disciplina
+- Lógica de avance automático: al finalizar una performance, el sistema identifica
+  la siguiente según posición en grilla (P-06)
+- Read Model `PerformanceActual` incluye el descriptor de disciplina para que el
+  cliente muestre el campo correcto
+
+---
+
+## Incremento 2.3 — Andariveles Simultáneos
+
+**Objetivo:** la grilla distribuye atletas en 2-3 andariveles. Performances en andariveles
+distintos pueden registrarse sin conflicto.
+
+### US-2.3.1 — Ejecución Multi-Andarivel
+
+| Campo | Valor |
+|-------|-------|
+| **Comandos** | `GenerarGrilla` (extendido) · `LlamarAtleta` (multi-lane) |
+| **Actor** | Sistema / Juez |
+| **RFs** | RF-PR-06 |
+
+- `GenerarGrilla` distribuye atletas en N andariveles (configurable, default=1)
+- El aggregate garantiza que no hay dos performances activas (en estado `Llamada`)
+  en el mismo andarivel simultáneamente
+- Read Model `AndarivelesActivos`: lista de andariveles con el atleta actual de cada uno
+- Endpoint `GET /competencia/{id}/andariveles` muestra estado de cada andarivel
+
+---
+
+## Incremento 2.4 — El Ranking
+
+**Objetivo:** al finalizar la disciplina, el ranking se calcula automáticamente y es
+visible con podio destacado.
+
+### US-2.4.1 — Competencia Finalizada (automático)
+
+| Campo | Valor |
+|-------|-------|
+| **Evento** | `CompetenciaFinalizada` |
+| **Actor** | Sistema (automático) |
+| **Invariantes** | INV-C-04, P-08 |
+| **ES candidata** | US-C-06 |
+
+Política P-08: cuando todas las Performances están en estado `Ejecutada` o `DNS`,
+el sistema emite `CompetenciaFinalizada` automáticamente.
+
+- `INV-C-04`: solo se finaliza cuando **todas** las Performances = Ejecutada o DNS
+- `CompetenciaFinalizada` dispara el cálculo del ranking en BC Resultados
+
+---
+
+### US-2.4.2 — Calcular Ranking (BC Resultados — núcleo)
+
+| Campo | Valor |
+|-------|-------|
+| **Comando** | `CalcularRanking` |
+| **Actor** | Sistema (disparo desde `CompetenciaFinalizada`) |
+| **RFs** | RF-PM-03 |
+| **BC** | Resultados (primer US del BC) |
+
+- Ranking ordenado: mejor marca primero (según descriptor de disciplina)
+- DNS y tarjeta roja al final, después de las performances válidas
+- Empates comparten posición (RF-PM-03) — misma posición y mismos puntos
+- Read Model `RankingDisciplina`: lista con posición, atleta, marca, tarjeta, podio destacado
+- Endpoint `GET /competencia/{id}/ranking`
+
+**Nota SP2:** BC Resultados se inicializa en este incremento. Solo se crea el scaffold
+mínimo necesario (equivalente a Inc 1.1 pero para BC Resultados).
+
+---
+
+## Mapping US Candidatas → ES Competencia
+
+| US SP2 | US ES (event-storming-competencia.md) | Incremento |
+|--------|---------------------------------------|-----------|
+| US-2.1.1 | US-C-01 (ConfigurarIntervaloOT) | Inc 2.1 |
+| US-2.1.2 | US-C-02 (GenerarGrilla) | Inc 2.1 |
+| US-2.1.3 | US-C-03 (AjustarGrilla) | Inc 2.1 |
+| US-2.1.4 | US-C-04 + US-C-05 (ConfirmarGrilla + IniciarCompetencia) | Inc 2.1 |
+| US-2.2.1 | — (DisciplinaDescriptor — value object) | Inc 2.2 |
+| US-2.2.2 | — (API disciplina-aware + avance automático) | Inc 2.2 |
+| US-2.3.1 | US-C-02 extendido (multi-andarivel) | Inc 2.3 |
+| US-2.4.1 | US-C-06 (CompetenciaFinalizada automático) | Inc 2.4 |
+| US-2.4.2 | — (CalcularRanking — BC Resultados núcleo) | Inc 2.4 |
+
+**US del ES Competencia pendientes para SPs posteriores:**
+- US-P-06 (CorregirResultado con INV-P-15): ventana de impugnación → SP3 (BC Torneo)
+
+---
+
+## Datos Hardcodeados en SP2
+
+SP2 opera sin BC Registro, BC Torneo ni BC Identidad.
+
+| Dato | Fuente real | En SP2 |
+|------|------------|--------|
+| Datos del atleta (nombre, categoría) | BC Registro | String + ID fijo en los tests / seed data |
+| `torneoId` | BC Torneo | UUID fijo |
+| `ventanaImpugnacion` | BC Torneo | Sin validación (INV-P-15 diferido a SP3) |
+| Roles (organizador / juez) | BC Identidad | Sin autenticación — comandos aceptan `actorId` string |
+| Descriptores de disciplina | BC Configuración (SP4) | Hardcodeados: STA→Segundos, DNF→Metros |
+
+---
+
+## Próximos Pasos
+
+1. ✅ Branch `feature/sp2-planificacion` creado desde `develop`
+2. ✅ Este documento
+3. Redactar `docs/specs/sp2/US-2.1.1.md` a `US-2.1.4.md` — primer incremento completo
+4. Crear issues en Linear: 4 incrementos + sub-issues US Inc 2.1
+5. Actualizar `docs/traceability/matrix.md` con US-IEDD SP2
+6. PR `feature/sp2-planificacion` → `develop`
+7. Al iniciar Inc 2.1: `git checkout -b feature/US-2.1.1-competencia-intervalo-ot develop`

--- a/docs/specs/sp2/US-2.1.1.md
+++ b/docs/specs/sp2/US-2.1.1.md
@@ -1,0 +1,148 @@
+# US-2.1.1: Scaffold Aggregate Competencia + ConfigurarIntervaloOT
+
+**Estado**: `Backlog`
+**Incremento**: Inc 2.1 — La Grilla de Salida
+**Subproyecto**: SP2 — La Competencia
+**Agregado principal**: `Competencia`
+**Bounded Context**: `competencia`
+
+---
+
+## Descripción (lenguaje de negocio)
+
+Como **organizador o juez**,
+quiero **configurar el intervalo de tiempo entre Official Tops para una competencia**
+para **que el sistema pueda calcular los OTs de cada atleta al generar la grilla**.
+
+---
+
+## Contexto del dominio
+
+### Modelo involucrado
+
+| Elemento DDD | Nombre | Responsabilidad |
+|---|---|---|
+| Aggregate | `Competencia` | Gestiona el ciclo de vida de una disciplina: Preparacion → Confirmada → EnEjecucion → Finalizada |
+| Value Object | `IntervaloDisciplina` | Tiempo en minutos entre OTs consecutivos |
+| Value Object | `EstadoCompetencia` | Máquina de estados: `Preparacion → Confirmada → EnEjecucion → Finalizada` |
+| Domain Event | `IntervaloOTConfigurado` | Señala que el intervalo fue establecido (o reconfigurado) para esta competencia |
+
+### Lenguaje ubicuo relevante
+
+- **OT (Official Top)**: momento exacto en que el atleta inicia su performance. Cada atleta tiene su OT calculado.
+- **IntervaloDisciplina**: tiempo en minutos entre OTs consecutivos. Configurable por competencia.
+- **Competencia**: aggregate que agrupa todas las performances de una disciplina en un torneo. Es el dueño de la grilla.
+- **Grilla de Salida**: lista ordenada de atletas con su posición, andarivel y OT asignado.
+
+---
+
+## Nota sobre deuda SOLID (incluida en esta US)
+
+Esta US liquida la deuda SOLID identificada en la retrospectiva de SP1:
+
+| Deuda | Resolución |
+|-------|-----------|
+| **DIP en `router.py`**: instancia dependencias directamente | Introducir inyección de dependencias via FastAPI `Depends()` — el router recibe handlers/ports como parámetros |
+| **OCP en `_apply_stored` de `Performance`**: cadena if/elif | Refactorizar a dispatch por tipo de evento usando un dict o método en cada evento |
+
+El refactor no modifica el comportamiento observable — todos los tests de SP1 deben seguir pasando.
+
+---
+
+## Especificación del comportamiento
+
+### Invariantes del aggregate
+
+- **INV-C-01**: `intervaloDisciplina` debe estar configurado antes de `GenerarGrilla`. Si se intenta generar la grilla sin intervalo configurado → excepción `IntervaloNoConfigurado`.
+
+### Operación principal
+
+**Nombre**: `configurar_intervalo_ot(intervalo_minutos: int)`
+
+| | Descripción |
+|---|---|
+| **Precondición** | La Competencia existe y está en estado `Preparacion`. |
+| **Postcondición** | Evento `IntervaloOTConfigurado` persiste en el stream `competencia-{id}`. La Competencia mantiene estado `Preparacion`. |
+| **Eventos generados** | `IntervaloOTConfigurado` |
+| **Excepciones** | `IntervaloInvalido` si `intervalo_minutos <= 0` |
+
+> **Nota:** la operación es repetible. Si ya existe un `IntervaloOTConfigurado` previo,
+> se emite uno nuevo con el valor actualizado. Los OTs de la grilla quedan desactualizados
+> hasta regenerar (P-03). Si la grilla ya está confirmada (`GrillaConfirmada` emitido),
+> `ConfigurarIntervaloOT` **no está permitido** — la grilla está congelada.
+
+**Ejemplo concreto:**
+
+```
+Precondición:  Competencia C001 en estado Preparacion, sin intervalo previo
+Operación:     configurar_intervalo_ot(intervalo_minutos=9)
+Postcondición: Competencia tiene intervaloDisciplina=9
+Evento:        IntervaloOTConfigurado{
+                 competenciaId="C001", disciplina="STA",
+                 intervaloDisciplina=9, configuradoPor="organizador-01"
+               }
+```
+
+---
+
+## Criterios de aceptación (BDD)
+
+```gherkin
+Feature: Configurar Intervalo OT de Competencia
+
+  Background:
+    Given una competencia con id "C001" en estado "Preparacion"
+    And la disciplina es "STA"
+
+  Scenario: Configurar intervalo exitosamente
+    Given no existe un intervalo previo configurado
+    When el organizador configura el intervalo en 9 minutos
+    Then el intervalo queda registrado en 9 minutos
+    And el evento IntervaloOTConfigurado persiste en el stream
+    And la competencia sigue en estado "Preparacion"
+
+  Scenario: Reconfigurar intervalo (repetición permitida)
+    Given ya existe un IntervaloOTConfigurado de 7 minutos
+    When el organizador reconfigura el intervalo a 10 minutos
+    Then el nuevo IntervaloOTConfigurado persiste con valor 10
+    And el intervalo activo de la competencia es 10 minutos
+
+  Scenario: Rechazo — intervalo cero o negativo
+    When el organizador intenta configurar el intervalo en 0 minutos
+    Then el sistema rechaza la operación con error "IntervaloInvalido"
+
+  Scenario: Rechazo — grilla ya confirmada
+    Given la grilla ya fue confirmada para esta competencia
+    When el organizador intenta reconfigurar el intervalo
+    Then el sistema rechaza la operación con error "GrillaYaConfirmada"
+```
+
+---
+
+## Impacto arquitectónico
+
+**¿Esta US requiere una decisión arquitectónica?**
+- [x] Sí — introduce el segundo aggregate con Event Sourcing en BC Competencia
+
+**Capas afectadas:**
+- [x] Domain — `Competencia` aggregate, value objects (`IntervaloDisciplina`, `EstadoCompetencia`), `IntervaloOTConfigurado` event
+- [x] Application — `ConfigurarIntervaloOTHandler` command handler
+- [x] Infrastructure — nuevo stream `competencia-{id}` en `SQLiteEventStore` (misma tabla `events`, distinto stream prefix)
+- [ ] API — endpoints se añaden en US-2.1.4
+
+**Refactors incluidos (deuda SP1):**
+- `router.py`: DIP — inyección via `Depends()`
+- `Performance._apply_stored`: OCP — dispatch por tipo
+
+---
+
+## Referencias
+
+- Event Storming Competencia: `docs/design/event-storming-competencia.md` — Flujo 1, US-C-01
+- Invariantes: INV-C-01, INV-C-02 (parcial)
+- Políticas: P-03 (OTs desactualizados si se reconfigura intervalo)
+- `docs/plans/sp2/SP2-candidatas.md` — Inc 2.1
+
+---
+
+*Redactado: 2026-03-24 — IEDD Capa 3*

--- a/docs/specs/sp2/US-2.1.2.md
+++ b/docs/specs/sp2/US-2.1.2.md
@@ -1,0 +1,185 @@
+# US-2.1.2: Generar / Regenerar Grilla de Salida
+
+**Estado**: `Backlog`
+**Incremento**: Inc 2.1 — La Grilla de Salida
+**Subproyecto**: SP2 — La Competencia
+**Agregado principal**: `Competencia`
+**Bounded Context**: `competencia`
+
+---
+
+## Descripción (lenguaje de negocio)
+
+Como **organizador o sistema**,
+quiero **generar la grilla de salida de una competencia a partir de los APs registrados**
+para **que los atletas queden ordenados según las reglas de la disciplina con sus OTs calculados**.
+
+---
+
+## Contexto del dominio
+
+### Modelo involucrado
+
+| Elemento DDD | Nombre | Responsabilidad |
+|---|---|---|
+| Aggregate | `Competencia` | Genera y gestiona la grilla — calcula posiciones, OTs y asigna andariveles |
+| Value Object | `PosicionGrilla` | Posición ordinal del atleta en la grilla (1-based) |
+| Value Object | `Andarivel` | Número de carril/andarivel asignado al atleta |
+| Value Object | `OTProgramado` | Timestamp calculado del Official Top del atleta |
+| Domain Event | `GrillaDeSalidaGenerada` | Snapshot de la grilla completa con todos los atletas ordenados |
+
+### Lenguaje ubicuo relevante
+
+- **Grilla de Salida**: lista ordenada de performances activas con posición, andarivel y OT calculado para cada atleta.
+- **AP (Announced Performance)**: la marca declarada es el criterio de ordenamiento — menor a mayor para distancia, mayor a menor para tiempo.
+- **Andarivel**: carril de competencia. En SP2 Inc 2.1 se usa un único andarivel (andariveles múltiples en Inc 2.3).
+- **OT (Official Top)**: OT_atleta = OT_inicio + (posición − 1) × intervaloDisciplina.
+
+---
+
+## Especificación del comportamiento
+
+### Invariantes del aggregate
+
+- **INV-C-01**: `intervaloDisciplina` debe estar configurado (evento `IntervaloOTConfigurado` en el stream) antes de `GenerarGrilla`. De lo contrario → `IntervaloNoConfigurado`.
+- **RF-PR-04** (política P-05): atletas sin AP registrado (`APRegistrado` no emitido para esa competencia) no aparecen en la grilla generada.
+- **Regeneración**: permitida mientras `GrillaConfirmada` no fue emitido. Si `GrillaConfirmada` existe → `GrillaYaConfirmada`.
+
+### Regla de ordenamiento (política P-01)
+
+| Tipo de disciplina | Ordenamiento AP |
+|-------------------|----------------|
+| Distancia (DNF, DYN, DYNB) | AP menor → mayor (primero el más conservador) |
+| Tiempo (STA) | AP mayor → menor (primero el más largo) |
+
+### Cálculo de OT (política P-02)
+
+```
+OT_atleta = OT_inicio + (posición − 1) × intervaloDisciplina
+```
+
+Donde `OT_inicio` es el timestamp de inicio de la competencia (hora de comienzo configurada
+o timestamp de `IniciarCompetencia` — se define en US-2.1.4).
+
+### Operación principal
+
+**Nombre**: `generar_grilla(ot_inicio: datetime, andariveles: int = 1)`
+
+| | Descripción |
+|---|---|
+| **Precondición** | `intervaloDisciplina` configurado. Grilla no confirmada. Existen al menos una Performance en estado `AnunciadaAP` para esta competencia. |
+| **Postcondición** | `GrillaDeSalidaGenerada` persiste con la lista ordenada `[{performanceId, atletaId, posicion, andarivel, ot_programado}]`. |
+| **Eventos generados** | `GrillaDeSalidaGenerada` |
+| **Excepciones** | `IntervaloNoConfigurado` (INV-C-01) · `GrillaYaConfirmada` · `SinPerformancesParaGrilla` |
+
+**Ejemplo concreto — STA (tiempo, mayor→menor):**
+
+```
+Input:  3 atletas con AP: A001→5:30, A002→6:00, A003→4:45
+        intervaloDisciplina=9 min, OT_inicio=10:00:00
+
+Ordenamiento: A002(6:00) > A001(5:30) > A003(4:45)
+
+Grilla generada:
+  Pos 1 | A002 | andarivel=1 | OT=10:00:00
+  Pos 2 | A001 | andarivel=1 | OT=10:09:00
+  Pos 3 | A003 | andarivel=1 | OT=10:18:00
+
+Evento: GrillaDeSalidaGenerada{
+  competenciaId="C001",
+  disciplina="STA",
+  performances=[
+    {performanceId, atletaId="A002", posicion=1, andarivel=1, ot_programado="10:00:00"},
+    {performanceId, atletaId="A001", posicion=2, andarivel=1, ot_programado="10:09:00"},
+    {performanceId, atletaId="A003", posicion=3, andarivel=1, ot_programado="10:18:00"},
+  ],
+  generadaEn=<timestamp>
+}
+```
+
+---
+
+## Criterios de aceptación (BDD)
+
+```gherkin
+Feature: Generar Grilla de Salida
+
+  Background:
+    Given una competencia "C001" con disciplina "STA" en estado "Preparacion"
+    And el intervalo OT está configurado en 9 minutos
+    And OT de inicio es "10:00:00"
+
+  Scenario: Grilla generada con orden correcto para STA (tiempo mayor→menor)
+    Given los siguientes APs registrados:
+      | atletaId | valorAP |
+      | A001     | 5:30    |
+      | A002     | 6:00    |
+      | A003     | 4:45    |
+    When el organizador genera la grilla
+    Then la grilla queda:
+      | posicion | atletaId | ot_programado |
+      | 1        | A002     | 10:00:00      |
+      | 2        | A001     | 10:09:00      |
+      | 3        | A003     | 10:18:00      |
+    And el evento GrillaDeSalidaGenerada persiste en el stream
+
+  Scenario: Atleta sin AP no aparece en la grilla (RF-PR-04)
+    Given los siguientes APs registrados: A001→5:30, A002→6:00
+    And el atleta A003 está inscripto pero no registró AP
+    When el organizador genera la grilla
+    Then la grilla contiene solo A002 y A001
+    And A003 no aparece en la grilla
+
+  Scenario: Regenerar grilla antes de confirmar
+    Given la grilla ya fue generada
+    And la grilla no está confirmada
+    When el organizador regenera la grilla con nuevos datos
+    Then se emite un nuevo GrillaDeSalidaGenerada
+    And el Read Model muestra la grilla actualizada
+
+  Scenario: Rechazo — intervalo no configurado
+    Given no se configuró el intervalo OT
+    When el organizador intenta generar la grilla
+    Then el sistema rechaza con error "IntervaloNoConfigurado"
+
+  Scenario: Rechazo — grilla ya confirmada
+    Given la grilla ya fue confirmada
+    When el organizador intenta regenerar la grilla
+    Then el sistema rechaza con error "GrillaYaConfirmada"
+
+  Scenario: Grilla DNF (distancia menor→mayor)
+    Given una competencia "C002" con disciplina "DNF"
+    And APs: A001→80m, A002→60m, A003→100m
+    And intervalo=10min, OT_inicio=09:00:00
+    When se genera la grilla
+    Then el orden es: A002(60m) pos=1, A001(80m) pos=2, A003(100m) pos=3
+```
+
+---
+
+## Impacto arquitectónico
+
+**¿Esta US requiere una decisión arquitectónica?**
+- [x] No — usa la arquitectura hexagonal ya establecida con el Event Store de SP1
+
+**Capas afectadas:**
+- [x] Domain — `Competencia.generar_grilla()`, `GrillaDeSalidaGenerada` event, política P-01/P-02
+- [x] Application — `GenerarGrillaHandler`
+- [ ] Infrastructure — no requiere cambios (usa `SQLiteEventStore` existente)
+- [ ] API — endpoints en US-2.1.4
+
+**Puerto nuevo:** `PerformancesAPPort` en `domain/ports/` — el aggregate consulta las Performances
+con AP registrado para esta competencia. El adaptador lee desde el Event Store.
+
+---
+
+## Referencias
+
+- Event Storming Competencia: `docs/design/event-storming-competencia.md` — Flujo 1 + Flujo 2
+- Invariantes: INV-C-01; Políticas: P-01, P-02, P-03, P-05
+- RFs: RF-PR-04, RF-PR-05, RF-PR-08
+- `docs/plans/sp2/SP2-candidatas.md` — Inc 2.1
+
+---
+
+*Redactado: 2026-03-24 — IEDD Capa 3*

--- a/docs/specs/sp2/US-2.1.3.md
+++ b/docs/specs/sp2/US-2.1.3.md
@@ -1,0 +1,142 @@
+# US-2.1.3: Ajustar Grilla Manualmente
+
+**Estado**: `Backlog`
+**Incremento**: Inc 2.1 — La Grilla de Salida
+**Subproyecto**: SP2 — La Competencia
+**Agregado principal**: `Competencia`
+**Bounded Context**: `competencia`
+
+---
+
+## Descripción (lenguaje de negocio)
+
+Como **organizador**,
+quiero **modificar manualmente el orden o andarivel de uno o más atletas en la grilla**
+para **ajustar la grilla generada automáticamente antes de confirmarla**.
+
+---
+
+## Contexto del dominio
+
+### Modelo involucrado
+
+| Elemento DDD | Nombre | Responsabilidad |
+|---|---|---|
+| Aggregate | `Competencia` | Aplica ajustes manuales sobre la grilla generada, recalcula OTs si cambia la posición |
+| Domain Event | `GrillaDeSalidaAjustada` | Registra los cambios puntuales: qué campo cambió, valor anterior y nuevo |
+
+### Lenguaje ubicuo relevante
+
+- **Ajuste de grilla**: modificación manual de posición y/o andarivel de un atleta, a diferencia de la generación automática que ordena por AP.
+- **OT recalculado**: si se cambia la posición de un atleta, su OT se recalcula según P-02.
+
+---
+
+## Especificación del comportamiento
+
+### Invariantes del aggregate
+
+- **INV-C-02** (parcial): `AjustarGrilla` no está permitido después de `GrillaConfirmada`. Una vez confirmada, la grilla es inmutable (v1).
+- La grilla debe haber sido generada (`GrillaDeSalidaGenerada` emitido) antes de poder ajustarse.
+
+### Operación principal
+
+**Nombre**: `ajustar_grilla(cambios: list[CambioGrilla])`
+
+donde `CambioGrilla = {performanceId, campo: "posicion"|"andarivel", valor_nuevo}`
+
+| | Descripción |
+|---|---|
+| **Precondición** | La grilla fue generada. La grilla **no** está confirmada (`GrillaConfirmada` no emitido). |
+| **Postcondición** | `GrillaDeSalidaAjustada` persiste con los cambios aplicados. Read Model actualizado. Si se modificó la posición, los OTs se recalculan para todos los atletas afectados. |
+| **Eventos generados** | `GrillaDeSalidaAjustada` |
+| **Excepciones** | `GrillaNoGenerada` · `GrillaYaConfirmada` (INV-C-02) · `PerformanceNoEncontrada` |
+
+**Ejemplo concreto:**
+
+```
+Estado previo: grilla con A002(pos=1), A001(pos=2), A003(pos=3), intervaloDisciplina=9min
+
+Operación: ajustar_grilla([{performanceId_A001, campo="posicion", valor_nuevo=1}])
+           (intercambiar A001 y A002)
+
+Resultado:
+  A001 → pos=1, OT=10:00:00
+  A002 → pos=2, OT=10:09:00
+  A003 → pos=3 (sin cambio)
+
+Evento: GrillaDeSalidaAjustada{
+  competenciaId="C001",
+  cambios=[
+    {performanceId: P_A001, campo: "posicion", valorAnterior: 2, valorNuevo: 1},
+    {performanceId: P_A002, campo: "posicion", valorAnterior: 1, valorNuevo: 2},
+  ],
+  ajustadaEn=<timestamp>
+}
+```
+
+---
+
+## Criterios de aceptación (BDD)
+
+```gherkin
+Feature: Ajustar Grilla Manualmente
+
+  Background:
+    Given una competencia "C001" con grilla generada (3 atletas: A002 pos=1, A001 pos=2, A003 pos=3)
+    And la grilla no está confirmada
+
+  Scenario: Ajustar posición de un atleta
+    When el organizador mueve A001 a la posición 1
+    Then la grilla queda: A001 pos=1, A002 pos=2, A003 pos=3
+    And los OTs se recalculan según el nuevo orden
+    And el evento GrillaDeSalidaAjustada persiste con los cambios
+
+  Scenario: Ajustar andarivel de un atleta
+    When el organizador asigna andarivel 2 al atleta A002
+    Then A002 queda en andarivel=2
+    And los demás atletas no se ven afectados
+    And el evento GrillaDeSalidaAjustada persiste
+
+  Scenario: Ajuste acumulativo sobre ajuste previo
+    Given ya existe un GrillaDeSalidaAjustada previo
+    When el organizador realiza otro ajuste
+    Then se emite un nuevo GrillaDeSalidaAjustada
+    And el Read Model refleja el estado final acumulado
+
+  Scenario: Rechazo — grilla no generada aún
+    Given una competencia sin GrillaDeSalidaGenerada
+    When el organizador intenta ajustar la grilla
+    Then el sistema rechaza con error "GrillaNoGenerada"
+
+  Scenario: Rechazo — grilla ya confirmada (INV-C-02)
+    Given la grilla ya fue confirmada
+    When el organizador intenta ajustar la grilla
+    Then el sistema rechaza con error "GrillaYaConfirmada"
+```
+
+---
+
+## Impacto arquitectónico
+
+**¿Esta US requiere una decisión arquitectónica?**
+- [x] No — sigue el mismo patrón de command/event/handler
+
+**Capas afectadas:**
+- [x] Domain — `Competencia.ajustar_grilla()`, `GrillaDeSalidaAjustada` event
+- [x] Application — `AjustarGrillaHandler`
+- [ ] Infrastructure — sin cambios
+- [ ] API — endpoints en US-2.1.4
+
+---
+
+## Referencias
+
+- Event Storming Competencia: `docs/design/event-storming-competencia.md` — Flujo 1
+- Invariante: INV-C-02 (parcial); Hot Spot HS-P1 (resuelto)
+- RF: RF-PR-07
+- `docs/plans/sp2/SP2-candidatas.md` — Inc 2.1
+
+---
+
+*Redactado: 2026-03-24 — IEDD Capa 3*

--- a/docs/specs/sp2/US-2.1.4.md
+++ b/docs/specs/sp2/US-2.1.4.md
@@ -1,0 +1,175 @@
+# US-2.1.4: Confirmar Grilla + Iniciar Competencia
+
+**Estado**: `Backlog`
+**Incremento**: Inc 2.1 — La Grilla de Salida
+**Subproyecto**: SP2 — La Competencia
+**Agregado principal**: `Competencia`
+**Bounded Context**: `competencia`
+
+---
+
+## Descripción (lenguaje de negocio)
+
+Como **organizador o juez**,
+quiero **confirmar la grilla de salida e iniciar la competencia**
+para **congelar el orden de los atletas y habilitar el registro de performances según la grilla**.
+
+Esta US también **reemplaza el stub `CompetenciaEstadoPort`** de SP1 por la
+implementación real que consulta el stream de Competencia.
+
+---
+
+## Contexto del dominio
+
+### Modelo involucrado
+
+| Elemento DDD | Nombre | Responsabilidad |
+|---|---|---|
+| Aggregate | `Competencia` | Transiciona de Preparacion → Confirmada → EnEjecucion |
+| Port | `CompetenciaEstadoPort` | Consultado por `Performance` para verificar estado de la competencia |
+| Domain Event | `GrillaConfirmada` | Hito de bloqueo: grilla congelada |
+| Domain Event | `CompetenciaIniciada` | Habilita la ejecución de performances según grilla |
+
+### Lenguaje ubicuo relevante
+
+- **GrillaConfirmada**: hito irreversible (v1) — después de este evento, la grilla no puede modificarse.
+- **CompetenciaIniciada**: la disciplina comienza. El juez puede llamar al primer atleta.
+- **Estado Confirmada**: estado intermedio entre grilla lista y competencia en marcha.
+
+---
+
+## Especificación del comportamiento
+
+### Operación 1: ConfirmarGrilla
+
+**Nombre**: `confirmar_grilla()`
+
+| | Descripción |
+|---|---|
+| **Precondición** | Grilla generada (`GrillaDeSalidaGenerada` emitido). Competencia en estado `Preparacion`. |
+| **Postcondición** | `GrillaConfirmada` persiste. Competencia en estado `Confirmada`. Grilla congelada: `GenerarGrilla`, `RegenerarGrilla`, `AjustarGrilla` y `ConfigurarIntervaloOT` quedan bloqueados. |
+| **Eventos generados** | `GrillaConfirmada` |
+| **Excepciones** | `GrillaNoGenerada` · `GrillaYaConfirmada` |
+
+**INV-C-02** (completo): `GrillaConfirmada` es unidireccional — no puede revertirse en v1.
+
+---
+
+### Operación 2: IniciarCompetencia
+
+**Nombre**: `iniciar_competencia(juez_id: str)`
+
+| | Descripción |
+|---|---|
+| **Precondición** | Competencia en estado `Confirmada` (`GrillaConfirmada` emitido). INV-C-03. |
+| **Postcondición** | `CompetenciaIniciada` persiste. Competencia en estado `EnEjecucion`. Las Performances habilitadas para `LlamarAtleta` (política P-06). |
+| **Eventos generados** | `CompetenciaIniciada` |
+| **Excepciones** | `CompetenciaNoConfirmada` (INV-C-03) |
+
+---
+
+### Implementación real de CompetenciaEstadoPort
+
+El stub `CompetenciaEstadoStub` de SP1 retornaba siempre:
+- `is_grilla_confirmada() → False`
+- `is_en_ejecucion() → True`
+
+La implementación real `CompetenciaEstadoAdapter` consulta el stream `competencia-{id}`
+del Event Store y retorna el estado proyectado:
+
+| Método | Lógica real |
+|--------|------------|
+| `is_grilla_confirmada(competencia_id)` | True si `GrillaConfirmada` existe en el stream |
+| `is_en_ejecucion(competencia_id)` | True si `CompetenciaIniciada` existe y `CompetenciaFinalizada` no existe |
+| `is_plazo_vencido(competencia_id)` | True si `PlazoAPVencido` existe en el stream |
+
+**Impacto en SP1:** los tests de SP1 que usaban el stub deben seguir pasando.
+Se reemplaza el registro del stub en el contenedor DI por el adaptador real.
+Para tests unitarios de `Performance`, el stub se mantiene como test double.
+
+---
+
+## Criterios de aceptación (BDD)
+
+```gherkin
+Feature: Confirmar Grilla e Iniciar Competencia
+
+  Background:
+    Given una competencia "C001" en estado "Preparacion"
+    And la grilla fue generada con 3 atletas
+
+  Scenario: Confirmar grilla exitosamente
+    When el organizador confirma la grilla
+    Then el evento GrillaConfirmada persiste
+    And la competencia pasa al estado "Confirmada"
+    And GenerarGrilla queda bloqueado
+
+  Scenario: Rechazo — confirmar sin grilla generada
+    Given la grilla no fue generada aún
+    When el organizador intenta confirmar la grilla
+    Then el sistema rechaza con error "GrillaNoGenerada"
+
+  Scenario: Iniciar competencia exitosamente
+    Given la grilla ya fue confirmada (estado "Confirmada")
+    When el juez inicia la competencia
+    Then el evento CompetenciaIniciada persiste
+    And la competencia pasa al estado "EnEjecucion"
+    And el comando LlamarAtleta queda habilitado para las performances
+
+  Scenario: Rechazo — iniciar sin grilla confirmada
+    Given la competencia está en estado "Preparacion" (no Confirmada)
+    When el juez intenta iniciar la competencia
+    Then el sistema rechaza con error "CompetenciaNoConfirmada"
+
+  Scenario: CompetenciaEstadoPort real — is_grilla_confirmada
+    Given el stream de Competencia "C001" contiene GrillaConfirmada
+    When Performance consulta CompetenciaEstadoPort.is_grilla_confirmada("C001")
+    Then retorna True
+    And el intento de registrar un nuevo AP falla con "GrillaYaConfirmada"
+
+  Scenario: CompetenciaEstadoPort real — is_en_ejecucion
+    Given el stream de Competencia "C001" contiene CompetenciaIniciada
+    When Performance consulta CompetenciaEstadoPort.is_en_ejecucion("C001")
+    Then retorna True
+    And LlamarAtleta queda habilitado para esa competencia
+```
+
+---
+
+## Impacto arquitectónico
+
+**¿Esta US requiere una decisión arquitectónica?**
+- [x] Sí — reemplaza el stub con la implementación real, cerrando el "agujero" de SP1
+
+**Capas afectadas:**
+- [x] Domain — `GrillaConfirmada` y `CompetenciaIniciada` events; transiciones de `EstadoCompetencia`
+- [x] Application — `ConfirmarGrillaHandler`, `IniciarCompetenciaHandler`
+- [x] Infrastructure — `CompetenciaEstadoAdapter` (reemplaza `CompetenciaEstadoStub`)
+- [x] API — endpoints `POST /competencia/{id}/confirmar-grilla` y `POST /competencia/{id}/iniciar`
+
+**Nota de migración del stub:**
+- El stub `CompetenciaEstadoStub` se mantiene como test double en `tests/` — no se elimina.
+- El adaptador real se registra en el contenedor DI del `router.py` / `app.py`.
+
+---
+
+## Read Models nuevos (o actualizados)
+
+| Read Model | Endpoint | Información |
+|-----------|----------|-------------|
+| `GrillaDeSalida` | `GET /competencia/{id}/grilla` | Lista ordenada: atleta, posición, andarivel, OT |
+| `EstadoCompetencia` | `GET /competencia/{id}/estado` | Estado actual + intervalo + grilla confirmada/no |
+
+---
+
+## Referencias
+
+- Event Storming Competencia: `docs/design/event-storming-competencia.md` — Flujo 1, US-C-04 + US-C-05
+- Invariantes: INV-C-02 (completo), INV-C-03; Hot Spot HS-P1 (resuelto)
+- Políticas: P-04, P-06
+- SP1 nota: `CompetenciaEstadoPort` stub definido en `docs/specs/sp1/US-1.2.1.md`
+- `docs/plans/sp2/SP2-candidatas.md` — Inc 2.1
+
+---
+
+*Redactado: 2026-03-24 — IEDD Capa 3*

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -160,7 +160,23 @@ Deben resolverse antes del SP que los involucra. No bloquean SP1 ni SP2.
 
 ---
 
-## 5. US-IEDD Candidatas para SP1
+## 5. US-IEDD Candidatas para SP2
+
+| US candidata | Inc. | RFs cubiertos | Comando/Contenido principal | Invariantes clave | Estado |
+|-------------|------|---------------|-----------------------------|------------------|--------|
+| US-2.1.1 | 2.1 | RF-PR-08 | `ConfigurarIntervaloOT` + scaffold aggregate Competencia + deuda SOLID SP1 | INV-C-01 | ⬜ Backlog |
+| US-2.1.2 | 2.1 | RF-PR-04, RF-PR-05 | `GenerarGrilla` / `RegenerarGrilla` | INV-C-01, P-01, P-02 | ⬜ Backlog |
+| US-2.1.3 | 2.1 | RF-PR-07 | `AjustarGrilla` | INV-C-02 (parcial) | ⬜ Backlog |
+| US-2.1.4 | 2.1 | — | `ConfirmarGrilla` + `IniciarCompetencia` + reemplazar stub `CompetenciaEstadoPort` | INV-C-02/03 | ⬜ Backlog |
+| US-2.2.1 | 2.2 | RF-EJ-08 | `DisciplinaDescriptor` value object + port (STA/tiempo, DNF/distancia) | — | ⬜ Backlog |
+| US-2.2.2 | 2.2 | RF-EJ-08 | API disciplina-aware + avance automático al siguiente atleta en grilla | P-06 | ⬜ Backlog |
+| US-2.3.1 | 2.3 | RF-PR-06 | Ejecución multi-andarivel — distribución en grilla + sin conflicto entre andariveles | — | ⬜ Backlog |
+| US-2.4.1 | 2.4 | — | `CompetenciaFinalizada` automático (política P-08) | INV-C-04 | ⬜ Backlog |
+| US-2.4.2 | 2.4 | RF-PM-03 | `CalcularRanking` — BC Resultados núcleo · empates · podio | RF-PM-03 | ⬜ Backlog |
+
+---
+
+## 6. US-IEDD Candidatas para SP1
 
 SP1 es el próximo SP a implementar. Estas US-IEDD se especifican formalmente
 en `docs/specs/spN/` antes de ejecutar `/implement-us`.


### PR DESCRIPTION
## Resumen

Cierra la preparación de SP2 "La Competencia": plan de incrementos, 4 specs US-IEDD del Inc 2.1 listas para implementar, y traceability matrix actualizada con las 9 US-IEDD del SP completo.

## Cambios Principales

- `docs/plans/sp2/SP2-candidatas.md`: plan completo — 4 incrementos, 9 US, DoD, deuda SOLID SP1→SP2, datos hardcodeados en SP2
- `docs/specs/sp2/US-2.1.1.md`: Scaffold Aggregate Competencia + ConfigurarIntervaloOT + deuda SOLID
- `docs/specs/sp2/US-2.1.2.md`: GenerarGrilla / RegenerarGrilla (P-01, P-02, INV-C-01)
- `docs/specs/sp2/US-2.1.3.md`: AjustarGrilla (INV-C-02 parcial)
- `docs/specs/sp2/US-2.1.4.md`: ConfirmarGrilla + IniciarCompetencia + reemplazo stub CompetenciaEstadoPort
- `docs/traceability/matrix.md`: §5 SP2 — 9 US-IEDD candidatas mapeadas a RFs e incrementos

## Linear

Issues creados en milestone BL-002:
- VVA-5: Inc 2.1 — La grilla de salida (padre de VVA-9..12)
- VVA-6: Inc 2.2 — Dos mecánicas, un modelo (bloqueado por VVA-5)
- VVA-7: Inc 2.3 — Andariveles simultáneos (bloqueado por VVA-6)
- VVA-8: Inc 2.4 — El ranking (bloqueado por VVA-7)
- VVA-9..12: sub-issues US-2.1.1 a US-2.1.4

## Test plan

- [ ] Sin código — artefactos de planificación únicamente
- [ ] Specs US-2.1.1..4 revisadas antes de ejecutar `/implement-us`

🤖 Generated with [Claude Code](https://claude.com/claude-code)