### PR TITLE
US-ADJ-4.6: value object tiempo ap

### DIFF
--- a/.claude/tracking/US-ADJ-4.6-tracking.json
+++ b/.claude/tracking/US-ADJ-4.6-tracking.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-4.6",
+    "us_title": "Tiempo AP",
+    "us_points": 2,
+    "producto": "ataraxiadive",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-03T20:34:27.490467+00:00",
+    "completed_at": "2026-04-03T20:38:15.597573+00:00",
+    "total_elapsed_seconds": 228,
+    "effective_seconds": 228,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de contexto",
+      "started_at": "2026-04-03T20:34:27.498279+00:00",
+      "completed_at": "2026-04-03T20:34:54.279284+00:00",
+      "elapsed_seconds": 26,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de implementacion",
+      "started_at": "2026-04-03T20:34:54.282472+00:00",
+      "completed_at": "2026-04-03T20:38:15.596348+00:00",
+      "elapsed_seconds": 201,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 2,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -242,6 +242,7 @@ classDiagram
 |-------------|-------------|
 | `FormulaPuntos` | Fórmula deportiva para calcular puntos por disciplina. Configurable por torneo (AIDA / CMAS / genérica). Consumida por BC Resultados para calcular el Overall. |
 | `VentanaImpugnacion` | Lapso en minutos desde `CompetenciaFinalizada` durante el cual se permite `CorregirResultado`. Configurable por torneo. Consumida por BC Competencia como INV-P-15. |
+| `TiempoAP` | Parser y normalizador de APs de tiempo en formato `MM:SS` o `HH:MM:SS` a segundos (`Decimal`). Reutilizable en seeds, ingesta y futuros flujos de registro/anuncio. |
 
 ### Eventos principales
 

--- a/docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md
+++ b/docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md
@@ -33,7 +33,7 @@ en el UAT de SP3 y producir output verificable contra la documentación oficial 
 | `US-ADJ-4.3` | Renombrar `JUVENIL → JUNIOR` en enum `Categoria` | ✅ Implementada |
 | `US-ADJ-4.4` | Agregar campo `club` a aggregate `Atleta` y exponerlo en grillas/reportes | ✅ Implementada |
 | `US-ADJ-4.5` | Ranking y overall por categoría/género | ✅ Implementada |
-| `US-ADJ-4.6` | Value Object `TiempoAP` para parsear `MM:SS → segundos` | ⏳ Pendiente |
+| `US-ADJ-4.6` | Value Object `TiempoAP` para parsear `MM:SS → segundos` | ✅ Implementada |
 
 ---
 

--- a/docs/plans/sp-adj-04/US-ADJ-4.6-plan.md
+++ b/docs/plans/sp-adj-04/US-ADJ-4.6-plan.md
@@ -1,0 +1,64 @@
+# Plan de Implementación — US-ADJ-4.6
+## Value Object `TiempoAP`
+
+**Branch:** `feature/US-ADJ-4.6-tiempo-ap`
+**Sprint:** SP-ADJ-04
+
+---
+
+## Cambios identificados
+
+### src/ (impacto bajo)
+| Archivo | Cambio |
+|---------|--------|
+| `src/shared/domain/value_objects/tiempo_ap.py` | Crear nuevo VO con `desde_mmss()` y `desde_segundos()` |
+| `src/shared/domain/value_objects/__init__.py` | Exportar `TiempoAP` |
+| `src/shared/domain/value_objects/disciplina.py` | Verificar si hace falta referencia cruzada en docstring de disciplinas de tiempo |
+
+### tests/ (impacto bajo)
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/shared/domain/test_tiempo_ap.py` | Casos válidos `MM:SS`, `HH:MM:SS`, constructor directo y rechazos |
+| `tests/features/steps/tiempo_ap_steps.py` | BDD del parsing si se decide cubrir la spec con feature |
+| `tests/features/US-ADJ-4.6-tiempo-ap.feature` | Escenarios de parseo y validación |
+
+### docs/ (mínimas de la US)
+| Archivo | Cambio |
+|---------|--------|
+| `docs/design/domain-model.md` | Agregar `TiempoAP` en Value Objects compartidos |
+| `docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md` | Marcar progreso cuando la US cierre |
+| `docs/reports/US-ADJ-4.6-report.md` | Evidencia de implementación |
+
+---
+
+## Tareas de implementación
+
+1. **[T1]** Crear `TiempoAP` en `shared/domain/value_objects/tiempo_ap.py`
+2. **[T2]** Implementar parsing `MM:SS` y `HH:MM:SS` a `Decimal` segundos
+3. **[T3]** Validar formato y valor positivo con mensajes claros de error
+4. **[T4]** Exportar el VO y alinear documentación mínima de dominio
+5. **[T5]** Agregar cobertura unitaria y BDD de la spec
+
+---
+
+## Validación pipeline
+
+1. Ejecutar `pytest` focalizado sobre `tests/unit/shared/domain/test_tiempo_ap.py` y BDD de `TiempoAP`
+2. Ejecutar `CodeGuard` sobre `src/shared/domain/value_objects`
+3. Crear reporte de implementación
+4. Actualizar tracking y cerrar la US
+
+---
+
+## Riesgos
+
+- El proyecto no tiene hoy una jerarquía clara de excepciones de dominio compartidas en `shared/domain`; conviene evitar sobre-diseñar y usar `ValueError` con mensajes claros si no aparece un patrón más fuerte.
+- `Disciplina.es_tiempo()` hoy sólo reconoce `STA`; la spec menciona `SPE`, pero el modelo vigente sigue tratando `SPE` como distancia. Esta US no debería reabrir esa decisión.
+- Hay que evitar mezclar este VO con el `AP` de Competencia: `TiempoAP` es parser/normalizador de entrada, no reemplazo del VO existente.
+
+---
+
+## Notas
+
+- Esta US es intencionalmente acotada y no debería tocar `competencia/` ni `resultados/`.
+- Los tests pertenecen a la validación del pipeline, no a las tareas de implementación.

--- a/docs/reports/US-ADJ-4.6-report.md
+++ b/docs/reports/US-ADJ-4.6-report.md
@@ -1,0 +1,62 @@
+# Reporte de Implementación — US-ADJ-4.6
+## Value Object `TiempoAP`
+
+**Sprint:** SP-ADJ-04
+**Branch:** `feature/US-ADJ-4.6-tiempo-ap`
+**Fecha:** 2026-04-03
+
+---
+
+## Resumen
+
+Se agregó `TiempoAP` en `shared/domain/value_objects` para encapsular el parsing
+de APs expresados en `MM:SS` o `HH:MM:SS` hacia segundos (`Decimal`).
+
+La conversión deja de depender de scripts o frontend y pasa a ser parte explícita
+del modelo compartido del dominio.
+
+---
+
+## Cambios implementados
+
+### Código
+| Archivo | Cambio |
+|---------|--------|
+| `src/shared/domain/value_objects/tiempo_ap.py` | Nuevo VO con `desde_mmss()` y `desde_segundos()` |
+| `src/shared/domain/value_objects/__init__.py` | Exporta `TiempoAP` |
+
+### Tests
+| Archivo | Cambio |
+|---------|--------|
+| `tests/unit/shared/domain/test_tiempo_ap.py` | Casos válidos e inválidos para `MM:SS`, `HH:MM:SS` y segundos directos |
+| `tests/features/US-ADJ-4.6-tiempo-ap.feature` | Escenarios BDD del parsing |
+| `tests/features/steps/tiempo_ap_steps.py` | Steps de validación BDD |
+
+### Documentación
+| Archivo | Cambio |
+|---------|--------|
+| `docs/design/domain-model.md` | `TiempoAP` agregado a los VOs compartidos |
+| `docs/plans/sp-adj-04/PLAN-SP-ADJ-04.md` | `US-ADJ-4.6` marcada como implementada |
+
+---
+
+## Resultados de calidad
+
+| Gate | Resultado |
+|------|-----------|
+| Pytest focalizado + BDD `TiempoAP` | ✅ 18/18 |
+| CodeGuard componente impactado | ✅ 0 errores, 0 advertencias |
+
+Comandos ejecutados:
+
+```bash
+./.venv/bin/pytest tests/unit/shared/domain/test_tiempo_ap.py tests/features/steps/tiempo_ap_steps.py -q
+./.venv/bin/codeguard src/shared/domain/value_objects
+```
+
+---
+
+## Notas
+
+- Se usó `ValueError` con mensajes claros (`FormatoTiempoInvalido`, `ValorTiempoInvalido`) para seguir el criterio pragmático del repo y evitar introducir una jerarquía nueva de excepciones sólo para esta US.
+- Esta US no reabre la semántica de `SPE`; el VO es parser compartido, no cambia cómo `Disciplina` clasifica tiempo/distancia hoy.

--- a/src/shared/domain/value_objects/__init__.py
+++ b/src/shared/domain/value_objects/__init__.py
@@ -2,6 +2,7 @@
 
 from shared.domain.value_objects.disciplina import Disciplina
 from shared.domain.value_objects.disciplina_descriptor import DisciplinaDescriptor
+from shared.domain.value_objects.tiempo_ap import TiempoAP
 from shared.domain.value_objects.unidad_medida import UnidadMedida
 
-__all__ = ["Disciplina", "DisciplinaDescriptor", "UnidadMedida"]
+__all__ = ["Disciplina", "DisciplinaDescriptor", "TiempoAP", "UnidadMedida"]

--- a/src/shared/domain/value_objects/tiempo_ap.py
+++ b/src/shared/domain/value_objects/tiempo_ap.py
@@ -1,0 +1,42 @@
+"""Value Object TiempoAP — parsing de APs en formato MM:SS a segundos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class TiempoAP:
+    """AP expresado en tiempo, normalizado a segundos."""
+
+    segundos: Decimal
+
+    @classmethod
+    def desde_mmss(cls, texto: str) -> "TiempoAP":
+        """Parsea MM:SS o HH:MM:SS a segundos."""
+        partes = texto.strip().split(":")
+        if len(partes) not in (2, 3):
+            raise ValueError("FormatoTiempoInvalido: usar MM:SS o HH:MM:SS")
+        if any(not parte.isdigit() for parte in partes):
+            raise ValueError("FormatoTiempoInvalido: solo se permiten numeros y ':'")
+
+        valores = [int(parte) for parte in partes]
+        if len(valores) == 2:
+            horas = 0
+            minutos, segundos = valores
+        else:
+            horas, minutos, segundos = valores
+
+        if segundos > 59 or minutos > 59 and len(valores) == 3:
+            raise ValueError("FormatoTiempoInvalido: minutos/segundos fuera de rango")
+
+        total = (horas * 3600) + (minutos * 60) + segundos
+        return cls.desde_segundos(Decimal(total))
+
+    @classmethod
+    def desde_segundos(cls, valor: Decimal) -> "TiempoAP":
+        """Construye el VO desde segundos ya normalizados."""
+        if valor <= 0:
+            raise ValueError("ValorTiempoInvalido: los segundos deben ser > 0")
+        return cls(segundos=valor)

--- a/tests/features/US-ADJ-4.6-tiempo-ap.feature
+++ b/tests/features/US-ADJ-4.6-tiempo-ap.feature
@@ -1,0 +1,29 @@
+Feature: Parseo de AP en formato MM:SS
+
+  Scenario: Parsear AP STA valido en formato MM:SS
+    When se crea TiempoAP desde "02:30"
+    Then el valor en segundos es 150
+
+  Scenario: Parsear AP largo valido en formato HH:MM:SS
+    When se crea TiempoAP desde "01:00:00"
+    Then el valor en segundos es 3600
+
+  Scenario: Formato invalido es rechazado
+    When se intenta crear TiempoAP desde "abc"
+    Then el sistema lanza FormatoTiempoInvalido
+
+  Scenario: Segundos fuera de rango son rechazados
+    When se intenta crear TiempoAP desde "02:60"
+    Then el sistema lanza FormatoTiempoInvalido
+
+  Scenario: Valor cero es rechazado
+    When se intenta crear TiempoAP desde "00:00"
+    Then el sistema lanza ValorTiempoInvalido
+
+  Scenario: Constructor desde segundos directo
+    When se crea TiempoAP desde segundos Decimal("196")
+    Then el valor en segundos es 196
+
+  Scenario: Segundos negativos o cero son rechazados desde constructor directo
+    When se intenta crear TiempoAP desde segundos Decimal("0")
+    Then el sistema lanza ValorTiempoInvalido

--- a/tests/features/steps/tiempo_ap_steps.py
+++ b/tests/features/steps/tiempo_ap_steps.py
@@ -1,0 +1,58 @@
+"""Step definitions BDD — US-ADJ-4.6: TiempoAP."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pytest_bdd import parsers, scenarios, then, when
+
+from shared.domain.value_objects.tiempo_ap import TiempoAP
+
+scenarios("../US-ADJ-4.6-tiempo-ap.feature")
+
+
+@pytest.fixture
+def context() -> dict:
+    return {}
+
+
+@when(parsers.parse('se crea TiempoAP desde "{texto}"'))
+def crear_desde_mmss(context: dict, texto: str) -> None:
+    context["tiempo_ap"] = TiempoAP.desde_mmss(texto)
+
+
+@when(parsers.parse('se intenta crear TiempoAP desde "{texto}"'))
+def intentar_desde_mmss(context: dict, texto: str) -> None:
+    try:
+        TiempoAP.desde_mmss(texto)
+    except ValueError as exc:
+        context["error"] = str(exc)
+
+
+@when(parsers.parse('se crea TiempoAP desde segundos Decimal("{valor}")'))
+def crear_desde_segundos(context: dict, valor: str) -> None:
+    context["tiempo_ap"] = TiempoAP.desde_segundos(Decimal(valor))
+
+
+@when(parsers.parse('se intenta crear TiempoAP desde segundos Decimal("{valor}")'))
+def intentar_desde_segundos(context: dict, valor: str) -> None:
+    try:
+        TiempoAP.desde_segundos(Decimal(valor))
+    except ValueError as exc:
+        context["error"] = str(exc)
+
+
+@then(parsers.parse("el valor en segundos es {segundos:d}"))
+def validar_segundos(context: dict, segundos: int) -> None:
+    assert context["tiempo_ap"].segundos == Decimal(segundos)
+
+
+@then("el sistema lanza FormatoTiempoInvalido")
+def validar_error_formato(context: dict) -> None:
+    assert "FormatoTiempoInvalido" in context["error"]
+
+
+@then("el sistema lanza ValorTiempoInvalido")
+def validar_error_valor(context: dict) -> None:
+    assert "ValorTiempoInvalido" in context["error"]

--- a/tests/unit/shared/domain/test_tiempo_ap.py
+++ b/tests/unit/shared/domain/test_tiempo_ap.py
@@ -1,0 +1,38 @@
+"""Tests unitarios de TiempoAP."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from shared.domain.value_objects.tiempo_ap import TiempoAP
+
+
+def test_desde_mmss_valido() -> None:
+    assert TiempoAP.desde_mmss("02:30").segundos == Decimal("150")
+
+
+def test_desde_hhmmss_valido() -> None:
+    assert TiempoAP.desde_mmss("01:00:00").segundos == Decimal("3600")
+
+
+@pytest.mark.parametrize("texto", ["abc", "2:xx", "1:2:3:4", "02:60", "01:99:00"])
+def test_desde_mmss_invalido(texto: str) -> None:
+    with pytest.raises(ValueError, match="FormatoTiempoInvalido"):
+        TiempoAP.desde_mmss(texto)
+
+
+def test_desde_mmss_cero_invalido() -> None:
+    with pytest.raises(ValueError, match="ValorTiempoInvalido"):
+        TiempoAP.desde_mmss("00:00")
+
+
+def test_desde_segundos_directo() -> None:
+    assert TiempoAP.desde_segundos(Decimal("196")).segundos == Decimal("196")
+
+
+@pytest.mark.parametrize("valor", [Decimal("0"), Decimal("-1")])
+def test_desde_segundos_invalido(valor: Decimal) -> None:
+    with pytest.raises(ValueError, match="ValorTiempoInvalido"):
+        TiempoAP.desde_segundos(valor)


### PR DESCRIPTION
## Resumen
- agrega TiempoAP en shared/domain/value_objects
- encapsula parsing MM:SS y HH:MM:SS a segundos Decimal
- agrega cobertura unitaria y BDD de parseo/validacion

## Validacion
- ./.venv/bin/pytest tests/unit/shared/domain/test_tiempo_ap.py tests/features/steps/tiempo_ap_steps.py -q
- ./.venv/bin/codeguard src/shared/domain/value_objects