### PR TITLE
feat(domain): GenerarGrilla — grilla de salida con ordenamiento P-01/P-02 [US-2.1.2]

### DIFF
--- a/docs/plans/sp2/US-2.1.2-plan.md
+++ b/docs/plans/sp2/US-2.1.2-plan.md
@@ -1,0 +1,65 @@
+# Plan de Implementación — US-2.1.2
+# Generar / Regenerar Grilla de Salida
+
+**Fecha:** 2026-03-25
+**Branch:** `feature/US-2.1.2-generar-grilla`
+**Estimación:** 60-90 min
+
+---
+
+## Artefactos nuevos
+
+| # | Tipo | Archivo | Descripción |
+|---|------|---------|-------------|
+| T1 | NEW | `domain/value_objects/entrada_grilla.py` | Dataclass `EntradaGrilla` — una fila de la grilla (performance_id, atleta_id, posicion, andarivel, ot_programado) |
+| T2 | NEW | `domain/events/grilla_de_salida_generada.py` | `GrillaDeSalidaGenerada` — snapshot completo de la grilla |
+| T3 | NEW | `domain/ports/performances_ap_port.py` | `PerformancesAPPort` (ABC) + `PerformancesAPData` (DTO) — contrato para consultar APs de una competencia |
+| T4 | MOD | `domain/aggregates/competencia.py` | Agregar `generar_grilla()` + `_apply_grilla_de_salida_generada()` en dispatch |
+| T5 | NEW | `infrastructure/repositories/performances_ap_adapter.py` | Implementación de `PerformancesAPPort` que lee el Event Store |
+| T6 | NEW | `application/commands/generar_grilla.py` | `GenerarGrillaCommand` + `GenerarGrillaHandler` |
+
+## Tests
+
+| # | Tipo | Archivo | Descripción |
+|---|------|---------|-------------|
+| T7 | NEW | `tests/unit/competencia/domain/test_generar_grilla.py` | Tests unitarios del método `generar_grilla()` — ordenamiento P-01, cálculo OT P-02, invariantes |
+| T8 | NEW | `tests/unit/competencia/application/test_generar_grilla_handler.py` | Tests del handler con mocks |
+| T9 | NEW | `tests/integration/competencia/test_generar_grilla_integration.py` | Test E2E con SQLite real: AP → GenerarGrilla → stream |
+| T10 | NEW | `tests/features/steps/generar_grilla_steps.py` | Step definitions BDD (6 escenarios) |
+
+---
+
+## Lógica de negocio clave
+
+### Ordenamiento P-01
+- `Disciplina.es_tiempo()` → sort AP descendente (STA: mayor primero)
+- `Disciplina.es_distancia()` → sort AP ascendente (DNF/DYN: menor primero)
+
+### Cálculo OT P-02
+```
+ot_atleta = ot_inicio + timedelta(minutes=(posicion - 1) * intervalo.minutos)
+```
+
+### Flujo del handler
+1. Load stream `competencia-{id}` → reconstituir `Competencia`
+2. Llamar `PerformancesAPPort.get_performances_con_ap(competencia_id)` → lista de `PerformancesAPData`
+3. `competencia.generar_grilla(ot_inicio, performances, andariveles=1)`
+4. Persistir `GrillaDeSalidaGenerada` en stream `competencia-{id}`
+
+### PerformancesAPAdapter
+- Lee todos los streams `performance-{competencia_id}-*`
+- Por cada stream, reconstruye la Performance y extrae (performance_id, atleta_id, ap)
+- Filtra solo los que tienen `_estado == AnunciadaAP`
+
+---
+
+## Orden de ejecución
+
+```
+T1 → T2 → T3 → T4 → T5 → T6   (dominio → infra → aplicación)
+T7 → T8 → T9 → T10              (tests al final)
+```
+
+---
+
+*Generado en Fase 2 de /implement-us*

--- a/docs/reports/US-2.1.2-report.md
+++ b/docs/reports/US-2.1.2-report.md
@@ -1,0 +1,70 @@
+# Reporte US-2.1.2 — Generar / Regenerar Grilla de Salida
+
+**Sprint:** SP2 · **Incremento:** Inc 2.1 — La Grilla de Salida
+**Branch:** `feature/US-2.1.2-generar-grilla`
+**Fecha:** 2026-03-25
+**Estado:** ✅ Completado
+
+---
+
+## Resumen
+
+Implementación del comando `GenerarGrilla` y su handler, incluyendo la lógica de dominio
+`Competencia.generar_grilla()`. Cubre ordenamiento STA (tiempo mayor→menor) y DNF (distancia
+menor→mayor), cálculo de OTs por posición, y la invariante INV-C-01 (intervalo configurado).
+
+---
+
+## Artefactos producidos
+
+### Dominio
+- `src/competencia/domain/value_objects/entrada_grilla.py` — `EntradaGrilla` frozen dataclass
+- `src/competencia/domain/events/grilla_de_salida_generada.py` — `GrillaDeSalidaGenerada`
+- `src/competencia/domain/ports/performances_ap_port.py` — `PerformancesAPPort` + `PerformancesAPData`
+- `src/competencia/domain/aggregates/competencia.py` — extendido: `generar_grilla()`, invariantes, reconstitución
+
+### Aplicación
+- `src/competencia/application/commands/generar_grilla.py` — `GenerarGrillaCommand` + `GenerarGrillaHandler`
+
+### Infraestructura
+- `src/competencia/infrastructure/repositories/performances_ap_adapter.py` — `PerformancesAPAdapter`
+
+### Tests
+- `tests/unit/competencia/domain/test_generar_grilla.py` — 14 tests unitarios de dominio
+- `tests/unit/competencia/application/test_generar_grilla_handler.py` — 7 tests del handler
+- `tests/integration/competencia/test_generar_grilla_integration.py` — 6 tests de integración
+- `tests/features/steps/generar_grilla_steps.py` — 6 escenarios BDD
+- `tests/features/US-2.1.2-generar-grilla.feature` — feature file
+
+---
+
+## Métricas de calidad
+
+| Métrica | Valor | Umbral |
+|---------|-------|--------|
+| Cobertura domain/ | 98% | ≥ 90% |
+| Cobertura application/ | 98% | ≥ 90% |
+| Tests totales | 33 nuevos (236 acumulados) | — |
+| BDD scenarios | 6/6 ✅ | 100% |
+| Warnings CodeGuard | 0 (post-fix) | — |
+| CRITICAL violations | 0 | 0 |
+
+---
+
+## Invariantes validadas
+
+- **INV-C-01:** Intervalo OT debe estar configurado antes de generar grilla → `IntervaloNoConfigurado`
+- **P-01:** STA ordena por AP descendente (tiempo); DNF ordena por AP ascendente (distancia)
+- **P-02:** `OT_pos = ot_inicio + timedelta(minutes=(pos-1) * intervalo.minutos)`
+- **GrillaYaConfirmada:** No se puede regenerar si la grilla fue confirmada
+
+---
+
+## Decisiones técnicas
+
+- **PerformancesAPPort pattern:** El handler consulta el puerto y pasa los datos al aggregate.
+  El aggregate no depende del puerto, manteniendo el dominio puro.
+- **tuple inmutable en GrillaDeSalidaGenerada:** `performances: tuple[dict, ...]` para
+  cumplir el requisito de frozen dataclass.
+- **pytest-bdd 8.x datatables:** Datatables se pasan como `list[list[str]]`, no como objeto
+  con `.rows`. Los steps usan `datatable[1:]` para saltar el header.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -165,7 +165,7 @@ Deben resolverse antes del SP que los involucra. No bloquean SP1 ni SP2.
 | US candidata | Inc. | RFs cubiertos | Comando/Contenido principal | Invariantes clave | Estado |
 |-------------|------|---------------|-----------------------------|------------------|--------|
 | US-2.1.1 | 2.1 | RF-PR-08 | `ConfigurarIntervaloOT` + scaffold aggregate Competencia + deuda SOLID SP1 | INV-C-01 | ✅ Done |
-| US-2.1.2 | 2.1 | RF-PR-04, RF-PR-05 | `GenerarGrilla` / `RegenerarGrilla` | INV-C-01, P-01, P-02 | ⬜ Backlog |
+| US-2.1.2 | 2.1 | RF-PR-04, RF-PR-05 | `GenerarGrilla` / `RegenerarGrilla` | INV-C-01, P-01, P-02 | ✅ Done |
 | US-2.1.3 | 2.1 | RF-PR-07 | `AjustarGrilla` | INV-C-02 (parcial) | ⬜ Backlog |
 | US-2.1.4 | 2.1 | — | `ConfirmarGrilla` + `IniciarCompetencia` + reemplazar stub `CompetenciaEstadoPort` | INV-C-02/03 | ⬜ Backlog |
 | US-2.2.1 | 2.2 | RF-EJ-08 | `DisciplinaDescriptor` value object + port (STA/tiempo, DNF/distancia) | — | ⬜ Backlog |

--- a/quality/reports/codeguard/US-2.1.2-coverage.json
+++ b/quality/reports/codeguard/US-2.1.2-coverage.json
@@ -1,0 +1,23 @@
+{
+  "us": "US-2.1.2",
+  "sprint": "SP2",
+  "incremento": "Inc 2.1",
+  "fecha": "2026-03-25",
+  "cobertura": {
+    "domain": 98,
+    "application": 98,
+    "total": 98
+  },
+  "tests": {
+    "unit_domain": 14,
+    "unit_handler": 7,
+    "integration": 6,
+    "bdd": 6,
+    "total": 33
+  },
+  "warnings": 2,
+  "criticals": 0,
+  "pylint_score": "n/a",
+  "status": "PASS",
+  "notes": "2 warnings F401 (Decimal import unused) corregidos antes del commit. Cobertura 98% en domain+application. 6/6 BDD scenarios passing."
+}

--- a/src/competencia/application/commands/generar_grilla.py
+++ b/src/competencia/application/commands/generar_grilla.py
@@ -1,0 +1,105 @@
+"""Command y Handler para GenerarGrilla — US-2.1.2."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from competencia.domain.aggregates.competencia import Competencia
+from competencia.domain.ports.event_store_port import EventStorePort
+from competencia.domain.ports.performances_ap_port import PerformancesAPPort
+from competencia.domain.value_objects.disciplina import Disciplina
+
+
+# ── Command ───────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GenerarGrillaCommand:
+    """Comando para generar (o regenerar) la Grilla de Salida.
+
+    Attributes:
+        competencia_id: Identificador de la competencia.
+        disciplina: Disciplina de la competencia.
+        ot_inicio: Timestamp de inicio usado para calcular los OTs.
+        andariveles: Número de andariveles disponibles (default 1).
+    """
+
+    competencia_id: UUID
+    disciplina: Disciplina
+    ot_inicio: datetime
+    andariveles: int = 1
+
+
+# ── Handler ───────────────────────────────────────────────────────────────────
+
+
+class GenerarGrillaHandler:
+    """Handler del comando GenerarGrilla.
+
+    Orquesta:
+    1. Reconstitución del aggregate Competencia desde el Event Store.
+    2. Consulta de performances con AP registrado via PerformancesAPPort.
+    3. Ejecución del método de dominio generar_grilla().
+    4. Persistencia del evento GrillaDeSalidaGenerada.
+
+    Args:
+        event_store: Puerto de persistencia de eventos.
+        performances_ap: Puerto para consultar performances con AP.
+    """
+
+    def __init__(
+        self,
+        event_store: EventStorePort,
+        performances_ap: PerformancesAPPort,
+    ) -> None:
+        self._event_store = event_store
+        self._performances_ap = performances_ap
+
+    async def handle(self, command: GenerarGrillaCommand) -> None:
+        """Ejecuta el comando GenerarGrilla.
+
+        Args:
+            command: Datos para generar la grilla.
+
+        Raises:
+            IntervaloNoConfigurado: INV-C-01 — intervalo no configurado.
+            GrillaYaConfirmada: La grilla fue confirmada — regeneración no permitida.
+            SinPerformancesParaGrilla: No hay performances con AP.
+        """
+        stream_id = _build_stream_id(command.competencia_id)
+        events = await self._event_store.load(stream_id)
+
+        competencia = Competencia.reconstitute(
+            competencia_id=command.competencia_id,
+            disciplina=command.disciplina,
+            events=events,
+        )
+
+        performances = await self._performances_ap.get_performances_con_ap(
+            command.competencia_id
+        )
+
+        competencia.generar_grilla(
+            ot_inicio=command.ot_inicio,
+            performances=performances,
+            andariveles=command.andariveles,
+        )
+
+        for event in competencia.pull_events():
+            await self._event_store.append(
+                stream_id=stream_id,
+                event_type=event.event_type,
+                payload=event.to_payload(),
+            )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _build_stream_id(competencia_id: UUID) -> str:
+    """Construye el stream ID canónico para una Competencia.
+
+    Format: "competencia-{competencia_id}"
+    """
+    return f"competencia-{competencia_id}"

--- a/src/competencia/domain/aggregates/competencia.py
+++ b/src/competencia/domain/aggregates/competencia.py
@@ -2,18 +2,30 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
 from shared.domain.base.aggregate_root import AggregateRoot
+from competencia.domain.events.grilla_de_salida_generada import GrillaDeSalidaGenerada
 from competencia.domain.events.intervalo_ot_configurado import IntervaloOTConfigurado
+from competencia.domain.ports.performances_ap_port import PerformancesAPData
 from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.entrada_grilla import EntradaGrilla
 from competencia.domain.value_objects.estado_competencia import EstadoCompetencia
 from competencia.domain.value_objects.intervalo_disciplina import IntervaloDisciplina
 
 
 class GrillaYaConfirmada(Exception):
-    """La grilla fue confirmada — no se puede reconfigurar el intervalo OT."""
+    """La grilla fue confirmada — no se puede reconfigurar ni regenerar."""
+
+
+class IntervaloNoConfigurado(Exception):
+    """INV-C-01: intervaloDisciplina no configurado — no se puede generar la grilla."""
+
+
+class SinPerformancesParaGrilla(Exception):
+    """No hay performances con AP registrado para generar la grilla."""
 
 
 class Competencia(AggregateRoot):
@@ -39,6 +51,7 @@ class Competencia(AggregateRoot):
         self._estado: EstadoCompetencia = EstadoCompetencia.Preparacion
         self._intervalo: IntervaloDisciplina | None = None
         self._grilla_confirmada: bool = False
+        self._grilla: list[EntradaGrilla] = []
 
     # ── Propiedades ───────────────────────────────────────────────────────────
 
@@ -61,6 +74,11 @@ class Competencia(AggregateRoot):
     def intervalo(self) -> IntervaloDisciplina | None:
         """Intervalo entre OTs configurado, o None si aún no fue configurado."""
         return self._intervalo
+
+    @property
+    def grilla(self) -> list[EntradaGrilla]:
+        """Grilla de salida actual (última generada), o lista vacía si no fue generada."""
+        return list(self._grilla)
 
     # ── Comandos de dominio ───────────────────────────────────────────────────
 
@@ -104,6 +122,92 @@ class Competencia(AggregateRoot):
         self._intervalo = intervalo
         self._record(event)
 
+    def generar_grilla(
+        self,
+        ot_inicio: datetime,
+        performances: list[PerformancesAPData],
+        andariveles: int = 1,
+    ) -> None:
+        """Genera (o regenera) la Grilla de Salida ordenando atletas por AP.
+
+        Ordenamiento (política P-01):
+            - Disciplinas de tiempo (STA): AP mayor → menor (primero el más largo).
+            - Disciplinas de distancia (DNF, DYN, etc.): AP menor → mayor
+              (primero el más conservador).
+
+        Cálculo de OT (política P-02):
+            OT_atleta = ot_inicio + (posicion − 1) × intervaloDisciplina
+
+        La operación es repetible mientras la grilla no esté confirmada.
+
+        Args:
+            ot_inicio: Timestamp de inicio de la competencia (hora cero de la grilla).
+            performances: Lista de performances con AP registrado para esta competencia.
+                Debe contener solo las que están en estado AnunciadaAP.
+            andariveles: Número de andariveles disponibles (default 1 — Inc 2.1).
+
+        Raises:
+            IntervaloNoConfigurado: INV-C-01 — intervalo no configurado.
+            GrillaYaConfirmada: La grilla fue confirmada — regeneración no permitida.
+            SinPerformancesParaGrilla: No hay performances con AP para generar la grilla.
+        """
+        if self._intervalo is None:
+            raise IntervaloNoConfigurado(
+                f"Competencia {self._competencia_id}: INV-C-01 — "
+                "intervaloDisciplina no configurado"
+            )
+        if self._grilla_confirmada:
+            raise GrillaYaConfirmada(
+                f"Competencia {self._competencia_id}: grilla confirmada — "
+                "no se puede regenerar"
+            )
+        if not performances:
+            raise SinPerformancesParaGrilla(
+                f"Competencia {self._competencia_id}: no hay performances con AP"
+            )
+
+        ordenadas = _ordenar_performances(performances, self._disciplina)
+        now = GrillaDeSalidaGenerada.now()
+
+        entradas = []
+        perf_payloads = []
+        for posicion, perf in enumerate(ordenadas, start=1):
+            ot_atleta = ot_inicio + timedelta(
+                minutes=(posicion - 1) * self._intervalo.minutos
+            )
+            andarivel = _calcular_andarivel(posicion, andariveles)
+            entradas.append(
+                EntradaGrilla(
+                    performance_id=perf.performance_id,
+                    atleta_id=perf.atleta_id,
+                    posicion=posicion,
+                    andarivel=andarivel,
+                    ot_programado=ot_atleta,
+                )
+            )
+            perf_payloads.append(
+                {
+                    "performance_id": str(perf.performance_id),
+                    "atleta_id": str(perf.atleta_id),
+                    "posicion": posicion,
+                    "andarivel": andarivel,
+                    "ot_programado": ot_atleta.isoformat(),
+                }
+            )
+
+        event = GrillaDeSalidaGenerada(
+            event_type="GrillaDeSalidaGenerada",
+            aggregate_id=str(self._competencia_id),
+            occurred_at=now,
+            competencia_id=str(self._competencia_id),
+            disciplina=self._disciplina.value,
+            ot_inicio=ot_inicio.isoformat(),
+            performances=tuple(perf_payloads),
+            generada_en=now.isoformat(),
+        )
+        self._grilla = entradas
+        self._record(event)
+
     # ── Reconstitución desde eventos ──────────────────────────────────────────
 
     @classmethod
@@ -132,6 +236,7 @@ class Competencia(AggregateRoot):
 
         _handlers: dict[str, Any] = {
             "IntervaloOTConfigurado": self._apply_intervalo_ot_configurado,
+            "GrillaDeSalidaGenerada": self._apply_grilla_de_salida_generada,
             "GrillaConfirmada": self._apply_grilla_confirmada,
         }
 
@@ -142,6 +247,18 @@ class Competencia(AggregateRoot):
     def _apply_intervalo_ot_configurado(self, payload: dict[str, Any]) -> None:
         self._intervalo = IntervaloDisciplina(minutos=payload["intervalo_minutos"])
 
+    def _apply_grilla_de_salida_generada(self, payload: dict[str, Any]) -> None:
+        self._grilla = [
+            EntradaGrilla(
+                performance_id=UUID(p["performance_id"]),
+                atleta_id=UUID(p["atleta_id"]),
+                posicion=p["posicion"],
+                andarivel=p["andarivel"],
+                ot_programado=datetime.fromisoformat(p["ot_programado"]),
+            )
+            for p in payload["performances"]
+        ]
+
     def _apply_grilla_confirmada(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
         self._grilla_confirmada = True
 
@@ -151,3 +268,27 @@ class Competencia(AggregateRoot):
         if isinstance(payload, str):
             return json.loads(payload)  # type: ignore[no-any-return]
         return payload  # type: ignore[return-value]
+
+
+# ── Helpers de dominio ────────────────────────────────────────────────────────
+
+
+def _ordenar_performances(
+    performances: list[PerformancesAPData], disciplina: Disciplina
+) -> list[PerformancesAPData]:
+    """Ordena las performances según la política P-01.
+
+    STA (tiempo): AP mayor → menor (primero el que declara más tiempo).
+    Distancia: AP menor → mayor (primero el más conservador).
+    """
+    reverse = disciplina.es_tiempo()
+    return sorted(performances, key=lambda p: p.valor_ap, reverse=reverse)
+
+
+def _calcular_andarivel(posicion: int, total_andariveles: int) -> int:
+    """Asigna andarivel round-robin por posición.
+
+    Con 1 andarivel: todos en andarivel 1.
+    Con N andariveles: posicion 1→1, 2→2, ..., N→N, N+1→1, ...
+    """
+    return ((posicion - 1) % total_andariveles) + 1

--- a/src/competencia/domain/events/__init__.py
+++ b/src/competencia/domain/events/__init__.py
@@ -1,14 +1,20 @@
 """Domain Events del BC Competencia."""
 from competencia.domain.events.ap_registrado import APRegistrado
 from competencia.domain.events.atleta_llamado import AtletaLlamado
+from competencia.domain.events.dns_registrado import DNSRegistrado
+from competencia.domain.events.grilla_de_salida_generada import GrillaDeSalidaGenerada
 from competencia.domain.events.intervalo_ot_configurado import IntervaloOTConfigurado
+from competencia.domain.events.resultado_corregido import ResultadoCorregido
 from competencia.domain.events.resultado_registrado import ResultadoRegistrado
 from competencia.domain.events.tarjeta_asignada import TarjetaAsignada
 
 __all__ = [
     "APRegistrado",
     "AtletaLlamado",
+    "DNSRegistrado",
+    "GrillaDeSalidaGenerada",
     "IntervaloOTConfigurado",
+    "ResultadoCorregido",
     "ResultadoRegistrado",
     "TarjetaAsignada",
 ]

--- a/src/competencia/domain/events/grilla_de_salida_generada.py
+++ b/src/competencia/domain/events/grilla_de_salida_generada.py
@@ -1,0 +1,56 @@
+"""Domain Event GrillaDeSalidaGenerada — snapshot completo de la grilla ordenada."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from shared.domain.base.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class GrillaDeSalidaGenerada(DomainEvent):
+    """Evento emitido al generar (o regenerar) la Grilla de Salida.
+
+    Persiste en el stream `competencia-{competencia_id}`.
+    Contiene un snapshot completo de la grilla ordenada con OTs calculados.
+
+    Attributes:
+        competencia_id: Identificador de la competencia (UUID str).
+        disciplina: Disciplina de la competencia.
+        ot_inicio: Timestamp de inicio usado para calcular los OTs.
+        performances: Lista ordenada de entradas: [{performance_id, atleta_id,
+            posicion, andarivel, ot_programado}].
+        generada_en: Timestamp de generación de la grilla.
+    """
+
+    competencia_id: str
+    disciplina: str
+    ot_inicio: str
+    performances: tuple[dict[str, Any], ...]
+    generada_en: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serializa el evento a payload JSON-serializable para el Event Store."""
+        return {
+            "competencia_id": self.competencia_id,
+            "disciplina": self.disciplina,
+            "ot_inicio": self.ot_inicio,
+            "performances": list(self.performances),
+            "generada_en": self.generada_en,
+            "occurred_at": self.occurred_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "GrillaDeSalidaGenerada":
+        """Reconstruye el evento desde el payload del Event Store."""
+        return cls(
+            event_type="GrillaDeSalidaGenerada",
+            aggregate_id=payload["competencia_id"],
+            occurred_at=datetime.fromisoformat(payload["occurred_at"]),
+            competencia_id=payload["competencia_id"],
+            disciplina=payload["disciplina"],
+            ot_inicio=payload["ot_inicio"],
+            performances=tuple(payload["performances"]),
+            generada_en=payload["generada_en"],
+        )

--- a/src/competencia/domain/ports/__init__.py
+++ b/src/competencia/domain/ports/__init__.py
@@ -1,5 +1,6 @@
 """Puertos del dominio de Competencia."""
 from competencia.domain.ports.competencia_estado_port import CompetenciaEstadoPort
 from competencia.domain.ports.event_store_port import EventStorePort
+from competencia.domain.ports.performances_ap_port import PerformancesAPData, PerformancesAPPort
 
-__all__ = ["CompetenciaEstadoPort", "EventStorePort"]
+__all__ = ["CompetenciaEstadoPort", "EventStorePort", "PerformancesAPData", "PerformancesAPPort"]

--- a/src/competencia/domain/ports/performances_ap_port.py
+++ b/src/competencia/domain/ports/performances_ap_port.py
@@ -1,0 +1,55 @@
+"""Puerto PerformancesAPPort — consulta de performances con AP registrado."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from competencia.domain.value_objects.unidad_medida import UnidadMedida
+
+
+@dataclass(frozen=True)
+class PerformancesAPData:
+    """DTO con los datos de una Performance que tiene AP registrado.
+
+    Attributes:
+        performance_id: Identificador de la Performance.
+        atleta_id: Identificador del atleta (participante_id).
+        valor_ap: Marca declarada.
+        unidad: Unidad de medida del AP (Metros | Segundos).
+    """
+
+    performance_id: UUID
+    atleta_id: UUID
+    valor_ap: Decimal
+    unidad: UnidadMedida
+
+
+class PerformancesAPPort(ABC):
+    """Puerto para obtener las performances con AP registrado de una competencia.
+
+    La implementación concreta (PerformancesAPAdapter) lee los streams
+    performance-{competencia_id}-* del Event Store y reconstruye el estado
+    de cada Performance para identificar las que están en estado AnunciadaAP.
+
+    Requerido por:
+        GenerarGrillaHandler: necesita los APs para ordenar y calcular OTs.
+    """
+
+    @abstractmethod
+    async def get_performances_con_ap(
+        self, competencia_id: UUID
+    ) -> list[PerformancesAPData]:
+        """Retorna todas las performances en estado AnunciadaAP para la competencia.
+
+        Solo se incluyen performances que tienen un APRegistrado y no han
+        avanzado a estados posteriores (Llamada, DNS, etc.).
+
+        Args:
+            competencia_id: Identificador de la competencia.
+
+        Returns:
+            Lista de PerformancesAPData — puede estar vacía si ningún atleta
+            registró AP.
+        """

--- a/src/competencia/domain/value_objects/__init__.py
+++ b/src/competencia/domain/value_objects/__init__.py
@@ -1,7 +1,20 @@
 """Value Objects del BC Competencia."""
 from competencia.domain.value_objects.ap import AP, ValorAPInvalido
 from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.entrada_grilla import EntradaGrilla
+from competencia.domain.value_objects.estado_competencia import EstadoCompetencia
 from competencia.domain.value_objects.estado_performance import EstadoPerformance
+from competencia.domain.value_objects.intervalo_disciplina import IntervaloDisciplina, IntervaloInvalido
 from competencia.domain.value_objects.unidad_medida import UnidadMedida
 
-__all__ = ["AP", "Disciplina", "EstadoPerformance", "UnidadMedida", "ValorAPInvalido"]
+__all__ = [
+    "AP",
+    "Disciplina",
+    "EntradaGrilla",
+    "EstadoCompetencia",
+    "EstadoPerformance",
+    "IntervaloDisciplina",
+    "IntervaloInvalido",
+    "UnidadMedida",
+    "ValorAPInvalido",
+]

--- a/src/competencia/domain/value_objects/entrada_grilla.py
+++ b/src/competencia/domain/value_objects/entrada_grilla.py
@@ -1,0 +1,28 @@
+"""Value Object EntradaGrilla — una fila de la Grilla de Salida."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class EntradaGrilla:
+    """Representa la asignación de un atleta en la Grilla de Salida.
+
+    Inmutable. Contiene la posición, andarivel y OT programado calculados
+    para una Performance específica dentro de una competencia.
+
+    Attributes:
+        performance_id: Identificador de la Performance.
+        atleta_id: Identificador del atleta.
+        posicion: Número de orden en la grilla (1-based).
+        andarivel: Carril asignado al atleta (1-based).
+        ot_programado: Timestamp calculado del Official Top.
+    """
+
+    performance_id: UUID
+    atleta_id: UUID
+    posicion: int
+    andarivel: int
+    ot_programado: datetime

--- a/src/competencia/infrastructure/repositories/performances_ap_adapter.py
+++ b/src/competencia/infrastructure/repositories/performances_ap_adapter.py
@@ -1,0 +1,63 @@
+"""Adaptador PerformancesAPAdapter — implementación de PerformancesAPPort sobre Event Store."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from competencia.domain.aggregates.performance import Performance
+from competencia.domain.ports.event_store_port import EventStorePort
+from competencia.domain.ports.performances_ap_port import (
+    PerformancesAPData,
+    PerformancesAPPort,
+)
+from competencia.domain.value_objects.estado_performance import EstadoPerformance
+
+
+class PerformancesAPAdapter(PerformancesAPPort):
+    """Implementación de PerformancesAPPort que lee del Event Store.
+
+    Carga todos los streams `performance-{competencia_id}-*`, reconstruye
+    cada Performance y retorna las que están en estado AnunciadaAP.
+
+    Args:
+        event_store: Puerto de persistencia de eventos.
+    """
+
+    def __init__(self, event_store: EventStorePort) -> None:
+        self._event_store = event_store
+
+    async def get_performances_con_ap(
+        self, competencia_id: UUID
+    ) -> list[PerformancesAPData]:
+        """Retorna las performances en estado AnunciadaAP para la competencia.
+
+        Args:
+            competencia_id: Identificador de la competencia.
+
+        Returns:
+            Lista de PerformancesAPData ordenada por registro de inserción
+            (orden natural del Event Store).
+        """
+        prefix = f"performance-{competencia_id}-"
+        all_streams = await self._event_store.load_all_streams_with_prefix(prefix)
+
+        result: list[PerformancesAPData] = []
+        for stream_events in all_streams:
+            if not stream_events:
+                continue
+
+            performance = Performance.reconstitute(stream_events)
+            if performance.estado != EstadoPerformance.AnunciadaAP:
+                continue
+            if performance.ap is None:
+                continue
+
+            result.append(
+                PerformancesAPData(
+                    performance_id=performance.performance_id,
+                    atleta_id=performance.participante_id,
+                    valor_ap=performance.ap.valor,
+                    unidad=performance.ap.unidad,
+                )
+            )
+
+        return result

--- a/tests/features/US-2.1.2-generar-grilla.feature
+++ b/tests/features/US-2.1.2-generar-grilla.feature
@@ -1,0 +1,74 @@
+# US-2.1.2: Generar / Regenerar Grilla de Salida
+# BC: competencia | Incremento: Inc 2.1 — La Grilla de Salida
+# Invariantes: INV-C-01 | Políticas: P-01, P-02, P-05
+
+@US-2.1.2
+Feature: Generar Grilla de Salida
+
+  Background:
+    Given una competencia "C001" con disciplina "STA" en estado "Preparacion"
+    And el intervalo OT está configurado en 9 minutos
+    And OT de inicio es "10:00:00"
+
+  @US-2.1.2 @happy_path
+  Scenario: Grilla generada con orden correcto para STA (tiempo mayor→menor)
+    Given los siguientes APs registrados para STA:
+      | atletaId | valorAP_segundos |
+      | A001     | 330              |
+      | A002     | 360              |
+      | A003     | 285              |
+    When el organizador genera la grilla
+    Then la grilla tiene 3 atletas
+    And la posicion 1 corresponde al atleta "A002" con OT "10:00:00"
+    And la posicion 2 corresponde al atleta "A001" con OT "10:09:00"
+    And la posicion 3 corresponde al atleta "A003" con OT "10:18:00"
+    And el evento GrillaDeSalidaGenerada persiste en el stream
+
+  @US-2.1.2 @happy_path
+  Scenario: Atleta sin AP no aparece en la grilla (RF-PR-04)
+    Given los siguientes APs registrados para STA:
+      | atletaId | valorAP_segundos |
+      | A001     | 330              |
+      | A002     | 360              |
+    When el organizador genera la grilla
+    Then la grilla tiene 2 atletas
+    And "A001" aparece en la grilla
+    And "A002" aparece en la grilla
+
+  @US-2.1.2 @happy_path
+  Scenario: Regenerar grilla antes de confirmar
+    Given los siguientes APs registrados para STA:
+      | atletaId | valorAP_segundos |
+      | A001     | 330              |
+    And la grilla ya fue generada previamente
+    When el organizador regenera la grilla
+    Then se emite un nuevo GrillaDeSalidaGenerada
+    And hay 2 eventos GrillaDeSalidaGenerada en el stream
+
+  @US-2.1.2 @error_case
+  Scenario: Rechazo — intervalo no configurado
+    Given una competencia "C003" sin intervalo OT configurado
+    When el organizador intenta generar la grilla sin intervalo
+    Then el sistema rechaza con error "IntervaloNoConfigurado"
+
+  @US-2.1.2 @error_case
+  Scenario: Rechazo — grilla ya confirmada
+    Given los siguientes APs registrados para STA:
+      | atletaId | valorAP_segundos |
+      | A001     | 330              |
+    And la grilla ya fue confirmada
+    When el organizador intenta regenerar la grilla
+    Then el sistema rechaza con error "GrillaYaConfirmada"
+
+  @US-2.1.2 @happy_path
+  Scenario: Grilla DNF (distancia menor→mayor)
+    Given una competencia "C002" con disciplina "DNF" e intervalo 10 minutos
+    And los siguientes APs registrados para DNF:
+      | atletaId | valorAP_metros |
+      | A001     | 80             |
+      | A002     | 60             |
+      | A003     | 100            |
+    When se genera la grilla con OT inicio "09:00:00"
+    Then la posicion 1 corresponde al atleta "A002"
+    And la posicion 2 corresponde al atleta "A001"
+    And la posicion 3 corresponde al atleta "A003"

--- a/tests/features/steps/generar_grilla_steps.py
+++ b/tests/features/steps/generar_grilla_steps.py
@@ -1,0 +1,338 @@
+"""Step definitions BDD — US-2.1.2: Generar Grilla de Salida."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import aiosqlite
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTCommand,
+    ConfigurarIntervaloOTHandler,
+)
+from competencia.application.commands.generar_grilla import (
+    GenerarGrillaCommand,
+    GenerarGrillaHandler,
+    _build_stream_id,
+)
+from competencia.application.commands.registrar_ap import (
+    RegistrarAPCommand,
+    RegistrarAPHandler,
+)
+from competencia.domain.aggregates.competencia import (
+    GrillaYaConfirmada,
+    IntervaloNoConfigurado,
+    SinPerformancesParaGrilla,
+)
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.unidad_medida import UnidadMedida
+from competencia.infrastructure.competencia_estado_stub import StubCompetenciaEstadoAdapter
+from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from competencia.infrastructure.repositories.performances_ap_adapter import (
+    PerformancesAPAdapter,
+)
+
+scenarios("../US-2.1.2-generar-grilla.feature")
+
+_CREATE_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+_C001 = UUID("00000000-0000-0000-0000-000000000001")
+_C002 = UUID("00000000-0000-0000-0000-000000000002")
+_C003 = UUID("00000000-0000-0000-0000-000000000003")
+_ORG = "organizador-01"
+
+_ATLETA_IDS: dict[str, UUID] = {
+    "A001": UUID("00000000-0000-0000-0000-000000000011"),
+    "A002": UUID("00000000-0000-0000-0000-000000000012"),
+    "A003": UUID("00000000-0000-0000-0000-000000000013"),
+}
+
+
+def _make_store(tmp_path: str, name: str) -> SQLiteEventStore:
+    db_path = f"{tmp_path}/bdd_{name}.db"
+    asyncio.run(_create_db(db_path))
+    return SQLiteEventStore(db_path)
+
+
+async def _create_db(db_path: str) -> None:
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(_CREATE_TABLE)
+        await db.commit()
+
+
+@pytest.fixture
+def context(tmp_path: object) -> dict:
+    return {
+        "store_c001": _make_store(str(tmp_path), "c001"),
+        "store_c002": _make_store(str(tmp_path), "c002"),
+        "store_c003": _make_store(str(tmp_path), "c003"),
+        "active_store": None,
+        "active_competencia_id": _C001,
+        "active_disciplina": Disciplina.STA,
+        "active_ot_inicio": datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+        "raised_exception": None,
+        "grilla_result": None,
+    }
+
+
+def _get_store(context: dict) -> SQLiteEventStore:
+    return context["active_store"] or context["store_c001"]
+
+
+# ── Given ─────────────────────────────────────────────────────────────────────
+
+@given(parsers.parse('una competencia "{cid}" con disciplina "STA" en estado "Preparacion"'))
+def dada_competencia_sta(context: dict, cid: str) -> None:
+    context["active_competencia_id"] = _C001
+    context["active_disciplina"] = Disciplina.STA
+    context["active_store"] = context["store_c001"]
+
+
+@given(parsers.parse('el intervalo OT está configurado en {minutos:d} minutos'))
+def dado_intervalo(context: dict, minutos: int) -> None:
+    store = _get_store(context)
+    cid = context["active_competencia_id"]
+    disciplina = context["active_disciplina"]
+    cmd = ConfigurarIntervaloOTCommand(
+        competencia_id=cid,
+        disciplina=disciplina,
+        intervalo_minutos=minutos,
+        configurado_por=_ORG,
+    )
+    asyncio.run(ConfigurarIntervaloOTHandler(store).handle(cmd))
+
+
+@given(parsers.parse('OT de inicio es "{ot_str}"'))
+def dado_ot_inicio(context: dict, ot_str: str) -> None:
+    h, m, s = map(int, ot_str.split(":"))
+    context["active_ot_inicio"] = datetime(2026, 1, 1, h, m, s, tzinfo=timezone.utc)
+
+
+@given("los siguientes APs registrados para STA:", target_fixture="aps_sta")
+def dados_aps_sta(context: dict, datatable: object) -> None:
+    store = _get_store(context)
+    stub = StubCompetenciaEstadoAdapter()
+    handler = RegistrarAPHandler(store, stub)
+    rows = datatable[1:]  # skip header
+    for row in rows:
+        atleta_str, ap_str = row[0].strip(), row[1].strip()
+        atleta_id = _ATLETA_IDS.get(atleta_str, uuid4())
+        asyncio.run(
+            handler.handle(
+                RegistrarAPCommand(
+                    competencia_id=context["active_competencia_id"],
+                    participante_id=atleta_id,
+                    disciplina=context["active_disciplina"],
+                    valor_ap=Decimal(ap_str),
+                    unidad=UnidadMedida.Segundos,
+                )
+            )
+        )
+
+
+@given("la grilla ya fue generada previamente")
+def dada_grilla_generada(context: dict) -> None:
+    store = _get_store(context)
+    adapter = PerformancesAPAdapter(store)
+    handler = GenerarGrillaHandler(store, adapter)
+    asyncio.run(
+        handler.handle(
+            GenerarGrillaCommand(
+                competencia_id=context["active_competencia_id"],
+                disciplina=context["active_disciplina"],
+                ot_inicio=context["active_ot_inicio"],
+            )
+        )
+    )
+
+
+@given('una competencia "C003" sin intervalo OT configurado')
+def dada_competencia_sin_intervalo(context: dict) -> None:
+    context["active_competencia_id"] = _C003
+    context["active_disciplina"] = Disciplina.STA
+    context["active_store"] = context["store_c003"]
+
+
+@given("la grilla ya fue confirmada")
+def dada_grilla_confirmada(context: dict) -> None:
+    store = _get_store(context)
+    cid = context["active_competencia_id"]
+    asyncio.run(
+        store.append(
+            stream_id=_build_stream_id(cid),
+            event_type="GrillaConfirmada",
+            payload={"competencia_id": str(cid)},
+        )
+    )
+
+
+@given(parsers.parse('una competencia "C002" con disciplina "DNF" e intervalo {minutos:d} minutos'))
+def dada_competencia_dnf(context: dict, minutos: int) -> None:
+    context["active_competencia_id"] = _C002
+    context["active_disciplina"] = Disciplina.DNF
+    context["active_store"] = context["store_c002"]
+    store = context["store_c002"]
+    asyncio.run(
+        ConfigurarIntervaloOTHandler(store).handle(
+            ConfigurarIntervaloOTCommand(
+                competencia_id=_C002,
+                disciplina=Disciplina.DNF,
+                intervalo_minutos=minutos,
+                configurado_por=_ORG,
+            )
+        )
+    )
+
+
+@given("los siguientes APs registrados para DNF:", target_fixture="aps_dnf")
+def dados_aps_dnf(context: dict, datatable: object) -> None:
+    store = _get_store(context)
+    stub = StubCompetenciaEstadoAdapter()
+    handler = RegistrarAPHandler(store, stub)
+    rows = datatable[1:]
+    for row in rows:
+        atleta_str, ap_str = row[0].strip(), row[1].strip()
+        atleta_id = _ATLETA_IDS.get(atleta_str, uuid4())
+        asyncio.run(
+            handler.handle(
+                RegistrarAPCommand(
+                    competencia_id=_C002,
+                    participante_id=atleta_id,
+                    disciplina=Disciplina.DNF,
+                    valor_ap=Decimal(ap_str),
+                    unidad=UnidadMedida.Metros,
+                )
+            )
+        )
+
+
+# ── When ──────────────────────────────────────────────────────────────────────
+
+@when("el organizador genera la grilla")
+def cuando_genera_grilla(context: dict) -> None:
+    _ejecutar_generar_grilla(context)
+
+
+@when("el organizador regenera la grilla")
+def cuando_regenera_grilla(context: dict) -> None:
+    _ejecutar_generar_grilla(context)
+
+
+@when("el organizador intenta generar la grilla sin intervalo")
+def cuando_intenta_sin_intervalo(context: dict) -> None:
+    _ejecutar_generar_grilla(context)
+
+
+@when("el organizador intenta regenerar la grilla")
+def cuando_intenta_regenerar(context: dict) -> None:
+    _ejecutar_generar_grilla(context)
+
+
+@when(parsers.parse('se genera la grilla con OT inicio "{ot_str}"'))
+def cuando_genera_grilla_dnf(context: dict, ot_str: str) -> None:
+    h, m, s = map(int, ot_str.split(":"))
+    context["active_ot_inicio"] = datetime(2026, 1, 1, h, m, s, tzinfo=timezone.utc)
+    _ejecutar_generar_grilla(context)
+
+
+def _ejecutar_generar_grilla(context: dict) -> None:
+    store = _get_store(context)
+    adapter = PerformancesAPAdapter(store)
+    handler = GenerarGrillaHandler(store, adapter)
+    try:
+        asyncio.run(
+            handler.handle(
+                GenerarGrillaCommand(
+                    competencia_id=context["active_competencia_id"],
+                    disciplina=context["active_disciplina"],
+                    ot_inicio=context["active_ot_inicio"],
+                )
+            )
+        )
+    except (IntervaloNoConfigurado, GrillaYaConfirmada, SinPerformancesParaGrilla) as exc:
+        context["raised_exception"] = exc
+
+
+# ── Then ──────────────────────────────────────────────────────────────────────
+
+@then(parsers.parse("la grilla tiene {n:d} atletas"))
+def entonces_grilla_tiene_n_atletas(context: dict, n: int) -> None:
+    perfs = _get_grilla_perfs(context)
+    assert len(perfs) == n
+
+
+@then(parsers.parse('la posicion {pos:d} corresponde al atleta "{atleta}" con OT "{ot_str}"'))
+def entonces_posicion_atleta_ot(context: dict, pos: int, atleta: str, ot_str: str) -> None:
+    perfs = _get_grilla_perfs(context)
+    entrada = next(p for p in perfs if p["posicion"] == pos)
+    assert entrada["atleta_id"] == str(_ATLETA_IDS[atleta])
+    h, m, s = map(int, ot_str.split(":"))
+    expected_ot = datetime(2026, 1, 1, h, m, s, tzinfo=timezone.utc)
+    assert datetime.fromisoformat(entrada["ot_programado"]) == expected_ot
+
+
+@then("el evento GrillaDeSalidaGenerada persiste en el stream")
+def entonces_evento_persiste(context: dict) -> None:
+    store = _get_store(context)
+    cid = context["active_competencia_id"]
+    events = asyncio.run(store.load(_build_stream_id(cid)))
+    assert any(e["event_type"] == "GrillaDeSalidaGenerada" for e in events)
+
+
+@then(parsers.parse('"{atleta}" aparece en la grilla'))
+def entonces_atleta_aparece(context: dict, atleta: str) -> None:
+    perfs = _get_grilla_perfs(context)
+    atleta_ids = [p["atleta_id"] for p in perfs]
+    assert str(_ATLETA_IDS[atleta]) in atleta_ids
+
+
+@then("se emite un nuevo GrillaDeSalidaGenerada")
+def entonces_nuevo_evento(context: dict) -> None:
+    entonces_evento_persiste(context)
+
+
+@then("hay 2 eventos GrillaDeSalidaGenerada en el stream")
+def entonces_dos_eventos_grilla(context: dict) -> None:
+    store = _get_store(context)
+    cid = context["active_competencia_id"]
+    events = asyncio.run(store.load(_build_stream_id(cid)))
+    grilla_events = [e for e in events if e["event_type"] == "GrillaDeSalidaGenerada"]
+    assert len(grilla_events) == 2
+
+
+@then(parsers.parse('el sistema rechaza con error "{error_type}"'))
+def entonces_rechaza(context: dict, error_type: str) -> None:
+    assert context["raised_exception"] is not None
+    assert type(context["raised_exception"]).__name__ == error_type
+
+
+@then(parsers.parse('la posicion {pos:d} corresponde al atleta "{atleta}"'))
+def entonces_posicion_atleta(context: dict, pos: int, atleta: str) -> None:
+    perfs = _get_grilla_perfs(context)
+    entrada = next(p for p in perfs if p["posicion"] == pos)
+    assert entrada["atleta_id"] == str(_ATLETA_IDS[atleta])
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _get_grilla_perfs(context: dict) -> list[dict]:
+    store = _get_store(context)
+    cid = context["active_competencia_id"]
+    events = asyncio.run(store.load(_build_stream_id(cid)))
+    grilla_events = [e for e in events if e["event_type"] == "GrillaDeSalidaGenerada"]
+    assert grilla_events, "No se encontró evento GrillaDeSalidaGenerada"
+    return grilla_events[-1]["payload"]["performances"]

--- a/tests/integration/competencia/test_generar_grilla_integration.py
+++ b/tests/integration/competencia/test_generar_grilla_integration.py
@@ -1,0 +1,236 @@
+"""Tests de integración — GenerarGrillaHandler con SQLiteEventStore real."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import UUID, uuid4
+
+import aiosqlite
+import pytest
+
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTCommand,
+    ConfigurarIntervaloOTHandler,
+)
+from competencia.application.commands.generar_grilla import (
+    GenerarGrillaCommand,
+    GenerarGrillaHandler,
+    _build_stream_id,
+)
+from competencia.application.commands.registrar_ap import (
+    RegistrarAPCommand,
+    RegistrarAPHandler,
+)
+from competencia.domain.aggregates.competencia import (
+    Competencia,
+    IntervaloNoConfigurado,
+    SinPerformancesParaGrilla,
+)
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.unidad_medida import UnidadMedida
+from competencia.infrastructure.competencia_estado_stub import StubCompetenciaEstadoAdapter
+from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from competencia.infrastructure.repositories.performances_ap_adapter import (
+    PerformancesAPAdapter,
+)
+
+CREATE_EVENTS_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL
+            DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+DISCIPLINA = Disciplina.STA
+OT_INICIO = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+A001 = UUID("00000000-0000-0000-0000-000000000011")
+A002 = UUID("00000000-0000-0000-0000-000000000012")
+A003 = UUID("00000000-0000-0000-0000-000000000013")
+
+
+@pytest.fixture
+async def event_store(tmp_path: Any) -> SQLiteEventStore:
+    db_path = str(tmp_path / "test_grilla.db")
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(CREATE_EVENTS_TABLE)
+        await db.commit()
+    return SQLiteEventStore(db_path)
+
+
+async def _seed_intervalo(store: SQLiteEventStore) -> None:
+    handler = ConfigurarIntervaloOTHandler(store)
+    await handler.handle(
+        ConfigurarIntervaloOTCommand(
+            competencia_id=COMPETENCIA_ID,
+            disciplina=DISCIPLINA,
+            intervalo_minutos=9,
+            configurado_por="org",
+        )
+    )
+
+
+async def _seed_ap(
+    store: SQLiteEventStore, atleta_id: UUID, valor: str
+) -> None:
+    stub = StubCompetenciaEstadoAdapter()
+    handler = RegistrarAPHandler(store, stub)
+    await handler.handle(
+        RegistrarAPCommand(
+            competencia_id=COMPETENCIA_ID,
+            participante_id=atleta_id,
+            disciplina=DISCIPLINA,
+            valor_ap=Decimal(valor),
+            unidad=UnidadMedida.Segundos,
+        )
+    )
+
+
+class TestGenerarGrillaIntegracion:
+    @pytest.mark.asyncio
+    async def test_grilla_generada_persiste_en_stream(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        await _seed_intervalo(event_store)
+        await _seed_ap(event_store, A001, "330")
+
+        adapter = PerformancesAPAdapter(event_store)
+        handler = GenerarGrillaHandler(event_store, adapter)
+        await handler.handle(
+            GenerarGrillaCommand(
+                competencia_id=COMPETENCIA_ID,
+                disciplina=DISCIPLINA,
+                ot_inicio=OT_INICIO,
+            )
+        )
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        event_types = [e["event_type"] for e in events]
+        assert "GrillaDeSalidaGenerada" in event_types
+
+    @pytest.mark.asyncio
+    async def test_orden_sta_correcto_tres_atletas(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        await _seed_intervalo(event_store)
+        await _seed_ap(event_store, A001, "330")  # 5:30
+        await _seed_ap(event_store, A002, "360")  # 6:00 — mayor, pos=1
+        await _seed_ap(event_store, A003, "285")  # 4:45 — menor, pos=3
+
+        adapter = PerformancesAPAdapter(event_store)
+        handler = GenerarGrillaHandler(event_store, adapter)
+        await handler.handle(
+            GenerarGrillaCommand(
+                competencia_id=COMPETENCIA_ID,
+                disciplina=DISCIPLINA,
+                ot_inicio=OT_INICIO,
+            )
+        )
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        grilla_event = next(e for e in events if e["event_type"] == "GrillaDeSalidaGenerada")
+        perfs = grilla_event["payload"]["performances"]
+
+        atletas_orden = [p["atleta_id"] for p in perfs]
+        assert atletas_orden[0] == str(A002)  # mayor AP primero
+        assert atletas_orden[2] == str(A003)  # menor AP último
+
+    @pytest.mark.asyncio
+    async def test_ot_calculados_correctamente(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        await _seed_intervalo(event_store)
+        await _seed_ap(event_store, A001, "330")
+        await _seed_ap(event_store, A002, "360")
+
+        adapter = PerformancesAPAdapter(event_store)
+        handler = GenerarGrillaHandler(event_store, adapter)
+        await handler.handle(
+            GenerarGrillaCommand(
+                competencia_id=COMPETENCIA_ID,
+                disciplina=DISCIPLINA,
+                ot_inicio=OT_INICIO,
+            )
+        )
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        grilla_event = next(e for e in events if e["event_type"] == "GrillaDeSalidaGenerada")
+        perfs = grilla_event["payload"]["performances"]
+
+        ot_pos1 = datetime.fromisoformat(perfs[0]["ot_programado"])
+        ot_pos2 = datetime.fromisoformat(perfs[1]["ot_programado"])
+        assert ot_pos2 - ot_pos1 == timedelta(minutes=9)
+
+    @pytest.mark.asyncio
+    async def test_reconstituyendo_grilla_desde_store(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        await _seed_intervalo(event_store)
+        await _seed_ap(event_store, A001, "330")
+
+        adapter = PerformancesAPAdapter(event_store)
+        handler = GenerarGrillaHandler(event_store, adapter)
+        await handler.handle(
+            GenerarGrillaCommand(
+                competencia_id=COMPETENCIA_ID,
+                disciplina=DISCIPLINA,
+                ot_inicio=OT_INICIO,
+            )
+        )
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        c = Competencia.reconstitute(COMPETENCIA_ID, DISCIPLINA, events)
+        assert len(c.grilla) == 1
+        assert c.grilla[0].posicion == 1
+
+    @pytest.mark.asyncio
+    async def test_regeneracion_agrega_segundo_evento(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        await _seed_intervalo(event_store)
+        await _seed_ap(event_store, A001, "330")
+
+        adapter = PerformancesAPAdapter(event_store)
+        handler = GenerarGrillaHandler(event_store, adapter)
+        cmd = GenerarGrillaCommand(
+            competencia_id=COMPETENCIA_ID,
+            disciplina=DISCIPLINA,
+            ot_inicio=OT_INICIO,
+        )
+        await handler.handle(cmd)
+        await handler.handle(cmd)
+
+        stream_id = _build_stream_id(COMPETENCIA_ID)
+        events = await event_store.load(stream_id)
+        grilla_events = [e for e in events if e["event_type"] == "GrillaDeSalidaGenerada"]
+        assert len(grilla_events) == 2
+
+    @pytest.mark.asyncio
+    async def test_sin_ap_registrado_lanza_excepcion(
+        self, event_store: SQLiteEventStore
+    ) -> None:
+        await _seed_intervalo(event_store)
+        # No se registran APs
+
+        adapter = PerformancesAPAdapter(event_store)
+        handler = GenerarGrillaHandler(event_store, adapter)
+        with pytest.raises(SinPerformancesParaGrilla):
+            await handler.handle(
+                GenerarGrillaCommand(
+                    competencia_id=COMPETENCIA_ID,
+                    disciplina=DISCIPLINA,
+                    ot_inicio=OT_INICIO,
+                )
+            )

--- a/tests/unit/competencia/application/test_generar_grilla_handler.py
+++ b/tests/unit/competencia/application/test_generar_grilla_handler.py
@@ -1,0 +1,134 @@
+"""Tests unitarios del GenerarGrillaHandler — US-2.1.2."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from competencia.application.commands.generar_grilla import (
+    GenerarGrillaCommand,
+    GenerarGrillaHandler,
+    _build_stream_id,
+)
+from competencia.domain.aggregates.competencia import (
+    IntervaloNoConfigurado,
+    SinPerformancesParaGrilla,
+)
+from competencia.domain.ports.performances_ap_port import PerformancesAPData
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.unidad_medida import UnidadMedida
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+OT_INICIO = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+A001 = UUID("00000000-0000-0000-0000-000000000011")
+
+_INTERVALO_EVENT = {
+    "event_type": "IntervaloOTConfigurado",
+    "payload": {
+        "competencia_id": str(COMPETENCIA_ID),
+        "disciplina": "STA",
+        "intervalo_minutos": 9,
+        "configurado_por": "org",
+        "occurred_at": "2026-01-01T00:00:00+00:00",
+    },
+}
+
+
+@pytest.fixture
+def mock_event_store() -> AsyncMock:
+    store = AsyncMock()
+    store.load.return_value = [_INTERVALO_EVENT]
+    store.append.return_value = None
+    return store
+
+
+@pytest.fixture
+def mock_performances_ap() -> AsyncMock:
+    port = AsyncMock()
+    port.get_performances_con_ap.return_value = [
+        PerformancesAPData(
+            performance_id=uuid4(),
+            atleta_id=A001,
+            valor_ap=Decimal("330"),
+            unidad=UnidadMedida.Segundos,
+        )
+    ]
+    return port
+
+
+def _command() -> GenerarGrillaCommand:
+    return GenerarGrillaCommand(
+        competencia_id=COMPETENCIA_ID,
+        disciplina=Disciplina.STA,
+        ot_inicio=OT_INICIO,
+    )
+
+
+class TestGenerarGrillaHandlerExitoso:
+    @pytest.mark.asyncio
+    async def test_append_llamado_una_vez(
+        self, mock_event_store: AsyncMock, mock_performances_ap: AsyncMock
+    ) -> None:
+        handler = GenerarGrillaHandler(mock_event_store, mock_performances_ap)
+        await handler.handle(_command())
+        assert mock_event_store.append.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_event_type_correcto(
+        self, mock_event_store: AsyncMock, mock_performances_ap: AsyncMock
+    ) -> None:
+        handler = GenerarGrillaHandler(mock_event_store, mock_performances_ap)
+        await handler.handle(_command())
+        assert mock_event_store.append.call_args[1]["event_type"] == "GrillaDeSalidaGenerada"
+
+    @pytest.mark.asyncio
+    async def test_performances_ap_consultado_con_competencia_id(
+        self, mock_event_store: AsyncMock, mock_performances_ap: AsyncMock
+    ) -> None:
+        handler = GenerarGrillaHandler(mock_event_store, mock_performances_ap)
+        await handler.handle(_command())
+        mock_performances_ap.get_performances_con_ap.assert_called_once_with(COMPETENCIA_ID)
+
+    @pytest.mark.asyncio
+    async def test_load_con_stream_id_correcto(
+        self, mock_event_store: AsyncMock, mock_performances_ap: AsyncMock
+    ) -> None:
+        handler = GenerarGrillaHandler(mock_event_store, mock_performances_ap)
+        await handler.handle(_command())
+        mock_event_store.load.assert_called_once_with(_build_stream_id(COMPETENCIA_ID))
+
+
+class TestGenerarGrillaHandlerErrores:
+    @pytest.mark.asyncio
+    async def test_sin_intervalo_lanza_excepcion(
+        self, mock_performances_ap: AsyncMock
+    ) -> None:
+        store = AsyncMock()
+        store.load.return_value = []  # sin IntervaloOTConfigurado
+        handler = GenerarGrillaHandler(store, mock_performances_ap)
+        with pytest.raises(IntervaloNoConfigurado):
+            await handler.handle(_command())
+
+    @pytest.mark.asyncio
+    async def test_sin_performances_lanza_excepcion(
+        self, mock_event_store: AsyncMock
+    ) -> None:
+        port = AsyncMock()
+        port.get_performances_con_ap.return_value = []
+        handler = GenerarGrillaHandler(mock_event_store, port)
+        with pytest.raises(SinPerformancesParaGrilla):
+            await handler.handle(_command())
+
+    @pytest.mark.asyncio
+    async def test_append_no_llamado_si_error(
+        self, mock_event_store: AsyncMock
+    ) -> None:
+        port = AsyncMock()
+        port.get_performances_con_ap.return_value = []
+        handler = GenerarGrillaHandler(mock_event_store, port)
+        with pytest.raises(SinPerformancesParaGrilla):
+            await handler.handle(_command())
+        mock_event_store.append.assert_not_called()

--- a/tests/unit/competencia/domain/test_generar_grilla.py
+++ b/tests/unit/competencia/domain/test_generar_grilla.py
@@ -1,0 +1,226 @@
+"""Tests unitarios de Competencia.generar_grilla() — US-2.1.2."""
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from competencia.domain.aggregates.competencia import (
+    Competencia,
+    GrillaYaConfirmada,
+    IntervaloNoConfigurado,
+    SinPerformancesParaGrilla,
+)
+from competencia.domain.events.grilla_de_salida_generada import GrillaDeSalidaGenerada
+from competencia.domain.ports.performances_ap_port import PerformancesAPData
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.unidad_medida import UnidadMedida
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+OT_INICIO = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_competencia(disciplina: Disciplina = Disciplina.STA) -> Competencia:
+    c = Competencia(competencia_id=COMPETENCIA_ID, disciplina=disciplina)
+    c.configurar_intervalo_ot(9, "org-01")
+    c.pull_events()  # limpiar eventos de configuración
+    return c
+
+
+def _perf(atleta_id: str, valor_ap: str, unidad: UnidadMedida) -> PerformancesAPData:
+    return PerformancesAPData(
+        performance_id=uuid4(),
+        atleta_id=UUID(atleta_id),
+        valor_ap=Decimal(valor_ap),
+        unidad=unidad,
+    )
+
+
+def _sta(atleta_id: str, segundos: str) -> PerformancesAPData:
+    return _perf(atleta_id, segundos, UnidadMedida.Segundos)
+
+
+def _dnf(atleta_id: str, metros: str) -> PerformancesAPData:
+    return _perf(atleta_id, metros, UnidadMedida.Metros)
+
+
+A001 = "00000000-0000-0000-0000-000000000011"
+A002 = "00000000-0000-0000-0000-000000000012"
+A003 = "00000000-0000-0000-0000-000000000013"
+
+
+# ── Invariantes ───────────────────────────────────────────────────────────────
+
+
+class TestInvariantes:
+    def test_sin_intervalo_lanza_intervalo_no_configurado(self) -> None:
+        c = Competencia(competencia_id=COMPETENCIA_ID, disciplina=Disciplina.STA)
+        with pytest.raises(IntervaloNoConfigurado):
+            c.generar_grilla(OT_INICIO, [_sta(A001, "330")])
+
+    def test_sin_performances_lanza_sin_performances(self) -> None:
+        c = _make_competencia()
+        with pytest.raises(SinPerformancesParaGrilla):
+            c.generar_grilla(OT_INICIO, [])
+
+    def test_grilla_confirmada_lanza_excepcion(self) -> None:
+        c = Competencia.reconstitute(
+            COMPETENCIA_ID,
+            Disciplina.STA,
+            [
+                {
+                    "event_type": "IntervaloOTConfigurado",
+                    "payload": {
+                        "competencia_id": str(COMPETENCIA_ID),
+                        "disciplina": "STA",
+                        "intervalo_minutos": 9,
+                        "configurado_por": "org",
+                        "occurred_at": "2026-01-01T00:00:00+00:00",
+                    },
+                },
+                {
+                    "event_type": "GrillaConfirmada",
+                    "payload": {"competencia_id": str(COMPETENCIA_ID)},
+                },
+            ],
+        )
+        with pytest.raises(GrillaYaConfirmada):
+            c.generar_grilla(OT_INICIO, [_sta(A001, "330")])
+
+
+# ── Ordenamiento STA (tiempo, mayor→menor) ────────────────────────────────────
+
+
+class TestOrdenamientoSTA:
+    def test_orden_mayor_a_menor_por_ap(self) -> None:
+        c = _make_competencia(Disciplina.STA)
+        performances = [
+            _sta(A001, "330"),  # 5:30
+            _sta(A002, "360"),  # 6:00 — mayor, debe ir primero
+            _sta(A003, "285"),  # 4:45 — menor, debe ir último
+        ]
+        c.generar_grilla(OT_INICIO, performances)
+        grilla = c.grilla
+        atletas_orden = [str(e.atleta_id) for e in grilla]
+        assert atletas_orden == [A002, A001, A003]
+
+    def test_posiciones_1_based(self) -> None:
+        c = _make_competencia(Disciplina.STA)
+        c.generar_grilla(OT_INICIO, [_sta(A001, "330"), _sta(A002, "360")])
+        posiciones = [e.posicion for e in c.grilla]
+        assert posiciones == [1, 2]
+
+    def test_ot_primera_posicion_es_ot_inicio(self) -> None:
+        c = _make_competencia(Disciplina.STA)
+        c.generar_grilla(OT_INICIO, [_sta(A001, "330")])
+        assert c.grilla[0].ot_programado == OT_INICIO
+
+    def test_ot_segunda_posicion_suma_intervalo(self) -> None:
+        c = _make_competencia(Disciplina.STA)
+        c.generar_grilla(OT_INICIO, [_sta(A002, "360"), _sta(A001, "330")])
+        expected = OT_INICIO + timedelta(minutes=9)
+        assert c.grilla[1].ot_programado == expected
+
+    def test_ot_tercera_posicion_suma_dos_intervalos(self) -> None:
+        c = _make_competencia(Disciplina.STA)
+        perfs = [_sta(A001, "330"), _sta(A002, "360"), _sta(A003, "285")]
+        c.generar_grilla(OT_INICIO, perfs)
+        expected = OT_INICIO + timedelta(minutes=18)
+        assert c.grilla[2].ot_programado == expected
+
+
+# ── Ordenamiento DNF (distancia, menor→mayor) ─────────────────────────────────
+
+
+class TestOrdenamientoDNF:
+    def test_orden_menor_a_mayor_por_ap(self) -> None:
+        c = _make_competencia(Disciplina.DNF)
+        performances = [
+            _dnf(A001, "80"),
+            _dnf(A002, "60"),   # menor — debe ir primero
+            _dnf(A003, "100"),  # mayor — debe ir último
+        ]
+        c.generar_grilla(OT_INICIO, performances)
+        atletas_orden = [str(e.atleta_id) for e in c.grilla]
+        assert atletas_orden == [A002, A001, A003]
+
+
+# ── Evento generado ───────────────────────────────────────────────────────────
+
+
+class TestEventoGenerado:
+    def test_emite_un_evento(self) -> None:
+        c = _make_competencia()
+        c.generar_grilla(OT_INICIO, [_sta(A001, "330")])
+        events = c.pull_events()
+        assert len(events) == 1
+        assert isinstance(events[0], GrillaDeSalidaGenerada)
+
+    def test_evento_contiene_datos_correctos(self) -> None:
+        c = _make_competencia()
+        c.generar_grilla(OT_INICIO, [_sta(A001, "330")])
+        event = c.pull_events()[0]
+        assert isinstance(event, GrillaDeSalidaGenerada)
+        assert event.competencia_id == str(COMPETENCIA_ID)
+        assert event.disciplina == "STA"
+        assert len(event.performances) == 1
+        assert event.performances[0]["posicion"] == 1
+
+    def test_regeneracion_emite_nuevo_evento(self) -> None:
+        c = _make_competencia()
+        c.generar_grilla(OT_INICIO, [_sta(A001, "330")])
+        c.pull_events()
+        c.generar_grilla(OT_INICIO, [_sta(A001, "330"), _sta(A002, "360")])
+        events = c.pull_events()
+        assert len(events) == 1
+        assert isinstance(events[0], GrillaDeSalidaGenerada)
+        assert len(events[0].performances) == 2
+
+
+# ── Andarivel ─────────────────────────────────────────────────────────────────
+
+
+class TestAndarivel:
+    def test_un_andarivel_todos_en_andarivel_1(self) -> None:
+        c = _make_competencia()
+        perfs = [_sta(A001, "330"), _sta(A002, "360"), _sta(A003, "285")]
+        c.generar_grilla(OT_INICIO, perfs, andariveles=1)
+        assert all(e.andarivel == 1 for e in c.grilla)
+
+
+# ── Reconstitución ────────────────────────────────────────────────────────────
+
+
+class TestReconstitucion:
+    def test_reconstituye_grilla_desde_evento(self) -> None:
+        c = _make_competencia()
+        perfs = [_sta(A001, "330"), _sta(A002, "360")]
+        c.generar_grilla(OT_INICIO, perfs)
+        event = c.pull_events()[0]
+        assert isinstance(event, GrillaDeSalidaGenerada)
+
+        # Reconstruir desde payload
+        c2 = Competencia.reconstitute(
+            COMPETENCIA_ID,
+            Disciplina.STA,
+            [
+                {
+                    "event_type": "IntervaloOTConfigurado",
+                    "payload": {
+                        "competencia_id": str(COMPETENCIA_ID),
+                        "disciplina": "STA",
+                        "intervalo_minutos": 9,
+                        "configurado_por": "org",
+                        "occurred_at": "2026-01-01T00:00:00+00:00",
+                    },
+                },
+                {
+                    "event_type": "GrillaDeSalidaGenerada",
+                    "payload": event.to_payload(),
+                },
+            ],
+        )
+        assert len(c2.grilla) == 2
+        assert c2.grilla[0].posicion == 1


### PR DESCRIPTION
## Summary

- Implementa `Competencia.generar_grilla()` con ordenamiento STA (AP desc) y DNF (AP asc), cálculo de OTs por posición (P-02), e invariantes INV-C-01 / GrillaYaConfirmada
- `PerformancesAPPort` + `PerformancesAPAdapter` para consultar APs sin acoplar el dominio a la infra
- `GenerarGrillaCommand` / `GenerarGrillaHandler` + `EntradaGrilla` value object + `GrillaDeSalidaGenerada` event

## Test plan

- [x] 14 tests unitarios de dominio (ordenamiento STA/DNF, OTs, invariantes, reconstitución)
- [x] 7 tests unitarios del handler (mocks)
- [x] 6 tests de integración con SQLite real
- [x] 6 escenarios BDD — 6/6 passing
- [x] Cobertura domain+application: 98%
- [x] 0 warnings CodeGuard post-fix
- [x] Linear VVA-10 → Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)