### PR TITLE
refactor(shared): renombrar DYNB→DBF y SPE2X50→SPE [US-ADJ-4.1]

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -215,7 +215,7 @@ classDiagram
 
 | Tipo | Valores / Descripción |
 |------|-----------------------|
-| `Disciplina` | STA, DNF, DYN, DYNB, SPE2X50, CNF, CWT, FIM, VWT |
+| `Disciplina` | STA, DNF, DYN, DBF, SPE, CNF, CWT, FIM, VWT |
 | `EstadoCompetencia` | Preparacion, Confirmada, EnEjecucion, Finalizada |
 | `EstadoPerformance` | AnunciadaAP, Llamada, Ejecutada, DNS |
 | `TipoTarjeta` | Blanca, Amarilla, Roja |

--- a/docs/dominio/05-requerimientos_funcionales.md
+++ b/docs/dominio/05-requerimientos_funcionales.md
@@ -20,7 +20,7 @@ Este cuestionario tiene como objetivo profundizar y completar la comprensión de
   **ID**     **Pregunta**                                                                                                                                         **Respuesta**
   ---------- ---------------------------------------------------------------------------------------------------------------------------------------------------- -------------------------------------------------------------------
   RF-GT-01   ¿Un torneo puede tener más de una sede o ubicación (por ejemplo, distintas piletas para distintas disciplinas)?                                      No
-  RF-GT-02   ¿Qué disciplinas específicas debe soportar el sistema? (STA, DNF, DYN, DYNB, CNF, CWT, FIM, etc.)                                                    Debe ser configurable, inicialmente: STA, DNF, DBF, DYN, SPE2X50.
+  RF-GT-02   ¿Qué disciplinas específicas debe soportar el sistema? (STA, DNF, DYN, DBF, CNF, CWT, FIM, etc.)                                                    Debe ser configurable, inicialmente: STA, DNF, DBF, DYN, SPE.
   RF-GT-03   ¿Pueden existir múltiples torneos activos simultáneamente en el sistema?                                                                             SI
   RF-GT-04   ¿Qué significa exactamente \'cancelar un torneo\'? ¿Se elimina o cambia a un estado cancelado conservando la información?                            Estado cancelado conservando la información
   RF-GT-05   ¿Existen restricciones para la transición entre fases del torneo? Por ejemplo, ¿se puede volver de Ejecución a Preparación si se detecta un error?   Si
@@ -74,7 +74,7 @@ Este cuestionario tiene como objetivo profundizar y completar la comprensión de
   RF-EJ-05   ¿El cronometraje lo realiza el sistema (cronómetro digital) o el juez ingresa el tiempo manualmente?                                El juez lo toma manualmente,
   RF-EJ-06   ¿Un juez puede corregir un resultado ya registrado para una performance? ¿Hay un período de protesta?                               Si
   RF-EJ-07   ¿Qué información se registra en un back-out? ¿Solo el hecho o también la distancia/tiempo alcanzado?                                Es black-out, la distancia también.
-  RF-EJ-08   ¿Para disciplinas de distancia (DNF, DYN, DYNB), cómo se mide? ¿Metros exactos, con decimales?                                      Si, con decimales
+  RF-EJ-08   ¿Para disciplinas de distancia (DNF, DYN, DBF), cómo se mide? ¿Metros exactos, con decimales?                                      Si, con decimales
   RF-EJ-09   ¿El protocolo de superficie (SP) es evaluado y registrado por el sistema?                                                           No
   RF-EJ-10   ¿Se debe registrar el resultado del protocolo de superficie por separado o solo su efecto (tarjeta blanca/amarilla/roja)?           Solo el resultado
 

--- a/docs/plans/sp-adj-04/US-ADJ-4.1-plan.md
+++ b/docs/plans/sp-adj-04/US-ADJ-4.1-plan.md
@@ -1,0 +1,49 @@
+# Plan de Implementación — US-ADJ-4.1
+## Renombrar disciplinas DYNB→DBF y SPE2X50→SPE
+
+**Branch:** `feature/US-ADJ-4.1-renombrar-disciplinas`
+**Sprint:** SP-ADJ-04
+
+---
+
+## Cambios identificados
+
+### src/ (1 archivo)
+| Archivo | Cambio |
+|---------|--------|
+| `src/shared/domain/value_objects/disciplina.py` | `DYNB = "DYNB"` → `DBF = "DBF"` · `SPE2X50 = "SPE2X50"` → `SPE = "SPE"` · Actualizar docstring |
+
+### tests/ (7 archivos)
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/torneo/domain/test_disciplinas_torneo.py` | `Disciplina.DYNB` → `Disciplina.DBF`, `Disciplina.SPE2X50` → `Disciplina.SPE` |
+| `tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py` | Ídem |
+| `tests/unit/competencia/domain/test_disciplina_descriptor.py` | Ídem |
+| `tests/integration/torneo/test_disciplinas_torneo_api.py` | `"DYNB"` → `"DBF"`, `"SPE2X50"` → `"SPE"` |
+| `tests/features/steps/test_US_3_4_1_steps.py` | Ídem |
+| `tests/features/US-3.4.1-asignar-disciplinas-juez.feature` | Strings de disciplinas |
+| `tests/features/US-2.2.1-disciplina-descriptor.feature` | Strings de disciplinas |
+
+### docs/ (2 archivos — solo los requeridos por la spec)
+| Archivo | Cambio |
+|---------|--------|
+| `docs/design/domain-model.md` | Tabla Disciplina: `DYNB` → `DBF`, `SPE2X50` → `SPE` |
+| `docs/dominio/05-requerimientos_funcionales.md` | RF-GT-02: `"DBF, SPE2X50"` → `"DBF, SPE"` |
+
+---
+
+## Tareas de implementación
+
+1. **[T1]** Editar `disciplina.py` — renombrar enum values y actualizar docstring
+2. **[T2]** Actualizar 7 archivos de tests con `replace_all`
+3. **[T3]** Actualizar 2 archivos de docs
+4. **[T4]** Ejecutar `pytest` — suite completa debe pasar sin errores
+5. **[T5]** Implementar BDD steps para el feature file de esta US
+6. **[T6]** Ejecutar `codeguard` — sin issues nuevos
+
+---
+
+## Notas
+- No hay migración de DB (SQLite en memoria en tests)
+- No hay cambio de comportamiento — solo renombrado de símbolos
+- Los docs históricos (specs, planes, event-storming, ADRs) no se tocan

--- a/docs/reports/US-ADJ-4.1-report.md
+++ b/docs/reports/US-ADJ-4.1-report.md
@@ -1,0 +1,70 @@
+# Reporte de Implementación — US-ADJ-4.1
+## Renombrar disciplinas DYNB→DBF y SPE2X50→SPE
+
+**Sprint:** SP-ADJ-04
+**Branch:** `feature/US-ADJ-4.1-renombrar-disciplinas`
+**Fecha:** 2026-04-03
+
+---
+
+## Resumen
+
+Refactor de lenguaje ubicuo: los acrónimos `DYNB` y `SPE2X50` fueron reemplazados por
+los acrónimos oficiales AIDA `DBF` y `SPE` en todo el codebase.
+
+El error fue detectado al contrastar el modelo con el dataset real "Apnea Indoor Buenos Aires 2025"
+(HITO-17, DISC-02 y DISC-03).
+
+---
+
+## Cambios implementados
+
+### Código
+| Archivo | Cambio |
+|---------|--------|
+| `src/shared/domain/value_objects/disciplina.py` | `DYNB="DYNB"` → `DBF="DBF"`, `SPE2X50="SPE2X50"` → `SPE="SPE"`, docstring actualizado |
+
+### Tests (7 archivos)
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/torneo/domain/test_disciplinas_torneo.py` | `Disciplina.DYNB` → `Disciplina.DBF` (3 ocurrencias) |
+| `tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py` | `Disciplina.DYNB` → `Disciplina.DBF` |
+| `tests/unit/competencia/domain/test_disciplina_descriptor.py` | `Disciplina.DYNB` → `Disciplina.DBF` |
+| `tests/integration/torneo/test_disciplinas_torneo_api.py` | `"DYNB"` → `"DBF"` (2 ocurrencias) |
+| `tests/features/steps/test_US_3_4_1_steps.py` | `Disciplina.DYNB` → `Disciplina.DBF` |
+| `tests/features/US-3.4.1-asignar-disciplinas-juez.feature` | `DYNB` → `DBF` |
+| `tests/features/US-2.2.1-disciplina-descriptor.feature` | `DYNB` → `DBF` |
+
+### BDD nuevo
+| Archivo | Descripción |
+|---------|-------------|
+| `tests/features/US-ADJ-4.1-disciplinas-acronimos-aida.feature` | 4 escenarios: DBF válido, SPE válido, DYNB rechazado, SPE2X50 rechazado |
+| `tests/features/steps/disciplinas_acronimos_steps.py` | Step definitions para los 4 escenarios |
+
+### Documentación
+| Archivo | Cambio |
+|---------|--------|
+| `docs/design/domain-model.md` | Tabla Disciplina: `DYNB, SPE2X50` → `DBF, SPE` |
+| `docs/dominio/05-requerimientos_funcionales.md` | RF-GT-02 y RF-EJ-08 actualizados |
+| `docs/plans/sp-adj-04/US-ADJ-4.1-plan.md` | Plan de implementación creado |
+
+---
+
+## Resultados de calidad
+
+| Gate | Resultado |
+|------|-----------|
+| pytest (suite completa) | ✅ 757 passed, 0 failed |
+| BDD US-ADJ-4.1 | ✅ 4/4 escenarios pasando |
+| CodeGuard | ✅ 0 errores, 0 advertencias |
+| DesignReviewer | ✅ 0 CRITICAL |
+
+---
+
+## Trazabilidad
+
+| Elemento | Referencia |
+|----------|------------|
+| Discrepancias origen | DISC-02 (DYNB≠DBF), DISC-03 (SPE2X50≠SPE) |
+| Análisis | HITO-17 · `.work/analisis-discrepancias-dataset-reales.md` |
+| INV aplicada | INV-D-01: acrónimos deben coincidir con estándar AIDA/CMAS |

--- a/src/shared/domain/value_objects/disciplina.py
+++ b/src/shared/domain/value_objects/disciplina.py
@@ -9,14 +9,14 @@ class Disciplina(StrEnum):
     """Disciplinas de apnea reconocidas por AIDA/CMAS.
 
     Valores de tiempo (segundos): STA
-    Valores de distancia (metros): DNF, DYN, DYNB, SPE2X50, CNF, CWT, FIM, VWT
+    Valores de distancia (metros): DNF, DYN, DBF, SPE, CNF, CWT, FIM, VWT
     """
 
     STA = "STA"  # Static Apnea — tiempo
     DNF = "DNF"  # Dynamic No Fins — distancia
     DYN = "DYN"  # Dynamic With Fins — distancia
-    DYNB = "DYNB"  # Dynamic Bi-Fins — distancia
-    SPE2X50 = "SPE2X50"  # Speed Endurance 2x50m — distancia
+    DBF = "DBF"  # Dynamic Bi-Fins — distancia (acrónimo oficial AIDA)
+    SPE = "SPE"  # Speed Endurance — distancia (acrónimo oficial AIDA)
     CNF = "CNF"  # Constant No Fins — distancia
     CWT = "CWT"  # Constant Weight — distancia
     FIM = "FIM"  # Free Immersion — distancia

--- a/tests/features/US-2.2.1-disciplina-descriptor.feature
+++ b/tests/features/US-2.2.1-disciplina-descriptor.feature
@@ -30,7 +30,7 @@ Feature: DisciplinaDescriptor — VO que encapsula reglas de disciplina
       | disciplina |
       | DNF        |
       | DYN        |
-      | DYNB       |
+      | DBF        |
       | CNF        |
       | CWT        |
       | FIM        |

--- a/tests/features/US-3.4.1-asignar-disciplinas-juez.feature
+++ b/tests/features/US-3.4.1-asignar-disciplinas-juez.feature
@@ -4,7 +4,7 @@ Feature: US-3.4.1 — Torneo: AsignarDisciplinas + AsignarJuez
     Given un torneo creado en estado CREADO
 
   Scenario: asignar disciplinas a torneo
-    When el organizador asigna las disciplinas [STA, DNF, DYNB] al torneo
+    When el organizador asigna las disciplinas [STA, DNF, DBF] al torneo
     Then el torneo tiene 3 disciplinas configuradas sin juez asignado
 
   Scenario: asignar juez a disciplina del torneo

--- a/tests/features/US-ADJ-4.1-disciplinas-acronimos-aida.feature
+++ b/tests/features/US-ADJ-4.1-disciplinas-acronimos-aida.feature
@@ -1,0 +1,22 @@
+Feature: Disciplinas con acrónimos AIDA correctos
+
+  Scenario: DBF es una disciplina de distancia válida
+    Given el sistema conoce las disciplinas AIDA
+    When se consulta la disciplina "DBF"
+    Then el sistema la reconoce como disciplina de distancia
+    And su orden de grilla es ascendente
+
+  Scenario: SPE es una disciplina de distancia válida
+    Given el sistema conoce las disciplinas AIDA
+    When se consulta la disciplina "SPE"
+    Then el sistema la reconoce como disciplina de distancia
+
+  Scenario: Los acrónimos obsoletos no son reconocidos
+    Given el sistema conoce las disciplinas AIDA
+    When se intenta usar "DYNB" como disciplina
+    Then el sistema rechaza el valor como disciplina desconocida
+
+  Scenario: Los acrónimos obsoletos SPE2X50 no son reconocidos
+    Given el sistema conoce las disciplinas AIDA
+    When se intenta usar "SPE2X50" como disciplina
+    Then el sistema rechaza el valor como disciplina desconocida

--- a/tests/features/steps/disciplinas_acronimos_steps.py
+++ b/tests/features/steps/disciplinas_acronimos_steps.py
@@ -1,0 +1,46 @@
+"""Step definitions BDD — US-ADJ-4.1: Disciplinas con acrónimos AIDA correctos."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from shared.domain.value_objects.disciplina import Disciplina
+from shared.domain.value_objects.disciplina_descriptor import DisciplinaDescriptor
+
+scenarios("../US-ADJ-4.1-disciplinas-acronimos-aida.feature")
+
+
+@given("el sistema conoce las disciplinas AIDA", target_fixture="disciplinas")
+def dado_sistema_con_disciplinas() -> set[str]:
+    return {d.value for d in Disciplina}
+
+
+@when(parsers.parse('se consulta la disciplina "{nombre}"'), target_fixture="disciplina")
+def cuando_consulta_disciplina(nombre: str) -> Disciplina:
+    return Disciplina(nombre)
+
+
+@then("el sistema la reconoce como disciplina de distancia")
+def entonces_es_distancia(disciplina: Disciplina) -> None:
+    assert disciplina.es_distancia()
+
+
+@then("su orden de grilla es ascendente")
+def entonces_orden_ascendente(disciplina: Disciplina) -> None:
+    descriptor = DisciplinaDescriptor.para(disciplina)
+    assert descriptor.orden_ascendente is True
+
+
+@when(
+    parsers.parse('se intenta usar "{nombre}" como disciplina'),
+    target_fixture="nombre_invalido",
+)
+def cuando_intenta_usar_invalido(nombre: str) -> str:
+    return nombre
+
+
+@then("el sistema rechaza el valor como disciplina desconocida")
+def entonces_rechaza_desconocido(nombre_invalido: str) -> None:
+    with pytest.raises(ValueError):
+        Disciplina(nombre_invalido)

--- a/tests/features/steps/test_US_3_4_1_steps.py
+++ b/tests/features/steps/test_US_3_4_1_steps.py
@@ -81,7 +81,7 @@ def given_torneo_con_disciplinas_simple(disciplinas: str) -> dict:
 @given("el torneo tiene 3 disciplinas y juez asignado a 2 de ellas", target_fixture="ctx")
 def given_torneo_juez_dos_disciplinas() -> dict:
     t = _torneo_base()
-    t.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF, Disciplina.DYNB}))
+    t.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF, Disciplina.DBF}))
     juez_id = uuid4()
     t.asignar_juez(Disciplina.STA, juez_id)
     t.asignar_juez(Disciplina.DNF, juez_id)

--- a/tests/integration/torneo/test_disciplinas_torneo_api.py
+++ b/tests/integration/torneo/test_disciplinas_torneo_api.py
@@ -108,7 +108,7 @@ class TestAsignarDisciplinasAPI:
     def test_put_disciplinas_200(self, app_client: TestClient) -> None:
         tid = _crear_torneo(app_client)
         resp = app_client.put(
-            f"/torneos/{tid}/disciplinas", json={"disciplinas": ["STA", "DNF", "DYNB"]}
+            f"/torneos/{tid}/disciplinas", json={"disciplinas": ["STA", "DNF", "DBF"]}
         )
         assert resp.status_code == 200
 
@@ -177,7 +177,7 @@ class TestAsignarJuezAPI:
 class TestDisciplinasDeJuezAPI:
     def test_get_disciplinas_juez(self, app_client: TestClient) -> None:
         tid = _crear_torneo(app_client)
-        app_client.put(f"/torneos/{tid}/disciplinas", json={"disciplinas": ["STA", "DNF", "DYNB"]})
+        app_client.put(f"/torneos/{tid}/disciplinas", json={"disciplinas": ["STA", "DNF", "DBF"]})
         juez_id = str(uuid4())
         app_client.put(f"/torneos/{tid}/disciplinas/STA/juez", json={"juez_id": juez_id})
         app_client.put(f"/torneos/{tid}/disciplinas/DNF/juez", json={"juez_id": juez_id})

--- a/tests/unit/competencia/domain/test_disciplina_descriptor.py
+++ b/tests/unit/competencia/domain/test_disciplina_descriptor.py
@@ -28,7 +28,7 @@ class TestDescriptorSTA:
     [
         Disciplina.DNF,
         Disciplina.DYN,
-        Disciplina.DYNB,
+        Disciplina.DBF,
         Disciplina.CNF,
         Disciplina.CWT,
         Disciplina.FIM,

--- a/tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py
+++ b/tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py
@@ -44,7 +44,7 @@ class TestAdapterDistancia:
         [
             Disciplina.DNF,
             Disciplina.DYN,
-            Disciplina.DYNB,
+            Disciplina.DBF,
             Disciplina.CNF,
             Disciplina.CWT,
             Disciplina.FIM,

--- a/tests/unit/torneo/domain/test_disciplinas_torneo.py
+++ b/tests/unit/torneo/domain/test_disciplinas_torneo.py
@@ -66,7 +66,7 @@ class TestDisciplinaTorneoVO:
 class TestAsignarDisciplinas:
     def test_asignar_disciplinas_happy_path(self) -> None:
         t = _torneo()
-        t.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF, Disciplina.DYNB}))
+        t.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF, Disciplina.DBF}))
         assert len(t.disciplinas_torneo) == 3
         assert all(dt.juez_id is None for dt in t.disciplinas_torneo)
 
@@ -114,9 +114,9 @@ class TestAsignarDisciplinas:
     def test_reasignar_disciplinas_sobreescribe(self) -> None:
         t = _torneo()
         t.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF}))
-        t.asignar_disciplinas(frozenset({Disciplina.DYNB}))
+        t.asignar_disciplinas(frozenset({Disciplina.DBF}))
         assert len(t.disciplinas_torneo) == 1
-        assert t.disciplinas_torneo[0].disciplina == Disciplina.DYNB
+        assert t.disciplinas_torneo[0].disciplina == Disciplina.DBF
 
 
 # ── asignar_juez ─────────────────────────────────────────────────────────────
@@ -165,7 +165,7 @@ class TestAsignarJuez:
 class TestObtenerDisciplinasDeJuez:
     def test_retorna_disciplinas_del_juez(self) -> None:
         t = _torneo()
-        t.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF, Disciplina.DYNB}))
+        t.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF, Disciplina.DBF}))
         juez = uuid4()
         t.asignar_juez(Disciplina.STA, juez)
         t.asignar_juez(Disciplina.DNF, juez)


### PR DESCRIPTION
## Summary
- Renombra `Disciplina.DYNB` → `Disciplina.DBF` y `Disciplina.SPE2X50` → `Disciplina.SPE` usando acrónimos oficiales AIDA
- Actualiza 7 archivos de tests y 2 docs de dominio
- Agrega feature BDD con 4 escenarios (incluyendo verificación de que los acrónimos obsoletos son rechazados)

**Origen:** DISC-02 y DISC-03 del análisis de dataset real Buenos Aires 2025 (HITO-17)

## Test plan
- [x] 757 tests pasando (suite completa)
- [x] 4 escenarios BDD pasando
- [x] 0 CRITICAL en DesignReviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)