### PR TITLE
US-ADJ-4.4: agregar club a atleta

### DIFF
--- a/.claude/tracking/US-ADJ-4.4-tracking.json
+++ b/.claude/tracking/US-ADJ-4.4-tracking.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-4.4",
+    "us_title": "Agregar club a atleta",
+    "us_points": 3,
+    "producto": "ataraxiadive",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-03T18:26:30.998180+00:00",
+    "completed_at": "2026-04-03T18:38:14.793366+00:00",
+    "total_elapsed_seconds": 703,
+    "effective_seconds": 703,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de contexto",
+      "started_at": "2026-04-03T18:27:19.782130+00:00",
+      "completed_at": "2026-04-03T18:27:31.233052+00:00",
+      "elapsed_seconds": 11,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de implementacion",
+      "started_at": "2026-04-03T18:27:31.234500+00:00",
+      "completed_at": "2026-04-03T18:29:34.155846+00:00",
+      "elapsed_seconds": 122,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 2,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -266,7 +266,7 @@ classDiagram
 
 | Aggregate | Tipo | Responsabilidad |
 |-----------|------|-----------------|
-| `Atleta` | Aggregate root | Datos personales, brevet, cuenta de usuario |
+| `Atleta` | Aggregate root | Datos personales, club, brevet, cuenta de usuario |
 | `Inscripcion` | Aggregate | Participación de un atleta en un torneo específico |
 
 ### Eventos principales

--- a/docs/dominio/05-requerimientos_funcionales.md
+++ b/docs/dominio/05-requerimientos_funcionales.md
@@ -43,6 +43,7 @@ Este cuestionario tiene como objetivo profundizar y completar la comprensión de
   RF-IN-07   ¿Cómo se resuelve si un atleta se inscribe con datos diferentes a los que tiene la base de datos externa?            Pendiente de definicion
   RF-IN-08   ¿El género se utiliza solo para categorización o tiene algún otro efecto en la competencia?                          Solo categoría
   RF-IN-09   ¿Puede un atleta inscribirse en categorías diferentes según la disciplina?                                           No
+  RF-IN-10   ¿El club del atleta es un dato requerido del registro y debe verse en grillas/reportes?                              Si, es obligatorio y debe reflejarse en grillas y reportes
 
 3. Preparación de Competencias
 ==============================

--- a/docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md
+++ b/docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md
@@ -31,7 +31,7 @@ en el UAT de SP3 y producir output verificable contra la documentación oficial 
 | `US-ADJ-4.1` | Renombrar `DYNB → DBF` y `SPE2X50 → SPE` en enum `Disciplina` | ✅ Implementada |
 | `US-ADJ-4.2` | Corregir orden de grilla STA: `orden_ascendente=True` | ✅ Implementada |
 | `US-ADJ-4.3` | Renombrar `JUVENIL → JUNIOR` en enum `Categoria` | ✅ Implementada |
-| `US-ADJ-4.4` | Agregar campo `club` a aggregate `Atleta` y exponerlo en grillas/reportes | ⏳ Pendiente |
+| `US-ADJ-4.4` | Agregar campo `club` a aggregate `Atleta` y exponerlo en grillas/reportes | ✅ Implementada |
 | `US-ADJ-4.5` | Ranking y overall por categoría/género | ⏳ Pendiente |
 | `US-ADJ-4.6` | Value Object `TiempoAP` para parsear `MM:SS → segundos` | ⏳ Pendiente |
 

--- a/docs/plans/sp-adj-04/US-ADJ-4.4-plan.md
+++ b/docs/plans/sp-adj-04/US-ADJ-4.4-plan.md
@@ -1,0 +1,68 @@
+# Plan de Implementación — US-ADJ-4.4
+## Agregar campo `club` al atleta
+
+**Branch:** `feature/US-ADJ-4.4-club-atleta`
+**Sprint:** SP-ADJ-04
+
+---
+
+## Cambios identificados
+
+### src/ (4 archivos)
+| Archivo | Cambio |
+|---------|--------|
+| `src/registro/domain/aggregates/atleta.py` | Agregar `club: str` y validar `INV-A-05` en `__post_init__` |
+| `src/registro/application/commands/registrar_atleta.py` | Agregar `club` a `RegistrarAtletaCommand` y al armado del aggregate |
+| `src/registro/infrastructure/repositories/sqlite_atleta_repository.py` | Agregar columna `club` en `CREATE TABLE`, `INSERT`, `SELECT` y rehidratación |
+| `src/registro/api/router.py` | Agregar `club` a `RegistrarAtletaRequest` y `AtletaResponse`; incluirlo en POST/GET |
+
+### tests/ (impacto esperado: medio)
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/registro/test_atleta.py` | Casos válidos e inválidos para `club` |
+| `tests/unit/registro/test_registrar_atleta_handler.py` | Commands y aggregates con `club` |
+| `tests/unit/registro/test_obtener_atleta_handler.py` | Fixtures con `club` |
+| `tests/integration/registro/test_sqlite_atleta_repository.py` | Persistencia/rehidratación de `club` |
+| `tests/**/registro*` | Buscar cualquier factory/fixture de `Atleta` o `RegistrarAtletaCommand` sin `club` |
+
+### docs/ (mínimas de la US)
+| Archivo | Cambio |
+|---------|--------|
+| `docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md` | Marcar progreso cuando la US cierre |
+| `docs/reports/US-ADJ-4.4-report.md` | Evidencia de implementación |
+| `docs/design/domain-model.md` | Atleta incluye `club` |
+| `docs/dominio/05-requerimientos_funcionales.md` | Reflejar `club` como dato obligatorio si corresponde |
+
+---
+
+## Tareas de implementación
+
+1. **[T1]** Extender `Atleta` con `club` y validar vacío/espacios
+2. **[T2]** Extender `RegistrarAtletaCommand` y handler
+3. **[T3]** Adaptar persistencia SQLite de atletas
+4. **[T4]** Adaptar request/response HTTP de registro de atletas
+5. **[T5]** Actualizar documentación mínima de la US si cambia contrato visible
+
+---
+
+## Validación pipeline
+
+1. Ejecutar `pytest` focalizado sobre `registro`
+2. Ejecutar `codeguard` sobre componentes impactados (`src/registro`)
+3. Crear reporte de implementación
+4. Actualizar tracking y cerrar la US
+
+---
+
+## Riesgos
+
+- El cambio rompe cualquier factory de `Atleta` o `RegistrarAtletaCommand` que no provea `club`.
+- La tabla `atletas` usa `CREATE TABLE IF NOT EXISTS`; en DBs persistentes viejas no habrá migración automática de columna. En tests con DB temporal no bloquea.
+- La parte “grillas/reportes” hoy no parece tener implementación directa en `registro`; puede quedar documentada pero no ejercitable aún si no existe un read model consumidor.
+
+---
+
+## Notas
+
+- Esta US sí cambia contrato API y persistencia.
+- No implementar hasta cerrar esta fase 2 con aprobación explícita.

--- a/docs/reports/US-ADJ-4.4-report.md
+++ b/docs/reports/US-ADJ-4.4-report.md
@@ -1,0 +1,76 @@
+# Reporte de Implementación — US-ADJ-4.4
+## Agregar campo `club` al atleta
+
+**Sprint:** SP-ADJ-04
+**Branch:** `feature/US-ADJ-4.4-club-atleta`
+**Fecha:** 2026-04-03
+
+---
+
+## Resumen
+
+Se extendió el aggregate `Atleta` para incorporar `club` como dato obligatorio de
+registro. El campo pasa a formar parte del contrato de alta y consulta de atletas,
+se persiste en SQLite y queda reflejado en la documentación mínima del BC Registro.
+
+El ajuste deja alineado el modelo con el dominio real y prepara la propagación de
+`club` hacia grillas y reportes en consumidores posteriores.
+
+---
+
+## Cambios implementados
+
+### Código
+| Archivo | Cambio |
+|---------|--------|
+| `src/registro/domain/aggregates/atleta.py` | Agrega `club: str` e invariante `INV-A-05` para rechazar vacío/espacios |
+| `src/registro/application/commands/registrar_atleta.py` | Agrega `club` a `RegistrarAtletaCommand` y al armado del aggregate |
+| `src/registro/infrastructure/repositories/sqlite_atleta_repository.py` | Persiste/rehidrata `club` y lo incorpora al esquema SQLite |
+| `src/registro/api/router.py` | Expone `club` en `RegistrarAtletaRequest` y `AtletaResponse` |
+
+### Tests
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/registro/test_atleta.py` | Casos válidos e inválidos para `club` |
+| `tests/unit/registro/test_registrar_atleta_handler.py` | Commands/aggregates con `club` |
+| `tests/unit/registro/test_obtener_atleta_handler.py` | Fixtures con `club` |
+| `tests/integration/registro/test_sqlite_atleta_repository.py` | Persistencia y lectura de `club` |
+| `tests/features/steps/test_US_3_2_2_steps.py` | Payloads BDD de registro alineados al nuevo contrato |
+| `tests/features/steps/test_US_3_2_3_steps.py` | Seed BDD de atletas para inscripción alineado al nuevo contrato |
+
+### Documentación
+| Archivo | Cambio |
+|---------|--------|
+| `docs/design/domain-model.md` | `Atleta` ahora incluye `club` en su responsabilidad |
+| `docs/dominio/05-requerimientos_funcionales.md` | Se explicita que `club` es obligatorio y visible en grillas/reportes |
+| `docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md` | `US-ADJ-4.4` marcada como implementada |
+
+---
+
+## Resultados de calidad
+
+| Gate | Resultado |
+|------|-----------|
+| Pytest focalizado `registro` + BDD impactados | ✅ 59/59 |
+| CodeGuard componentes impactados | ✅ 0 errores, 0 advertencias |
+
+Comandos ejecutados:
+
+```bash
+./.venv/bin/pytest tests/unit/registro tests/integration/registro tests/features/steps/test_US_3_2_2_steps.py tests/features/steps/test_US_3_2_3_steps.py -q
+./.venv/bin/codeguard src/registro/domain src/registro/application src/registro/infrastructure/repositories src/registro/api
+```
+
+Observaciones:
+
+- `pytest` emitió 26 warnings deprecados preexistentes vinculados a `datetime.utcnow()`.
+- No se detectaron errores ni advertencias nuevas de calidad sobre los componentes modificados.
+
+---
+
+## Riesgos y notas
+
+- La tabla `atletas` se crea con `CREATE TABLE IF NOT EXISTS`; una base SQLite ya
+  existente sin columna `club` requerirá migración explícita fuera de esta US.
+- La exposición de `club` en grillas/reportes queda habilitada desde el dato fuente
+  del BC Registro, pero los read models consumidores se ajustarán en US posteriores.

--- a/src/registro/api/router.py
+++ b/src/registro/api/router.py
@@ -54,6 +54,7 @@ class RegistrarAtletaRequest(BaseModel):
     email: str
     fecha_nacimiento: date
     categoria: Categoria
+    club: str
     brevet: str | None = None
 
     @field_validator("nombre", "apellido")
@@ -71,6 +72,7 @@ class AtletaResponse(BaseModel):
     email: str
     fecha_nacimiento: date
     categoria: Categoria
+    club: str
     brevet: str | None
 
 
@@ -121,6 +123,7 @@ async def registrar_atleta(body: RegistrarAtletaRequest, _: AtletaDep) -> JSONRe
         email=body.email,
         fecha_nacimiento=body.fecha_nacimiento,
         categoria=body.categoria,
+        club=body.club,
         brevet=body.brevet,
     )
     try:
@@ -149,6 +152,7 @@ async def obtener_atleta(atleta_id: UUID) -> JSONResponse:
             email=atleta.email,
             fecha_nacimiento=atleta.fecha_nacimiento,
             categoria=atleta.categoria,
+            club=atleta.club,
             brevet=atleta.brevet,
         ).model_dump(mode="json"),
     )

--- a/src/registro/application/commands/registrar_atleta.py
+++ b/src/registro/application/commands/registrar_atleta.py
@@ -18,6 +18,7 @@ class RegistrarAtletaCommand:
     email: str
     fecha_nacimiento: date
     categoria: Categoria
+    club: str
     brevet: str | None = None
 
 
@@ -37,6 +38,7 @@ class RegistrarAtletaHandler:
             email=cmd.email,
             fecha_nacimiento=cmd.fecha_nacimiento,
             categoria=cmd.categoria,
+            club=cmd.club,
             brevet=cmd.brevet,
         )
         await self._repo.save(atleta)

--- a/src/registro/domain/aggregates/atleta.py
+++ b/src/registro/domain/aggregates/atleta.py
@@ -18,6 +18,7 @@ class Atleta:
     email: str
     fecha_nacimiento: date
     categoria: Categoria
+    club: str
     brevet: str | None = field(default=None)
 
     def __post_init__(self) -> None:
@@ -29,3 +30,5 @@ class Atleta:
             raise ValueError("INV-A-02: email debe tener formato válido")
         if self.fecha_nacimiento >= date.today():
             raise ValueError("INV-A-04: fecha_nacimiento debe ser en el pasado")
+        if not self.club or not self.club.strip():
+            raise ValueError("INV-A-05: club no puede ser vacío")

--- a/src/registro/infrastructure/repositories/sqlite_atleta_repository.py
+++ b/src/registro/infrastructure/repositories/sqlite_atleta_repository.py
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS atletas (
     email            TEXT NOT NULL,
     fecha_nacimiento TEXT NOT NULL,
     categoria        TEXT NOT NULL,
+    club             TEXT NOT NULL,
     brevet           TEXT
 )
 """
@@ -37,8 +38,8 @@ class SQLiteAtletaRepository(AtletaRepositoryPort):
             await conn.execute(
                 """
                 INSERT OR REPLACE INTO atletas
-                    (atleta_id, nombre, apellido, email, fecha_nacimiento, categoria, brevet)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (atleta_id, nombre, apellido, email, fecha_nacimiento, categoria, club, brevet)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     str(atleta.atleta_id),
@@ -47,6 +48,7 @@ class SQLiteAtletaRepository(AtletaRepositoryPort):
                     atleta.email,
                     atleta.fecha_nacimiento.isoformat(),
                     str(atleta.categoria),
+                    atleta.club,
                     atleta.brevet,
                 ),
             )
@@ -56,8 +58,11 @@ class SQLiteAtletaRepository(AtletaRepositoryPort):
         async with aiosqlite.connect(self._db_path) as conn:
             await self._ensure_table(conn)
             async with conn.execute(
-                "SELECT atleta_id, nombre, apellido, email, fecha_nacimiento, categoria, brevet "
-                "FROM atletas WHERE atleta_id = ?",
+                (
+                    "SELECT atleta_id, nombre, apellido, email, fecha_nacimiento, "
+                    "categoria, club, brevet "
+                    "FROM atletas WHERE atleta_id = ?"
+                ),
                 (str(atleta_id),),
             ) as cursor:
                 row = await cursor.fetchone()
@@ -67,8 +72,11 @@ class SQLiteAtletaRepository(AtletaRepositoryPort):
         async with aiosqlite.connect(self._db_path) as conn:
             await self._ensure_table(conn)
             async with conn.execute(
-                "SELECT atleta_id, nombre, apellido, email, fecha_nacimiento, categoria, brevet "
-                "FROM atletas WHERE email = ?",
+                (
+                    "SELECT atleta_id, nombre, apellido, email, fecha_nacimiento, "
+                    "categoria, club, brevet "
+                    "FROM atletas WHERE email = ?"
+                ),
                 (email,),
             ) as cursor:
                 row = await cursor.fetchone()
@@ -83,5 +91,6 @@ class SQLiteAtletaRepository(AtletaRepositoryPort):
             email=row[3],
             fecha_nacimiento=date.fromisoformat(row[4]),
             categoria=Categoria(row[5]),
-            brevet=row[6],
+            club=row[6],
+            brevet=row[7],
         )

--- a/tests/features/steps/test_US_3_2_2_steps.py
+++ b/tests/features/steps/test_US_3_2_2_steps.py
@@ -66,6 +66,7 @@ def datos_personales_completos(
         "email": email,
         "fecha_nacimiento": fecha,
         "categoria": categoria,
+        "club": "Club Apnea Norte",
     }
 
 
@@ -78,6 +79,7 @@ def datos_sin_brevet(context: dict[str, Any]) -> None:
         "email": "carlos@example.com",
         "fecha_nacimiento": "1985-03-20",
         "categoria": "MASTER_MASCULINO",
+        "club": "Club Apnea Norte",
     }
 
 
@@ -91,6 +93,7 @@ def atleta_ya_registrado(client: TestClient, context: dict[str, Any]) -> None:
         "email": "pedro@example.com",
         "fecha_nacimiento": "1988-07-10",
         "categoria": "SENIOR_MASCULINO",
+        "club": "Club Apnea Norte",
     }
     resp = client.post("/registro/atletas", json=payload)
     assert resp.status_code == 201
@@ -107,6 +110,7 @@ def nombre_vacio(context: dict[str, Any]) -> None:
         "email": "vacio@example.com",
         "fecha_nacimiento": "1990-01-01",
         "categoria": "SENIOR_FEMENINO",
+        "club": "Club Apnea Norte",
     }
 
 
@@ -161,6 +165,7 @@ def then_get_atleta(client: TestClient, context: dict[str, Any]) -> None:
     data = get_resp.json()
     assert data["nombre"] == context["payload"]["nombre"]
     assert data["email"] == context["payload"]["email"]
+    assert data["club"] == context["payload"]["club"]
 
 
 @then(parsers.parse("la respuesta es {status_code:d} y brevet es nulo en la respuesta"))

--- a/tests/features/steps/test_US_3_2_3_steps.py
+++ b/tests/features/steps/test_US_3_2_3_steps.py
@@ -90,6 +90,7 @@ def given_atleta_y_torneo_abierto(context: dict[str, Any], client: TestClient) -
             "email": "ana@test.com",
             "fecha_nacimiento": "1990-01-01",
             "categoria": "SENIOR_FEMENINO",
+            "club": "Club Apnea Norte",
         },
     )
     _seed_torneo(context["torneo_db_path"], torneo_id, "INSCRIPCION_ABIERTA", "2026-12-01")
@@ -128,6 +129,7 @@ def given_atleta_ya_inscripto(context: dict[str, Any], client: TestClient) -> No
             "email": "carlos@test.com",
             "fecha_nacimiento": "1985-05-20",
             "categoria": "SENIOR_MASCULINO",
+            "club": "Club Apnea Norte",
         },
     )
     _seed_torneo(context["torneo_db_path"], torneo_id, "INSCRIPCION_ABIERTA", "2026-12-01")
@@ -155,6 +157,7 @@ def given_inscripcion_activa_maniana(context: dict[str, Any], client: TestClient
             "email": "pedro@test.com",
             "fecha_nacimiento": "1992-03-15",
             "categoria": "SENIOR_MASCULINO",
+            "club": "Club Apnea Norte",
         },
     )
     resp = client.post(
@@ -182,6 +185,7 @@ def given_inscripcion_activa_hoy(context: dict[str, Any], client: TestClient) ->
             "email": "laura@test.com",
             "fecha_nacimiento": "1995-07-10",
             "categoria": "SENIOR_FEMENINO",
+            "club": "Club Apnea Norte",
         },
     )
     resp = client.post(
@@ -208,6 +212,7 @@ def given_tres_inscriptos(context: dict[str, Any], client: TestClient) -> None:
                 "email": f"atleta{i}@test.com",
                 "fecha_nacimiento": "1990-01-01",
                 "categoria": "SENIOR_MASCULINO",
+                "club": "Club Apnea Norte",
             },
         )
         resp = client.post(

--- a/tests/integration/registro/test_sqlite_atleta_repository.py
+++ b/tests/integration/registro/test_sqlite_atleta_repository.py
@@ -18,6 +18,7 @@ def _atleta(**kwargs) -> Atleta:
         email="ana@example.com",
         fecha_nacimiento=date(1990, 5, 15),
         categoria=Categoria.SENIOR_FEMENINO,
+        club="Club Apnea Norte",
         brevet=None,
     )
     defaults.update(kwargs)
@@ -38,6 +39,7 @@ class TestSQLiteAtletaRepository:
         assert result.atleta_id == atleta.atleta_id
         assert result.nombre == atleta.nombre
         assert result.email == atleta.email
+        assert result.club == atleta.club
         assert result.brevet is None
 
     async def test_save_y_find_by_id_con_brevet(self, repo: SQLiteAtletaRepository):
@@ -45,6 +47,7 @@ class TestSQLiteAtletaRepository:
         await repo.save(atleta)
         result = await repo.find_by_id(atleta.atleta_id)
         assert result is not None
+        assert result.club == atleta.club
         assert result.brevet == "AIDA-3"
 
     async def test_find_by_email(self, repo: SQLiteAtletaRepository):
@@ -53,6 +56,7 @@ class TestSQLiteAtletaRepository:
         result = await repo.find_by_email("carlos@example.com")
         assert result is not None
         assert result.atleta_id == atleta.atleta_id
+        assert result.club == atleta.club
 
     async def test_find_by_id_no_existente(self, repo: SQLiteAtletaRepository):
         result = await repo.find_by_id(uuid4())

--- a/tests/unit/registro/test_atleta.py
+++ b/tests/unit/registro/test_atleta.py
@@ -15,6 +15,7 @@ def _valid_atleta(**kwargs) -> Atleta:
         email="ana@example.com",
         fecha_nacimiento=date(1990, 5, 15),
         categoria=Categoria.SENIOR_FEMENINO,
+        club="Club Apnea Norte",
         brevet=None,
     )
     defaults.update(kwargs)
@@ -25,6 +26,7 @@ class TestAtletaCreacion:
     def test_crea_atleta_valido(self):
         atleta = _valid_atleta()
         assert atleta.nombre == "Ana"
+        assert atleta.club == "Club Apnea Norte"
         assert atleta.brevet is None
 
     def test_crea_atleta_con_brevet(self):
@@ -69,3 +71,11 @@ class TestAtletaInvariantes:
     def test_inv_a05_brevet_none_permitido(self):
         atleta = _valid_atleta(brevet=None)
         assert atleta.brevet is None
+
+    def test_inv_a05_club_vacio(self):
+        with pytest.raises(ValueError, match="INV-A-05"):
+            _valid_atleta(club="")
+
+    def test_inv_a05_club_espacios(self):
+        with pytest.raises(ValueError, match="INV-A-05"):
+            _valid_atleta(club="   ")

--- a/tests/unit/registro/test_obtener_atleta_handler.py
+++ b/tests/unit/registro/test_obtener_atleta_handler.py
@@ -18,6 +18,7 @@ def _atleta(atleta_id=None) -> Atleta:
         email="ana@example.com",
         fecha_nacimiento=date(1990, 5, 15),
         categoria=Categoria.SENIOR_FEMENINO,
+        club="Club Apnea Norte",
     )
 
 

--- a/tests/unit/registro/test_registrar_atleta_handler.py
+++ b/tests/unit/registro/test_registrar_atleta_handler.py
@@ -21,6 +21,7 @@ def _cmd(**kwargs) -> RegistrarAtletaCommand:
         email="ana@example.com",
         fecha_nacimiento=date(1990, 5, 15),
         categoria=Categoria.SENIOR_FEMENINO,
+        club="Club Apnea Norte",
         brevet=None,
     )
     defaults.update(kwargs)
@@ -49,6 +50,7 @@ class TestRegistrarAtletaHandler:
             email="ana@example.com",
             fecha_nacimiento=date(1990, 5, 15),
             categoria=Categoria.SENIOR_FEMENINO,
+            club="Club Apnea Norte",
         )
         handler = RegistrarAtletaHandler(repo)
         cmd = _cmd(atleta_id=atleta_id)
@@ -67,4 +69,5 @@ class TestRegistrarAtletaHandler:
         await handler.handle(cmd)
 
         saved: Atleta = repo.save.call_args[0][0]
+        assert saved.club == "Club Apnea Norte"
         assert saved.brevet is None


### PR DESCRIPTION
## Resumen
- agrega club como dato obligatorio del aggregate Atleta
- expone club en API y persistencia SQLite
- alinea tests BDD/API y documentacion minima de Registro

## Validacion
- ./.venv/bin/pytest tests/unit/registro tests/integration/registro tests/features/steps/test_US_3_2_2_steps.py tests/features/steps/test_US_3_2_3_steps.py -q
- ./.venv/bin/codeguard src/registro/domain src/registro/application src/registro/infrastructure/repositories src/registro/api