### PR TITLE
feat(domain): US-2.1.1 — Aggregate Competencia + ConfigurarIntervaloOT

### DIFF
--- a/docs/plans/sp2/US-2.1.1-plan.md
+++ b/docs/plans/sp2/US-2.1.1-plan.md
@@ -1,0 +1,58 @@
+# Plan de Implementación — US-2.1.1
+# Scaffold Aggregate Competencia + ConfigurarIntervaloOT
+
+**Fecha:** 2026-03-25
+**Branch:** `feature/US-2.1.1-competencia-intervalo-ot`
+**Estimación:** 45-60 min
+
+---
+
+## Artefactos a crear
+
+| # | Tipo | Archivo | Descripción |
+|---|------|---------|-------------|
+| T1 | NEW | `src/competencia/domain/value_objects/estado_competencia.py` | Enum `EstadoCompetencia` (Preparacion → Confirmada → EnEjecucion → Finalizada) |
+| T2 | NEW | `src/competencia/domain/value_objects/intervalo_disciplina.py` | VO `IntervaloDisciplina` — valida `intervalo_minutos > 0` |
+| T3 | NEW | `src/competencia/domain/events/intervalo_ot_configurado.py` | `IntervaloOTConfigurado` event (competenciaId, disciplina, intervaloDisciplina, configuradoPor) |
+| T4 | NEW | `src/competencia/domain/aggregates/competencia.py` | `Competencia` aggregate con `configurar_intervalo_ot()` + reconstitución desde eventos |
+| T5 | NEW | `src/competencia/application/commands/configurar_intervalo_ot.py` | `ConfigurarIntervaloOTCommand` + `ConfigurarIntervaloOTHandler` |
+
+## Refactors de deuda SOLID (SP1)
+
+| # | Tipo | Archivo | Descripción |
+|---|------|---------|-------------|
+| R1 | REFACTOR | `src/competencia/domain/aggregates/performance.py` | OCP: reemplazar cadena if/elif en `_apply_stored` por dispatch dict `{event_type: apply_fn}` |
+| R2 | REFACTOR | `src/competencia/api/router.py` | DIP: handlers instanciados directamente → mover instanciación a funciones `Depends()` |
+
+## Tests
+
+| # | Tipo | Archivo | Descripción |
+|---|------|---------|-------------|
+| T6 | NEW | `tests/unit/competencia/domain/test_competencia.py` | Tests unitarios del aggregate Competencia (happy paths + invariantes) |
+| T7 | NEW | `tests/unit/competencia/application/test_configurar_intervalo_ot_handler.py` | Tests del handler con event store in-memory |
+| T8 | NEW | `tests/integration/competencia/test_configurar_intervalo_ot_integration.py` | Test integración end-to-end con SQLite real |
+| T9 | NEW | `tests/features/steps/US-2.1.1_steps.py` | Step definitions BDD para los 4 escenarios |
+
+---
+
+## Orden de ejecución
+
+```
+T1 → T2 → T3 → T4 → T5   (dominio primero, luego aplicación)
+R1 → R2                    (refactors en paralelo conceptual)
+T6 → T7 → T8 → T9         (tests al final, una vez implementado)
+```
+
+## Invariantes a implementar
+
+- **INV-C-01:** `intervaloDisciplina` debe estar configurado antes de `GenerarGrilla`
+- **IntervaloInvalido:** si `intervalo_minutos <= 0`
+- **GrillaYaConfirmada:** si `GrillaConfirmada` ya fue emitida — impide reconfigurar
+
+## Stream ID
+
+`competencia-{competencia_id}` — misma tabla `events`, distinto prefijo que `performance-*`
+
+---
+
+*Generado en Fase 2 de /implement-us*

--- a/docs/reports/US-2.1.1-report.md
+++ b/docs/reports/US-2.1.1-report.md
@@ -1,0 +1,63 @@
+# Reporte de Implementación — US-2.1.1
+
+**Historia:** Scaffold Aggregate Competencia + ConfigurarIntervaloOT
+**Branch:** `feature/US-2.1.1-competencia-intervalo-ot`
+**Fecha:** 2026-03-25
+**Duración real:** ~18 min
+**Estimación:** 45-60 min
+
+---
+
+## Artefactos creados
+
+### Dominio
+| Archivo | Tipo | Descripción |
+|---------|------|-------------|
+| `src/competencia/domain/value_objects/estado_competencia.py` | NEW | Enum `EstadoCompetencia` |
+| `src/competencia/domain/value_objects/intervalo_disciplina.py` | NEW | VO `IntervaloDisciplina` con validación INV-C-01 |
+| `src/competencia/domain/events/intervalo_ot_configurado.py` | NEW | `IntervaloOTConfigurado` domain event |
+| `src/competencia/domain/aggregates/competencia.py` | NEW | `Competencia` aggregate con `configurar_intervalo_ot()` y reconstitución |
+
+### Aplicación
+| Archivo | Tipo | Descripción |
+|---------|------|-------------|
+| `src/competencia/application/commands/configurar_intervalo_ot.py` | NEW | `ConfigurarIntervaloOTCommand` + `ConfigurarIntervaloOTHandler` |
+
+### Refactors (deuda SOLID SP1)
+| Archivo | Tipo | Deuda resuelta |
+|---------|------|----------------|
+| `src/competencia/domain/aggregates/performance.py` | REFACTOR | OCP: `_apply_stored` → dispatch dict por tipo de evento |
+| `src/competencia/api/router.py` | REFACTOR | DIP: handlers instanciados via `Depends()` |
+
+### Tests
+| Archivo | Tipo | Tests |
+|---------|------|-------|
+| `tests/unit/competencia/domain/test_competencia.py` | NEW | 17 tests unitarios del aggregate |
+| `tests/unit/competencia/application/test_configurar_intervalo_ot_handler.py` | NEW | 11 tests del handler |
+| `tests/integration/competencia/test_configurar_intervalo_ot_integration.py` | NEW | 6 tests integración con SQLite real |
+| `tests/features/US-2.1.1-configurar-intervalo-ot.feature` | NEW | 4 escenarios BDD |
+| `tests/features/steps/configurar_intervalo_ot_steps.py` | NEW | Step definitions BDD |
+
+---
+
+## Quality Gates
+
+| Métrica | Resultado | Umbral |
+|---------|-----------|--------|
+| CodeGuard warnings | 0 | ≤ 0 |
+| Cobertura domain + application | 98% | ≥ 90% |
+| Tests pasando | 245/245 | 100% |
+| Tiempo total | ~18 min | — |
+
+---
+
+## Notas
+
+- Deuda SOLID SP1 liquidada: OCP en `Performance._apply_stored` + DIP en `router.py`
+- Stream `competencia-{id}` aislado de stream `performance-*` — verificado en tests
+- `GrillaConfirmada` mantenido como evento futuro (US-2.1.4) — `Competencia` ya lo procesa en `_apply_stored` vía dispatch
+- BDD 4/4 escenarios pasando con SQLite real
+
+---
+
+*Generado en Fase 9 de /implement-us*

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -164,7 +164,7 @@ Deben resolverse antes del SP que los involucra. No bloquean SP1 ni SP2.
 
 | US candidata | Inc. | RFs cubiertos | Comando/Contenido principal | Invariantes clave | Estado |
 |-------------|------|---------------|-----------------------------|------------------|--------|
-| US-2.1.1 | 2.1 | RF-PR-08 | `ConfigurarIntervaloOT` + scaffold aggregate Competencia + deuda SOLID SP1 | INV-C-01 | ⬜ Backlog |
+| US-2.1.1 | 2.1 | RF-PR-08 | `ConfigurarIntervaloOT` + scaffold aggregate Competencia + deuda SOLID SP1 | INV-C-01 | ✅ Done |
 | US-2.1.2 | 2.1 | RF-PR-04, RF-PR-05 | `GenerarGrilla` / `RegenerarGrilla` | INV-C-01, P-01, P-02 | ⬜ Backlog |
 | US-2.1.3 | 2.1 | RF-PR-07 | `AjustarGrilla` | INV-C-02 (parcial) | ⬜ Backlog |
 | US-2.1.4 | 2.1 | — | `ConfirmarGrilla` + `IniciarCompetencia` + reemplazar stub `CompetenciaEstadoPort` | INV-C-02/03 | ⬜ Backlog |

--- a/quality/reports/codeguard/US-2.1.1-quality.json
+++ b/quality/reports/codeguard/US-2.1.1-quality.json
@@ -1,0 +1,2883 @@
+{
+  "summary": {
+    "total_files": 45,
+    "checks_executed": 6,
+    "elapsed_seconds": 37.67,
+    "timestamp": "2026-03-25T16:19:20.231358",
+    "total_issues": 135,
+    "errors": 0,
+    "warnings": 0,
+    "infos": 135
+  },
+  "results": [
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/aggregates/competencia.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/aggregates/competencia.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/aggregates/competencia.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/aggregates/performance.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/aggregates/performance.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/aggregates/performance.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/unidad_medida.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/unidad_medida.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/value_objects/unidad_medida.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/disciplina.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/disciplina.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/value_objects/disciplina.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/ap.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/ap.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/value_objects/ap.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/estado_performance.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/estado_performance.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/value_objects/estado_performance.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/value_objects/estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/ap_registrado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/ap_registrado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/events/ap_registrado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/tarjeta_asignada.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/tarjeta_asignada.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/events/tarjeta_asignada.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/resultado_corregido.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/resultado_corregido.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/events/resultado_corregido.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/dns_registrado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/dns_registrado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/events/dns_registrado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/resultado_registrado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/resultado_registrado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/events/resultado_registrado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/events/atleta_llamado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/events/atleta_llamado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/events/atleta_llamado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/ports/event_store_port.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/ports/event_store_port.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/ports/event_store_port.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/ports/competencia_estado_port.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/ports/competencia_estado_port.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/ports/competencia_estado_port.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/queries/obtener_progreso.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/queries/obtener_progreso.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/queries/obtener_progreso.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/queries/obtener_eventos.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/queries/obtener_eventos.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/queries/obtener_eventos.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/queries/obtener_performance_actual.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/queries/obtener_performance_actual.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/queries/obtener_performance_actual.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/registrar_ap.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/registrar_ap.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/commands/registrar_ap.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/registrar_resultado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/registrar_resultado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/commands/registrar_resultado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/registrar_dns.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/registrar_dns.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/commands/registrar_dns.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/corregir_resultado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/corregir_resultado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/commands/corregir_resultado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/competencia/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/asignar_tarjeta.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/asignar_tarjeta.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/commands/asignar_tarjeta.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/commands/llamar_atleta.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/commands/llamar_atleta.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/commands/llamar_atleta.py",
+      "line": null
+    }
+  ],
+  "by_severity": {
+    "errors": [],
+    "warnings": [],
+    "infos": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/performance.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/performance.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/aggregates/performance.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/unidad_medida.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/unidad_medida.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/unidad_medida.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/disciplina.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/ap.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/ap.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/ap.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/estado_performance.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/estado_performance.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/estado_performance.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/ap_registrado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/ap_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/ap_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/tarjeta_asignada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/tarjeta_asignada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/tarjeta_asignada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/resultado_corregido.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/resultado_corregido.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/resultado_corregido.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/dns_registrado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/dns_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/dns_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/resultado_registrado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/resultado_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/resultado_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/atleta_llamado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/atleta_llamado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/atleta_llamado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/ports/event_store_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/ports/event_store_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/ports/event_store_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/ports/competencia_estado_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/ports/competencia_estado_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/ports/competencia_estado_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_progreso.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_progreso.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_progreso.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_eventos.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_eventos.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_eventos.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_performance_actual.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_performance_actual.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_performance_actual.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/registrar_ap.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/registrar_ap.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/registrar_ap.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/registrar_resultado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/registrar_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/registrar_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/registrar_dns.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/registrar_dns.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/registrar_dns.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/corregir_resultado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/corregir_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/corregir_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/asignar_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/asignar_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/asignar_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/llamar_atleta.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/llamar_atleta.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/llamar_atleta.py",
+        "line": null
+      }
+    ]
+  },
+  "by_package": {
+    "aggregates": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/performance.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/performance.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/aggregates/performance.py",
+        "line": null
+      }
+    ],
+    "api": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      }
+    ],
+    "application": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/application/__init__.py",
+        "line": null
+      }
+    ],
+    "commands": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/registrar_ap.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/registrar_ap.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/registrar_ap.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/registrar_resultado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/registrar_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/registrar_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/registrar_dns.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/registrar_dns.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/registrar_dns.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/corregir_resultado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/corregir_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/corregir_resultado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/asignar_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/asignar_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/asignar_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/configurar_intervalo_ot.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/commands/llamar_atleta.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/commands/llamar_atleta.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/commands/llamar_atleta.py",
+        "line": null
+      }
+    ],
+    "competencia": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/__init__.py",
+        "line": null
+      }
+    ],
+    "domain": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/__init__.py",
+        "line": null
+      }
+    ],
+    "event_store": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/infrastructure/event_store/sqlite_event_store.py",
+        "line": null
+      }
+    ],
+    "events": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/ap_registrado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/ap_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/ap_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/intervalo_ot_configurado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/tarjeta_asignada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/tarjeta_asignada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/tarjeta_asignada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/resultado_corregido.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/resultado_corregido.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/resultado_corregido.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/dns_registrado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/dns_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/dns_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/resultado_registrado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/resultado_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/resultado_registrado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/events/atleta_llamado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/events/atleta_llamado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/events/atleta_llamado.py",
+        "line": null
+      }
+    ],
+    "infrastructure": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/infrastructure/competencia_estado_stub.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/infrastructure/__init__.py",
+        "line": null
+      }
+    ],
+    "ports": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/ports/event_store_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/ports/event_store_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/ports/event_store_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/ports/competencia_estado_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/ports/competencia_estado_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/ports/competencia_estado_port.py",
+        "line": null
+      }
+    ],
+    "queries": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_progreso.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_progreso.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_progreso.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_eventos.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_eventos.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_eventos.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_performance_actual.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_performance_actual.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_performance_actual.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_proximas_performances.py",
+        "line": null
+      }
+    ],
+    "repositories": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/infrastructure/repositories/__init__.py",
+        "line": null
+      }
+    ],
+    "value_objects": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/unidad_medida.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/unidad_medida.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/unidad_medida.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/disciplina.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/competencia/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/ap.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/ap.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/ap.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/estado_performance.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/estado_performance.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/estado_performance.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/intervalo_disciplina.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/value_objects/tipo_tarjeta.py",
+        "line": null
+      }
+    ]
+  }
+}

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -8,6 +8,13 @@ from uuid import UUID
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTHandler,
+)
+from competencia.application.queries.obtener_eventos import (
+    ObtenerEventosHandler,
+    ObtenerEventosQuery,
+)
 from competencia.application.queries.obtener_performance_actual import (
     ObtenerPerformanceActualHandler,
     ObtenerPerformanceActualQuery,
@@ -23,13 +30,12 @@ from competencia.application.queries.obtener_progreso import (
     ObtenerProgresoQuery,
     ProgresoCompetenciaDTO,
 )
-from competencia.application.queries.obtener_eventos import (
-    ObtenerEventosHandler,
-    ObtenerEventosQuery,
-)
 from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
 
 router = APIRouter(prefix="/competencia", tags=["competencia"])
+
+
+# ── Dependency providers ──────────────────────────────────────────────────────
 
 
 def get_event_store() -> SQLiteEventStore:
@@ -41,10 +47,65 @@ def get_event_store() -> SQLiteEventStore:
 EventStoreDep = Annotated[SQLiteEventStore, Depends(get_event_store)]
 
 
+def get_obtener_eventos_handler(
+    event_store: EventStoreDep,
+) -> ObtenerEventosHandler:
+    """Dependency: handler de consulta de eventos."""
+    return ObtenerEventosHandler(event_store)
+
+
+def get_obtener_performance_actual_handler(
+    event_store: EventStoreDep,
+) -> ObtenerPerformanceActualHandler:
+    """Dependency: handler de performance actual."""
+    return ObtenerPerformanceActualHandler(event_store)
+
+
+def get_obtener_proximas_performances_handler(
+    event_store: EventStoreDep,
+) -> ObtenerProximasPerformancesHandler:
+    """Dependency: handler de próximas performances."""
+    return ObtenerProximasPerformancesHandler(event_store)
+
+
+def get_obtener_progreso_handler(
+    event_store: EventStoreDep,
+) -> ObtenerProgresoHandler:
+    """Dependency: handler de progreso de competencia."""
+    return ObtenerProgresoHandler(event_store)
+
+
+def get_configurar_intervalo_ot_handler(
+    event_store: EventStoreDep,
+) -> ConfigurarIntervaloOTHandler:
+    """Dependency: handler para configurar intervalo OT."""
+    return ConfigurarIntervaloOTHandler(event_store)
+
+
+ObtenerEventosHandlerDep = Annotated[
+    ObtenerEventosHandler, Depends(get_obtener_eventos_handler)
+]
+ObtenerPerformanceActualHandlerDep = Annotated[
+    ObtenerPerformanceActualHandler, Depends(get_obtener_performance_actual_handler)
+]
+ObtenerProximasPerformancesHandlerDep = Annotated[
+    ObtenerProximasPerformancesHandler, Depends(get_obtener_proximas_performances_handler)
+]
+ObtenerProgresoHandlerDep = Annotated[
+    ObtenerProgresoHandler, Depends(get_obtener_progreso_handler)
+]
+ConfigurarIntervaloOTHandlerDep = Annotated[
+    ConfigurarIntervaloOTHandler, Depends(get_configurar_intervalo_ot_handler)
+]
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
 @router.get("/{competencia_id}/events", response_class=JSONResponse)
 async def get_eventos(
     competencia_id: UUID,
-    event_store: EventStoreDep,
+    handler: ObtenerEventosHandlerDep,
 ) -> JSONResponse:
     """Retorna todos los eventos del Event Store para una competencia en orden de inserción.
 
@@ -55,7 +116,6 @@ async def get_eventos(
         JSON con competencia_id, total_events y lista de eventos con
         sequence, event_type, performance_id, occurred_at y data.
     """
-    handler = ObtenerEventosHandler(event_store)
     eventos = await handler.handle(ObtenerEventosQuery(competencia_id=competencia_id))
     return JSONResponse(
         content={
@@ -79,7 +139,7 @@ async def get_eventos(
 @router.get("/{competencia_id}/performance/actual", response_class=JSONResponse)
 async def get_performance_actual(
     competencia_id: UUID,
-    event_store: EventStoreDep,
+    handler: ObtenerPerformanceActualHandlerDep,
 ) -> PerformanceActualDTO | None:
     """Retorna la performance que el juez está evaluando en este momento.
 
@@ -87,8 +147,9 @@ async def get_performance_actual(
         PerformanceActualDTO si hay una performance en estado Llamada o
         ResultadoRegistrado, null si no hay ninguna activa.
     """
-    handler = ObtenerPerformanceActualHandler(event_store)
-    result = await handler.handle(ObtenerPerformanceActualQuery(competencia_id=competencia_id))
+    result = await handler.handle(
+        ObtenerPerformanceActualQuery(competencia_id=competencia_id)
+    )
     if result is None:
         return JSONResponse(content=None, status_code=200)
     return JSONResponse(
@@ -107,14 +168,13 @@ async def get_performance_actual(
 @router.get("/{competencia_id}/performance/proximas", response_class=JSONResponse)
 async def get_proximas_performances(
     competencia_id: UUID,
-    event_store: EventStoreDep,
+    handler: ObtenerProximasPerformancesHandlerDep,
 ) -> list[ProximoAtletaDTO]:
     """Retorna los próximos 3 atletas a competir (en estado AnunciadaAP).
 
     Returns:
         Lista de hasta 3 ProximoAtletaDTO ordenados por momento de registro (SP1).
     """
-    handler = ObtenerProximasPerformancesHandler(event_store)
     result = await handler.handle(
         ObtenerProximasPerformancesQuery(competencia_id=competencia_id)
     )
@@ -135,14 +195,13 @@ async def get_proximas_performances(
 @router.get("/{competencia_id}/progreso", response_class=JSONResponse)
 async def get_progreso(
     competencia_id: UUID,
-    event_store: EventStoreDep,
+    handler: ObtenerProgresoHandlerDep,
 ) -> ProgresoCompetenciaDTO:
     """Retorna el progreso de ejecución de la competencia.
 
     Returns:
         ProgresoCompetenciaDTO con total, ejecutadas, dns_count y completadas.
     """
-    handler = ObtenerProgresoHandler(event_store)
     result = await handler.handle(ObtenerProgresoQuery(competencia_id=competencia_id))
     return JSONResponse(
         content={

--- a/src/competencia/application/commands/configurar_intervalo_ot.py
+++ b/src/competencia/application/commands/configurar_intervalo_ot.py
@@ -1,0 +1,89 @@
+"""Command y Handler para ConfigurarIntervaloOT — US-2.1.1."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from competencia.domain.aggregates.competencia import Competencia
+from competencia.domain.ports.event_store_port import EventStorePort
+from competencia.domain.value_objects.disciplina import Disciplina
+
+
+# ── Command ───────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ConfigurarIntervaloOTCommand:
+    """Comando para configurar el intervalo entre OTs de una competencia.
+
+    Attributes:
+        competencia_id: Identificador de la competencia.
+        disciplina: Disciplina de la competencia.
+        intervalo_minutos: Tiempo en minutos entre OTs. Debe ser > 0.
+        configurado_por: Identificador del organizador o juez.
+    """
+
+    competencia_id: UUID
+    disciplina: Disciplina
+    intervalo_minutos: int
+    configurado_por: str
+
+
+# ── Handler ───────────────────────────────────────────────────────────────────
+
+
+class ConfigurarIntervaloOTHandler:
+    """Handler del comando ConfigurarIntervaloOT.
+
+    Carga el aggregate Competencia desde el Event Store (o crea uno nuevo
+    si no existe), ejecuta el método de dominio y persiste el evento
+    IntervaloOTConfigurado.
+
+    Args:
+        event_store: Puerto de persistencia de eventos.
+    """
+
+    def __init__(self, event_store: EventStorePort) -> None:
+        self._event_store = event_store
+
+    async def handle(self, command: ConfigurarIntervaloOTCommand) -> None:
+        """Ejecuta el comando ConfigurarIntervaloOT.
+
+        Args:
+            command: Datos del intervalo a configurar.
+
+        Raises:
+            IntervaloInvalido: Si intervalo_minutos <= 0.
+            GrillaYaConfirmada: Si la grilla ya fue confirmada.
+        """
+        stream_id = _build_stream_id(command.competencia_id)
+        events = await self._event_store.load(stream_id)
+
+        competencia = Competencia.reconstitute(
+            competencia_id=command.competencia_id,
+            disciplina=command.disciplina,
+            events=events,
+        )
+
+        competencia.configurar_intervalo_ot(
+            intervalo_minutos=command.intervalo_minutos,
+            configurado_por=command.configurado_por,
+        )
+
+        for event in competencia.pull_events():
+            await self._event_store.append(
+                stream_id=stream_id,
+                event_type=event.event_type,
+                payload=event.to_payload(),
+            )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _build_stream_id(competencia_id: UUID) -> str:
+    """Construye el stream ID canónico para una Competencia.
+
+    Format: "competencia-{competencia_id}"
+    """
+    return f"competencia-{competencia_id}"

--- a/src/competencia/domain/aggregates/__init__.py
+++ b/src/competencia/domain/aggregates/__init__.py
@@ -1,4 +1,5 @@
 """Aggregates del BC Competencia."""
+from competencia.domain.aggregates.competencia import Competencia
 from competencia.domain.aggregates.performance import Performance
 
-__all__ = ["Performance"]
+__all__ = ["Competencia", "Performance"]

--- a/src/competencia/domain/aggregates/competencia.py
+++ b/src/competencia/domain/aggregates/competencia.py
@@ -1,0 +1,153 @@
+"""Aggregate Competencia — ciclo de vida de una disciplina en un torneo."""
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+from shared.domain.base.aggregate_root import AggregateRoot
+from competencia.domain.events.intervalo_ot_configurado import IntervaloOTConfigurado
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.estado_competencia import EstadoCompetencia
+from competencia.domain.value_objects.intervalo_disciplina import IntervaloDisciplina
+
+
+class GrillaYaConfirmada(Exception):
+    """La grilla fue confirmada — no se puede reconfigurar el intervalo OT."""
+
+
+class Competencia(AggregateRoot):
+    """Aggregate raíz que modela el ciclo de vida de una disciplina en un torneo.
+
+    Stream ID: "competencia-{competencia_id}"
+
+    Estados:
+        Preparacion → Confirmada → EnEjecucion → Finalizada
+
+    Invariantes:
+        INV-C-01: intervaloDisciplina debe estar configurado antes de GenerarGrilla.
+    """
+
+    def __init__(
+        self,
+        competencia_id: UUID,
+        disciplina: Disciplina,
+    ) -> None:
+        super().__init__()
+        self._competencia_id = competencia_id
+        self._disciplina = disciplina
+        self._estado: EstadoCompetencia = EstadoCompetencia.Preparacion
+        self._intervalo: IntervaloDisciplina | None = None
+        self._grilla_confirmada: bool = False
+
+    # ── Propiedades ───────────────────────────────────────────────────────────
+
+    @property
+    def competencia_id(self) -> UUID:
+        """Identificador único de la Competencia."""
+        return self._competencia_id
+
+    @property
+    def disciplina(self) -> Disciplina:
+        """Disciplina asociada a esta Competencia."""
+        return self._disciplina
+
+    @property
+    def estado(self) -> EstadoCompetencia:
+        """Estado actual de la Competencia."""
+        return self._estado
+
+    @property
+    def intervalo(self) -> IntervaloDisciplina | None:
+        """Intervalo entre OTs configurado, o None si aún no fue configurado."""
+        return self._intervalo
+
+    # ── Comandos de dominio ───────────────────────────────────────────────────
+
+    def configurar_intervalo_ot(
+        self, intervalo_minutos: int, configurado_por: str
+    ) -> None:
+        """Configura (o reconfigura) el intervalo de tiempo entre OTs consecutivos.
+
+        La operación es repetible. Si ya existe un IntervaloOTConfigurado previo,
+        se emite uno nuevo con el valor actualizado (P-03: OTs desactualizados
+        hasta regenerar grilla).
+
+        Si la grilla ya fue confirmada (GrillaConfirmada emitido), la operación
+        no está permitida — la grilla está congelada.
+
+        Args:
+            intervalo_minutos: Tiempo en minutos entre OTs. Debe ser > 0.
+            configurado_por: Identificador del organizador o juez.
+
+        Raises:
+            IntervaloInvalido: Si intervalo_minutos <= 0.
+            GrillaYaConfirmada: Si la grilla ya fue confirmada para esta competencia.
+        """
+        if self._grilla_confirmada:
+            raise GrillaYaConfirmada(
+                f"Competencia {self._competencia_id}: grilla confirmada — "
+                "no se puede reconfigurar el intervalo OT"
+            )
+
+        intervalo = IntervaloDisciplina(minutos=intervalo_minutos)  # valida > 0
+
+        event = IntervaloOTConfigurado(
+            event_type="IntervaloOTConfigurado",
+            aggregate_id=str(self._competencia_id),
+            occurred_at=IntervaloOTConfigurado.now(),
+            competencia_id=str(self._competencia_id),
+            disciplina=self._disciplina.value,
+            intervalo_minutos=intervalo.minutos,
+            configurado_por=configurado_por,
+        )
+        self._intervalo = intervalo
+        self._record(event)
+
+    # ── Reconstitución desde eventos ──────────────────────────────────────────
+
+    @classmethod
+    def reconstitute(
+        cls, competencia_id: UUID, disciplina: Disciplina, events: list[dict[str, Any]]
+    ) -> "Competencia":
+        """Reconstruye el aggregate desde los eventos del Event Store.
+
+        Args:
+            competencia_id: Identificador de la competencia.
+            disciplina: Disciplina asociada.
+            events: Lista de registros del Event Store (con event_type, payload).
+
+        Returns:
+            Competencia con el estado proyectado desde los eventos.
+        """
+        competencia = cls(competencia_id=competencia_id, disciplina=disciplina)
+        for event in events:
+            competencia._apply_stored(event)
+        return competencia
+
+    def _apply_stored(self, event: dict[str, Any]) -> None:
+        """Aplica un evento almacenado al estado interno del aggregate."""
+        event_type = event["event_type"]
+        payload = self._parse_payload(event["payload"])
+
+        _handlers: dict[str, Any] = {
+            "IntervaloOTConfigurado": self._apply_intervalo_ot_configurado,
+            "GrillaConfirmada": self._apply_grilla_confirmada,
+        }
+
+        handler = _handlers.get(event_type)
+        if handler is not None:
+            handler(payload)
+
+    def _apply_intervalo_ot_configurado(self, payload: dict[str, Any]) -> None:
+        self._intervalo = IntervaloDisciplina(minutos=payload["intervalo_minutos"])
+
+    def _apply_grilla_confirmada(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
+        self._grilla_confirmada = True
+
+    @staticmethod
+    def _parse_payload(payload: Any) -> dict[str, Any]:
+        """Parsea el payload del Event Store (puede ser str JSON o dict)."""
+        if isinstance(payload, str):
+            return json.loads(payload)  # type: ignore[no-any-return]
+        return payload  # type: ignore[return-value]

--- a/src/competencia/domain/aggregates/performance.py
+++ b/src/competencia/domain/aggregates/performance.py
@@ -82,6 +82,14 @@ class Performance(AggregateRoot):
         self._estado: EstadoPerformance | None = None
         self._ot_programado: datetime | None = None
         self._distancia_blackout: Decimal | None = None
+        self._event_handlers: dict[str, Any] = {
+            "APRegistrado": self._apply_ap_registrado,
+            "AtletaLlamado": self._apply_atleta_llamado,
+            "ResultadoRegistrado": self._apply_resultado_registrado,
+            "DNSRegistrado": self._apply_dns_registrado,
+            "TarjetaAsignada": self._apply_tarjeta_asignada,
+            "ResultadoCorregido": self._apply_resultado_corregido,
+        }
 
     # ── Propiedades ───────────────────────────────────────────────────────────
 
@@ -326,12 +334,12 @@ class Performance(AggregateRoot):
             tipo: Tipo de tarjeta — Blanca, Amarilla o Roja.
             asignada_por: Identificador del juez que asigna la tarjeta.
             motivo: Motivo obligatorio para Amarilla y Roja (INV-P-11).
-            distancia_blackout: Distancia alcanzada — obligatoria si motivo == "black-out" (RF-EJ-07).
+            distancia_blackout: Distancia alcanzada — obligatoria si motivo == "black-out".
 
         Raises:
             EstadoInvalidoParaAsignarTarjeta: Performance no en ResultadoRegistrado (INV-P-07).
             MotivoObligatorio: tarjeta Amarilla o Roja sin motivo (INV-P-11).
-            DistanciaBlackoutObligatoria: motivo "black-out" sin distancia o distancia <= 0 (RF-EJ-07).
+            DistanciaBlackoutObligatoria: motivo "black-out" sin distancia o distancia <= 0.
         """
         if self._estado != EstadoPerformance.ResultadoRegistrado:
             raise EstadoInvalidoParaAsignarTarjeta(
@@ -405,31 +413,43 @@ class Performance(AggregateRoot):
         return performance
 
     def _apply_stored(self, event: dict[str, Any]) -> None:
-        """Aplica un evento almacenado al estado interno del aggregate."""
+        """Aplica un evento almacenado al estado interno del aggregate.
+
+        Usa dispatch por tipo de evento (OCP: agregar un tipo nuevo no requiere
+        modificar este método, solo registrar el handler en _event_handlers).
+        """
         event_type = event["event_type"]
         payload = self._parse_payload(event["payload"])
+        handler = self._event_handlers.get(event_type)
+        if handler is not None:
+            handler(payload)
 
-        if event_type == "APRegistrado":
-            self._ap = AP(
-                valor=Decimal(payload["valor_ap"]),
-                unidad=UnidadMedida(payload["unidad"]),
-            )
-            self._estado = EstadoPerformance.AnunciadaAP
-        elif event_type == "AtletaLlamado":
-            self._estado = EstadoPerformance.Llamada
-            self._ot_programado = datetime.fromisoformat(payload["ot_programado"])
-        elif event_type == "ResultadoRegistrado":
-            self._rp = Decimal(payload["valor_rp"])
-            self._estado = EstadoPerformance.ResultadoRegistrado
-        elif event_type == "DNSRegistrado":
-            self._estado = EstadoPerformance.DNS
-        elif event_type == "TarjetaAsignada":
-            self._tarjeta = TipoTarjeta(payload["tipo"])
-            self._estado = EstadoPerformance.Ejecutada
-            if payload.get("distancia_blackout"):
-                self._distancia_blackout = Decimal(payload["distancia_blackout"])
-        elif event_type == "ResultadoCorregido":
-            self._rp = Decimal(payload["valor_rp_nuevo"])
+    def _apply_ap_registrado(self, payload: dict[str, Any]) -> None:
+        self._ap = AP(
+            valor=Decimal(payload["valor_ap"]),
+            unidad=UnidadMedida(payload["unidad"]),
+        )
+        self._estado = EstadoPerformance.AnunciadaAP
+
+    def _apply_atleta_llamado(self, payload: dict[str, Any]) -> None:
+        self._estado = EstadoPerformance.Llamada
+        self._ot_programado = datetime.fromisoformat(payload["ot_programado"])
+
+    def _apply_resultado_registrado(self, payload: dict[str, Any]) -> None:
+        self._rp = Decimal(payload["valor_rp"])
+        self._estado = EstadoPerformance.ResultadoRegistrado
+
+    def _apply_dns_registrado(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
+        self._estado = EstadoPerformance.DNS
+
+    def _apply_tarjeta_asignada(self, payload: dict[str, Any]) -> None:
+        self._tarjeta = TipoTarjeta(payload["tipo"])
+        self._estado = EstadoPerformance.Ejecutada
+        if payload.get("distancia_blackout"):
+            self._distancia_blackout = Decimal(payload["distancia_blackout"])
+
+    def _apply_resultado_corregido(self, payload: dict[str, Any]) -> None:
+        self._rp = Decimal(payload["valor_rp_nuevo"])
 
     @staticmethod
     def _parse_payload(payload: Any) -> dict[str, Any]:

--- a/src/competencia/domain/events/__init__.py
+++ b/src/competencia/domain/events/__init__.py
@@ -1,7 +1,14 @@
 """Domain Events del BC Competencia."""
 from competencia.domain.events.ap_registrado import APRegistrado
 from competencia.domain.events.atleta_llamado import AtletaLlamado
+from competencia.domain.events.intervalo_ot_configurado import IntervaloOTConfigurado
 from competencia.domain.events.resultado_registrado import ResultadoRegistrado
 from competencia.domain.events.tarjeta_asignada import TarjetaAsignada
 
-__all__ = ["APRegistrado", "AtletaLlamado", "ResultadoRegistrado", "TarjetaAsignada"]
+__all__ = [
+    "APRegistrado",
+    "AtletaLlamado",
+    "IntervaloOTConfigurado",
+    "ResultadoRegistrado",
+    "TarjetaAsignada",
+]

--- a/src/competencia/domain/events/intervalo_ot_configurado.py
+++ b/src/competencia/domain/events/intervalo_ot_configurado.py
@@ -1,0 +1,51 @@
+"""Domain Event IntervaloOTConfigurado — emitido al configurar el intervalo entre OTs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from shared.domain.base.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class IntervaloOTConfigurado(DomainEvent):
+    """Evento emitido cuando el organizador configura (o reconfigura) el intervalo OT.
+
+    Persiste en el stream `competencia-{competencia_id}`.
+    La Competencia mantiene estado Preparacion tras este evento.
+
+    Attributes:
+        competencia_id: Identificador de la competencia (UUID str).
+        disciplina: Disciplina asociada a la competencia.
+        intervalo_minutos: Tiempo en minutos entre OTs consecutivos.
+        configurado_por: Identificador del organizador o juez que configuró el intervalo.
+    """
+
+    competencia_id: str
+    disciplina: str
+    intervalo_minutos: int
+    configurado_por: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serializa el evento a payload JSON-serializable para el Event Store."""
+        return {
+            "competencia_id": self.competencia_id,
+            "disciplina": self.disciplina,
+            "intervalo_minutos": self.intervalo_minutos,
+            "configurado_por": self.configurado_por,
+            "occurred_at": self.occurred_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "IntervaloOTConfigurado":
+        """Reconstruye el evento desde el payload del Event Store."""
+        return cls(
+            event_type="IntervaloOTConfigurado",
+            aggregate_id=payload["competencia_id"],
+            occurred_at=datetime.fromisoformat(payload["occurred_at"]),
+            competencia_id=payload["competencia_id"],
+            disciplina=payload["disciplina"],
+            intervalo_minutos=payload["intervalo_minutos"],
+            configurado_por=payload["configurado_por"],
+        )

--- a/src/competencia/domain/value_objects/estado_competencia.py
+++ b/src/competencia/domain/value_objects/estado_competencia.py
@@ -1,0 +1,17 @@
+"""Value Object EstadoCompetencia — máquina de estados del aggregate Competencia."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EstadoCompetencia(str, Enum):
+    """Estados posibles del aggregate Competencia.
+
+    Transiciones válidas:
+        Preparacion → Confirmada → EnEjecucion → Finalizada
+    """
+
+    Preparacion = "Preparacion"
+    Confirmada = "Confirmada"
+    EnEjecucion = "EnEjecucion"
+    Finalizada = "Finalizada"

--- a/src/competencia/domain/value_objects/intervalo_disciplina.py
+++ b/src/competencia/domain/value_objects/intervalo_disciplina.py
@@ -1,0 +1,31 @@
+"""Value Object IntervaloDisciplina — tiempo en minutos entre OTs consecutivos."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class IntervaloInvalido(Exception):
+    """Intervalo en minutos debe ser > 0 (INV-C-01)."""
+
+
+@dataclass(frozen=True)
+class IntervaloDisciplina:
+    """Tiempo en minutos entre Official Tops consecutivos.
+
+    Inmutable. Valida que el valor sea positivo en construcción.
+
+    Attributes:
+        minutos: Tiempo en minutos entre OTs. Debe ser > 0.
+
+    Raises:
+        IntervaloInvalido: Si minutos <= 0.
+    """
+
+    minutos: int
+
+    def __post_init__(self) -> None:
+        """Valida INV-C-01: intervalo debe ser > 0."""
+        if self.minutos <= 0:
+            raise IntervaloInvalido(
+                f"IntervaloDisciplina debe ser > 0, recibido: {self.minutos}"
+            )

--- a/tests/features/US-2.1.1-configurar-intervalo-ot.feature
+++ b/tests/features/US-2.1.1-configurar-intervalo-ot.feature
@@ -1,0 +1,36 @@
+# US-2.1.1: Scaffold Aggregate Competencia + ConfigurarIntervaloOT
+# BC: competencia | Incremento: Inc 2.1 — La Grilla de Salida
+# Invariantes: INV-C-01
+
+@US-2.1.1
+Feature: Configurar Intervalo OT de Competencia
+
+  Background:
+    Given una competencia con id "C001" en estado "Preparacion"
+    And la disciplina es "STA"
+
+  @US-2.1.1 @happy_path
+  Scenario: Configurar intervalo exitosamente
+    Given no existe un intervalo previo configurado
+    When el organizador configura el intervalo en 9 minutos
+    Then el intervalo queda registrado en 9 minutos
+    And el evento IntervaloOTConfigurado persiste en el stream
+    And la competencia sigue en estado "Preparacion"
+
+  @US-2.1.1 @happy_path
+  Scenario: Reconfigurar intervalo (repetición permitida)
+    Given ya existe un IntervaloOTConfigurado de 7 minutos
+    When el organizador reconfigura el intervalo a 10 minutos
+    Then el nuevo IntervaloOTConfigurado persiste con valor 10
+    And el intervalo activo de la competencia es 10 minutos
+
+  @US-2.1.1 @error_case
+  Scenario: Rechazo — intervalo cero o negativo
+    When el organizador intenta configurar el intervalo en 0 minutos
+    Then el sistema rechaza la operación con error "IntervaloInvalido"
+
+  @US-2.1.1 @error_case
+  Scenario: Rechazo — grilla ya confirmada
+    Given la grilla ya fue confirmada para esta competencia
+    When el organizador intenta reconfigurar el intervalo
+    Then el sistema rechaza la operación con error "GrillaYaConfirmada"

--- a/tests/features/steps/configurar_intervalo_ot_steps.py
+++ b/tests/features/steps/configurar_intervalo_ot_steps.py
@@ -1,0 +1,198 @@
+"""Step definitions BDD — US-2.1.1: Configurar Intervalo OT.
+
+pytest-bdd no soporta async steps nativamente. Los steps que requieren
+operaciones async usan asyncio.run() como wrapper síncrono.
+"""
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import aiosqlite
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTCommand,
+    ConfigurarIntervaloOTHandler,
+    _build_stream_id,
+)
+from competencia.domain.aggregates.competencia import GrillaYaConfirmada
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.estado_competencia import EstadoCompetencia
+from competencia.domain.value_objects.intervalo_disciplina import IntervaloInvalido
+from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+
+scenarios("../US-2.1.1-configurar-intervalo-ot.feature")
+
+_CREATE_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+_COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+_CONFIGURADO_POR = "organizador-01"
+
+
+def _make_event_store(tmp_path: str) -> SQLiteEventStore:
+    db_path = f"{tmp_path}/bdd_test_us211.db"
+    asyncio.run(_create_db(db_path))
+    return SQLiteEventStore(db_path)
+
+
+async def _create_db(db_path: str) -> None:
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(_CREATE_TABLE)
+        await db.commit()
+
+
+# ── Context ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def context(tmp_path: object) -> dict:
+    return {
+        "event_store": _make_event_store(str(tmp_path)),
+        "competencia_id": _COMPETENCIA_ID,
+        "disciplina": Disciplina.STA,
+        "raised_exception": None,
+        "intervalo_configurado": None,
+    }
+
+
+# ── Given ─────────────────────────────────────────────────────────────────────
+
+
+@given(parsers.parse('una competencia con id "{competencia_id}" en estado "Preparacion"'))
+def dada_competencia_en_preparacion(context: dict, competencia_id: str) -> None:
+    # El estado Preparacion es el inicial — no requiere persistir eventos previos.
+    pass
+
+
+@given(parsers.parse('la disciplina es "{disciplina}"'))
+def dada_disciplina(context: dict, disciplina: str) -> None:
+    context["disciplina"] = Disciplina(disciplina)
+
+
+@given("no existe un intervalo previo configurado")
+def sin_intervalo_previo(context: dict) -> None:
+    # El stream está vacío por defecto — no requiere acción.
+    pass
+
+
+@given(parsers.parse("ya existe un IntervaloOTConfigurado de {minutos:d} minutos"))
+def dado_intervalo_previo(context: dict, minutos: int) -> None:
+    cmd = ConfigurarIntervaloOTCommand(
+        competencia_id=context["competencia_id"],
+        disciplina=context["disciplina"],
+        intervalo_minutos=minutos,
+        configurado_por=_CONFIGURADO_POR,
+    )
+    handler = ConfigurarIntervaloOTHandler(context["event_store"])
+    asyncio.run(handler.handle(cmd))
+
+
+@given("la grilla ya fue confirmada para esta competencia")
+def dada_grilla_confirmada(context: dict) -> None:
+    stream_id = _build_stream_id(context["competencia_id"])
+
+    async def _seed() -> None:
+        await context["event_store"].append(
+            stream_id=stream_id,
+            event_type="GrillaConfirmada",
+            payload={"competencia_id": str(context["competencia_id"])},
+        )
+
+    asyncio.run(_seed())
+
+
+# ── When ──────────────────────────────────────────────────────────────────────
+
+
+@when(parsers.parse("el organizador configura el intervalo en {minutos:d} minutos"))
+def cuando_configura_intervalo(context: dict, minutos: int) -> None:
+    cmd = ConfigurarIntervaloOTCommand(
+        competencia_id=context["competencia_id"],
+        disciplina=context["disciplina"],
+        intervalo_minutos=minutos,
+        configurado_por=_CONFIGURADO_POR,
+    )
+    handler = ConfigurarIntervaloOTHandler(context["event_store"])
+    try:
+        asyncio.run(handler.handle(cmd))
+        context["intervalo_configurado"] = minutos
+    except (IntervaloInvalido, GrillaYaConfirmada) as exc:
+        context["raised_exception"] = exc
+
+
+@when(parsers.parse("el organizador reconfigura el intervalo a {minutos:d} minutos"))
+def cuando_reconfigura_intervalo(context: dict, minutos: int) -> None:
+    cuando_configura_intervalo(context, minutos)
+
+
+@when(parsers.parse("el organizador intenta configurar el intervalo en {minutos:d} minutos"))
+def cuando_intenta_configurar(context: dict, minutos: int) -> None:
+    cuando_configura_intervalo(context, minutos)
+
+
+@when("el organizador intenta reconfigurar el intervalo")
+def cuando_intenta_reconfigurar(context: dict) -> None:
+    cuando_configura_intervalo(context, 9)
+
+
+# ── Then ──────────────────────────────────────────────────────────────────────
+
+
+@then(parsers.parse("el intervalo queda registrado en {minutos:d} minutos"))
+def entonces_intervalo_registrado(context: dict, minutos: int) -> None:
+    stream_id = _build_stream_id(context["competencia_id"])
+    events = asyncio.run(context["event_store"].load(stream_id))
+    last = events[-1]
+    assert last["event_type"] == "IntervaloOTConfigurado"
+    assert last["payload"]["intervalo_minutos"] == minutos
+
+
+@then("el evento IntervaloOTConfigurado persiste en el stream")
+def entonces_evento_persiste(context: dict) -> None:
+    stream_id = _build_stream_id(context["competencia_id"])
+    events = asyncio.run(context["event_store"].load(stream_id))
+    assert any(e["event_type"] == "IntervaloOTConfigurado" for e in events)
+
+
+@then(parsers.parse('la competencia sigue en estado "Preparacion"'))
+def entonces_estado_preparacion(context: dict) -> None:
+    # El estado se deriva del stream — sin eventos de transición, sigue Preparacion.
+    stream_id = _build_stream_id(context["competencia_id"])
+    events = asyncio.run(context["event_store"].load(stream_id))
+    from competencia.domain.aggregates.competencia import Competencia
+    c = Competencia.reconstitute(context["competencia_id"], context["disciplina"], events)
+    assert c.estado == EstadoCompetencia.Preparacion
+
+
+@then(parsers.parse("el nuevo IntervaloOTConfigurado persiste con valor {minutos:d}"))
+def entonces_nuevo_evento_persiste(context: dict, minutos: int) -> None:
+    entonces_intervalo_registrado(context, minutos)
+
+
+@then(parsers.parse("el intervalo activo de la competencia es {minutos:d} minutos"))
+def entonces_intervalo_activo(context: dict, minutos: int) -> None:
+    stream_id = _build_stream_id(context["competencia_id"])
+    events = asyncio.run(context["event_store"].load(stream_id))
+    from competencia.domain.aggregates.competencia import Competencia
+    c = Competencia.reconstitute(context["competencia_id"], context["disciplina"], events)
+    assert c.intervalo is not None
+    assert c.intervalo.minutos == minutos
+
+
+@then(parsers.parse('el sistema rechaza la operación con error "{error_type}"'))
+def entonces_rechaza_con_error(context: dict, error_type: str) -> None:
+    assert context["raised_exception"] is not None, "Se esperaba una excepción pero no se lanzó"
+    exc_name = type(context["raised_exception"]).__name__
+    assert exc_name == error_type, f"Esperado {error_type}, recibido {exc_name}"

--- a/tests/integration/competencia/test_configurar_intervalo_ot_integration.py
+++ b/tests/integration/competencia/test_configurar_intervalo_ot_integration.py
@@ -1,0 +1,134 @@
+"""Tests de integración — ConfigurarIntervaloOTHandler con SQLiteEventStore real."""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import aiosqlite
+import pytest
+
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTCommand,
+    ConfigurarIntervaloOTHandler,
+    _build_stream_id,
+)
+from competencia.domain.aggregates.competencia import Competencia, GrillaYaConfirmada
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.estado_competencia import EstadoCompetencia
+from competencia.domain.value_objects.intervalo_disciplina import IntervaloInvalido
+from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+
+CREATE_EVENTS_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL
+            DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+DISCIPLINA = Disciplina.STA
+CONFIGURADO_POR = "organizador-01"
+
+
+@pytest.fixture
+async def event_store(tmp_path: Any) -> SQLiteEventStore:
+    db_path = str(tmp_path / "test_competencia.db")
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(CREATE_EVENTS_TABLE)
+        await db.commit()
+    return SQLiteEventStore(db_path)
+
+
+def _command(intervalo_minutos: int = 9) -> ConfigurarIntervaloOTCommand:
+    return ConfigurarIntervaloOTCommand(
+        competencia_id=COMPETENCIA_ID,
+        disciplina=DISCIPLINA,
+        intervalo_minutos=intervalo_minutos,
+        configurado_por=CONFIGURADO_POR,
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestConfigurarIntervaloOTIntegracion:
+    @pytest.mark.asyncio
+    async def test_persiste_evento_en_stream(self, event_store: SQLiteEventStore) -> None:
+        handler = ConfigurarIntervaloOTHandler(event_store)
+        await handler.handle(_command(9))
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        assert len(events) == 1
+        assert events[0]["event_type"] == "IntervaloOTConfigurado"
+
+    @pytest.mark.asyncio
+    async def test_payload_correcto_en_store(self, event_store: SQLiteEventStore) -> None:
+        handler = ConfigurarIntervaloOTHandler(event_store)
+        await handler.handle(_command(9))
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        payload = events[0]["payload"]
+        assert payload["intervalo_minutos"] == 9
+        assert payload["disciplina"] == DISCIPLINA.value
+        assert payload["configurado_por"] == CONFIGURADO_POR
+
+    @pytest.mark.asyncio
+    async def test_reconfiguracion_agrega_segundo_evento(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        handler = ConfigurarIntervaloOTHandler(event_store)
+        await handler.handle(_command(7))
+        await handler.handle(_command(10))
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        assert len(events) == 2
+        assert events[1]["payload"]["intervalo_minutos"] == 10
+
+    @pytest.mark.asyncio
+    async def test_reconstituyendo_desde_store_refleja_ultimo_intervalo(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        handler = ConfigurarIntervaloOTHandler(event_store)
+        await handler.handle(_command(7))
+        await handler.handle(_command(10))
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        c = Competencia.reconstitute(COMPETENCIA_ID, DISCIPLINA, events)
+        assert c.intervalo is not None
+        assert c.intervalo.minutos == 10
+
+    @pytest.mark.asyncio
+    async def test_stream_id_aislado_de_performance(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        """El stream competencia-* no interfiere con el stream performance-*."""
+        handler = ConfigurarIntervaloOTHandler(event_store)
+        await handler.handle(_command(9))
+
+        performance_events = await event_store.load(f"performance-{COMPETENCIA_ID}")
+        assert len(performance_events) == 0
+
+    @pytest.mark.asyncio
+    async def test_intervalo_invalido_no_persiste(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        handler = ConfigurarIntervaloOTHandler(event_store)
+        with pytest.raises(IntervaloInvalido):
+            await handler.handle(_command(0))
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        assert len(events) == 0
+
+
+# ── Type alias para fixture ────────────────────────────────────────────────────
+from typing import Any  # noqa: E402

--- a/tests/unit/competencia/application/test_configurar_intervalo_ot_handler.py
+++ b/tests/unit/competencia/application/test_configurar_intervalo_ot_handler.py
@@ -1,0 +1,155 @@
+"""Tests unitarios del ConfigurarIntervaloOTHandler — US-2.1.1."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, call
+from uuid import UUID, uuid4
+
+import pytest
+
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTCommand,
+    ConfigurarIntervaloOTHandler,
+    _build_stream_id,
+)
+from competencia.domain.aggregates.competencia import GrillaYaConfirmada
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.intervalo_disciplina import IntervaloInvalido
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+DISCIPLINA = Disciplina.STA
+CONFIGURADO_POR = "organizador-01"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_event_store() -> AsyncMock:
+    """EventStorePort mock: stream vacío y append sin efecto."""
+    store = AsyncMock()
+    store.load.return_value = []
+    store.append.return_value = None
+    return store
+
+
+@pytest.fixture
+def handler(mock_event_store: AsyncMock) -> ConfigurarIntervaloOTHandler:
+    return ConfigurarIntervaloOTHandler(mock_event_store)
+
+
+def _command(intervalo_minutos: int = 9) -> ConfigurarIntervaloOTCommand:
+    return ConfigurarIntervaloOTCommand(
+        competencia_id=COMPETENCIA_ID,
+        disciplina=DISCIPLINA,
+        intervalo_minutos=intervalo_minutos,
+        configurado_por=CONFIGURADO_POR,
+    )
+
+
+# ── Happy paths ───────────────────────────────────────────────────────────────
+
+
+class TestConfiguracionExitosa:
+    @pytest.mark.asyncio
+    async def test_append_llamado_una_vez(self, handler: ConfigurarIntervaloOTHandler, mock_event_store: AsyncMock) -> None:
+        await handler.handle(_command(9))
+        assert mock_event_store.append.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_append_con_stream_id_correcto(self, handler: ConfigurarIntervaloOTHandler, mock_event_store: AsyncMock) -> None:
+        await handler.handle(_command(9))
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        assert mock_event_store.append.call_args[1]["stream_id"] == stream_id
+
+    @pytest.mark.asyncio
+    async def test_append_con_event_type_correcto(self, handler: ConfigurarIntervaloOTHandler, mock_event_store: AsyncMock) -> None:
+        await handler.handle(_command(9))
+        assert mock_event_store.append.call_args[1]["event_type"] == "IntervaloOTConfigurado"
+
+    @pytest.mark.asyncio
+    async def test_payload_contiene_intervalo(self, handler: ConfigurarIntervaloOTHandler, mock_event_store: AsyncMock) -> None:
+        await handler.handle(_command(9))
+        payload = mock_event_store.append.call_args[1]["payload"]
+        assert payload["intervalo_minutos"] == 9
+
+    @pytest.mark.asyncio
+    async def test_load_con_stream_id_correcto(self, handler: ConfigurarIntervaloOTHandler, mock_event_store: AsyncMock) -> None:
+        await handler.handle(_command(9))
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        mock_event_store.load.assert_called_once_with(stream_id)
+
+
+class TestReconfiguracion:
+    @pytest.mark.asyncio
+    async def test_reconfiguracion_sobre_stream_existente(
+        self, mock_event_store: AsyncMock
+    ) -> None:
+        """Con eventos previos en el stream, el handler reconfigura correctamente."""
+        mock_event_store.load.return_value = [
+            {
+                "event_type": "IntervaloOTConfigurado",
+                "payload": {
+                    "competencia_id": str(COMPETENCIA_ID),
+                    "disciplina": DISCIPLINA.value,
+                    "intervalo_minutos": 7,
+                    "configurado_por": CONFIGURADO_POR,
+                    "occurred_at": "2026-01-01T00:00:00+00:00",
+                },
+            }
+        ]
+        handler = ConfigurarIntervaloOTHandler(mock_event_store)
+        await handler.handle(_command(10))
+        assert mock_event_store.append.call_count == 1
+        payload = mock_event_store.append.call_args[1]["payload"]
+        assert payload["intervalo_minutos"] == 10
+
+
+# ── Error cases ───────────────────────────────────────────────────────────────
+
+
+class TestErrores:
+    @pytest.mark.asyncio
+    async def test_intervalo_cero_lanza_intervalo_invalido(
+        self, handler: ConfigurarIntervaloOTHandler
+    ) -> None:
+        with pytest.raises(IntervaloInvalido):
+            await handler.handle(_command(0))
+
+    @pytest.mark.asyncio
+    async def test_intervalo_negativo_lanza_intervalo_invalido(
+        self, handler: ConfigurarIntervaloOTHandler
+    ) -> None:
+        with pytest.raises(IntervaloInvalido):
+            await handler.handle(_command(-1))
+
+    @pytest.mark.asyncio
+    async def test_grilla_confirmada_lanza_excepcion(
+        self, mock_event_store: AsyncMock
+    ) -> None:
+        mock_event_store.load.return_value = [
+            {
+                "event_type": "GrillaConfirmada",
+                "payload": {"competencia_id": str(COMPETENCIA_ID)},
+            }
+        ]
+        handler = ConfigurarIntervaloOTHandler(mock_event_store)
+        with pytest.raises(GrillaYaConfirmada):
+            await handler.handle(_command(9))
+
+    @pytest.mark.asyncio
+    async def test_append_no_llamado_si_error(
+        self, handler: ConfigurarIntervaloOTHandler, mock_event_store: AsyncMock
+    ) -> None:
+        with pytest.raises(IntervaloInvalido):
+            await handler.handle(_command(0))
+        mock_event_store.append.assert_not_called()
+
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+
+class TestBuildStreamId:
+    def test_stream_id_formato_correcto(self) -> None:
+        cid = UUID("12345678-1234-5678-1234-567812345678")
+        assert _build_stream_id(cid) == f"competencia-{cid}"

--- a/tests/unit/competencia/domain/test_competencia.py
+++ b/tests/unit/competencia/domain/test_competencia.py
@@ -1,0 +1,190 @@
+"""Tests unitarios del aggregate Competencia — US-2.1.1."""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from competencia.domain.aggregates.competencia import Competencia, GrillaYaConfirmada
+from competencia.domain.events.intervalo_ot_configurado import IntervaloOTConfigurado
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.estado_competencia import EstadoCompetencia
+from competencia.domain.value_objects.intervalo_disciplina import IntervaloInvalido
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+DISCIPLINA = Disciplina.STA
+CONFIGURADO_POR = "organizador-01"
+
+
+def _make_competencia() -> Competencia:
+    return Competencia(competencia_id=COMPETENCIA_ID, disciplina=DISCIPLINA)
+
+
+# ── Estado inicial ────────────────────────────────────────────────────────────
+
+
+class TestEstadoInicial:
+    def test_estado_inicial_es_preparacion(self) -> None:
+        c = _make_competencia()
+        assert c.estado == EstadoCompetencia.Preparacion
+
+    def test_intervalo_inicial_es_none(self) -> None:
+        c = _make_competencia()
+        assert c.intervalo is None
+
+    def test_disciplina_asignada(self) -> None:
+        c = _make_competencia()
+        assert c.disciplina == DISCIPLINA
+
+
+# ── Configurar intervalo ──────────────────────────────────────────────────────
+
+
+class TestConfigurarIntervaloOT:
+    def test_configurar_intervalo_exitosamente(self) -> None:
+        c = _make_competencia()
+        c.configurar_intervalo_ot(9, CONFIGURADO_POR)
+        assert c.intervalo is not None
+        assert c.intervalo.minutos == 9
+
+    def test_emite_evento_intervalo_ot_configurado(self) -> None:
+        c = _make_competencia()
+        c.configurar_intervalo_ot(9, CONFIGURADO_POR)
+        events = c.pull_events()
+        assert len(events) == 1
+        assert isinstance(events[0], IntervaloOTConfigurado)
+
+    def test_evento_tiene_datos_correctos(self) -> None:
+        c = _make_competencia()
+        c.configurar_intervalo_ot(9, CONFIGURADO_POR)
+        event = c.pull_events()[0]
+        assert isinstance(event, IntervaloOTConfigurado)
+        assert event.competencia_id == str(COMPETENCIA_ID)
+        assert event.disciplina == DISCIPLINA.value
+        assert event.intervalo_minutos == 9
+        assert event.configurado_por == CONFIGURADO_POR
+
+    def test_estado_sigue_siendo_preparacion(self) -> None:
+        c = _make_competencia()
+        c.configurar_intervalo_ot(9, CONFIGURADO_POR)
+        assert c.estado == EstadoCompetencia.Preparacion
+
+    def test_reconfiguracion_permitida(self) -> None:
+        c = _make_competencia()
+        c.configurar_intervalo_ot(7, CONFIGURADO_POR)
+        c.pull_events()  # limpiar
+        c.configurar_intervalo_ot(10, CONFIGURADO_POR)
+        assert c.intervalo is not None
+        assert c.intervalo.minutos == 10
+        events = c.pull_events()
+        assert len(events) == 1
+        assert isinstance(events[0], IntervaloOTConfigurado)
+        assert events[0].intervalo_minutos == 10
+
+    def test_rechazo_intervalo_cero(self) -> None:
+        c = _make_competencia()
+        with pytest.raises(IntervaloInvalido):
+            c.configurar_intervalo_ot(0, CONFIGURADO_POR)
+
+    def test_rechazo_intervalo_negativo(self) -> None:
+        c = _make_competencia()
+        with pytest.raises(IntervaloInvalido):
+            c.configurar_intervalo_ot(-5, CONFIGURADO_POR)
+
+    def test_rechazo_grilla_ya_confirmada(self) -> None:
+        c = _make_competencia()
+        # Simular que ya se emitió GrillaConfirmada reconstituyendo con ese evento
+        c_reconstituida = Competencia.reconstitute(
+            competencia_id=COMPETENCIA_ID,
+            disciplina=DISCIPLINA,
+            events=[
+                {
+                    "event_type": "GrillaConfirmada",
+                    "payload": {"competencia_id": str(COMPETENCIA_ID)},
+                }
+            ],
+        )
+        with pytest.raises(GrillaYaConfirmada):
+            c_reconstituida.configurar_intervalo_ot(9, CONFIGURADO_POR)
+
+    def test_intervalo_estado_no_cambia_tras_rechazo(self) -> None:
+        c = _make_competencia()
+        with pytest.raises(IntervaloInvalido):
+            c.configurar_intervalo_ot(0, CONFIGURADO_POR)
+        assert c.intervalo is None
+        assert len(c.pull_events()) == 0
+
+
+# ── Reconstitución desde eventos ──────────────────────────────────────────────
+
+
+class TestReconstitucion:
+    def test_reconstituye_con_intervalo_configurado(self) -> None:
+        events = [
+            {
+                "event_type": "IntervaloOTConfigurado",
+                "payload": {
+                    "competencia_id": str(COMPETENCIA_ID),
+                    "disciplina": DISCIPLINA.value,
+                    "intervalo_minutos": 9,
+                    "configurado_por": CONFIGURADO_POR,
+                    "occurred_at": "2026-01-01T00:00:00+00:00",
+                },
+            }
+        ]
+        c = Competencia.reconstitute(COMPETENCIA_ID, DISCIPLINA, events)
+        assert c.intervalo is not None
+        assert c.intervalo.minutos == 9
+
+    def test_reconstituye_con_lista_vacia(self) -> None:
+        c = Competencia.reconstitute(COMPETENCIA_ID, DISCIPLINA, [])
+        assert c.intervalo is None
+        assert c.estado == EstadoCompetencia.Preparacion
+
+    def test_reconstituye_ultima_reconfiguracion(self) -> None:
+        events = [
+            {
+                "event_type": "IntervaloOTConfigurado",
+                "payload": {
+                    "competencia_id": str(COMPETENCIA_ID),
+                    "disciplina": DISCIPLINA.value,
+                    "intervalo_minutos": 7,
+                    "configurado_por": CONFIGURADO_POR,
+                    "occurred_at": "2026-01-01T00:00:00+00:00",
+                },
+            },
+            {
+                "event_type": "IntervaloOTConfigurado",
+                "payload": {
+                    "competencia_id": str(COMPETENCIA_ID),
+                    "disciplina": DISCIPLINA.value,
+                    "intervalo_minutos": 10,
+                    "configurado_por": CONFIGURADO_POR,
+                    "occurred_at": "2026-01-01T00:01:00+00:00",
+                },
+            },
+        ]
+        c = Competencia.reconstitute(COMPETENCIA_ID, DISCIPLINA, events)
+        assert c.intervalo is not None
+        assert c.intervalo.minutos == 10
+
+    def test_reconstituye_grilla_confirmada(self) -> None:
+        events = [
+            {
+                "event_type": "GrillaConfirmada",
+                "payload": {"competencia_id": str(COMPETENCIA_ID)},
+            }
+        ]
+        c = Competencia.reconstitute(COMPETENCIA_ID, DISCIPLINA, events)
+        with pytest.raises(GrillaYaConfirmada):
+            c.configurar_intervalo_ot(9, CONFIGURADO_POR)
+
+    def test_ignora_eventos_desconocidos(self) -> None:
+        events = [
+            {
+                "event_type": "EventoDesconocido",
+                "payload": {"foo": "bar"},
+            }
+        ]
+        c = Competencia.reconstitute(COMPETENCIA_ID, DISCIPLINA, events)
+        assert c.intervalo is None


### PR DESCRIPTION
## Summary

- Nuevo aggregate `Competencia` con `configurar_intervalo_ot()` e INV-C-01; stream `competencia-{id}` aislado de `performance-*`
- Refactor OCP: `Performance._apply_stored` → dispatch dict (liquida deuda SP1)
- Refactor DIP: `router.py` — handlers instanciados via FastAPI `Depends()` (liquida deuda SP1)

## Quality Gates

| Métrica | Resultado |
|---------|-----------|
| Tests | 245/245 ✅ |
| Cobertura domain+application | 98% ✅ |
| CodeGuard warnings | 0 ✅ |
| BDD escenarios | 4/4 ✅ |

## Test plan

- [ ] `pytest tests/unit/competencia/domain/test_competencia.py` — 17 tests aggregate
- [ ] `pytest tests/unit/competencia/application/test_configurar_intervalo_ot_handler.py` — 11 tests handler
- [ ] `pytest tests/integration/competencia/test_configurar_intervalo_ot_integration.py` — 6 tests SQLite real
- [ ] `pytest tests/features/steps/configurar_intervalo_ot_steps.py` — 4 BDD escenarios
- [ ] `pytest tests/unit/` — suite completa SP1 sigue pasando (155 tests)

## Linear

Closes VVA-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)