### PR TITLE
feat(resultados): US-3.5.1 overall posicional

### DIFF
--- a/.claude/tracking/US-3.5.1-tracking.json
+++ b/.claude/tracking/US-3.5.1-tracking.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {
+    "us_id": "US-3.5.1",
+    "us_title": "Aggregate RankingOverall — formula posicional",
+    "us_points": 3,
+    "producto": "ataraxiadive",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-02T12:22:55.236944+00:00",
+    "completed_at": "2026-04-02T13:05:00.000000+00:00",
+    "total_elapsed_seconds": 2525,
+    "effective_seconds": 2525,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de Contexto",
+      "started_at": "2026-04-02T12:23:21.521902+00:00",
+      "completed_at": "2026-04-02T12:23:50.000000+00:00",
+      "elapsed_seconds": 28,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generacion de Escenarios BDD",
+      "started_at": "2026-04-02T12:23:50.000000+00:00",
+      "completed_at": "2026-04-02T12:24:10.500000+00:00",
+      "elapsed_seconds": 20,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementacion",
+      "started_at": "2026-04-02T12:24:11.284759+00:00",
+      "completed_at": "2026-04-02T12:27:01.737473+00:00",
+      "elapsed_seconds": 170,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementacion",
+      "started_at": "2026-04-02T12:27:02.000000+00:00",
+      "completed_at": "2026-04-02T12:48:00.000000+00:00",
+      "elapsed_seconds": 1258,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-02T12:48:00.000000+00:00",
+      "completed_at": "2026-04-02T12:50:00.000000+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integracion",
+      "started_at": "2026-04-02T12:50:00.000000+00:00",
+      "completed_at": "2026-04-02T12:52:00.000000+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validacion BDD",
+      "started_at": "2026-04-02T12:52:00.000000+00:00",
+      "completed_at": "2026-04-02T12:54:00.000000+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-02T12:54:00.000000+00:00",
+      "completed_at": "2026-04-02T13:01:00.000000+00:00",
+      "elapsed_seconds": 420,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentacion",
+      "started_at": "2026-04-02T13:01:00.000000+00:00",
+      "completed_at": "2026-04-02T13:03:00.000000+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte final",
+      "started_at": "2026-04-02T13:03:00.000000+00:00",
+      "completed_at": "2026-04-02T13:05:00.000000+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 10,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 42,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/contexto/HITO-16-SECUENCIALIDAD-PRESCRIPTIVA-PIPELINE.md
+++ b/docs/contexto/HITO-16-SECUENCIALIDAD-PRESCRIPTIVA-PIPELINE.md
@@ -1,0 +1,156 @@
+# HITO-16 — La secuencialidad del pipeline no es una optimización: es una prescripción metodológica
+
+| Campo | Valor |
+|-------|-------|
+| **Documento** | HITO-16 — Aprendizaje experimental durante SP3 |
+| **Fecha** | 2026-04-02 |
+| **Sprint** | SP3 — US-3.5.1 (RankingOverall) |
+| **Relacionado** | `docs/plans/WORKFLOW-DESARROLLO.md` · `docs/specs/sp3/US-3.5.1.md` · `docs/reports/US-3.5.1-report.md` |
+
+---
+
+## Contexto
+
+Durante la ejecución de `US-3.5.1` se intentó operar el tracking del pipeline
+de `/implement-us` con invocaciones paralelas del CLI (`init`, `start-phase`,
+`end-phase`) mientras se inspeccionaban otros artefactos en paralelo.
+
+El resultado fue:
+
+- pérdida intermitente del "tracking activo";
+- fases abiertas/cerradas en estados inconsistentes;
+- archivos JSON del tracker con contenido corrupto o truncado;
+- necesidad de reconstrucción manual del tracker al cierre de la US.
+
+El problema parecía, en la superficie, una falla técnica del sistema de tracking.
+El análisis posterior mostró algo más importante.
+
+---
+
+## El hallazgo
+
+**La secuencialidad del pipeline `/implement-us` no es una preferencia operativa.
+Es una restricción constitutiva del método.**
+
+El workflow del proyecto ya lo prescribía:
+
+- una branch por US;
+- un tracker activo por vez;
+- una fase por vez;
+- aprobación explícita en Fase 2 y Fase 8;
+- artefactos físicos producidos en orden.
+
+La herramienta de tracking no está diseñada para tolerar concurrencia porque
+el método no la contempla. Tratar esa linealidad como "detalle de implementación"
+fue un error conceptual.
+
+---
+
+## Qué pasó realmente
+
+La interpretación inicial fue: "el tracker se corrompe con facilidad; tal vez
+habría que endurecerlo técnicamente con locks, writes atómicos o mayor tolerancia
+a concurrencia".
+
+Ese diagnóstico es incorrecto dentro del marco del experimento.
+
+Lo que falló no fue la herramienta frente a un uso legítimo. Lo que falló fue
+la ejecución frente a una **violación del protocolo prescripto**.
+
+Cuando se paralelizaron operaciones del tracker:
+
+- se rompió la hipótesis de "una sola transición de estado por vez";
+- se invalidó el criterio de "tracker activo";
+- dejó de ser confiable la correspondencia entre pipeline real y artefacto de control.
+
+En otras palabras: la corrupción observada no fue evidencia contra la
+herramienta; fue evidencia de que el método depende de la secuencialidad.
+
+---
+
+## Aprendizaje metodológico central
+
+> En un pipeline prescriptivo como `/implement-us`, la secuencialidad no debe
+> tratarse como una característica accidental de tooling, sino como parte del
+> contrato metodológico que garantiza trazabilidad y confiabilidad del proceso.
+
+Esto tiene una consecuencia práctica fuerte:
+
+- hay actividades que sí pueden paralelizarse, como lecturas auxiliares o
+  inspecciones de contexto;
+- pero **ninguna transición de estado del pipeline** debe ejecutarse en paralelo:
+  ni tracker, ni cambios de fase, ni cierres/aprobaciones.
+
+El pipeline expresa un proceso linealmente gobernado. Su valor experimental
+depende de preservar esa linealidad.
+
+---
+
+## Relación con HITO-12
+
+HITO-12 mostró que las instrucciones textuales no alcanzan cuando el LLM tiene
+un modelo implícito de completitud distinto del protocolo.
+
+HITO-16 agrega una dimensión nueva:
+
+- HITO-12: un gate textual puede ser insuficiente para forzar completitud.
+- HITO-16: incluso con protocolo correcto, si se viola la secuencialidad
+  prescripta, los artefactos de control dejan de representar fielmente el proceso.
+
+Ambos hitos apuntan a la misma dirección: el comportamiento procedimental del
+LLM debe gobernarse con reglas operativas explícitas, no solo con intención.
+
+---
+
+## Aprendizaje secundario surgido en la misma US
+
+La implementación de `US-3.5.1` dejó además un hallazgo arquitectónico útil:
+
+**El Overall conviene calcularse desde rankings por disciplina ya construidos en
+el BC `resultados`, no desde performances crudas de `competencia`.**
+
+La spec permitía una lectura ambigua sobre la fuente del cálculo. El trabajo
+real mostró que:
+
+- `US-3.5.1` debe concentrarse en la lógica de agregación overall;
+- `US-3.5.2` debe encargarse de la política P-09 que decide cuándo dispararlo;
+- mantener el cálculo dentro de `resultados` preserva mejor la frontera del BC.
+
+Esto refuerza una idea ya sugerida por HITO-15: ciertas decisiones de lectura y
+proyección no emergen plenamente de la especificación de dominio, sino del
+contacto entre especificación, implementación y arquitectura.
+
+---
+
+## Implicancia para el experimento
+
+Este HITO fortalece la hipótesis de que el `human-in-the-loop` sigue siendo
+esencial no solo para decidir sobre dominio y arquitectura, sino también para
+**gobernar el propio proceso de automatización**.
+
+No alcanza con tener:
+
+- specs rigurosas,
+- skill definido,
+- quality gates,
+- tracking automático.
+
+También hace falta criterio humano para preservar las condiciones de validez del
+método. En este caso, la condición era la secuencialidad del pipeline.
+
+---
+
+## Regla operativa derivada
+
+Para futuras US del experimento:
+
+1. Las operaciones del tracker y del pipeline de fases se ejecutan siempre en serie.
+2. Solo las lecturas auxiliares pueden paralelizarse.
+3. Si el tracker queda inconsistente, se registra como incidente metodológico,
+   no como simple bug técnico.
+4. La pregunta correcta no es "¿cómo hacemos el tracker concurrente?" sino
+   "¿cómo evitamos violar la secuencialidad prescripta?".
+
+---
+
+*Registrado: 2026-04-02 — durante la ejecución de US-3.5.1 en SP3*

--- a/docs/contexto/INDICE-HITOS.md
+++ b/docs/contexto/INDICE-HITOS.md
@@ -23,6 +23,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | HITO-11 | SP2 pre-Inc 2.1 | 2026-03-26 | Quality gate como catalizador de decisión arquitectónica | ¿Una métrica automatizada puede derivar en una decisión de diseño no anticipada? | [HITO-11](./HITO-11-QUALITY-GATE-COMO-CATALIZADOR-COLABORATIVO.md) |
 | HITO-12 | SP2 Inc 2.2 | 2026-03-26 | Gates de texto vs constraints de herramienta | ¿Las instrucciones procedurales en lenguaje natural son barreras reales para LLMs? | [HITO-12](./HITO-12-GATES-TEXTO-VS-HERRAMIENTA.md) |
 | HITO-13 | SP2 cierre | 2026-03-28 | SP-ADJ como etapa formal del ciclo IEDD | ¿La deuda técnica post-SP merece un sub-sprint formal propio en lugar de backlog? | [HITO-13](./HITO-13-SP-ADJ-DEUDA-TECNICA-COMO-ETAPA-FORMAL.md) |
+| HITO-16 | SP3 Inc 3.5 | 2026-04-02 | Secuencialidad prescriptiva del pipeline | ¿La linealidad de `/implement-us` es una preferencia operativa o parte del método? | [HITO-16](./HITO-16-SECUENCIALIDAD-PRESCRIPTIVA-PIPELINE.md) |
 
 ---
 
@@ -33,6 +34,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | Fase 0 / Pre-SP1 | 1, 2 | Validación metodológica inicial, consistencia del stack |
 | SP1 (La Performance) | 3, 4, 5, 6, 7, 8, 9 | Primer ciclo IEDD completo, fricción del ecosistema, BDD + ES |
 | SP2 (La Competencia) | 10, 11, 12, 13 | Patrones DDD avanzados, quality gates, deuda técnica formal |
+| SP3 (El Torneo) | 15, 16 | Proyecciones CQRS emergentes, secuencialidad del pipeline y gobierno del proceso |
 
 ---
 
@@ -45,6 +47,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | RQ2: IEDD mejora especificaciones | HITO-1, HITO-4, HITO-6 | 🔄 En evaluación |
 | SP-ADJ como etapa necesaria | HITO-13 | ✅ Confirmada |
 | Gates de texto no son barreras para LLMs | HITO-12 | ✅ Confirmada |
+| La secuencialidad del pipeline es parte del método | HITO-16 | ✅ Confirmada |
 
 ---
 

--- a/docs/plans/sp3/US-3.5.1-plan.md
+++ b/docs/plans/sp3/US-3.5.1-plan.md
@@ -1,0 +1,83 @@
+# Plan de Implementación — US-3.5.1
+
+## Resumen
+
+Implementar `RankingOverall` en el BC `resultados` reutilizando el patrón de
+`RankingCompetencia`, pero con agregación por torneo y fórmula posicional
+multi-disciplina.
+
+## Objetivo observable
+
+Dejar disponible un aggregate y un command handler capaces de calcular y
+persistir el ranking overall de un torneo a partir de rankings por disciplina.
+
+## Alcance
+
+- `resultados/domain/value_objects/entrada_overall.py`
+- `resultados/domain/aggregates/ranking_overall.py`
+- `resultados/domain/events/ranking_overall_calculado.py`
+- `resultados/application/commands/calcular_overall.py`
+- tests unitarios de dominio y aplicación
+- test de integración del cálculo overall
+- feature BDD + step definitions
+
+No incluye todavía:
+
+- política P-09 (`US-3.5.2`)
+- endpoint REST overall (`US-3.5.3`)
+
+## Decisiones de diseño
+
+1. `RankingOverall` vive en `resultados/domain/aggregates/` y usa Event Sourcing.
+2. El stream canónico será `ranking-overall-{torneo_id}`.
+3. El handler leerá rankings ya calculados por disciplina desde el Event Store de
+   `resultados`, no reconstruirá el overall desde performances crudas de
+   `competencia`.
+4. La ausencia en una disciplina ejecutada se penaliza con `peor_posicion + 1`.
+5. Una disciplina sin ranking calculado aún se excluye completamente del cálculo.
+
+## Implementación por capa
+
+### Dominio
+
+- Crear `EntradaOverall` con:
+  - `posicion`
+  - `atleta_id`
+  - `puntaje`
+  - `detalle`
+  - `en_podio`
+- Crear `RankingOverallCalculado` con payload serializable.
+- Implementar `RankingOverall` con:
+  - estado interno de entradas calculadas
+  - `calcular(torneo_id, rankings_por_disciplina, penalizacion_ausente=None)`
+  - reconstitución desde eventos
+
+### Aplicación
+
+- Crear `CalcularOverallCommand`.
+- Crear `CalcularOverallHandler` con dependencia solo a `ranking_store`.
+- El handler debe:
+  - cargar eventos existentes del stream overall
+  - leer los rankings por disciplina desde streams `ranking-{competencia_id}-{disciplina}`
+    ya almacenados en `resultados`
+  - agrupar por `torneo_id` y disciplina según input de la US
+  - delegar el cálculo al aggregate
+  - persistir `RankingOverallCalculado`
+
+## Riesgos a resolver
+
+1. La spec menciona `competencia_store`, pero para esta US el insumo correcto son
+   rankings de disciplina ya calculados. Se implementará sobre `ranking_store`
+   para mantener la frontera del BC limpia.
+2. El overall necesita mapear `torneo_id + disciplina` a competencia/ranking
+   existente. Si el stream actual no alcanza, el test de integración debe
+   explicitar el contrato mínimo esperado para `US-3.5.2`.
+
+## Artefactos esperados al cierre
+
+- código en `src/resultados/`
+- `tests/unit/resultados/domain/test_ranking_overall.py`
+- `tests/unit/resultados/application/test_calcular_overall_handler.py`
+- `tests/integration/resultados/test_calcular_overall_integration.py`
+- `tests/features/steps/calcular_overall_steps.py`
+- `docs/reports/US-3.5.1-report.md`

--- a/docs/reports/US-3.5.1-report.md
+++ b/docs/reports/US-3.5.1-report.md
@@ -1,0 +1,127 @@
+# Reporte de Implementación — US-3.5.1
+## RankingOverall — fórmula posicional
+
+**Fecha:** 2026-04-02
+**Branch:** `feature/US-3.5.1-overall-posicional`
+**Sprint:** SP3 — El Torneo
+**Incremento:** INC-3.5
+
+---
+
+## Resumen
+
+Implementación del aggregate `RankingOverall` en el BC `resultados` para calcular
+el overall de un torneo a partir de rankings por disciplina, usando fórmula
+posicional: menor puntaje total = mejor posición.
+
+La US deja listo el núcleo de dominio y aplicación para que `US-3.5.2` dispare
+el cálculo automáticamente y `US-3.5.3` lo exponga por API.
+
+---
+
+## Artefactos Producidos
+
+| Artefacto | Tipo | Descripción |
+|-----------|------|-------------|
+| `src/resultados/domain/value_objects/entrada_overall.py` | VO nuevo | Línea del overall con posición, puntaje y detalle por disciplina |
+| `src/resultados/domain/events/ranking_overall_calculado.py` | Evento nuevo | Persistencia del overall calculado |
+| `src/resultados/domain/aggregates/ranking_overall.py` | Aggregate nuevo | Cálculo posicional multi-disciplina + reconstitución ES |
+| `src/resultados/application/commands/calcular_overall.py` | Command + Handler | Orquesta lectura de competencias/rankings y persistencia del overall |
+| `tests/unit/resultados/domain/test_ranking_overall.py` | Unit | Reglas de suma, empates, podio, ausencia y reconstitución |
+| `tests/unit/resultados/application/test_calcular_overall_handler.py` | Unit | Persistencia del evento y caso sin rankings fuente |
+| `tests/integration/resultados/test_calcular_overall_integration.py` | Integración | Event stores reales de Competencia + Resultados |
+| `tests/features/US-3.5.1-ranking-overall.feature` | BDD | 5 escenarios Gherkin |
+| `tests/features/steps/calcular_overall_steps.py` | Steps BDD | Siembra de competencias/rankings y validación overall |
+| `docs/plans/sp3/US-3.5.1-plan.md` | Plan | Plan técnico de la US |
+| `quality/reports/codeguard/US-3.5.1-quality.txt` | Quality gate | Salida de CodeGuard sobre `src/resultados` |
+
+---
+
+## Decisiones Técnicas
+
+### Fuente de datos del overall
+
+El overall no se calcula desde performances crudas, sino desde rankings de
+disciplina ya calculados en el BC `resultados`. El handler usa:
+
+- `competencia_store` para mapear `torneo_id -> competencia/disciplina`
+- `ranking_store` para leer los streams `ranking-{competencia_id}-{disciplina}`
+
+Esto deja a `US-3.5.2` la responsabilidad de decidir cuándo disparar el cálculo.
+
+### Penalización por ausencia
+
+La ausencia en una disciplina ejecutada se resuelve con `peor_posicion + 1`.
+Si una disciplina todavía no tiene ranking calculado, se excluye completamente
+del overall en esta US.
+
+### Empates y podio
+
+- empate en puntaje total -> misma posición
+- la posición siguiente se omite
+- `en_podio = True` si `posicion <= 3`
+
+---
+
+## Tests
+
+| Suite | Tests | Resultado |
+|-------|-------|-----------|
+| Unitarios dominio + aplicación | 7 | ✅ 7/7 |
+| Integración | 1 | ✅ 1/1 |
+| BDD | 5 | ✅ 5/5 |
+| **Total nuevo** | **13** | ✅ **13/13** |
+
+**Regresiones observadas en la suite focalizada:** 0
+
+Comando validado:
+
+```bash
+./.venv/bin/pytest \
+  tests/unit/resultados/domain/test_ranking_overall.py \
+  tests/unit/resultados/application/test_calcular_overall_handler.py \
+  tests/integration/resultados/test_calcular_overall_integration.py \
+  tests/features/steps/calcular_overall_steps.py
+```
+
+---
+
+## Quality Gates
+
+| Gate | Resultado |
+|------|-----------|
+| Black | ✅ Formateado |
+| Pytest focalizado | ✅ 13/13 |
+| CodeGuard sobre `src/resultados` | ✅ sin errores críticos para esta US |
+
+**Artefacto:** `quality/reports/codeguard/US-3.5.1-quality.txt`
+
+Observación: durante la sesión hubo inestabilidad del CLI de tracking y del modo
+de invocación más fino de CodeGuard; el barrido útil que se preserva es el
+ejecutado sobre `src/resultados`.
+
+---
+
+## Invariantes Cubiertos
+
+| ID | Descripción | Estado |
+|----|-------------|--------|
+| INV-OV-01 | Ausente en disciplina ejecutada -> peor posición + 1 | ✅ |
+| INV-OV-02 | Empates en puntaje -> misma posición | ✅ |
+| INV-OV-03 | Solo atletas presentes en al menos una disciplina | ✅ |
+| INV-OV-04 | `en_podio` si `posicion <= 3` | ✅ |
+| INV-OV-05 | Sin rankings calculados -> overall vacío | ✅ |
+
+---
+
+## Pendiente para la siguiente US
+
+- `US-3.5.2`: política P-09 en `src/app.py` para disparar `CalcularOverall`
+- `US-3.5.3`: endpoint `GET /resultados/{torneo_id}/overall`
+
+---
+
+## Nota Operativa
+
+El CLI de tracking dejó el tracker en estado inconsistente durante la ejecución.
+Debe corregirse al cierre para que `US-3.5.1` no quede como tracking activo.

--- a/quality/reports/codeguard/US-3.5.1-quality.txt
+++ b/quality/reports/codeguard/US-3.5.1-quality.txt
@@ -1,0 +1,221 @@
+CodeGuard v0.2.0 (Arquitectura Modular)
+Analizando: /Users/victor/PycharmProjects/ataraxiadive/src/resultados
+Archivos Python encontrados: 26
+Tipo de análisis: pre-commit
+
+Checks disponibles: 6
+---
+╭──────────────────────────────────────────────────────────────────────────────╮
+│  🛡️  CodeGuard - Control de Calidad Automatizado                             │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+Archivos analizados:  26    
+Checks ejecutados:    6     
+Tiempo de ejecución:  67.56s
+Resultados totales:   78    
+
+────────────────────────── 📦  aggregates  (9 issues) ──────────────────────────
+
+                                Informativos (9)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/domain/aggrega… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/aggrega… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/aggrega… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/domain/aggrega… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/aggrega… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/aggrega… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+│ Security   │ src/resultados/domain/aggrega… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/aggrega… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/aggrega… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+───────────────────────────── 📦  api  (6 issues) ──────────────────────────────
+
+                                Informativos (6)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/api/__init__.py │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/api/__init__.py │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/api/__init__.py │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/api/router.py   │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/api/router.py   │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/api/router.py   │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+───────────────────────── 📦  application  (3 issues) ──────────────────────────
+
+                                Informativos (3)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/application/__… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/application/__… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/application/__… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+─────────────────────────── 📦  commands  (9 issues) ───────────────────────────
+
+                                Informativos (9)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/application/co… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/application/co… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/application/co… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+│ Security   │ src/resultados/application/co… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/application/co… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/application/co… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/application/co… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/application/co… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/application/co… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+──────────────────────────── 📦  domain  (6 issues) ────────────────────────────
+
+                                Informativos (6)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/domain/__init_… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/__init_… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/__init_… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/domain/excepti… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/excepti… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/excepti… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+──────────────────────────── 📦  events  (9 issues) ────────────────────────────
+
+                                Informativos (9)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/domain/events/… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/events/… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/events/… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/domain/events/… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/events/… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/events/… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+│ Security   │ src/resultados/domain/events/… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/events/… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/events/… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+──────────────────────── 📦  infrastructure  (3 issues) ────────────────────────
+
+                                Informativos (3)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/infrastructure… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/infrastructure… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/infrastructure… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+──────────────────────────── 📦  ports  (6 issues) ─────────────────────────────
+
+                                Informativos (6)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/domain/ports/_… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/ports/_… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/ports/_… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/domain/ports/r… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/ports/r… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/ports/r… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+─────────────────────────── 📦  queries  (6 issues) ────────────────────────────
+
+                                Informativos (6)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/application/qu… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/application/qu… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/application/qu… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/application/qu… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/application/qu… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/application/qu… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+───────────────────────── 📦  repositories  (9 issues) ─────────────────────────
+
+                                Informativos (9)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/infrastructure… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/infrastructure… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/infrastructure… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+│ Security   │ src/resultados/infrastructure… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/infrastructure… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/infrastructure… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/infrastructure… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/infrastructure… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/infrastructure… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+────────────────────────── 📦  resultados  (3 issues) ──────────────────────────
+
+                              Informativos (3)                               
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                  ┃ Mensaje                         ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/__init__.py │ ✓ No security issues detected   │
+│ PEP8       │ src/resultados/__init__.py │ ✓ PEP8 compliant                │
+│ Complexity │ src/resultados/__init__.py │ ✓ No complex functions detected │
+└────────────┴────────────────────────────┴─────────────────────────────────┘
+
+──────────────────────── 📦  value_objects  (9 issues) ─────────────────────────
+
+                                Informativos (9)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/resultados/domain/value_o… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/value_o… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/value_o… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+│ Security   │ src/resultados/domain/value_o… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/value_o… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/value_o… │ ✓ No complex functions         │
+│            │                                │ detected                       │
+│ Security   │ src/resultados/domain/value_o… │ ✓ No security issues detected  │
+│ PEP8       │ src/resultados/domain/value_o… │ ✓ PEP8 compliant               │
+│ Complexity │ src/resultados/domain/value_o… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+╭─────────────────────────────── Resumen Final ────────────────────────────────╮
+│  Resumen:                                                                    │
+│            0 errores                                                         │
+│            0 advertencias                                                    │
+│            78 informativos                                                   │
+╰──────────────────────────────────────────────────────────────────────────────╯

--- a/src/resultados/application/commands/calcular_overall.py
+++ b/src/resultados/application/commands/calcular_overall.py
@@ -1,0 +1,92 @@
+"""Command y Handler para CalcularOverall — US-3.5.1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from resultados.domain.aggregates.ranking_overall import RankingOverall
+from resultados.domain.aggregates.ranking_competencia import RankingCompetencia
+from shared.domain.ports.event_store_port import EventStorePort
+from shared.domain.value_objects.disciplina import Disciplina
+
+
+@dataclass(frozen=True)
+class CalcularOverallCommand:
+    """Comando para calcular el ranking overall de un torneo."""
+
+    torneo_id: UUID
+    disciplinas: list[Disciplina]
+
+
+class CalcularOverallHandler:
+    """Handler del comando CalcularOverall.
+
+    Usa el Event Store de Competencia para mapear torneo -> competencia/disciplina
+    y el Event Store de Resultados para leer los rankings ya calculados por disciplina.
+    """
+
+    def __init__(
+        self,
+        ranking_store: EventStorePort,
+        competencia_store: EventStorePort,
+    ) -> None:
+        self._ranking_store = ranking_store
+        self._competencia_store = competencia_store
+
+    async def handle(self, command: CalcularOverallCommand) -> list:
+        """Calcula y persiste el overall del torneo."""
+        competencias = await _mapear_competencias_por_torneo(
+            self._competencia_store, command.torneo_id, command.disciplinas
+        )
+        rankings_por_disciplina = {}
+        for disciplina, competencia_id in competencias.items():
+            stream_id = f"ranking-{competencia_id}-{disciplina.value}"
+            events = await self._ranking_store.load(stream_id)
+            ranking = RankingCompetencia.reconstitute(competencia_id, disciplina, events)
+            if ranking.entries:
+                rankings_por_disciplina[disciplina] = ranking.entries
+
+        overall_stream = _build_stream_id(command.torneo_id)
+        existing = await self._ranking_store.load(overall_stream)
+        ranking_overall = RankingOverall.reconstitute(command.torneo_id, existing)
+        entries = ranking_overall.calcular(command.torneo_id, rankings_por_disciplina)
+
+        for event in ranking_overall.pull_events():
+            await self._ranking_store.append(
+                stream_id=overall_stream,
+                event_type=event.event_type,
+                payload=event.to_payload(),
+            )
+        return entries
+
+
+async def _mapear_competencias_por_torneo(
+    competencia_store: EventStorePort,
+    torneo_id: UUID,
+    disciplinas: list[Disciplina],
+) -> dict[Disciplina, UUID]:
+    """Obtiene la competencia por disciplina para un torneo dado."""
+    streams = await competencia_store.load_all_streams_with_prefix("competencia-")
+    disciplinas_buscadas = set(disciplinas)
+    mapeo: dict[Disciplina, UUID] = {}
+
+    for events in streams:
+        for event in events:
+            if event["event_type"] != "IntervaloOTConfigurado":
+                continue
+            payload = event["payload"]
+            torneo_raw = payload.get("torneo_id")
+            if torneo_raw != str(torneo_id):
+                continue
+            disciplina = Disciplina(payload["disciplina"])
+            if disciplina not in disciplinas_buscadas:
+                continue
+            mapeo[disciplina] = UUID(payload["competencia_id"])
+            break
+    return mapeo
+
+
+def _build_stream_id(torneo_id: UUID) -> str:
+    """Construye el stream ID canónico para RankingOverall."""
+    return f"ranking-overall-{torneo_id}"

--- a/src/resultados/domain/aggregates/__init__.py
+++ b/src/resultados/domain/aggregates/__init__.py
@@ -1,0 +1,6 @@
+"""Aggregates del BC Resultados."""
+
+from resultados.domain.aggregates.ranking_competencia import RankingCompetencia
+from resultados.domain.aggregates.ranking_overall import RankingOverall
+
+__all__ = ["RankingCompetencia", "RankingOverall"]

--- a/src/resultados/domain/aggregates/ranking_overall.py
+++ b/src/resultados/domain/aggregates/ranking_overall.py
@@ -1,0 +1,183 @@
+"""Aggregate RankingOverall — cálculo posicional multi-disciplina por torneo."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+from resultados.domain.events.ranking_overall_calculado import RankingOverallCalculado
+from resultados.domain.value_objects.entrada_overall import EntradaOverall
+from resultados.domain.value_objects.entrada_ranking import EntradaRanking
+from shared.domain.base.aggregate_root import AggregateRoot
+from shared.domain.value_objects.disciplina import Disciplina
+
+
+class RankingOverall(AggregateRoot):
+    """Aggregate raíz del ranking general por torneo.
+
+    Stream ID: "ranking-overall-{torneo_id}"
+    """
+
+    def __init__(self, torneo_id: UUID) -> None:
+        super().__init__()
+        self._torneo_id = torneo_id
+        self._entries: list[EntradaOverall] = []
+        self._calculado = False
+
+    @property
+    def torneo_id(self) -> UUID:
+        """Identificador del torneo."""
+        return self._torneo_id
+
+    @property
+    def entries(self) -> list[EntradaOverall]:
+        """Entradas calculadas del overall."""
+        return list(self._entries)
+
+    @property
+    def calculado(self) -> bool:
+        """True si el overall ya fue calculado."""
+        return self._calculado
+
+    def calcular(
+        self,
+        torneo_id: UUID,
+        rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
+        penalizacion_ausente: int | None = None,
+    ) -> list[EntradaOverall]:
+        """Calcula y registra el ranking overall."""
+        entries = _calcular_entries(rankings_por_disciplina, penalizacion_ausente)
+        if not entries:
+            self._entries = []
+            self._calculado = False
+            return []
+
+        event = RankingOverallCalculado(
+            event_type="RankingOverallCalculado",
+            aggregate_id=str(torneo_id),
+            occurred_at=RankingOverallCalculado.now(),
+            torneo_id=str(torneo_id),
+            disciplinas=tuple(disciplina.value for disciplina in rankings_por_disciplina),
+            total=len(entries),
+            entries=tuple(_entrada_a_dict(entry) for entry in entries),
+            calculado_en=RankingOverallCalculado.now().isoformat(),
+        )
+        self._entries = entries
+        self._calculado = True
+        self._record(event)
+        return list(entries)
+
+    @classmethod
+    def reconstitute(cls, torneo_id: UUID, events: list[dict[str, Any]]) -> "RankingOverall":
+        """Reconstruye el aggregate desde el Event Store."""
+        ranking = cls(torneo_id)
+        for event in events:
+            ranking._apply_stored(event)
+        return ranking
+
+    def _apply_stored(self, event: dict[str, Any]) -> None:
+        payload = self._parse_payload(event["payload"])
+        if event["event_type"] == "RankingOverallCalculado":
+            self._entries = [_dict_a_entrada(entry) for entry in payload["entries"]]
+            self._calculado = True
+
+    @staticmethod
+    def _parse_payload(payload: Any) -> dict[str, Any]:
+        if isinstance(payload, str):
+            return json.loads(payload)  # type: ignore[no-any-return]
+        return payload  # type: ignore[return-value]
+
+
+def _calcular_entries(
+    rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
+    penalizacion_ausente: int | None,
+) -> list[EntradaOverall]:
+    """Aplica la fórmula posicional overall."""
+    rankings_validos = _filtrar_rankings_validos(rankings_por_disciplina)
+    if not rankings_validos:
+        return []
+
+    acumulado = _acumular_puntajes(rankings_validos, penalizacion_ausente)
+    puntuados = _ordenar_puntuados(acumulado)
+
+    entries: list[EntradaOverall] = []
+    posicion_actual = 1
+    for index, (atleta_id, detalle, puntaje) in enumerate(puntuados):
+        if index > 0 and puntaje == puntuados[index - 1][2]:
+            posicion = entries[-1].posicion
+        else:
+            posicion = posicion_actual
+
+        entries.append(
+            EntradaOverall(
+                posicion=posicion,
+                atleta_id=atleta_id,
+                puntaje=puntaje,
+                detalle=detalle,
+                en_podio=posicion <= 3,
+            )
+        )
+        posicion_actual = len(entries) + 1
+
+    return entries
+
+
+def _filtrar_rankings_validos(
+    rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
+) -> dict[Disciplina, list[EntradaRanking]]:
+    return {
+        disciplina: entries for disciplina, entries in rankings_por_disciplina.items() if entries
+    }
+
+
+def _acumular_puntajes(
+    rankings_validos: dict[Disciplina, list[EntradaRanking]],
+    penalizacion_ausente: int | None,
+) -> dict[UUID, dict[str, int]]:
+    atletas = {entry.atleta_id for entries in rankings_validos.values() for entry in entries}
+    acumulado: dict[UUID, dict[str, int]] = {atleta_id: {} for atleta_id in atletas}
+
+    for disciplina, entries in rankings_validos.items():
+        posiciones = {entry.atleta_id: entry.posicion for entry in entries}
+        peor_posicion = _calcular_penalizacion(entries, penalizacion_ausente)
+        for atleta_id in atletas:
+            acumulado[atleta_id][disciplina.value] = posiciones.get(atleta_id, peor_posicion)
+    return acumulado
+
+
+def _calcular_penalizacion(entries: list[EntradaRanking], penalizacion_ausente: int | None) -> int:
+    if penalizacion_ausente is not None:
+        return penalizacion_ausente
+    return max(entry.posicion for entry in entries) + 1
+
+
+def _ordenar_puntuados(
+    acumulado: dict[UUID, dict[str, int]],
+) -> list[tuple[UUID, dict[str, int], int]]:
+    return sorted(
+        ((atleta_id, detalle, sum(detalle.values())) for atleta_id, detalle in acumulado.items()),
+        key=lambda item: (item[2], str(item[0])),
+    )
+
+
+def _entrada_a_dict(entry: EntradaOverall) -> dict[str, Any]:
+    """Serializa EntradaOverall a payload JSON."""
+    return {
+        "posicion": entry.posicion,
+        "atleta_id": str(entry.atleta_id),
+        "puntaje": entry.puntaje,
+        "detalle": entry.detalle,
+        "en_podio": entry.en_podio,
+    }
+
+
+def _dict_a_entrada(data: dict[str, Any]) -> EntradaOverall:
+    """Deserializa payload a EntradaOverall."""
+    return EntradaOverall(
+        posicion=data["posicion"],
+        atleta_id=UUID(data["atleta_id"]),
+        puntaje=data["puntaje"],
+        detalle=dict(data["detalle"]),
+        en_podio=data["en_podio"],
+    )

--- a/src/resultados/domain/events/__init__.py
+++ b/src/resultados/domain/events/__init__.py
@@ -1,0 +1,6 @@
+"""Eventos de dominio del BC Resultados."""
+
+from resultados.domain.events.ranking_overall_calculado import RankingOverallCalculado
+from resultados.domain.events.resultados_calculados import ResultadosCalculados
+
+__all__ = ["RankingOverallCalculado", "ResultadosCalculados"]

--- a/src/resultados/domain/events/ranking_overall_calculado.py
+++ b/src/resultados/domain/events/ranking_overall_calculado.py
@@ -1,0 +1,45 @@
+"""Domain Event RankingOverallCalculado — ranking general del torneo disponible."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from shared.domain.base.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class RankingOverallCalculado(DomainEvent):
+    """Evento emitido cuando el overall de un torneo fue calculado."""
+
+    torneo_id: str
+    disciplinas: tuple[str, ...]
+    total: int
+    entries: tuple[dict[str, Any], ...]
+    calculado_en: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serializa el evento para el Event Store."""
+        return {
+            "torneo_id": self.torneo_id,
+            "disciplinas": list(self.disciplinas),
+            "total": self.total,
+            "entries": list(self.entries),
+            "calculado_en": self.calculado_en,
+            "occurred_at": self.occurred_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "RankingOverallCalculado":
+        """Reconstruye el evento desde el payload persistido."""
+        return cls(
+            event_type="RankingOverallCalculado",
+            aggregate_id=payload["torneo_id"],
+            occurred_at=datetime.fromisoformat(payload["occurred_at"]),
+            torneo_id=payload["torneo_id"],
+            disciplinas=tuple(payload["disciplinas"]),
+            total=payload["total"],
+            entries=tuple(payload["entries"]),
+            calculado_en=payload["calculado_en"],
+        )

--- a/src/resultados/domain/value_objects/__init__.py
+++ b/src/resultados/domain/value_objects/__init__.py
@@ -1,0 +1,6 @@
+"""Value Objects del BC Resultados."""
+
+from resultados.domain.value_objects.entrada_overall import EntradaOverall
+from resultados.domain.value_objects.entrada_ranking import EntradaRanking
+
+__all__ = ["EntradaOverall", "EntradaRanking"]

--- a/src/resultados/domain/value_objects/entrada_overall.py
+++ b/src/resultados/domain/value_objects/entrada_overall.py
@@ -1,0 +1,25 @@
+"""Value Object EntradaOverall — una línea del ranking general del torneo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class EntradaOverall:
+    """Una entrada en el ranking overall del torneo.
+
+    Attributes:
+        posicion: Posición overall (1-based). Empates comparten posición.
+        atleta_id: Identificador del atleta.
+        puntaje: Suma de posiciones por disciplina (menor es mejor).
+        detalle: Mapa disciplina -> posición utilizada en la suma.
+        en_podio: True si la posición overall está en el podio.
+    """
+
+    posicion: int
+    atleta_id: UUID
+    puntaje: int
+    detalle: dict[str, int]
+    en_podio: bool

--- a/tests/features/US-3.5.1-ranking-overall.feature
+++ b/tests/features/US-3.5.1-ranking-overall.feature
@@ -1,0 +1,41 @@
+Feature: Ranking Overall por torneo
+  # US-3.5.1 | RF-PM-01 | RF-PM-02
+  # Como organizador, quiero calcular el ranking general de un torneo
+  # a partir de los rankings por disciplina usando formula posicional.
+
+  Scenario: overall con 3 atletas en 2 disciplinas
+    Given rankings del torneo con STA: A=1, B=2, C=3
+    And rankings del torneo con DNF: A=2, B=1, C=3
+    When el sistema calcula el overall del torneo
+    Then A tiene puntaje overall 3 y posicion 1
+    And B tiene puntaje overall 3 y posicion 1
+    And C tiene puntaje overall 6 y posicion 3
+    And A y B tienen en_podio overall igual a True
+
+  Scenario: atleta ausente en una disciplina ejecutada
+    Given rankings del torneo con STA: A=1, B=2
+    And rankings del torneo con DNF: solo B participa con posicion 1
+    When el sistema calcula el overall del torneo
+    Then A recibe penalizacion por ausencia en DNF
+    And A tiene puntaje overall 3 y posicion 1
+    And B tiene puntaje overall 3 y posicion 1
+
+  Scenario: disciplinas sin ranking calculado no participan del overall
+    Given rankings del torneo con STA: A=1, B=2
+    And la disciplina DNF del torneo aun no tiene ranking calculado
+    When el sistema calcula el overall del torneo
+    Then el overall se calcula solo con STA
+    And A tiene puntaje overall 1 y posicion 1
+    And B tiene puntaje overall 2 y posicion 2
+
+  Scenario: torneo sin rankings calculados
+    Given un torneo sin rankings calculados
+    When el sistema calcula el overall del torneo
+    Then el overall del torneo es vacio
+
+  Scenario: empate total conserva la misma posicion
+    Given rankings del torneo con STA: A=1, B=2
+    And rankings del torneo con DNF: A=2, B=1
+    When el sistema calcula el overall del torneo
+    Then A y B tienen la misma posicion overall
+    And no existe entrada overall con posicion 2

--- a/tests/features/steps/calcular_overall_steps.py
+++ b/tests/features/steps/calcular_overall_steps.py
@@ -1,0 +1,360 @@
+"""Step definitions BDD — US-3.5.1: Calcular Overall."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from uuid import UUID, uuid4
+
+import aiosqlite
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from resultados.application.commands.calcular_overall import (
+    CalcularOverallCommand,
+    CalcularOverallHandler,
+)
+from resultados.domain.aggregates.ranking_overall import RankingOverall
+from shared.domain.value_objects.disciplina import Disciplina
+from shared.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+
+scenarios("../US-3.5.1-ranking-overall.feature")
+
+CREATE_EVENTS_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL
+            DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+
+async def _init_db(db_path: str) -> None:
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(CREATE_EVENTS_TABLE)
+        await db.commit()
+
+
+async def _append_competencia(ctx: dict, disciplina: Disciplina) -> UUID:
+    competencia_id = uuid4()
+    await ctx["competencia_store"].append(
+        stream_id=f"competencia-{competencia_id}",
+        event_type="IntervaloOTConfigurado",
+        payload={
+            "competencia_id": str(competencia_id),
+            "disciplina": disciplina.value,
+            "intervalo_minutos": 3,
+            "configurado_por": "organizador",
+            "torneo_id": str(ctx["torneo_id"]),
+            "occurred_at": "2026-04-02T12:00:00+00:00",
+        },
+    )
+    return competencia_id
+
+
+async def _append_ranking(
+    ctx: dict, competencia_id: UUID, disciplina: Disciplina, entries: list[dict]
+) -> None:
+    await ctx["ranking_store"].append(
+        stream_id=f"ranking-{competencia_id}-{disciplina.value}",
+        event_type="ResultadosCalculados",
+        payload={
+            "competencia_id": str(competencia_id),
+            "disciplina": disciplina.value,
+            "total": len(entries),
+            "entries": entries,
+            "calculado_en": "2026-04-02T12:05:00+00:00",
+            "occurred_at": "2026-04-02T12:05:00+00:00",
+        },
+    )
+
+
+@pytest.fixture
+def ctx() -> dict:
+    async def _build() -> dict:
+        competencia_dir = tempfile.mkdtemp()
+        resultados_dir = tempfile.mkdtemp()
+        competencia_db = competencia_dir + "/competencia.db"
+        resultados_db = resultados_dir + "/resultados.db"
+        await _init_db(competencia_db)
+        await _init_db(resultados_db)
+        return {
+            "torneo_id": uuid4(),
+            "competencia_store": SQLiteEventStore(competencia_db),
+            "ranking_store": SQLiteEventStore(resultados_db),
+            "athletes": {"A": uuid4(), "B": uuid4(), "C": uuid4()},
+        }
+
+    return asyncio.run(_build())
+
+
+@given("rankings del torneo con STA: A=1, B=2, C=3")
+def given_sta_abc(ctx: dict) -> None:
+    async def _run() -> None:
+        competencia_id = await _append_competencia(ctx, Disciplina.STA)
+        ctx["competencia_sta"] = competencia_id
+        await _append_ranking(
+            ctx,
+            competencia_id,
+            Disciplina.STA,
+            [
+                {
+                    "posicion": 1,
+                    "atleta_id": str(ctx["athletes"]["A"]),
+                    "rp": "310",
+                    "unidad": "Segundos",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+                {
+                    "posicion": 2,
+                    "atleta_id": str(ctx["athletes"]["B"]),
+                    "rp": "300",
+                    "unidad": "Segundos",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+                {
+                    "posicion": 3,
+                    "atleta_id": str(ctx["athletes"]["C"]),
+                    "rp": "280",
+                    "unidad": "Segundos",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+            ],
+        )
+
+    asyncio.run(_run())
+
+
+@given("rankings del torneo con DNF: A=2, B=1, C=3")
+def given_dnf_abc(ctx: dict) -> None:
+    async def _run() -> None:
+        competencia_id = await _append_competencia(ctx, Disciplina.DNF)
+        ctx["competencia_dnf"] = competencia_id
+        await _append_ranking(
+            ctx,
+            competencia_id,
+            Disciplina.DNF,
+            [
+                {
+                    "posicion": 2,
+                    "atleta_id": str(ctx["athletes"]["A"]),
+                    "rp": "80",
+                    "unidad": "Metros",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+                {
+                    "posicion": 1,
+                    "atleta_id": str(ctx["athletes"]["B"]),
+                    "rp": "90",
+                    "unidad": "Metros",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+                {
+                    "posicion": 3,
+                    "atleta_id": str(ctx["athletes"]["C"]),
+                    "rp": "70",
+                    "unidad": "Metros",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+            ],
+        )
+
+    asyncio.run(_run())
+
+
+@given("rankings del torneo con STA: A=1, B=2")
+def given_sta_ab(ctx: dict) -> None:
+    async def _run() -> None:
+        competencia_id = await _append_competencia(ctx, Disciplina.STA)
+        ctx["competencia_sta"] = competencia_id
+        await _append_ranking(
+            ctx,
+            competencia_id,
+            Disciplina.STA,
+            [
+                {
+                    "posicion": 1,
+                    "atleta_id": str(ctx["athletes"]["A"]),
+                    "rp": "310",
+                    "unidad": "Segundos",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+                {
+                    "posicion": 2,
+                    "atleta_id": str(ctx["athletes"]["B"]),
+                    "rp": "300",
+                    "unidad": "Segundos",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+            ],
+        )
+
+    asyncio.run(_run())
+
+
+@given("rankings del torneo con DNF: solo B participa con posicion 1")
+def given_dnf_only_b(ctx: dict) -> None:
+    async def _run() -> None:
+        competencia_id = await _append_competencia(ctx, Disciplina.DNF)
+        ctx["competencia_dnf"] = competencia_id
+        await _append_ranking(
+            ctx,
+            competencia_id,
+            Disciplina.DNF,
+            [
+                {
+                    "posicion": 1,
+                    "atleta_id": str(ctx["athletes"]["B"]),
+                    "rp": "90",
+                    "unidad": "Metros",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+            ],
+        )
+
+    asyncio.run(_run())
+
+
+@given("la disciplina DNF del torneo aun no tiene ranking calculado")
+def given_dnf_sin_ranking(ctx: dict) -> None:
+    async def _run() -> None:
+        ctx["competencia_dnf"] = await _append_competencia(ctx, Disciplina.DNF)
+
+    asyncio.run(_run())
+
+
+@given("un torneo sin rankings calculados")
+def given_torneo_sin_rankings(ctx: dict) -> None:
+    async def _run() -> None:
+        await _append_competencia(ctx, Disciplina.STA)
+
+    asyncio.run(_run())
+
+
+@given("rankings del torneo con DNF: A=2, B=1")
+def given_dnf_ab(ctx: dict) -> None:
+    async def _run() -> None:
+        competencia_id = await _append_competencia(ctx, Disciplina.DNF)
+        ctx["competencia_dnf"] = competencia_id
+        await _append_ranking(
+            ctx,
+            competencia_id,
+            Disciplina.DNF,
+            [
+                {
+                    "posicion": 2,
+                    "atleta_id": str(ctx["athletes"]["A"]),
+                    "rp": "80",
+                    "unidad": "Metros",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+                {
+                    "posicion": 1,
+                    "atleta_id": str(ctx["athletes"]["B"]),
+                    "rp": "90",
+                    "unidad": "Metros",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                },
+            ],
+        )
+
+    asyncio.run(_run())
+
+
+@when("el sistema calcula el overall del torneo")
+def when_calcula_overall(ctx: dict) -> None:
+    async def _run() -> None:
+        handler = CalcularOverallHandler(ctx["ranking_store"], ctx["competencia_store"])
+        await handler.handle(
+            CalcularOverallCommand(
+                torneo_id=ctx["torneo_id"],
+                disciplinas=[Disciplina.STA, Disciplina.DNF],
+            )
+        )
+        events = await ctx["ranking_store"].load(f"ranking-overall-{ctx['torneo_id']}")
+        ctx["overall"] = RankingOverall.reconstitute(ctx["torneo_id"], events)
+
+    asyncio.run(_run())
+
+
+@then(parsers.parse("{atleta} tiene puntaje overall {puntaje:d} y posicion {posicion:d}"))
+def then_puntaje_posicion(ctx: dict, atleta: str, puntaje: int, posicion: int) -> None:
+    entry = next(
+        entry for entry in ctx["overall"].entries if entry.atleta_id == ctx["athletes"][atleta]
+    )
+    assert entry.puntaje == puntaje
+    assert entry.posicion == posicion
+
+
+@then("A y B tienen en_podio overall igual a True")
+def then_a_b_podio(ctx: dict) -> None:
+    atleta_a = next(
+        entry for entry in ctx["overall"].entries if entry.atleta_id == ctx["athletes"]["A"]
+    )
+    atleta_b = next(
+        entry for entry in ctx["overall"].entries if entry.atleta_id == ctx["athletes"]["B"]
+    )
+    assert atleta_a.en_podio is True
+    assert atleta_b.en_podio is True
+
+
+@then("A recibe penalizacion por ausencia en DNF")
+def then_a_penalizado(ctx: dict) -> None:
+    atleta_a = next(
+        entry for entry in ctx["overall"].entries if entry.atleta_id == ctx["athletes"]["A"]
+    )
+    assert atleta_a.detalle["DNF"] == 2
+
+
+@then("el overall se calcula solo con STA")
+def then_solo_sta(ctx: dict) -> None:
+    for entry in ctx["overall"].entries:
+        assert list(entry.detalle) == ["STA"]
+
+
+@then("el overall del torneo es vacio")
+def then_vacio(ctx: dict) -> None:
+    assert ctx["overall"].entries == []
+
+
+@then("A y B tienen la misma posicion overall")
+def then_empate_posicion(ctx: dict) -> None:
+    atleta_a = next(
+        entry for entry in ctx["overall"].entries if entry.atleta_id == ctx["athletes"]["A"]
+    )
+    atleta_b = next(
+        entry for entry in ctx["overall"].entries if entry.atleta_id == ctx["athletes"]["B"]
+    )
+    assert atleta_a.posicion == atleta_b.posicion
+
+
+@then("no existe entrada overall con posicion 2")
+def then_no_posicion_2(ctx: dict) -> None:
+    assert all(entry.posicion != 2 for entry in ctx["overall"].entries)

--- a/tests/integration/resultados/test_calcular_overall_integration.py
+++ b/tests/integration/resultados/test_calcular_overall_integration.py
@@ -1,0 +1,177 @@
+"""Tests de integración del cálculo overall — US-3.5.1."""
+
+from __future__ import annotations
+
+import tempfile
+from uuid import uuid4
+
+import aiosqlite
+import pytest
+
+from resultados.application.commands.calcular_overall import (
+    CalcularOverallCommand,
+    CalcularOverallHandler,
+)
+from resultados.domain.aggregates.ranking_overall import RankingOverall
+from shared.domain.value_objects.disciplina import Disciplina
+from shared.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+
+CREATE_EVENTS_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL
+            DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+
+async def _init_db(db_path: str) -> None:
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(CREATE_EVENTS_TABLE)
+        await db.commit()
+
+
+async def _append_competencia(
+    store: SQLiteEventStore, competencia_id, torneo_id, disciplina: Disciplina
+) -> None:
+    await store.append(
+        stream_id=f"competencia-{competencia_id}",
+        event_type="IntervaloOTConfigurado",
+        payload={
+            "competencia_id": str(competencia_id),
+            "disciplina": disciplina.value,
+            "intervalo_minutos": 3,
+            "configurado_por": "organizador",
+            "torneo_id": str(torneo_id),
+            "occurred_at": "2026-04-02T12:00:00+00:00",
+        },
+    )
+
+
+async def _append_ranking(
+    store: SQLiteEventStore, competencia_id, disciplina: Disciplina, entries: list[dict]
+) -> None:
+    await store.append(
+        stream_id=f"ranking-{competencia_id}-{disciplina.value}",
+        event_type="ResultadosCalculados",
+        payload={
+            "competencia_id": str(competencia_id),
+            "disciplina": disciplina.value,
+            "total": len(entries),
+            "entries": entries,
+            "calculado_en": "2026-04-02T12:05:00+00:00",
+            "occurred_at": "2026-04-02T12:05:00+00:00",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_calcular_overall_persiste_y_reconstituye() -> None:
+    competencia_dir = tempfile.mkdtemp()
+    resultados_dir = tempfile.mkdtemp()
+    competencia_db = competencia_dir + "/competencia.db"
+    resultados_db = resultados_dir + "/resultados.db"
+    await _init_db(competencia_db)
+    await _init_db(resultados_db)
+
+    competencia_store = SQLiteEventStore(competencia_db)
+    ranking_store = SQLiteEventStore(resultados_db)
+
+    torneo_id = uuid4()
+    competencia_sta = uuid4()
+    competencia_dnf = uuid4()
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    atleta_c = uuid4()
+
+    await _append_competencia(competencia_store, competencia_sta, torneo_id, Disciplina.STA)
+    await _append_competencia(competencia_store, competencia_dnf, torneo_id, Disciplina.DNF)
+    await _append_ranking(
+        ranking_store,
+        competencia_sta,
+        Disciplina.STA,
+        [
+            {
+                "posicion": 1,
+                "atleta_id": str(atleta_a),
+                "rp": "310",
+                "unidad": "Segundos",
+                "tarjeta": "Blanca",
+                "es_dns": False,
+                "en_podio": True,
+            },
+            {
+                "posicion": 2,
+                "atleta_id": str(atleta_b),
+                "rp": "300",
+                "unidad": "Segundos",
+                "tarjeta": "Blanca",
+                "es_dns": False,
+                "en_podio": True,
+            },
+            {
+                "posicion": 3,
+                "atleta_id": str(atleta_c),
+                "rp": "280",
+                "unidad": "Segundos",
+                "tarjeta": "Blanca",
+                "es_dns": False,
+                "en_podio": True,
+            },
+        ],
+    )
+    await _append_ranking(
+        ranking_store,
+        competencia_dnf,
+        Disciplina.DNF,
+        [
+            {
+                "posicion": 2,
+                "atleta_id": str(atleta_a),
+                "rp": "80",
+                "unidad": "Metros",
+                "tarjeta": "Blanca",
+                "es_dns": False,
+                "en_podio": True,
+            },
+            {
+                "posicion": 1,
+                "atleta_id": str(atleta_b),
+                "rp": "90",
+                "unidad": "Metros",
+                "tarjeta": "Blanca",
+                "es_dns": False,
+                "en_podio": True,
+            },
+            {
+                "posicion": 3,
+                "atleta_id": str(atleta_c),
+                "rp": "70",
+                "unidad": "Metros",
+                "tarjeta": "Blanca",
+                "es_dns": False,
+                "en_podio": True,
+            },
+        ],
+    )
+
+    handler = CalcularOverallHandler(ranking_store, competencia_store)
+    await handler.handle(
+        CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA, Disciplina.DNF])
+    )
+
+    events = await ranking_store.load(f"ranking-overall-{torneo_id}")
+    overall = RankingOverall.reconstitute(torneo_id, events)
+
+    assert len(overall.entries) == 3
+    assert overall.entries[0].puntaje == 3
+    assert overall.entries[0].posicion == 1
+    assert overall.entries[1].puntaje == 3
+    assert overall.entries[1].posicion == 1
+    assert overall.entries[2].puntaje == 6
+    assert overall.entries[2].posicion == 3

--- a/tests/unit/resultados/application/test_calcular_overall_handler.py
+++ b/tests/unit/resultados/application/test_calcular_overall_handler.py
@@ -1,0 +1,104 @@
+"""Tests unitarios del CalcularOverallHandler — US-3.5.1."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from resultados.application.commands.calcular_overall import (
+    CalcularOverallCommand,
+    CalcularOverallHandler,
+)
+from shared.domain.value_objects.disciplina import Disciplina
+
+
+def _competencia_event(competencia_id, torneo_id, disciplina: Disciplina) -> dict:
+    return {
+        "event_type": "IntervaloOTConfigurado",
+        "payload": {
+            "competencia_id": str(competencia_id),
+            "disciplina": disciplina.value,
+            "intervalo_minutos": 3,
+            "configurado_por": "organizador",
+            "torneo_id": str(torneo_id),
+            "occurred_at": "2026-04-02T12:00:00+00:00",
+        },
+    }
+
+
+def _ranking_event(competencia_id, disciplina: Disciplina, atleta_id, posicion: int) -> dict:
+    return {
+        "event_type": "ResultadosCalculados",
+        "payload": {
+            "competencia_id": str(competencia_id),
+            "disciplina": disciplina.value,
+            "total": 1,
+            "entries": [
+                {
+                    "posicion": posicion,
+                    "atleta_id": str(atleta_id),
+                    "rp": "300",
+                    "unidad": "Segundos",
+                    "tarjeta": "Blanca",
+                    "es_dns": False,
+                    "en_podio": True,
+                }
+            ],
+            "calculado_en": "2026-04-02T12:00:00+00:00",
+            "occurred_at": "2026-04-02T12:00:00+00:00",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_persiste_ranking_overall_calculado() -> None:
+    torneo_id = uuid4()
+    competencia_sta = uuid4()
+    atleta_id = uuid4()
+
+    ranking_store = AsyncMock()
+    ranking_store.load = AsyncMock(
+        side_effect=[
+            [_ranking_event(competencia_sta, Disciplina.STA, atleta_id, 1)],
+            [],
+        ]
+    )
+    ranking_store.append = AsyncMock()
+
+    competencia_store = AsyncMock()
+    competencia_store.load_all_streams_with_prefix = AsyncMock(
+        return_value=[[_competencia_event(competencia_sta, torneo_id, Disciplina.STA)]]
+    )
+
+    handler = CalcularOverallHandler(ranking_store, competencia_store)
+    await handler.handle(CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA]))
+
+    ranking_store.append.assert_called_once()
+    call = ranking_store.append.call_args.kwargs
+    assert call["stream_id"] == f"ranking-overall-{torneo_id}"
+    assert call["event_type"] == "RankingOverallCalculado"
+
+
+@pytest.mark.asyncio
+async def test_handle_sin_rankings_fuente_no_persiste() -> None:
+    torneo_id = uuid4()
+    competencia_id = uuid4()
+
+    ranking_store = AsyncMock()
+    ranking_store.load = AsyncMock(side_effect=[[], []])
+    ranking_store.append = AsyncMock()
+
+    competencia_store = AsyncMock()
+    competencia_store.load_all_streams_with_prefix = AsyncMock(
+        return_value=[[_competencia_event(competencia_id, torneo_id, Disciplina.STA)]]
+    )
+
+    handler = CalcularOverallHandler(ranking_store, competencia_store)
+    result = await handler.handle(
+        CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA])
+    )
+
+    assert result == []
+    ranking_store.append.assert_not_called()

--- a/tests/unit/resultados/domain/test_ranking_overall.py
+++ b/tests/unit/resultados/domain/test_ranking_overall.py
@@ -1,0 +1,107 @@
+"""Tests unitarios del aggregate RankingOverall — US-3.5.1."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from resultados.domain.aggregates.ranking_overall import RankingOverall
+from resultados.domain.value_objects.entrada_ranking import EntradaRanking
+from shared.domain.value_objects.disciplina import Disciplina
+
+
+def _entry(posicion: int, atleta_id=None) -> EntradaRanking:
+    return EntradaRanking(
+        posicion=posicion,
+        atleta_id=atleta_id or uuid4(),
+        rp=None,
+        unidad=None,
+        tarjeta="Blanca",
+        es_dns=False,
+        en_podio=posicion <= 3,
+    )
+
+
+def test_calcular_overall_suma_posiciones_y_empates() -> None:
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    atleta_c = uuid4()
+    ranking = RankingOverall(uuid4())
+
+    entries = ranking.calcular(
+        ranking.torneo_id,
+        {
+            Disciplina.STA: [_entry(1, atleta_a), _entry(2, atleta_b), _entry(3, atleta_c)],
+            Disciplina.DNF: [_entry(2, atleta_a), _entry(1, atleta_b), _entry(3, atleta_c)],
+        },
+    )
+
+    by_id = {entry.atleta_id: entry for entry in entries}
+    assert by_id[atleta_a].puntaje == 3
+    assert by_id[atleta_a].posicion == 1
+    assert by_id[atleta_b].puntaje == 3
+    assert by_id[atleta_b].posicion == 1
+    assert by_id[atleta_c].puntaje == 6
+    assert by_id[atleta_c].posicion == 3
+
+
+def test_calcular_overall_penaliza_ausente_con_ultimo_mas_uno() -> None:
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    ranking = RankingOverall(uuid4())
+
+    entries = ranking.calcular(
+        ranking.torneo_id,
+        {
+            Disciplina.STA: [_entry(1, atleta_a), _entry(2, atleta_b)],
+            Disciplina.DNF: [_entry(1, atleta_b)],
+        },
+    )
+
+    by_id = {entry.atleta_id: entry for entry in entries}
+    assert by_id[atleta_a].detalle == {"STA": 1, "DNF": 2}
+    assert by_id[atleta_a].puntaje == 3
+    assert by_id[atleta_b].puntaje == 3
+
+
+def test_calcular_overall_excluye_disciplinas_sin_ranking() -> None:
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    ranking = RankingOverall(uuid4())
+
+    entries = ranking.calcular(
+        ranking.torneo_id,
+        {
+            Disciplina.STA: [_entry(1, atleta_a), _entry(2, atleta_b)],
+            Disciplina.DNF: [],
+        },
+    )
+
+    assert len(entries) == 2
+    assert entries[0].puntaje == 1
+    assert entries[1].puntaje == 2
+
+
+def test_calcular_overall_sin_rankings_devuelve_vacio() -> None:
+    ranking = RankingOverall(uuid4())
+    assert ranking.calcular(ranking.torneo_id, {}) == []
+    assert ranking.pull_events() == []
+
+
+def test_reconstitute_recupera_estado_desde_evento() -> None:
+    torneo_id = uuid4()
+    atleta_id = uuid4()
+    ranking = RankingOverall(torneo_id)
+    ranking.calcular(
+        torneo_id,
+        {Disciplina.STA: [_entry(1, atleta_id)]},
+    )
+    event = ranking.pull_events()[0]
+
+    reconstituido = RankingOverall.reconstitute(
+        torneo_id,
+        [{"event_type": event.event_type, "payload": event.to_payload()}],
+    )
+
+    assert len(reconstituido.entries) == 1
+    assert reconstituido.entries[0].atleta_id == atleta_id
+    assert reconstituido.calculado is True


### PR DESCRIPTION
## Resumen
- implementa RankingOverall en BC Resultados con formula posicional
- agrega command handler CalcularOverall y suite de tests (unit, integration, BDD)
- registra HITO-16 sobre la secuencialidad prescriptiva del pipeline

## Validacion
- ./.venv/bin/pytest tests/unit/resultados/domain/test_ranking_overall.py tests/unit/resultados/application/test_calcular_overall_handler.py tests/integration/resultados/test_calcular_overall_integration.py tests/features/steps/calcular_overall_steps.py
- CodeGuard sobre src/resultados guardado en quality/reports/codeguard/US-3.5.1-quality.txt