### PR TITLE
US-ADJ-4.2: corregir orden de grilla STA

### DIFF
--- a/.claude/tracking/US-ADJ-3.8-tracking.json
+++ b/.claude/tracking/US-ADJ-3.8-tracking.json
@@ -8,9 +8,9 @@
   },
   "timeline": {
     "started_at": "2026-04-03T13:26:57.799771+00:00",
-    "completed_at": null,
-    "total_elapsed_seconds": 0,
-    "effective_seconds": 0,
+    "completed_at": "2026-04-03T17:58:24.454006+00:00",
+    "total_elapsed_seconds": 16286,
+    "effective_seconds": 16286,
     "paused_seconds": 0
   },
   "phases": [],

--- a/.claude/tracking/US-ADJ-4.2-tracking.json
+++ b/.claude/tracking/US-ADJ-4.2-tracking.json
@@ -1,0 +1,85 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-4.2",
+    "us_title": "Corregir orden STA",
+    "us_points": 2,
+    "producto": "ataraxiadive",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-03T17:58:44.565120+00:00",
+    "completed_at": "2026-04-03T18:05:05.874855+00:00",
+    "total_elapsed_seconds": 381,
+    "effective_seconds": 381,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de contexto",
+      "started_at": "2026-04-03T17:59:03.855524+00:00",
+      "completed_at": "2026-04-03T18:05:00.096181+00:00",
+      "elapsed_seconds": 356,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de implementacion",
+      "started_at": "2026-04-03T18:08:00.000000+00:00",
+      "completed_at": "2026-04-03T18:10:00.000000+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_plan_001",
+          "task_name": "Crear plan US-ADJ-4.2",
+          "task_type": "docs",
+          "estimated_minutes": 10,
+          "started_at": "2026-04-03T18:08:00.000000+00:00",
+          "completed_at": "2026-04-03T18:10:00.000000+00:00",
+          "elapsed_seconds": 120,
+          "status": "completed",
+          "file_created": "docs/plans/sp-adj-04/US-ADJ-4.2-plan.md"
+        }
+      ],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Cierre y evidencia",
+      "started_at": "2026-04-03T18:10:00.000000+00:00",
+      "completed_at": "2026-04-03T18:12:00.000000+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_close_001",
+          "task_name": "Crear reporte US-ADJ-4.2",
+          "task_type": "docs",
+          "estimated_minutes": 10,
+          "started_at": "2026-04-03T18:10:00.000000+00:00",
+          "completed_at": "2026-04-03T18:12:00.000000+00:00",
+          "elapsed_seconds": 120,
+          "status": "completed",
+          "file_created": "docs/reports/US-ADJ-4.2-report.md"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 2,
+    "completed_tasks": 2,
+    "total_phases": 3,
+    "estimated_total_minutes": 20,
+    "actual_total_minutes": 10,
+    "variance_minutes": -10,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/design/event-storming-big-picture.md
+++ b/docs/design/event-storming-big-picture.md
@@ -138,7 +138,7 @@ BCs previos.
 | Política | Descripción |
 |----------|-------------|
 | 🟣 P-04 | Cuando `PlazoAPVencido` → atletas sin AP quedan en estado NoCompite (no compiten) |
-| 🟣 P-05 | Orden de grilla: disciplinas de distancia (DNF, DYN, DYNB) → menor a mayor AP; disciplinas de tiempo (STA) → mayor a menor AP |
+| 🟣 P-05 | Orden de grilla: disciplinas de distancia (DNF, DYN, DBF, SPE) → menor a mayor AP; disciplinas de tiempo (STA) → menor a mayor AP |
 | 🟣 P-06 | Asignación de andariveles → automática por el sistema al generar la grilla |
 
 ### Hot Spots

--- a/docs/design/event-storming-competencia.md
+++ b/docs/design/event-storming-competencia.md
@@ -130,7 +130,7 @@ classDiagram
 
 | Política | Descripción |
 |----------|-------------|
-| 🟣 P-01 | Orden grilla: disciplinas de distancia (DNF, DYN, DYNB) → AP menor a mayor; tiempo (STA) → AP mayor a menor |
+| 🟣 P-01 | Orden grilla: disciplinas de distancia (DNF, DYN, DBF, SPE) → AP menor a mayor; tiempo (STA) → AP menor a mayor |
 | 🟣 P-02 | OT de cada atleta = OT_inicio + (posición × intervaloDisciplina) |
 | 🟣 P-03 | Si se modifica `IntervaloOTConfigurado` → los OTs de la grilla quedan desactualizados hasta regenerar |
 | 🟣 P-04 | `GrillaConfirmada` → grilla congelada; `GenerarGrilla` y `ConfigurarIntervaloOT` no permitidos |

--- a/docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md
+++ b/docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md
@@ -28,11 +28,11 @@ en el UAT de SP3 y producir output verificable contra la documentación oficial 
 
 | US | Descripción | Estado |
 |----|-------------|--------|
-| `US-ADJ-4.1` | Renombrar `DYNB → DBF` y `SPE2X50 → SPE` en enum `Disciplina` | ⏳ Pendiente |
-| `US-ADJ-4.2` | Corregir orden de grilla STA: `orden_ascendente=True` | ⏳ Pendiente |
+| `US-ADJ-4.1` | Renombrar `DYNB → DBF` y `SPE2X50 → SPE` en enum `Disciplina` | ✅ Implementada |
+| `US-ADJ-4.2` | Corregir orden de grilla STA: `orden_ascendente=True` | ✅ Implementada |
 | `US-ADJ-4.3` | Renombrar `JUVENIL → JUNIOR` en enum `Categoria` | ⏳ Pendiente |
-| `US-ADJ-4.4` | Agregar campo `club` a aggregate `Atleta` | ⏳ Pendiente |
-| `US-ADJ-4.5` | Ranking por (disciplina, categoría): segmentar `RankingCompetencia` | ⏳ Pendiente |
+| `US-ADJ-4.4` | Agregar campo `club` a aggregate `Atleta` y exponerlo en grillas/reportes | ⏳ Pendiente |
+| `US-ADJ-4.5` | Ranking y overall por categoría/género | ⏳ Pendiente |
 | `US-ADJ-4.6` | Value Object `TiempoAP` para parsear `MM:SS → segundos` | ⏳ Pendiente |
 
 ---
@@ -128,7 +128,7 @@ de string value — requiere migración de datos almacenados.
 **Issue:** DISC-05
 
 `club` (escuela/club de freediving) es dato obligatorio en todos los documentos
-oficiales del torneo: grilla de salida, resultados, certificados. El aggregate
+oficiales del torneo: grilla de salida, resultados, reportes y certificados. El aggregate
 `Atleta` no lo modela. Sin este campo, la app no puede generar documentación oficial.
 
 **Cambios:**
@@ -136,20 +136,21 @@ oficiales del torneo: grilla de salida, resultados, certificados. El aggregate
 - Agregar `club: str` a `RegistrarAtletaCommand`
 - Agregar columna `club` en `SqliteAtletaRepository`
 - Agregar `club` en el schema de la API (`RegistrarAtletaRequest`, `AtletaResponse`)
+- Propagar `club` a las salidas de grillas y reportes oficiales
 
 **Spec:** `docs/specs/sp-adj-04/US-ADJ-4.4.md`
 
 ---
 
-### US-ADJ-4.5 — Ranking por (disciplina, categoría): segmentar `RankingCompetencia`
+### US-ADJ-4.5 — Ranking y overall por categoría/género
 **Prioridad: Alta**
 **Capa:** `resultados/domain/` + `resultados/application/` + `resultados/infrastructure/`
 **Issue:** DISC-01
 
 BC Resultados produce un ranking flat que mezcla atletas de distintas categorías y sexos.
 En ningún torneo de apnea real existe ese ranking. El ranking real es siempre por
-`(disciplina, categoría)`, donde `Categoria` ya encoda el sexo (`SENIOR_MASCULINO`,
-`MASTER_FEMENINO`, etc.).
+`(disciplina, categoría)` y el overall del torneo también se publica por categoría/género,
+donde `Categoria` ya encoda el sexo (`SENIOR_MASCULINO`, `MASTER_FEMENINO`, etc.).
 
 **Cambios necesarios:**
 1. `ResultadoFinal` (port): agregar campo `categoria: Categoria`
@@ -159,10 +160,28 @@ En ningún torneo de apnea real existe ese ranking. El ranking real es siempre p
    — requiere un nuevo port hacia BC Registro en `resultados/domain/ports/`
 5. `ResultadosCalculados` (evento): incluir `categoria` en el payload de cada entrada
 6. API `GET /resultados/{id}/ranking`: respuesta agrupada por categoría
+7. `RankingOverall` / `CalcularOverall`: segmentar también el overall por categoría
+8. API `GET /resultados/{torneo_id}/overall`: respuesta agrupada por categoría
 
 La categoría viaja como dato del atleta desde BC Registro, atraviesa el ACL en
 `resultados/infrastructure/`, y se incorpora al `ResultadoFinal` que procesa el dominio.
 BC Resultados no "sabe" qué es un atleta — solo ve el `atleta_id` + su `categoria`.
+
+El contrato HTTP acordado para ambos endpoints usa listas de categorías:
+
+```json
+{
+  "calculado": true,
+  "rankings": [
+    {
+      "categoria": "SENIOR_FEMENINO",
+      "entradas": []
+    }
+  ]
+}
+```
+
+No se usarán keys dinámicas por categoría en la respuesta JSON.
 
 **Spec:** `docs/specs/sp-adj-04/US-ADJ-4.5.md`
 
@@ -223,7 +242,7 @@ Ubicación: `shared/domain/value_objects/tiempo_ap.py` si se usa en más de un B
 | 2 (Alta) | US-ADJ-4.2 | Orden STA invertido — la grilla generada es incorrecta |
 | 3 (Alta) | US-ADJ-4.5 | Ranking sin categoría — el output es inútil operacionalmente |
 | 4 (Media) | US-ADJ-4.3 | JUNIOR/JUVENIL — lenguaje ubicuo, fácil, alto impacto simbólico |
-| 5 (Media) | US-ADJ-4.4 | Club en Atleta — dato obligatorio en documentos oficiales |
+| 5 (Media) | US-ADJ-4.4 | Club en Atleta — dato obligatorio en grillas, reportes y documentos oficiales |
 | 6 (Media) | US-ADJ-4.6 | TiempoAP — facilita seed/UAT, encapsula conocimiento del dominio |
 
 ---
@@ -235,12 +254,13 @@ Ubicación: `shared/domain/value_objects/tiempo_ap.py` si se usa en más de un B
 2. US-ADJ-4.2    ← shared/domain/ — corregir orden STA (misma zona de código)
 3. US-ADJ-4.3    ← registro/domain/ — renombrar JUVENIL→JUNIOR
 4. US-ADJ-4.4    ← registro/ — agregar club a Atleta
-5. US-ADJ-4.5    ← resultados/ — ranking por categoría (la más compleja)
+5. US-ADJ-4.5    ← resultados/ — ranking y overall por categoría (la más compleja)
 6. US-ADJ-4.6    ← shared/domain/ — TiempoAP parser
 ```
 
 Las dos primeras (4.1 y 4.2) tocan `shared/domain/` y se pueden agrupar en el mismo
-branch si el scope no lo desaconseja. US-ADJ-4.5 es la más compleja y debe ir sola.
+branch si el scope no lo desaconseja. US-ADJ-4.5 es la más compleja, impacta `ranking`
+y `overall`, y debe ir sola.
 
 ---
 

--- a/docs/plans/sp-adj-04/US-ADJ-4.2-plan.md
+++ b/docs/plans/sp-adj-04/US-ADJ-4.2-plan.md
@@ -1,0 +1,56 @@
+# Plan de Implementación — US-ADJ-4.2
+## Corregir orden de grilla STA a ascendente
+
+**Branch:** `feature/US-ADJ-4.2-orden-sta`
+**Sprint:** SP-ADJ-04
+
+---
+
+## Cambios identificados
+
+### src/ (1 archivo)
+| Archivo | Cambio |
+|---------|--------|
+| `src/shared/domain/value_objects/disciplina_descriptor.py` | `DisciplinaDescriptor.para(STA)` cambia `orden_ascendente=False` → `True`; actualizar docstring de P-01 |
+
+### tests/ (9 archivos)
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py` | STA pasa a esperar `orden_ascendente=True` |
+| `tests/unit/competencia/domain/test_disciplina_descriptor.py` | Idem |
+| `tests/unit/competencia/domain/test_generar_grilla.py` | Orden STA invertido a menor AP primero |
+| `tests/integration/competencia/test_generar_grilla_integration.py` | Validación STA actualizada a ascendente |
+| `tests/integration/competencia/test_flujo_e2e_inc21.py` | DoD de Inc 2.1 alineado con STA ascendente |
+| `tests/integration/e2e/test_flujo_torneo_competencia.py` | RF-PR-05 alineado con STA ascendente |
+| `tests/features/US-2.2.1-disciplina-descriptor.feature` | Descriptor y grilla STA actualizados |
+| `tests/features/US-2.2.2-api-disciplina-aware.feature` | Background y orden esperado actualizados |
+| `tests/features/steps/api_disciplina_aware_steps.py` | Seed y asserts alineados con el nuevo orden |
+
+### docs/ (6 archivos)
+| Archivo | Cambio |
+|---------|--------|
+| `docs/design/event-storming-competencia.md` | P-01: STA menor AP primero |
+| `docs/design/event-storming-big-picture.md` | P-05: STA menor AP primero |
+| `docs/specs/sp2/US-2.2.1.md` | Histórica alineada con la política corregida |
+| `docs/plans/sp2/US-2.2.1-plan.md` | Histórica alineada |
+| `docs/reports/US-2.2.1-report.md` | Histórica alineada |
+| `docs/plans/sp3/US-3.3.2-plan.md` | Referencia RF-PR-05 alineada |
+
+---
+
+## Tareas de implementación
+
+1. **[T1]** Corregir `DisciplinaDescriptor.para(STA)` a `orden_ascendente=True`
+2. **[T2]** Actualizar tests unitarios e integración que asumen STA descendente
+3. **[T3]** Actualizar BDD de descriptor y API disciplina-aware
+4. **[T4]** Corregir documentación de diseño y artefactos históricos mínimos
+5. **[T5]** Ejecutar pytest focalizado sobre unit, integración y BDD afectados
+6. **[T6]** Ejecutar `codeguard src/` y guardar evidencia en el reporte
+
+---
+
+## Notas
+
+- El cambio es deliberadamente correctivo: la implementación previa estaba alineada con una política de dominio mal especificada.
+- Se corrigen documentos históricos que todavía funcionaban como fuente de verdad visible del comportamiento.
+- El alcance no toca ranking ni overall; solo la política de orden de grilla STA.

--- a/docs/plans/sp2/US-2.2.1-plan.md
+++ b/docs/plans/sp2/US-2.2.1-plan.md
@@ -15,7 +15,7 @@
   - `DisciplinaDescriptor` dataclass inmutable (frozen)
   - Campos: `disciplina: Disciplina`, `unidad_esperada: UnidadMedida`, `orden_ascendente: bool`
   - Factory method de clase `para(disciplina)` que construye el descriptor correcto
-  - Invariante: STA → Segundos + orden_ascendente=False; distancia → Metros + orden_ascendente=True
+  - Invariante: STA → Segundos + orden_ascendente=True; distancia → Metros + orden_ascendente=True
 
 ### 2. Domain — Port
 
@@ -55,7 +55,7 @@
 ### 7. Unit tests — DisciplinaDescriptor VO
 
 - [ ] `tests/unit/competencia/domain/value_objects/test_disciplina_descriptor.py` (10 min)
-  - Descriptor STA: unidad=Segundos, orden_ascendente=False
+  - Descriptor STA: unidad=Segundos, orden_ascendente=True
   - Descriptor por cada disciplina de distancia: unidad=Metros, orden_ascendente=True
   - Factory method cubre todas las disciplinas del enum
 
@@ -69,7 +69,7 @@
 ### 9. Integration tests — GenerarGrillaHandler con adapter real
 
 - [ ] `tests/integration/competencia/test_generar_grilla_integration.py` (ampliar, 10 min)
-  - Nuevo test: grilla STA ordenada mayor→menor AP usando adapter real
+  - Nuevo test: grilla STA ordenada menor→mayor AP usando adapter real
   - Nuevo test: grilla DNF ordenada menor→mayor AP usando adapter real
 
 ### 10. BDD steps

--- a/docs/plans/sp3/US-3.3.2-plan.md
+++ b/docs/plans/sp3/US-3.3.2-plan.md
@@ -39,7 +39,7 @@ Verifica RF-PR-04.
 
 ### T4 — Test E2E orden por AP (5 min)
 `test_multiples_atletas_ordenados_por_ap`: 3 atletas con APs 360s/300s/240s.
-Verifica RF-PR-05 (STA: mayor AP primero).
+Verifica RF-PR-05 (STA: menor AP primero).
 
 ### T5 — Steps BDD (5 min)
 Step definitions para el `.feature` de US-3.3.2 usando el fixture compartido.

--- a/docs/reports/US-2.2.1-report.md
+++ b/docs/reports/US-2.2.1-report.md
@@ -21,7 +21,7 @@
 - ✅ **DisciplinaDescriptor** (`src/competencia/domain/value_objects/disciplina_descriptor.py`)
   - Frozen dataclass: `disciplina`, `unidad_esperada`, `orden_ascendente`
   - Factory method `para(disciplina)` — encapsula política P-01
-  - STA → Segundos + orden_ascendente=False; distancia → Metros + orden_ascendente=True
+  - STA → Segundos + orden_ascendente=True; distancia → Metros + orden_ascendente=True
 
 - ✅ **DisciplinaDescriptorPort** (`src/competencia/domain/ports/disciplina_descriptor_port.py`)
   - ABC con método `describe(disciplina: Disciplina) -> DisciplinaDescriptor`
@@ -63,7 +63,7 @@
 ### Tests Unitarios (34 tests nuevos)
 
 - ✅ `tests/unit/competencia/domain/test_disciplina_descriptor.py`
-  - Descriptor STA: unidad=Segundos, orden_ascendente=False
+  - Descriptor STA: unidad=Segundos, orden_ascendente=True
   - Descriptor por cada disciplina de distancia: unidad=Metros, orden_ascendente=True
   - Factory method cubre todas las disciplinas del enum
   - Inmutabilidad del VO
@@ -76,16 +76,16 @@
 ### Tests de Integración (2 tests nuevos)
 
 - ✅ `tests/integration/competencia/test_disciplina_descriptor_integration.py`
-  - Grilla STA ordenada mayor→menor AP con adapter real
+  - Grilla STA ordenada menor→mayor AP con adapter real
   - Grilla DNF ordenada menor→mayor AP con adapter real
 
 ### Escenarios BDD (12 escenarios)
 
 - ✅ `tests/features/US-2.2.1-disciplina-descriptor.feature`
-  - Descriptor STA retorna unidad Segundos y orden descendente
+  - Descriptor STA retorna unidad Segundos y orden ascendente
   - Descriptor DNF retorna unidad Metros y orden ascendente
   - Todas las disciplinas de distancia retornan Metros y orden ascendente (6 ejemplos)
-  - GenerarGrilla usa descriptor para ordenar STA — mayor AP primero
+  - GenerarGrilla usa descriptor para ordenar STA — menor AP primero
   - GenerarGrilla usa descriptor para ordenar DNF — menor AP primero
 
 **Todos los tests pasando:** ✅ 395 passed, 0 failed
@@ -126,7 +126,7 @@
 
 ## Criterios de Aceptación
 
-- [x] `DisciplinaDescriptor.para(STA)` → unidad=Segundos, orden_ascendente=False
+- [x] `DisciplinaDescriptor.para(STA)` → unidad=Segundos, orden_ascendente=True
 - [x] `DisciplinaDescriptor.para(DNF)` → unidad=Metros, orden_ascendente=True
 - [x] Todas las disciplinas de distancia retornan Metros + orden_ascendente=True
 - [x] `GenerarGrillaHandler` inyecta `DisciplinaDescriptorPort` y lo usa en `handle()`

--- a/docs/reports/US-ADJ-4.2-report.md
+++ b/docs/reports/US-ADJ-4.2-report.md
@@ -1,0 +1,80 @@
+# Reporte de Implementación — US-ADJ-4.2
+## Corregir orden de grilla STA a ascendente
+
+**Sprint:** SP-ADJ-04
+**Branch:** `feature/US-ADJ-4.2-orden-sta`
+**Fecha:** 2026-04-03
+
+---
+
+## Resumen
+
+Corrección de la política de dominio P-01: la grilla de STA ahora ordena de menor AP
+a mayor AP, consistente con el dataset real "Apnea Indoor Buenos Aires 2025".
+
+El comportamiento previo era incorrecto: trataba STA como la única disciplina con orden
+descendente. La corrección aplica tanto al descriptor de disciplina como a los tests y a
+la documentación que describía esa política invertida.
+
+---
+
+## Cambios implementados
+
+### Código
+| Archivo | Cambio |
+|---------|--------|
+| `src/shared/domain/value_objects/disciplina_descriptor.py` | `DisciplinaDescriptor.para(STA)` pasa de `orden_ascendente=False` a `True`; docstring alineado con P-01 corregida |
+
+### Tests
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py` | STA ahora espera `orden_ascendente=True` |
+| `tests/unit/competencia/domain/test_disciplina_descriptor.py` | STA ahora espera orden ascendente |
+| `tests/unit/competencia/domain/test_generar_grilla.py` | Orden STA invertido a `285 → 330 → 360` |
+| `tests/integration/competencia/test_generar_grilla_integration.py` | Validación de grilla STA actualizada a menor AP primero |
+| `tests/integration/competencia/test_flujo_e2e_inc21.py` | DoD E2E actualizado a `120 → 180 → 300` |
+| `tests/integration/e2e/test_flujo_torneo_competencia.py` | RF-PR-05 actualizado a STA ascendente |
+| `tests/features/US-2.2.1-disciplina-descriptor.feature` | Escenarios BDD de descriptor y grilla STA actualizados |
+| `tests/features/US-2.2.2-api-disciplina-aware.feature` | Background y expectativas de próximas performances alineadas |
+| `tests/features/steps/api_disciplina_aware_steps.py` | Seed STA y expectativas de orden alineadas |
+| `tests/features/steps/ejecucion_multi_andarivel_steps.py` | Comentario/documentación de orden alineados |
+
+### Documentación
+| Archivo | Cambio |
+|---------|--------|
+| `docs/design/event-storming-competencia.md` | P-01 corregida: STA también ordena menor AP primero |
+| `docs/design/event-storming-big-picture.md` | P-05 corregida con orden ascendente para STA |
+| `docs/specs/sp2/US-2.2.1.md` | Especificación histórica alineada con la política corregida |
+| `docs/plans/sp2/US-2.2.1-plan.md` | Plan histórico alineado con STA ascendente |
+| `docs/reports/US-2.2.1-report.md` | Reporte histórico alineado con STA ascendente |
+| `docs/plans/sp3/US-3.3.2-plan.md` | Referencia RF-PR-05 corregida |
+
+---
+
+## Resultados de calidad
+
+| Gate | Resultado |
+|------|-----------|
+| Unit tests focalizados | ✅ 25/25 |
+| Integración focalizada | ✅ 11/11 |
+| BDD focalizado | ✅ 22/22 |
+| Regresión focalizada total | ✅ 58/58 |
+
+Comandos ejecutados:
+
+```bash
+./.venv/bin/pytest tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py tests/unit/competencia/domain/test_generar_grilla.py -q
+./.venv/bin/pytest tests/unit/competencia/domain/test_disciplina_descriptor.py tests/integration/competencia/test_generar_grilla_integration.py tests/integration/competencia/test_flujo_e2e_inc21.py tests/integration/e2e/test_flujo_torneo_competencia.py -q
+./.venv/bin/pytest tests/features/steps/disciplina_descriptor_steps.py tests/features/steps/api_disciplina_aware_steps.py tests/features/steps/ejecucion_multi_andarivel_steps.py -q
+```
+
+---
+
+## Trazabilidad
+
+| Elemento | Referencia |
+|----------|------------|
+| Discrepancia origen | DISC-04 |
+| Análisis | HITO-17 · `.work/analisis-discrepancias-dataset-reales.md` |
+| Política corregida | P-01 / P-05 |
+| Invariante aplicada | Menor AP primero en todas las disciplinas, incluida STA |

--- a/docs/specs/sp-adj-04/US-ADJ-4.4.md
+++ b/docs/specs/sp-adj-04/US-ADJ-4.4.md
@@ -11,7 +11,7 @@
 
 Como **organizador de un torneo de apnea**,
 quiero que cada atleta tenga registrado su club o escuela de freediving
-para que los documentos oficiales del torneo (grilla, resultados, diplomas)
+para que los documentos oficiales del torneo (grilla, resultados, reportes, diplomas)
 incluyan esa información tal como lo requiere la federación.
 
 ---
@@ -50,7 +50,7 @@ DISC-05). No es una feature nueva — es un dato del dominio que faltaba.
 | | Descripción |
 |---|---|
 | **Precondición** | No existe un atleta con el mismo email. `club` es un string no vacío. |
-| **Postcondición** | El atleta queda registrado con `club` persistido. `GET /atletas/{id}` incluye el campo `club` en la respuesta. |
+| **Postcondición** | El atleta queda registrado con `club` persistido. `GET /atletas/{id}` incluye el campo `club` en la respuesta. El dato queda disponible para grillas y reportes oficiales. |
 | **Eventos generados** | `AtletaRegistrado` (sin cambio — `club` se agrega al payload) |
 | **Excepciones** | `club` vacío o solo espacios → `ValueError("INV-A-05: club no puede ser vacío")` |
 
@@ -80,6 +80,11 @@ Feature: Club del atleta
     Then el atleta queda registrado exitosamente
     And GET /atletas/{id} retorna club="Regatas Santa Fe"
 
+  Scenario: Club se expone en documentos operativos
+    Given existe un atleta registrado con club "Regatas Santa Fe"
+    When se genera una grilla o un reporte oficial que incluye al atleta
+    Then el documento muestra el club "Regatas Santa Fe"
+
   Scenario: Club vacío es rechazado
     Given los datos del atleta son válidos
     When se intenta registrar con club=""
@@ -103,6 +108,7 @@ Feature: Club del atleta
 - [x] Application (`RegistrarAtletaCommand` — agregar `club: str`)
 - [x] Infrastructure (`SqliteAtletaRepository` — agregar columna `club` en `CREATE TABLE` y en queries)
 - [x] API (`RegistrarAtletaRequest` schema — agregar `club: str`; `AtletaResponse` — incluir `club`)
+- [x] Read models / reportes (`grillas` y salidas oficiales que consuman datos de atleta)
 
 ---
 
@@ -112,6 +118,7 @@ Feature: Club del atleta
 |-----------|---------|-----------------|
 | `docs/design/domain-model.md` | BC Registro — diagrama de `Atleta` | Agregar `+String club` al diagrama Mermaid y a la descripción del aggregate |
 | `docs/dominio/05-requerimientos_funcionales.md` | RF-IN (Registro e Inscripción) | Agregar o marcar RF que especifique el club como dato obligatorio del atleta |
+| `docs/specs/sp-adj-04/US-ADJ-4.4.md` | Alcance de exposición | Mantener explícito que `club` se usa también en grillas y reportes |
 
 ---
 
@@ -119,7 +126,8 @@ Feature: Club del atleta
 
 1. `club` es un string libre — no es un enum ni un aggregate separado. En este dominio el club es solo un nombre, no tiene ciclo de vida propio en el sistema.
 2. La columna `club TEXT NOT NULL` debe agregarse al `CREATE TABLE` de `atletas` en `SqliteAtletaRepository`. Todos los tests que crean atletas deben incluir `club`.
-3. No hay migración de datos real (SQLite en memoria en tests).
+3. Además de persistirse en Registro, `club` debe propagarse a los datos usados por grillas y reportes oficiales.
+4. No hay migración de datos real (SQLite en memoria en tests).
 
 ---
 

--- a/docs/specs/sp-adj-04/US-ADJ-4.5.md
+++ b/docs/specs/sp-adj-04/US-ADJ-4.5.md
@@ -1,8 +1,8 @@
-# US-ADJ-4.5: Ranking por (disciplina, categoría) en BC Resultados
+# US-ADJ-4.5: Ranking y Overall por (disciplina/torneo, categoría) en BC Resultados
 
 **Estado**: `Pendiente`
 **Iteración / Sprint**: SP-ADJ-04
-**Agregado principal afectado**: `RankingCompetencia`
+**Agregado principal afectado**: `RankingCompetencia` · `RankingOverall`
 **Bounded Context**: `resultados` (con ACL hacia `registro`)
 
 ---
@@ -11,6 +11,7 @@
 
 Como **juez de una competencia de apnea**,
 quiero que el sistema calcule rankings separados por categoría dentro de cada disciplina
+y overalls separados por categoría dentro de cada torneo
 para que los resultados oficiales muestren quién ganó en cada categoría,
 tal como lo requieren los reglamentos AIDA y la documentación oficial del torneo.
 
@@ -23,6 +24,7 @@ tal como lo requieren los reglamentos AIDA y la documentación oficial del torne
 | Elemento DDD | Nombre | Responsabilidad |
 |---|---|---|
 | Aggregate | `RankingCompetencia` | Calcula y persiste el ranking de una disciplina |
+| Aggregate | `RankingOverall` | Calcula y persiste el overall de un torneo |
 | Value Object | `EntradaRanking` | Una línea del ranking (posición, atleta, RP, tarjeta) |
 | DTO (port) | `ResultadoFinal` | Datos de una performance al cierre de la disciplina |
 | Port | `ResultadosCompetenciaPort` | ACL hacia BC Competencia — provee los resultados finales |
@@ -31,6 +33,7 @@ tal como lo requieren los reglamentos AIDA y la documentación oficial del torne
 ### Lenguaje ubicuo relevante
 
 - **Ranking por categoría**: tabla de posiciones dentro de un grupo `(disciplina, categoría)`. Cada categoría tiene su propio ranking independiente con posiciones 1, 2, 3...
+- **Overall por categoría**: tabla de posiciones dentro de un grupo `(torneo, categoría)`, calculada a partir de todas las disciplinas del torneo. No existe overall flat que mezcle categorías.
 - **Categoría**: en este contexto, el valor de `Categoria` del atleta (`SENIOR_MASCULINO`, `MASTER_FEMENINO`, etc.), que encoda sexo y grupo etario.
 - **RF-PM-05** (requerimiento funcional existente): "¿Se deben generar rankings separados por categoría y género dentro de cada disciplina?" → **"Sí"** — este RF existía pero nunca fue implementado.
 
@@ -39,6 +42,9 @@ tal como lo requieren los reglamentos AIDA y la documentación oficial del torne
 `domain-model.md` ya describe `RankingCompetencia` como "Ranking por disciplina y
 categoría/género". RF-PM-05 lo requería explícitamente. Sin embargo, la implementación
 hizo un ranking flat. El dataset real expuso la brecha (HITO-17, DISC-01).
+
+La misma brecha aplica al `overall`: el ranking general del torneo también debe publicarse
+por categoría/género, no como una tabla única cross-categoría.
 
 ---
 
@@ -50,6 +56,8 @@ hizo un ranking flat. El dataset real expuso la brecha (HITO-17, DISC-01).
 - INV-R-02: dentro de cada categoría se aplican las mismas reglas de ordenamiento: válidas (Blanca/Amarilla) por RP desc, inválidas (DNS/Roja) al final. Empates comparten posición.
 - INV-R-03: el podio (posiciones 1, 2, 3) se determina dentro de cada categoría de forma independiente.
 - INV-R-04: `RankingCompetencia` no consulta BC Registro directamente — lo hace a través del puerto `AtletaCategoriaPort` inyectado en el handler.
+- INV-R-05: el `overall` del torneo está siempre segmentado por categoría. No existe overall flat cross-categoría.
+- INV-R-06: `RankingOverall` solo combina posiciones de rankings pertenecientes a la misma categoría.
 
 ### Operación principal
 
@@ -103,6 +111,17 @@ del atleta via `AtletaCategoriaPort`.
 **Precondición:** `CompetenciaFinalizada` fue emitido — todos los atletas tienen resultado (Ejecutada o DNS).
 **Postcondición:** `ResultadosCalculados` persiste entradas agrupadas por categoría, cada una con `categoria` en el payload. `GET /resultados/{id}/ranking` retorna resultados segmentados.
 
+### Overall del torneo
+
+`CalcularOverall` y `RankingOverall` deben aplicar la misma segmentación:
+
+1. Agrupar las entradas de ranking por `categoria`.
+2. Combinar solo disciplinas del mismo torneo y la misma categoría.
+3. Calcular posiciones y podio dentro de cada categoría.
+
+**Postcondición adicional:** `GET /resultados/{torneo_id}/overall` retorna el overall agrupado
+por categoría/género. No existe respuesta flat que mezcle categorías.
+
 **Ejemplo concreto:**
 
 ```
@@ -119,6 +138,14 @@ Postcondición — ranking calculado:
   MASTER_MASCULINO:
     pos.1 → atleta_C (196s, en_podio=True)
     pos.2 → atleta_D (DNS, en_podio=False)
+
+Overall del torneo:
+  SENIOR_FEMENINO:
+    pos.1 → atleta_A
+    pos.2 → atleta_B
+  MASTER_MASCULINO:
+    pos.1 → atleta_C
+    pos.2 → atleta_D
 ```
 
 ---
@@ -159,6 +186,18 @@ Feature: Ranking por categoría en una disciplina
     When  GET /resultados/{id}/ranking?disciplina=STA
     Then  la respuesta incluye una sección por cada categoría presente
     And   cada sección tiene sus propias posiciones comenzando en 1
+
+  Scenario: Overall del torneo se calcula y publica por categoría
+    Given existen rankings calculados de varias disciplinas y categorías para un torneo
+    When  se calcula el overall del torneo
+    Then  cada categoría obtiene su propio overall independiente
+    And   no se mezclan atletas de categorías distintas en la misma tabla
+
+  Scenario: GET overall retorna resultado agrupado por categoría
+    Given el overall del torneo fue calculado con 2 categorías
+    When  GET /resultados/{torneo_id}/overall
+    Then  la respuesta incluye una entrada por cada categoría presente
+    And   cada entrada tiene sus propias posiciones comenzando en 1
 ```
 
 ---
@@ -169,10 +208,65 @@ Feature: Ranking por categoría en una disciplina
 - [x] No — implementa un requerimiento existente (RF-PM-05) con el patrón de ports/ACL ya establecido
 
 **Capa(s) afectadas:**
-- [x] Domain (`ResultadoFinal`, `EntradaRanking`, `RankingCompetencia.calcular()`, nuevo `AtletaCategoriaPort`)
-- [x] Application (`CalcularRankingHandler` — enriquecer con categoría; `ObtenerRankingHandler` — adaptar respuesta)
+- [x] Domain (`ResultadoFinal`, `EntradaRanking`, `RankingCompetencia.calcular()`, `RankingOverall`, nuevo `AtletaCategoriaPort`)
+- [x] Application (`CalcularRankingHandler` — enriquecer con categoría; `ObtenerRankingHandler` — adaptar respuesta; `CalcularOverallHandler` y `ObtenerOverallHandler` — segmentación por categoría)
 - [x] Infrastructure (`AtletaCategoriaAdapter` — consulta BC Registro; `ResultadosCompetenciaAdapter` — no necesita cambio en el DTO si la categoría viene del port separado)
-- [x] API (`GET /resultados/{id}/ranking` — respuesta agrupada por categoría)
+- [x] API (`GET /resultados/{id}/ranking` y `GET /resultados/{torneo_id}/overall` — respuesta agrupada por categoría)
+
+## Contrato HTTP acordado
+
+La respuesta HTTP para `ranking` y `overall` usa listas de categorías, no keys dinámicas.
+
+**GET `/resultados/{id}/ranking?disciplina=STA`**
+
+```json
+{
+  "calculado": true,
+  "rankings": [
+    {
+      "categoria": "SENIOR_FEMENINO",
+      "entradas": [
+        {
+          "posicion": 1,
+          "atleta_id": "uuid",
+          "rp": "277",
+          "unidad": "Segundos",
+          "tarjeta": "Blanca",
+          "es_dns": false,
+          "en_podio": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+**GET `/resultados/{torneo_id}/overall`**
+
+```json
+{
+  "calculado": true,
+  "rankings": [
+    {
+      "categoria": "SENIOR_FEMENINO",
+      "entradas": [
+        {
+          "posicion": 1,
+          "atleta_id": "uuid",
+          "puntaje": 4,
+          "detalle": {
+            "STA": 1,
+            "DNF": 3
+          },
+          "en_podio": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+Si no fue calculado aún, ambos endpoints responden `200` con `calculado=false` y `rankings=[]`.
 
 ---
 
@@ -181,10 +275,12 @@ Feature: Ranking por categoría en una disciplina
 | Documento | Sección | Cambio requerido |
 |-----------|---------|-----------------|
 | `docs/design/domain-model.md` | BC Resultados — `RankingCompetencia` y `EntradaRanking` | Actualizar diagramas y descripciones para reflejar la segmentación por categoría |
+| `docs/design/domain-model.md` | BC Resultados — `RankingOverall` | Actualizar diagramas y descripciones para reflejar overall por categoría |
 | `docs/design/domain-model.md` | BC Resultados — Ports | Agregar `AtletaCategoriaPort` como nuevo puerto hacia BC Registro |
 | `docs/design/domain-model.md` | Context Map / ACLs | Documentar nueva dependencia: Resultados consulta Registro via port |
 | `docs/dominio/05-requerimientos_funcionales.md` | RF-PM-05 | Marcar como implementado (era "sí" pero nunca fue implementado) |
 | `docs/design/context-map.md` | Relación Resultados ↔ Registro | Agregar ACL: Resultados consulta categoría de atletas en Registro |
+| `docs/specs/sp-adj-04/US-ADJ-4.5.md` | Contrato HTTP | Mantener sincronizados los shapes de `ranking` y `overall` por categoría |
 
 ---
 
@@ -193,8 +289,9 @@ Feature: Ranking por categoría en una disciplina
 1. `ResultadoFinal` recibe `categoria` desde `CalcularRankingHandler`, que la obtiene via `AtletaCategoriaPort`. El aggregate `RankingCompetencia` no sabe nada de BC Registro.
 2. El patrón de ACL es el mismo que `ResultadosCompetenciaAdapter`: consulta SQLite de BC Registro directamente desde `resultados/infrastructure/`.
 3. `ResultadosCalculados` (evento) debe incluir `categoria` en cada entrada del payload para poder reconstituir el aggregate con los datos correctos.
-4. La API puede retornar un dict `{ "SENIOR_FEMENINO": [...], "MASTER_MASCULINO": [...] }` o una lista con el campo `categoria` por entrada — acordar el schema antes de implementar.
-5. Esta US tiene el mayor scope del SP-ADJ-04. Ir sola en su propio branch.
+4. El contrato HTTP acordado usa `rankings: [{categoria, entradas}]` tanto para `ranking` como para `overall`. No usar keys dinámicas por categoría.
+5. `RankingOverall` debe recalcularse y exponerse con la misma segmentación por categoría/género que `RankingCompetencia`.
+6. Esta US tiene el mayor scope del SP-ADJ-04. Ir sola en su propio branch.
 
 ---
 

--- a/docs/specs/sp2/US-2.2.1.md
+++ b/docs/specs/sp2/US-2.2.1.md
@@ -32,7 +32,7 @@ prepara el terreno para la validación de unidades en US-2.2.2.
 
 ### Lenguaje ubicuo relevante
 
-- **Descriptor de disciplina**: conjunto de reglas que caracterizan cómo se mide y ordena una disciplina. Para STA: unidad = Segundos, orden = mayor a menor AP. Para DNF/DYN/...: unidad = Metros, orden = menor a mayor AP.
+- **Descriptor de disciplina**: conjunto de reglas que caracterizan cómo se mide y ordena una disciplina. Para STA: unidad = Segundos, orden = menor a mayor AP. Para DNF/DYN/...: unidad = Metros, orden = menor a mayor AP.
 - **Unidad esperada**: la única unidad válida para registrar un AP o un RP en una disciplina dada.
 - **Orden de grilla**: si los atletas se ordenan con AP ascendente (distancia) o descendente (tiempo).
 
@@ -46,7 +46,7 @@ prepara el terreno para la validación de unidades en US-2.2.2.
 DisciplinaDescriptor(
     disciplina: Disciplina,
     unidad_esperada: UnidadMedida,     # Segundos para STA, Metros para el resto
-    orden_ascendente: bool,            # False (mayor→menor) para STA; True (menor→mayor) para distancia
+    orden_ascendente: bool,            # True (menor→mayor) para STA y distancia
 )
 ```
 
@@ -54,7 +54,7 @@ DisciplinaDescriptor(
 (e.g., STA + Metros es un estado imposible — debe rechazarse con `DescriptorInvalido`).
 
 **Invariante del VO:**
-- `DisciplinaDescriptor` para STA → `unidad_esperada = Segundos`, `orden_ascendente = False`
+- `DisciplinaDescriptor` para STA → `unidad_esperada = Segundos`, `orden_ascendente = True`
 - `DisciplinaDescriptor` para disciplinas de distancia → `unidad_esperada = Metros`, `orden_ascendente = True`
 
 ### El Port DisciplinaDescriptorPort
@@ -92,7 +92,7 @@ El handler `GenerarGrillaHandler` lo obtiene del `DisciplinaDescriptorPort` e in
 
 ```
 Port.describe(Disciplina.STA)
-→ DisciplinaDescriptor(STA, Segundos, orden_ascendente=False)
+→ DisciplinaDescriptor(STA, Segundos, orden_ascendente=True)
 
 Port.describe(Disciplina.DNF)
 → DisciplinaDescriptor(DNF, Metros, orden_ascendente=True)
@@ -105,11 +105,11 @@ Port.describe(Disciplina.DNF)
 ```gherkin
 Feature: DisciplinaDescriptor — VO que encapsula reglas de disciplina
 
-  Scenario: Descriptor STA retorna unidad Segundos y orden descendente
+  Scenario: Descriptor STA retorna unidad Segundos y orden ascendente
     Given la disciplina es "STA"
     When se consulta el DisciplinaDescriptorPort
     Then unidad_esperada es "Segundos"
-    And orden_ascendente es False
+    And orden_ascendente es True
 
   Scenario: Descriptor DNF retorna unidad Metros y orden ascendente
     Given la disciplina es "DNF"
@@ -117,11 +117,11 @@ Feature: DisciplinaDescriptor — VO que encapsula reglas de disciplina
     Then unidad_esperada es "Metros"
     And orden_ascendente es True
 
-  Scenario: GenerarGrilla usa descriptor para ordenar STA (mayor AP primero)
+  Scenario: GenerarGrilla usa descriptor para ordenar STA (menor AP primero)
     Given una competencia STA con 3 atletas: AP 120s, 300s, 180s
     And el intervalo OT está configurado en 9 minutos
     When se genera la grilla usando el DisciplinaDescriptorPort
-    Then el orden de la grilla es: 300s → 180s → 120s (mayor AP primero)
+    Then el orden de la grilla es: 120s → 180s → 300s (menor AP primero)
 
   Scenario: GenerarGrilla usa descriptor para ordenar DNF (menor AP primero)
     Given una competencia DNF con 3 atletas: AP 80m, 40m, 60m

--- a/src/shared/domain/value_objects/disciplina_descriptor.py
+++ b/src/shared/domain/value_objects/disciplina_descriptor.py
@@ -13,14 +13,13 @@ class DisciplinaDescriptor:
     """Encapsula las reglas de una disciplina: unidad esperada y orden de grilla.
 
     Política P-01:
-        - STA (tiempo): unidad=Segundos, orden_ascendente=False (mayor AP primero)
+        - STA (tiempo): unidad=Segundos, orden_ascendente=True (menor AP primero)
         - Distancia (DNF, DYN, ...): unidad=Metros, orden_ascendente=True (menor AP primero)
 
     Attributes:
         disciplina: Disciplina a la que pertenece este descriptor.
         unidad_esperada: Unidad de medida válida para APs y RPs de esta disciplina.
-        orden_ascendente: True si la grilla ordena de menor a mayor AP (distancia);
-            False si ordena de mayor a menor (tiempo).
+        orden_ascendente: True si la grilla ordena de menor a mayor AP.
     """
 
     disciplina: Disciplina
@@ -41,7 +40,7 @@ class DisciplinaDescriptor:
             return cls(
                 disciplina=disciplina,
                 unidad_esperada=UnidadMedida.Segundos,
-                orden_ascendente=False,
+                orden_ascendente=True,
             )
         return cls(
             disciplina=disciplina,

--- a/tests/features/US-2.2.1-disciplina-descriptor.feature
+++ b/tests/features/US-2.2.1-disciplina-descriptor.feature
@@ -6,11 +6,11 @@
 Feature: DisciplinaDescriptor — VO que encapsula reglas de disciplina
 
   @US-2.2.1 @happy_path
-  Scenario: Descriptor STA retorna unidad Segundos y orden descendente
+  Scenario: Descriptor STA retorna unidad Segundos y orden ascendente
     Given la disciplina es "STA"
     When se consulta el DisciplinaDescriptorPort
     Then unidad_esperada es "Segundos"
-    And orden_ascendente es False
+    And orden_ascendente es True
 
   @US-2.2.1 @happy_path
   Scenario: Descriptor DNF retorna unidad Metros y orden ascendente
@@ -36,11 +36,11 @@ Feature: DisciplinaDescriptor — VO que encapsula reglas de disciplina
       | FIM        |
 
   @US-2.2.1 @happy_path
-  Scenario: GenerarGrilla usa descriptor para ordenar STA — mayor AP primero
+  Scenario: GenerarGrilla usa descriptor para ordenar STA — menor AP primero
     Given una competencia STA con 3 atletas con APs 120s, 300s y 180s
     And el intervalo OT está configurado en 9 minutos
     When se genera la grilla usando el DisciplinaDescriptorPort
-    Then el orden de la grilla es posición 1 con AP 300s, posición 2 con AP 180s, posición 3 con AP 120s
+    Then el orden de la grilla es posición 1 con AP 120s, posición 2 con AP 180s, posición 3 con AP 300s
 
   @US-2.2.1 @happy_path
   Scenario: GenerarGrilla usa descriptor para ordenar DNF — menor AP primero

--- a/tests/features/US-2.2.2-api-disciplina-aware.feature
+++ b/tests/features/US-2.2.2-api-disciplina-aware.feature
@@ -2,7 +2,7 @@ Feature: API Disciplina-Aware — validación de unidades y avance por grilla
 
   Background:
     Given una competencia en estado EnEjecucion con 3 atletas en grilla STA
-    And el orden de grilla es posicion 1 con AP 300s, posicion 2 con AP 180s, posicion 3 con AP 120s
+    And el orden de grilla es posicion 1 con AP 120s, posicion 2 con AP 180s, posicion 3 con AP 300s
 
   Scenario: Registrar resultado STA con unidad correcta Segundos
     Given el atleta en posicion 1 fue llamado
@@ -30,7 +30,7 @@ Feature: API Disciplina-Aware — validación de unidades y avance por grilla
     Given el atleta en posicion 1 fue llamado y completo su performance
     When el juez consulta las proximas performances
     Then el primer resultado es el atleta en posicion 2 con AP 180s
-    And el segundo resultado es el atleta en posicion 3 con AP 120s
+    And el segundo resultado es el atleta en posicion 3 con AP 300s
 
   Scenario: PerformanceActual incluye unidad_esperada para STA
     Given el atleta en posicion 1 esta en estado Llamada para STA

--- a/tests/features/steps/api_disciplina_aware_steps.py
+++ b/tests/features/steps/api_disciplina_aware_steps.py
@@ -107,9 +107,9 @@ def ctx() -> dict:  # type: ignore[type-arg]
         "client": client,
         # STA background competencia
         "sta_cid": uuid4(),
-        "sta_p1": uuid4(),  # AP 300s
+        "sta_p1": uuid4(),  # AP 120s
         "sta_p2": uuid4(),  # AP 180s
-        "sta_p3": uuid4(),  # AP 120s
+        "sta_p3": uuid4(),  # AP 300s
         # Competencia actual (puede ser distinta a la STA)
         "current_cid": None,
         "current_pid": None,
@@ -208,9 +208,9 @@ def _setup_competencia_sta_con_grilla(ctx: dict) -> None:  # type: ignore[type-a
     cid = ctx["sta_cid"]
     p1, p2, p3 = ctx["sta_p1"], ctx["sta_p2"], ctx["sta_p3"]
 
-    _registrar_ap(store, cid, p1, "300", Disciplina.STA, UnidadMedida.Segundos)
+    _registrar_ap(store, cid, p1, "120", Disciplina.STA, UnidadMedida.Segundos)
     _registrar_ap(store, cid, p2, "180", Disciplina.STA, UnidadMedida.Segundos)
-    _registrar_ap(store, cid, p3, "120", Disciplina.STA, UnidadMedida.Segundos)
+    _registrar_ap(store, cid, p3, "300", Disciplina.STA, UnidadMedida.Segundos)
 
     _run(
         ConfigurarIntervaloOTHandler(store).handle(
@@ -250,10 +250,10 @@ def step_background_sta_en_ejecucion(ctx: dict) -> None:  # type: ignore[type-ar
 
 
 @given(
-    "el orden de grilla es posicion 1 con AP 300s, posicion 2 con AP 180s, posicion 3 con AP 120s"
+    "el orden de grilla es posicion 1 con AP 120s, posicion 2 con AP 180s, posicion 3 con AP 300s"
 )
 def step_orden_grilla(ctx: dict) -> None:  # type: ignore[type-arg]
-    # El orden es garantizado por el dominio (STA: mayor AP primero).
+    # El orden es garantizado por el dominio (STA: menor AP primero).
     # Este step documenta la postcondición del Background.
     pass
 

--- a/tests/features/steps/ejecucion_multi_andarivel_steps.py
+++ b/tests/features/steps/ejecucion_multi_andarivel_steps.py
@@ -147,7 +147,7 @@ def _setup_competencia_en_ejecucion(
     andariveles: int = 2,
 ) -> None:
     """Setup completo: AP → ConfigOT → GenerarGrilla → ConfirmarGrilla → Iniciar."""
-    # APs: A=300s, B=280s, C=260s (orden descendente → grilla)
+    # APs: A=300s, B=280s, C=260s (orden ascendente → grilla)
     for pid, valor in [(pid_a, "300"), (pid_b, "280"), (pid_c, "260")]:
         _run(
             RegistrarAPHandler(store, _ESTADO_STUB, _DESCRIPTOR).handle(

--- a/tests/integration/competencia/test_flujo_e2e_inc21.py
+++ b/tests/integration/competencia/test_flujo_e2e_inc21.py
@@ -1,15 +1,15 @@
 """Test de integración E2E — Inc 2.1: Juez avanza por la grilla atleta a atleta.
 
 DoD observable de Inc 2.1:
-  - Grilla generada con orden correcto (AP STA: mayor a menor)
+  - Grilla generada con orden correcto (AP STA: menor a mayor)
   - Juez confirma grilla → inicia competencia → avanza atleta por atleta
   - CompetenciaEstadoAdapter REAL lee del Event Store (no stub)
 
 Escenario: disciplina STA con 3 atletas
-  Atleta A: AP 300s (5 min) → posición 1 (mayor AP primero en STA)
+  Atleta C: AP 120s (2 min) → posición 1 (menor AP primero en STA)
   Atleta B: AP 180s (3 min) → posición 2
-  Atleta C: AP 120s (2 min) → posición 3
-  Flujo: generar → confirmar → iniciar → llamar A → llamar B → llamar C
+  Atleta A: AP 300s (5 min) → posición 3
+  Flujo: generar → confirmar → iniciar → llamar C → llamar B → llamar A
 """
 
 from __future__ import annotations
@@ -129,7 +129,7 @@ async def _setup_grilla_generada(
 
 @pytest.mark.asyncio
 async def test_grilla_generada_con_orden_correcto_sta(store: SQLiteEventStore) -> None:
-    """STA ordena AP mayor a menor: A(300s) → B(180s) → C(120s)."""
+    """STA ordena AP menor a mayor: C(120s) → B(180s) → A(300s)."""
     cid = uuid4()
     atleta_a, atleta_b, atleta_c = uuid4(), uuid4(), uuid4()
 
@@ -143,10 +143,10 @@ async def test_grilla_generada_con_orden_correcto_sta(store: SQLiteEventStore) -
     assert entradas[0].posicion == 1
     assert entradas[1].posicion == 2
     assert entradas[2].posicion == 3
-    # STA: mayor AP primero → A(300s) en posición 1
-    assert str(atleta_a) in entradas[0].atleta_id
+    # STA: menor AP primero → C(120s) en posición 1
+    assert str(atleta_c) in entradas[0].atleta_id
     assert str(atleta_b) in entradas[1].atleta_id
-    assert str(atleta_c) in entradas[2].atleta_id
+    assert str(atleta_a) in entradas[2].atleta_id
 
 
 @pytest.mark.asyncio

--- a/tests/integration/competencia/test_generar_grilla_integration.py
+++ b/tests/integration/competencia/test_generar_grilla_integration.py
@@ -121,8 +121,8 @@ class TestGenerarGrillaIntegracion:
     async def test_orden_sta_correcto_tres_atletas(self, event_store: SQLiteEventStore) -> None:
         await _seed_intervalo(event_store)
         await _seed_ap(event_store, A001, "330")  # 5:30
-        await _seed_ap(event_store, A002, "360")  # 6:00 — mayor, pos=1
-        await _seed_ap(event_store, A003, "285")  # 4:45 — menor, pos=3
+        await _seed_ap(event_store, A002, "360")  # 6:00 — mayor, pos=3
+        await _seed_ap(event_store, A003, "285")  # 4:45 — menor, pos=1
 
         adapter = PerformancesAPAdapter(event_store)
         handler = GenerarGrillaHandler(event_store, adapter, DisciplinaDescriptorAdapter())
@@ -140,8 +140,8 @@ class TestGenerarGrillaIntegracion:
         perfs = grilla_event["payload"]["performances"]
 
         atletas_orden = [p["atleta_id"] for p in perfs]
-        assert atletas_orden[0] == str(A002)  # mayor AP primero
-        assert atletas_orden[2] == str(A003)  # menor AP último
+        assert atletas_orden[0] == str(A003)  # menor AP primero
+        assert atletas_orden[2] == str(A002)  # mayor AP último
 
     @pytest.mark.asyncio
     async def test_ot_calculados_correctamente(self, event_store: SQLiteEventStore) -> None:

--- a/tests/integration/e2e/test_flujo_torneo_competencia.py
+++ b/tests/integration/e2e/test_flujo_torneo_competencia.py
@@ -298,8 +298,8 @@ async def test_atleta_sin_ap_no_aparece_en_grilla(infra):
 
 
 @pytest.mark.asyncio
-async def test_multiples_atletas_ordenados_por_ap_descendente(infra):
-    """RF-PR-05: STA — mayor AP primero (360s → 300s → 240s)."""
+async def test_multiples_atletas_ordenados_por_ap_ascendente(infra):
+    """RF-PR-05: STA — menor AP primero (240s → 300s → 360s)."""
     torneo_id = await _crear_torneo_abierto(infra["torneo_repo"])
     competencia_id = await _configurar_competencia(infra["event_store"], torneo_id)
 
@@ -331,6 +331,6 @@ async def test_multiples_atletas_ordenados_por_ap_descendente(infra):
         ObtenerGrillaQuery(competencia_id=competencia_id, disciplina=Disciplina.STA)
     )
     assert len(grilla) == 3
-    assert grilla[0].atleta_id == str(atletas_y_aps[0][0])  # 360s — posición 1
+    assert grilla[0].atleta_id == str(atletas_y_aps[2][0])  # 240s — posición 1
     assert grilla[1].atleta_id == str(atletas_y_aps[1][0])  # 300s — posición 2
-    assert grilla[2].atleta_id == str(atletas_y_aps[2][0])  # 240s — posición 3
+    assert grilla[2].atleta_id == str(atletas_y_aps[0][0])  # 360s — posición 3

--- a/tests/unit/competencia/domain/test_disciplina_descriptor.py
+++ b/tests/unit/competencia/domain/test_disciplina_descriptor.py
@@ -14,9 +14,9 @@ class TestDescriptorSTA:
         d = DisciplinaDescriptor.para(Disciplina.STA)
         assert d.unidad_esperada == UnidadMedida.Segundos
 
-    def test_orden_descendente(self) -> None:
+    def test_orden_ascendente(self) -> None:
         d = DisciplinaDescriptor.para(Disciplina.STA)
-        assert d.orden_ascendente is False
+        assert d.orden_ascendente is True
 
     def test_disciplina_correcta(self) -> None:
         d = DisciplinaDescriptor.para(Disciplina.STA)

--- a/tests/unit/competencia/domain/test_generar_grilla.py
+++ b/tests/unit/competencia/domain/test_generar_grilla.py
@@ -95,21 +95,21 @@ class TestInvariantes:
             c.generar_grilla(OT_INICIO, [_sta(A001, "330")], _DESC_STA)
 
 
-# ── Ordenamiento STA (tiempo, mayor→menor) ────────────────────────────────────
+# ── Ordenamiento STA (tiempo, menor→mayor) ────────────────────────────────────
 
 
 class TestOrdenamientoSTA:
-    def test_orden_mayor_a_menor_por_ap(self) -> None:
+    def test_orden_menor_a_mayor_por_ap(self) -> None:
         c = _make_competencia(Disciplina.STA)
         performances = [
             _sta(A001, "330"),  # 5:30
-            _sta(A002, "360"),  # 6:00 — mayor, debe ir primero
-            _sta(A003, "285"),  # 4:45 — menor, debe ir último
+            _sta(A002, "360"),  # 6:00 — mayor, debe ir último
+            _sta(A003, "285"),  # 4:45 — menor, debe ir primero
         ]
         c.generar_grilla(OT_INICIO, performances, _DESC_STA)
         grilla = c.grilla
         atletas_orden = [str(e.atleta_id) for e in grilla]
-        assert atletas_orden == [A002, A001, A003]
+        assert atletas_orden == [A003, A001, A002]
 
     def test_posiciones_1_based(self) -> None:
         c = _make_competencia(Disciplina.STA)

--- a/tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py
+++ b/tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py
@@ -21,11 +21,11 @@ class TestAdapterSTA:
         desc = adapter.describe(Disciplina.STA)
         assert desc.unidad_esperada == UnidadMedida.Segundos
 
-    def test_describe_sta_retorna_orden_descendente(
+    def test_describe_sta_retorna_orden_ascendente(
         self, adapter: DisciplinaDescriptorAdapter
     ) -> None:
         desc = adapter.describe(Disciplina.STA)
-        assert desc.orden_ascendente is False
+        assert desc.orden_ascendente is True
 
 
 class TestAdapterDistancia:


### PR DESCRIPTION
## Resumen
- corrige la politica de STA para ordenar menor AP primero
- actualiza tests unitarios, integracion y BDD afectados por el cambio
- alinea documentacion, plan, tracking y reporte de la US

## Verificacion
- ./.venv/bin/pytest tests/unit/competencia/infrastructure/test_disciplina_descriptor_adapter.py tests/unit/competencia/domain/test_generar_grilla.py -q
- ./.venv/bin/pytest tests/unit/competencia/domain/test_disciplina_descriptor.py tests/integration/competencia/test_generar_grilla_integration.py tests/integration/competencia/test_flujo_e2e_inc21.py tests/integration/e2e/test_flujo_torneo_competencia.py -q
- ./.venv/bin/pytest tests/features/steps/disciplina_descriptor_steps.py tests/features/steps/api_disciplina_aware_steps.py tests/features/steps/ejecucion_multi_andarivel_steps.py -q
- ./.venv/bin/codeguard src/shared/domain/value_objects
