### PR TITLE
docs(sp-adj-05): ajuste documental y metodológico post-BL-003

### DIFF
--- a/.claude/tracking/README.md
+++ b/.claude/tracking/README.md
@@ -1,216 +1,48 @@
-# Sistema de Tracking - Documentación Técnica
+# Sistema de Tracking — Documentación Técnica
 
-Documentación técnica de la arquitectura interna del sistema de tracking.
+Módulo de tracking automático de tiempo usado por el skill `/implement-us`.
+Los archivos `*-tracking.json` en este directorio son generados automáticamente — no editar a mano.
 
-> **Para usuarios:** Ver [docs/tracking/user-guide.md](../docs/tracking/user-guide.md)
-
-Módulo core del sistema de tracking automático para el skill `/implement-us`.
+---
 
 ## Componentes
 
-### Modelos de Datos
+| Archivo | Rol |
+|---------|-----|
+| `time_tracker.py` | Clase `TimeTracker` — lógica central de tracking |
+| `tracker_cli.py` | CLI para operaciones desde `/implement-us` |
+| `commands.py` | Comandos de alto nivel |
+| `reports.py` | Generación de reportes de tiempo |
+| `*-tracking.json` | Datos persistidos por US (generados automáticamente) |
 
-#### Task
-Representa una tarea individual dentro de una fase.
+---
 
-**Campos:**
-- `task_id` (str): Identificador único (ej: "task_001")
-- `task_name` (str): Nombre descriptivo
-- `task_type` (str): Tipo (modelo, vista, controlador, test)
-- `estimated_minutes` (float): Estimación del plan en minutos
-- `started_at` (datetime): Timestamp de inicio
-- `completed_at` (datetime): Timestamp de finalización
-- `elapsed_seconds` (int): Duración real en segundos
-- `file_created` (str): Path del archivo creado (opcional)
-- `status` (str): Estado actual (pending, in_progress, completed)
+## Uso desde /implement-us
 
-**Propiedades calculadas:**
-- `actual_minutes`: Duración en minutos (elapsed_seconds / 60)
-- `variance_minutes`: Diferencia entre real y estimado
-- `variance_percent`: Varianza porcentual
-
-#### Phase
-Representa una fase del skill implement-us (0-9).
-
-**Campos:**
-- `phase_number` (int): Número de fase (0-9)
-- `phase_name` (str): Nombre descriptivo
-- `started_at` (datetime): Timestamp de inicio
-- `completed_at` (datetime): Timestamp de finalización
-- `elapsed_seconds` (int): Duración total en segundos
-- `status` (str): Estado (pending, in_progress, completed)
-- `tasks` (List[Task]): Lista de tareas de esta fase
-- `auto_approved` (bool): Si se completó automáticamente
-- `user_approval_time_seconds` (int): Tiempo esperando aprobación del usuario
-
-**Propiedades calculadas:**
-- `elapsed_minutes`: Duración en minutos
-
-#### Pause
-Representa una pausa manual del tracking.
-
-**Campos:**
-- `pause_id` (str): Identificador único (ej: "pause_001")
-- `started_at` (datetime): Timestamp de inicio de la pausa
-- `resumed_at` (datetime): Timestamp de reanudación
-- `duration_seconds` (int): Duración de la pausa en segundos
-- `reason` (str): Motivo de la pausa
-
-**Propiedades calculadas:**
-- `duration_minutes`: Duración en minutos
-- `is_active`: True si la pausa está activa (resumed_at es None)
-
-### TimeTracker
-
-Gestor central de tracking de tiempo.
-
-**Uso básico:**
+El skill `/implement-us` inicializa y gestiona el tracker automáticamente en cada fase.
+No requiere intervención manual del usuario.
 
 ```python
 from tracking import TimeTracker
 
-# Inicializar tracker
-tracker = TimeTracker(
-    us_id="US-001",
-    us_title="Implementar panel display",
-    us_points=3,
-    producto="mi_producto"
-)
-
-# Iniciar tracking
+tracker = TimeTracker(us_id="US-1.2.1", us_title="...", us_points=3, producto="ataraxiadive")
 tracker.start_tracking()
-
-# Iniciar una fase
 tracker.start_phase(0, "Validación de Contexto")
-
-# Trabajar...
-
-# Finalizar fase
+# ... trabajo ...
 tracker.end_phase(0)
-
-# Finalizar tracking
 tracker.end_tracking()
 ```
 
-**Métodos principales:**
+---
 
-- `start_tracking()`: Inicia el tracking de la Historia de Usuario
-- `end_tracking()`: Finaliza el tracking
-- `start_phase(number, name)`: Inicia una fase (0-9)
-- `end_phase(number)`: Finaliza una fase
-- `start_task(id, name, type, estimated)`: Inicia una tarea dentro de la fase actual
-- `end_task(id, file_created)`: Finaliza una tarea
-- `pause(reason)`: Pausa el tracking con razón opcional
-- `resume()`: Reanuda el tracking después de una pausa
-- `get_status()`: Obtiene el estado actual del tracking
+## Notas operativas
 
-## Persistencia
+- **Bug conocido:** `tracker_cli.py` usa `glob("US-*-tracking.json")` — IDs con prefijo distinto
+  a `US-` (ej: `INC-2.0`) no son encontrados. Workaround: usar prefijo `US-` para todos los IDs.
+  Ver `docs/plans/WORKFLOW-DESARROLLO.md §5`.
 
-Los datos se guardan automáticamente en `.claude/tracking/{us_id}-tracking.json` en formato JSON.
+- Los archivos JSON se acumulan indefinidamente. No hay política de archivo automático.
 
-**Ejemplo de archivo:**
+---
 
-```json
-{
-  "metadata": {
-    "us_id": "US-001",
-    "us_title": "Implementar panel display",
-    "us_points": 3,
-    "producto": "mi_producto",
-    "tracking_version": "1.0"
-  },
-  "timeline": {
-    "started_at": "2026-02-15T10:00:00Z",
-    "completed_at": "2026-02-15T14:00:00Z",
-    "total_elapsed_seconds": 14400,
-    "effective_seconds": 13500,
-    "paused_seconds": 900
-  },
-  "phases": [
-    {
-      "phase_number": 0,
-      "phase_name": "Validación de Contexto",
-      "started_at": "2026-02-15T10:00:00Z",
-      "completed_at": "2026-02-15T10:15:00Z",
-      "elapsed_seconds": 900,
-      "status": "completed",
-      "tasks": [],
-      "auto_approved": true
-    }
-  ],
-  "pauses": [],
-  "summary": {
-    "total_tasks": 15,
-    "completed_tasks": 15,
-    "total_phases": 10,
-    "estimated_total_minutes": 120,
-    "actual_total_minutes": 135,
-    "variance_minutes": 15,
-    "variance_percent": 12.5
-  }
-}
-```
-
-## Skills de Tracking
-
-Los siguientes skills interactúan con este módulo:
-
-- `/track-pause [razón]`: Pausar tracking con razón opcional
-- `/track-resume`: Reanudar tracking
-- `/track-status`: Ver estado actual del tracking
-- `/track-report [us_id]`: Generar reporte detallado
-- `/track-history [--last N]`: Ver historial de tracking
-
-Ver documentación de cada skill para detalles de uso.
-
-## Integración con /implement-us
-
-El skill `/implement-us` usa este módulo automáticamente para trackear tiempo en cada fase de implementación.
-
-No requiere intervención manual del usuario (excepto para pausas).
-
-## Ejemplo Avanzado
-
-```python
-from tracking import TimeTracker
-
-# Crear y iniciar tracker
-tracker = TimeTracker("US-001", "Nueva feature", 5, "mi_app")
-tracker.start_tracking()
-
-# Ejecutar múltiples fases
-for phase_num, phase_name in [
-    (0, "Validación"),
-    (1, "Escenarios BDD"),
-    (2, "Planning")
-]:
-    tracker.start_phase(phase_num, phase_name)
-
-    # Simular trabajo con tareas
-    if phase_num == 2:
-        tracker.start_task("task_001", "Crear plan", "docs", 15)
-        # ... trabajo ...
-        tracker.end_task("task_001")
-
-    tracker.end_phase(phase_num)
-
-# Pausar manualmente
-tracker.pause("Reunión del equipo")
-# ... 30 minutos ...
-tracker.resume()
-
-# Continuar con más fases...
-
-# Finalizar
-tracker.end_tracking()
-
-# Ver estado final
-status = tracker.get_status()
-print(f"Tiempo efectivo: {status['effective_seconds'] / 60} minutos")
-```
-
-## Documentación Adicional
-
-- **Guía de Usuario**: `docs/tracking/user-guide.md`
-- **Arquitectura**: `docs/developer/architecture/tracking.md`
-- **Ejemplos**: `docs/tracking/examples.md`
+*Actualizado: SP-ADJ-5.5 (2026-04-04) — eliminadas referencias a docs/skills inexistentes*

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Repositorio del experimento IEDD + Software Limpio aplicado a un producto real.
 |-------------|--------|----------|
 | SP1 — La Performance | ✅ Cerrado | BL-001 |
 | SP2 — La Competencia | ✅ Cerrado | BL-002 |
-| SP3 — El Torneo | 🔄 Implementación funcional completa, cierre formal pendiente | BL-003 |
+| SP3 — El Torneo | ✅ Cerrado | BL-003 |
 | SP4 — La Plataforma | 🔲 Pendiente | BL-004 |
 | SP5 — La Puesta en Marcha | 🔲 Pendiente | BL-005 |
 
-SP3 ya dejó implementados `Torneo`, `Registro`, `Identidad`, auth por rol y el flujo de overall por torneo (`US-3.5.1` a `US-3.5.3`).
+SP3 implementó `Torneo`, `Registro`, `Identidad`, auth por rol y el flujo de overall por torneo (`US-3.5.1` a `US-3.5.3`). Cerrado con tag `v0.4.0`.
 
 ## Stack
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,8 @@
+# ESTADO: histórico — propuesta pre-ADR de Febrero 2026.
+# El stack actual usa SQLite por BC (ADR-007) y no requiere Docker en desarrollo (ADR-010).
+# Ver: CLAUDE.md §13 para el comando de desarrollo actual (uv run fastapi dev src/app.py).
+# Conservar como referencia de despliegue productivo futuro (a actualizar en SP5).
+
 services:
   db:
     image: postgres:16-alpine

--- a/docs/contexto/ARTEFACTOS-WORKFLOW.md
+++ b/docs/contexto/ARTEFACTOS-WORKFLOW.md
@@ -1,0 +1,95 @@
+# ARTEFACTOS-WORKFLOW — Clasificación de Artefactos del Proceso de Desarrollo
+
+**Versión:** 1.0
+**Fecha:** 2026-04-04
+**Fuente:** HITO-14 D-01 — poda metodológica al cierre de SP3
+**Complementa:** `docs/plans/WORKFLOW-DESARROLLO.md`
+
+---
+
+## Propósito
+
+Este documento clasifica cada artefacto del workflow por su carácter operativo:
+
+| Categoría | Definición |
+|-----------|------------|
+| **obligatorio** | Sin él el workflow no funciona o la trazabilidad se rompe |
+| **opcional** | Aporta valor pero se puede omitir sin consecuencias sistémicas |
+| **derivado** | Se genera automáticamente — no requiere mantenimiento manual |
+
+El objetivo es identificar qué se puede eliminar o automatizar para reducir el overhead de sesión.
+
+---
+
+## Nivel US-IEDD
+
+| Artefacto | Categoría | Cuándo se crea | Quién lo crea |
+|-----------|-----------|----------------|---------------|
+| `feature/US-X.Y.Z-*` (branch) | **obligatorio** | Antes de cualquier trabajo | Claude |
+| `.claude/tracking/US-X.Y.Z-tracking.json` | **obligatorio** | Fase 0 de `/implement-us` | `/implement-us` |
+| `docs/specs/spX/US-X.Y.Z.md` | **obligatorio** | Antes del sprint, Fase 0 lo usa como input | Claude (planificación) |
+| GitHub Issue | **obligatorio** | Al inicio del sprint | Claude |
+| Tests (unit + integration + BDD) | **obligatorio** | Fases 5–6 de `/implement-us` | `/implement-us` |
+| `docs/reports/US-X.Y.Z-report.md` | **obligatorio** | Fase 10 de `/implement-us` | `/implement-us` |
+| `quality/reports/codeguard/US-X.Y.Z-*.txt` | **derivado** | Pre-commit hook automático | CodeGuard |
+| `quality/reports/designreviewer/*` (pre-push) | **derivado** | Pre-push hook automático | DesignReviewer |
+| `.feature` file (BDD) | **opcional** | Fase 5, si hay comportamiento observable desde fuera | `/implement-us` |
+
+---
+
+## Nivel Incremento
+
+| Artefacto | Categoría | Cuándo se crea | Quién lo crea |
+|-----------|-----------|----------------|---------------|
+| Ajuste de umbrales `pyproject.toml` (CBO/WMC) | **obligatorio** | Antes de la primera US del incremento | Claude |
+| Registro en BL activa (inventario de CIs) | **obligatorio** | Al cerrar el último PR del incremento | Claude |
+| DesignReviewer manual post-incremento | **obligatorio** | Después del último merge del incremento | Claude |
+| `quality/reports/designreviewer/INC-X.Y-report.txt` | **opcional** | Solo si hay hallazgos o CRITICAL | Claude |
+| Mini-retrospectiva en BL activa | **opcional** | Al cierre del incremento, si hay aprendizajes | Claude |
+| Cierre del Issue en GitHub | **derivado** | Automático al mergear PR con referencia `Closes #N` | GitHub |
+
+---
+
+## Nivel Subproyecto (Baseline)
+
+| Artefacto | Categoría | Cuándo se crea | Quién lo crea |
+|-----------|-----------|----------------|---------------|
+| `docs/plans/spX/SP-N-candidatas.md` | **obligatorio** | Planificación del SP, antes de la primera US | Claude |
+| `docs/plans/spX/PLAN-SP-N.md` | **obligatorio** | Planificación del SP | Claude |
+| `quality/reports/architectanalyst/BL-NNN-*.json` | **obligatorio** | Antes del merge a main | Claude (manual) |
+| `quality/reports/uat/SPN/design.md` | **obligatorio** | Antes del UAT | Claude |
+| `tests/uat/spN/` (seed + script) | **obligatorio** | Antes del UAT | Claude |
+| `quality/reports/uat/SPN/report.md` | **obligatorio** | Al ejecutar el UAT | Claude |
+| `.cm/baselines/BL-NNN.md` | **obligatorio** | Al cerrar el SP | Claude |
+| Actualización CLAUDE.md §14 | **obligatorio** | Al cerrar el SP | Claude |
+| Merge develop → main + tag vN | **obligatorio** | Al cerrar el SP | Claude |
+| `docs/contexto/HITO-N-*.md` | **opcional** | Si hay aprendizajes experimentales relevantes | Claude |
+| ADR nuevo | **opcional** | Si hay decisión arquitectónica nueva | Claude |
+| Actualización matrix.md | **opcional** | Si el SP incluye SP-ADJ con US-ADJ-N.M | Claude |
+| SP-ADJ (sprint de ajuste) | **opcional** | Si hay deuda acumulada técnica o documental | Victor + Claude |
+| `.cm/baselines/BL-NNN-arquitectura.json` (copia) | **derivado** | Copia del reporte ArchitectAnalyst | Claude |
+
+---
+
+## Observaciones de Poda (post-SP3)
+
+### Lo que se puede eliminar sin pérdida sistémica
+
+- **`quality/reports/designreviewer/` por US individual:** el pre-push automático ya persiste el resultado en el log del hook. El archivo manual por US es redundante salvo que haya CRITICAL que documentar.
+- **Mini-retrospectiva en BL por incremento:** valioso si hay aprendizajes, pero en incrementos simples (CRUD) genera overhead sin retorno. Condicionarlo a si hay algo relevante para el paper o futuras sesiones.
+- **`.feature` files para lógica de dominio pura:** pytest-bdd agrega overhead real (datatables, glue code, lenguaje Gherkin). Reservar para flujos end-to-end observables desde el exterior.
+
+### Lo que no se puede automatizar fácilmente
+
+- **DesignReviewer manual post-incremento:** requiere lectura consciente del reporte consolidado, no solo ejecución.
+- **ArchitectAnalyst:** ídem — su valor está en la interpretación de tendencias, no en la ejecución.
+- **UAT design.md:** requiere conocimiento del dominio para diseñar los checks correctos.
+
+### Candidatos a automatización en SP4
+
+- **Cierre de Issue GitHub** ya es automático con `Closes #N` en el PR.
+- **Registro en BL activa post-incremento:** podría generarse parcialmente desde git log + tracker.
+
+---
+
+*Creado: 2026-04-04 — SP-ADJ-05 / SP-ADJ-5.1 — HITO-14 D-01*

--- a/docs/design/context-map.md
+++ b/docs/design/context-map.md
@@ -6,7 +6,7 @@
 | **Capa IEDD** | Capa 2 — Modelo DDD (diseño estratégico) |
 | **Fecha** | 2026-03-18 |
 | **Fuente** | Event Storming Big Picture (`docs/design/event-storming-big-picture.md`) |
-| **Estado** | ✅ v1.1 — Notificaciones promovido a BC Generic con Event Sourcing |
+| **Estado** | ✅ v1.2 — Columna Madurez agregada post-BL-003 |
 
 ---
 
@@ -16,14 +16,16 @@ El ES Big Picture identificó 4 BCs de dominio + 1 genérico. El análisis del C
 incorporó `Notificaciones` como BC Generic adicional con Event Sourcing.
 Resultado final: **4 BCs de dominio + 2 genéricos**.
 
-| BC | Tipo DDD | Event Sourcing | Descripción |
-|----|----------|:--------------:|-------------|
-| **Torneo** | Supporting | — | Ciclo de vida del torneo: creación, disciplinas, organización, sede, estados (Abierto → Cerrado/Cancelado). Incluye catálogos de `EntidadOrganizadora` y `Sede`. |
-| **Registro** | Supporting | — | Atleta como persona (datos personales, brevet). Inscripción al torneo: habilitación, anuncios de participación, cancelaciones. |
-| **Competencia** | **Core Domain** | ✅ | Announced Performance, grilla de salida, ejecución de performances, asignación de tarjetas. Modela el corazón del deporte. |
-| **Resultados** | Supporting | — | Cálculo de rankings por disciplina y género, Overall multi-disciplina, publicación incremental. |
-| **Identidad** | Generic | — | Usuarios del sistema, roles (organizador, juez, atleta), autenticación/autorización. Cross-cutting. |
-| **Notificaciones** | Generic | ✅ | Suscribe a eventos de todos los BCs. Gestiona el ciclo de vida de cada notificación (solicitada → enviada → fallida). Idempotencia por Event Sourcing. |
+| BC | Tipo DDD | Event Sourcing | Madurez | Descripción |
+|----|----------|:--------------:|:-------:|-------------|
+| **Torneo** | Supporting | — | operativo | Ciclo de vida del torneo: creación, disciplinas, organización, sede, estados (Abierto → Cerrado/Cancelado). Incluye catálogos de `EntidadOrganizadora` y `Sede`. |
+| **Registro** | Supporting | — | operativo | Atleta como persona (datos personales, brevet). Inscripción al torneo: habilitación, anuncios de participación, cancelaciones. |
+| **Competencia** | **Core Domain** | ✅ | operativo | Announced Performance, grilla de salida, ejecución de performances, asignación de tarjetas. Modela el corazón del deporte. |
+| **Resultados** | Supporting | — | operativo | Cálculo de rankings por disciplina y género, Overall multi-disciplina, publicación incremental. |
+| **Identidad** | Generic | — | operativo | Usuarios del sistema, roles (organizador, juez, atleta), autenticación/autorización. Cross-cutting. |
+| **Notificaciones** | Generic | ✅ | modelado | Suscribe a eventos de todos los BCs. Gestiona el ciclo de vida de cada notificación (solicitada → enviada → fallida). Idempotencia por Event Sourcing. |
+
+> **Madurez:** `operativo` = aggregate + API + tests completos · `modelado` = diseño DDD completo, implementación mínima (estado post-BL-003)
 
 > **Nota — Configuración:** no emergió como BC propio en el ES. Los conceptos de
 > disciplinas y reglas de tarjetas son datos de configuración que residen en los BCs
@@ -359,5 +361,6 @@ Este Context Map es insumo directo para:
 
 *Documento creado: 2026-03-18 — Semana 0, Fase 0*
 *v1.1: Notificaciones promovido a BC Generic con Event Sourcing*
+*v1.2: Columna Madurez agregada — estado post-BL-003 (SP-ADJ-5.3)*
 *Fuente: Event Storming Big Picture + análisis Context Map con Victor Valotto*
 *Mantenido por: Claude Cowork + Victor Valotto*

--- a/docs/dominio/04-estrategia_desarrollo.md
+++ b/docs/dominio/04-estrategia_desarrollo.md
@@ -4,6 +4,11 @@ Plataforma de Gestión de Torneos de Apnea
 
 Estrategia de Desarrollo --- Subproyectos e Incrementos
 
+> **Estado documental:** histórico — planificación inicial de Febrero 2026.
+> Las DoDs de SP1/SP2 mencionan PostgreSQL y docker-compose, que fueron reemplazados
+> por SQLite por BC (ADR-007) y desarrollo sin Docker (ADR-010) antes de iniciar la implementación.
+> La estructura de subproyectos e incrementos sigue vigente. Ver `CLAUDE.md §9` para el estado actual.
+
   **Proyecto:**            Ataraxiadive
   ------------------------ ------------------------------------------------------------------
   **Versión:**             2.0


### PR DESCRIPTION
## Resumen

Cierra los ítems documentales y metodológicos de HITO-14 (D-01, D-02, D-03, D-07, D-08, D-09) prescriptos al cierre de SP3. No hay cambios de código — es deuda documental acumulada que conviene saldar antes de arrancar SP4.

## Cambios principales

- **SP-ADJ-5.1** — `docs/contexto/ARTEFACTOS-WORKFLOW.md`: nuevo documento que clasifica cada artefacto del workflow como obligatorio/opcional/derivado. Identifica qué se puede eliminar o automatizar para reducir overhead de sesión.
- **SP-ADJ-5.2** — Consistencia documental residual: README actualizado (SP3 → ✅ Cerrado, v0.4.0), `docker-compose.yml` y `docs/dominio/04-estrategia_desarrollo.md` marcados como históricos pre-ADR.
- **SP-ADJ-5.3** — `docs/design/context-map.md`: columna Madurez agregada a la tabla de BCs (operativo/modelado), alineada con CLAUDE.md §7.
- **SP-ADJ-5.4** — Vigencia histórica: completado en sesión anterior (PLAN-EXPERIMENTO.md + 02-arquitectura_referencia.md).
- **SP-ADJ-5.5** — `.claude/tracking/README.md`: eliminadas referencias a 3 docs y 5 skills que nunca existieron.

## Impacto

- Tests: sin cambios
- Archivos: 6 modificados (5 docs + 1 tracking README)
- Líneas: ~144 agregadas, ~204 eliminadas (mayoría en tracking/README reescrito)

## Checklist

- [x] Sin cambios de código — solo documentación
- [x] Todos los paths referenciados verificados
- [x] Issue vvalotto/claude-dev-kit#46 creado para D-04 (fuera de scope de este SP-ADJ)