### PR TITLE
docs(design): INC-4.0 UX Design — paquete completo todos los roles [INC-4.0]

### DIFF
--- a/docs/contexto/HITO-18-UX-PROTOTIPO-NAVEGABLE-COMO-ETAPA-VALIDACION.md
+++ b/docs/contexto/HITO-18-UX-PROTOTIPO-NAVEGABLE-COMO-ETAPA-VALIDACION.md
@@ -1,0 +1,160 @@
+# HITO-18 — El prototipo navegable como etapa de validación entre especificación e implementación
+
+| Campo | Valor |
+|-------|-------|
+| **Documento** | HITO-18 — Hallazgo metodológico al inicio de INC-4.0 |
+| **Fecha** | 2026-04-04 |
+| **Sprint** | SP4 — La Plataforma — inicio de INC-4.0 |
+| **Relacionado** | `docs/design/ux/README.md` · `docs/plans/sp4/PLAN-SP4.md` |
+
+---
+
+## Contexto
+
+Al iniciar INC-4.0 —el primer incremento con frontend real en el proyecto—, el plan
+original preveía producir cinco artefactos Markdown (`flujos-por-rol.md`,
+`wireframes-*.md`, `decisiones-frontend.md`) como especificaciones de diseño para Code.
+
+La primera pregunta de Victor fue directa: *"¿cómo valido la interfaz si no tengo
+una visualización de alguna maqueta o wireframe?"*
+
+Esa pregunta expuso un gap en el proceso que no era evidente en los sprints anteriores
+—porque los sprints anteriores no tenían interfaz de usuario.
+
+---
+
+## El gap identificado
+
+El proceso IEDD en sprints de backend sigue esta cadena:
+
+```
+Dominio → Modelo DDD → Especificación (US-IEDD) → Implementación
+```
+
+En esa cadena, la especificación es textual (precondiciones, postcondiciones, invariantes,
+escenarios BDD) y es suficiente porque el dominio es lógica de negocio: o una regla
+se cumple o no se cumple, y eso se puede verificar con tests automatizados.
+
+Cuando aparece el frontend, emerge una dimensión nueva: **la interacción física**.
+
+La interfaz del juez de AtaraxiaDive tiene restricciones que no son verificables con
+tests ni con revisión de texto:
+- Botones ≥ 48px — ¿se toca cómodamente con el dedo mojado en el borde de la pileta?
+- Alto contraste — ¿se lee bajo sol directo?
+- ≤ 6 toques por performance — ¿el flujo es naturalmente ejecutable sin mirar la pantalla?
+- Tarjeta amarilla como estado transitorio — ¿el juez entiende sin texto de ayuda que
+  debe resolver antes de cerrar?
+
+Ninguna de estas preguntas tiene respuesta en un archivo Markdown. La especificación
+puede describir la restricción, pero no puede validarla. Solo el ojo y el dedo en una
+pantalla real pueden hacerlo.
+
+El gap es este: **entre la especificación y la implementación, cuando hay UX con
+restricciones físicas, falta una etapa de validación visual e interactiva**.
+
+---
+
+## La decisión tomada
+
+Se acordó un proceso en dos pasos por cada pantalla o flujo:
+
+```
+Paso 1 — Prototipo navegable (HTML autocontenido)
+    → Creado por Cowork
+    → Renderizado en el chat via Claude in Chrome (GIF del flujo)
+    → Abierto por Victor en el celular — validación táctil real
+    → Iteración hasta aprobación visual
+
+Paso 2 — Spec Markdown formal
+    → Escrita por Cowork a partir del prototipo aprobado
+    → Consumida por Code en /implement-us
+    → Commiteada al repo junto con el prototipo HTML
+```
+
+El prototipo no reemplaza la spec — la precede y la fundamenta. La spec sigue siendo
+el artefacto que Code consume. Pero la spec ahora describe algo que fue validado
+físicamente, no solo conceptualmente.
+
+Los prototipos se guardan en `docs/design/ux/prototipos/` y se commitean al repo.
+No son descartables: son documentación viva del diseño que sirve de referencia
+para SP5 cuando haya usuarios reales haciendo pruebas.
+
+---
+
+## El aprendizaje central
+
+> Cuando una US-IEDD afecta una interfaz con restricciones físicas de uso,
+> la especificación textual es necesaria pero no suficiente como entrada para
+> la implementación. Se necesita una etapa intermedia de prototipado navegable
+> que permita validar la interacción antes de formalizarla en código.
+
+Esta etapa no es optativa cuando:
+- El usuario opera bajo condiciones físicas adversas (manos mojadas, sol, tensión)
+- La densidad de información por pantalla está restringida (≤ 6 toques)
+- Los estados de la UI mapean a estados del dominio con invariantes duros
+  (tarjeta amarilla que bloquea el cierre de disciplina)
+- El dispositivo de uso difiere del dispositivo de desarrollo (mobile vs desktop)
+
+En esos casos, el prototipo navegable actúa como un **oráculo de interacción**: no
+verifica la lógica de negocio (eso lo hace el test), verifica que la interacción
+diseñada es ejecutable en las condiciones reales de uso.
+
+---
+
+## Implicancia para IEDD como metodología
+
+La cadena de 5 capas de IEDD no contempla explícitamente la validación de UX. Para
+proyectos con frontend, la Capa 3 (Especificación) debería distinguir dos sub-tipos:
+
+```
+Capa 3a — Especificación de comportamiento (US-IEDD clásica)
+          → precondiciones, postcondiciones, invariantes, BDD
+          → suficiente para backend puro
+
+Capa 3b — Especificación de interacción (cuando hay UI con restricciones físicas)
+          → prototipo navegable aprobado → spec formal derivada del prototipo
+          → necesaria cuando el dispositivo de uso o las condiciones físicas
+            no pueden inferirse del texto
+```
+
+La distinción no invalida el proceso — lo extiende. Los proyectos sin UI o con UI
+convencional (desktop, sin restricciones físicas) pueden operar con Capa 3a solamente.
+Cuando el uso físico importa, Capa 3b se vuelve obligatoria antes de implementar.
+
+---
+
+## Herramienta que habilitó el proceso
+
+**Claude in Chrome** es la pieza que cierra el ciclo dentro del mismo entorno de trabajo:
+permite crear un HTML, abrirlo en el browser, navegar el prototipo, grabar un GIF del
+flujo, y mostrarlo en el chat — sin salir de la sesión Cowork. Esto reduce la fricción
+de validación al mínimo y hace que el ciclo prototipo → feedback → ajuste sea rápido
+enough para iterar en una sesión.
+
+Sin esa capacidad, el ciclo requeriría que el desarrollador abra un archivo externo,
+tome capturas manualmente, y las comparta en el chat — agregando fricción suficiente
+como para saltearse la validación.
+
+---
+
+## Regla práctica identificada
+
+> Para cualquier pantalla con restricciones físicas de uso, el proceso es:
+> prototipo navegable validado en el dispositivo real → spec formal → implementación.
+> No existe atajo: la spec sin prototipo previo produce interfaces que fallan la
+> validación táctil aunque sean correctas en papel.
+
+---
+
+## Acción incorporada
+
+- [x] Proceso documentado en `docs/design/ux/README.md`
+- [x] Prototipo HTML como artefacto de primera clase en INC-4.0
+- [x] Carpeta `docs/design/ux/prototipos/` definida en la estructura del proyecto
+- [ ] Evaluar si la plantilla US-IEDD debería incluir un campo
+      "¿requiere prototipo navegable?" con criterio de decisión basado en
+      restricciones físicas de uso
+
+---
+
+*Registrado al inicio de INC-4.0 — la pregunta sobre validación que reveló el gap entre spec e implementación en proyectos con frontend físicamente restringido*

--- a/docs/design/ux/README.md
+++ b/docs/design/ux/README.md
@@ -1,0 +1,162 @@
+# INC-4.0 — UX Design — Proceso y Artefactos
+
+| Campo | Valor |
+|-------|-------|
+| **Incremento** | INC-4.0 — UX Design |
+| **Sprint** | SP4 — La Plataforma |
+| **Responsable** | Cowork (claude.ai) con input de Victor |
+| **Fecha** | 2026-04-04 |
+| **DoD** | Todos los artefactos comprometidos en esta carpeta y aprobados por Victor antes de escribir una línea de frontend |
+
+---
+
+## Propósito de esta carpeta
+
+`docs/design/ux/` contiene los artefactos de diseño de interfaz que son el **input directo
+de INC-4.1 y siguientes**. Sin estos artefactos aprobados, Code no puede iniciar la
+implementación del frontend.
+
+Esta carpeta tiene dos tipos de artefactos con roles distintos:
+
+| Tipo | Formato | Propósito | Consumidor |
+|------|---------|-----------|-----------|
+| **Prototipo navegable** | HTML autocontenido | Validación visual e interactiva — se revisa en el chat y en el celular | Victor (revisión) |
+| **Spec de diseño** | Markdown | Especificación técnica que Code usa para implementar | Claude Code + `/implement-us` |
+
+Los prototipos se guardan en `prototipos/`. Las specs en la raíz de esta carpeta.
+Ambos se commitean al repo — los prototipos son documentación viva del diseño.
+
+---
+
+## Artefactos de INC-4.0
+
+### Specs (Markdown — input para Code)
+
+| Artefacto | Estado | Descripción |
+|-----------|--------|-------------|
+| `flujos-por-rol.md` | ⏳ Pendiente | Flujos de usuario por rol: juez, organizador, atleta |
+| `wireframes-juez.md` | ⏳ Pendiente | Pantallas del juez: 6 pasos + amarilla en revisión + BKO + offline |
+| `wireframes-organizador.md` | ⏳ Pendiente | Panel del organizador: torneo, grilla, jueces asignados, auditoría |
+| `wireframes-atleta.md` | ⏳ Pendiente | Portal del atleta: inscripción, anuncios, resultados |
+| `decisiones-frontend.md` | ⏳ Pendiente | Stack final: librería UI, routing, state management, estrategia offline |
+
+### Prototipos (HTML — input para validación visual)
+
+| Artefacto | Estado | Descripción |
+|-----------|--------|-------------|
+| `prototipos/prototipo-juez.html` | ⏳ Pendiente | Flujo completo del juez — navegable, mobile-first |
+| `prototipos/prototipo-organizador.html` | ⏳ Pendiente | Panel del organizador — navegable |
+| `prototipos/prototipo-atleta.html` | ⏳ Pendiente | Portal del atleta — navegable |
+
+---
+
+## Proceso de validación por artefacto
+
+El orden no es opcional. Cada pantalla sigue este ciclo antes de pasar a la siguiente:
+
+```
+1. Cowork crea prototipo HTML navegable
+       ↓
+2. Se renderiza en el chat (Claude in Chrome → GIF del flujo)
+       ↓
+3. Victor lo abre en el celular y toca los botones con el dedo
+       ↓
+4. Iteración hasta aprobación visual
+       ↓
+5. Cowork escribe la spec Markdown formal (wireframes-*.md)
+       ↓
+6. Commit de ambos (prototipo + spec)
+       ↓
+7. Victor revisa el Markdown y aprueba
+       ↓
+8. Siguiente artefacto
+```
+
+La validación en celular es **obligatoria para la interfaz del juez** por las restricciones
+físicas del dominio (ver más abajo). Para organizador y atleta es recomendable pero no bloqueante.
+
+---
+
+## Restricciones de diseño del dominio (no negociables)
+
+Estas restricciones son invariantes de UX — equivalentes a los invariantes de dominio.
+Aplican a **toda** la interfaz del juez y guían el diseño de las demás.
+
+### Interfaz del juez
+
+| Restricción | Valor | Fundamento |
+|-------------|-------|-----------|
+| Toques por performance | ≤ 6 | El juez no puede distraerse de la performance del atleta |
+| Tamaño mínimo de botón | ≥ 48px | Operación con manos mojadas en borde de pileta |
+| Contraste | Alto — fondo oscuro / texto blanco | Uso bajo sol directo en competencias al aire libre |
+| Tipografía | ≥ 18px para datos críticos | Legibilidad a distancia y bajo tensión |
+| El juez solo ve sus disciplinas asignadas | — | Invariante de seguridad del BC Competencia |
+
+### Flujo del juez — los 6 pasos
+
+```
+[1] Llamar atleta
+    ↓
+[2] Confirmar presencia
+    ↓
+[3] Iniciar performance (OT)
+    ↓
+[4] Finalizar performance
+    ↓
+[5] Registrar marca (RP)
+    ↓
+[6] Asignar tarjeta  →  Blanca | Amarilla* | Roja
+```
+
+### Casos especiales obligatorios
+
+**Tarjeta amarilla — estado de revisión transitorio:**
+```
+AsignarTarjeta(Amarilla) → Performance en revisión
+    ├── ResolverRevision(Blanca) → Performance válida
+    └── ResolverRevision(Roja)  → Performance descalificada
+
+INV: CerrarCompetencia falla si existe alguna Performance con tarjeta Amarilla sin resolver.
+```
+
+**BKO (black-out):**
+```
+El juez activa BKO → tarjeta Roja automática + campo distancia alcanzada obligatorio
+```
+
+**DNS (Did Not Start):**
+```
+El atleta no se presenta al OT → el juez registra DNS → siguiente atleta en la grilla
+```
+
+---
+
+## Stack técnico (a confirmar en decisiones-frontend.md)
+
+```
+Vite + React + TypeScript
+├── Routing:       React Router v6
+├── Estado global: Zustand (preferido) o React Query
+├── UI:            shadcn/ui + Tailwind — mobile-first, alto contraste
+├── PWA:           vite-plugin-pwa (Workbox)
+└── Offline:       IndexedDB via Dexie.js
+```
+
+La decisión final entre Zustand y React Query se documenta en `decisiones-frontend.md`
+con fundamento en los patrones de estado de cada rol.
+
+---
+
+## Herramientas usadas en INC-4.0
+
+| Herramienta | Uso |
+|------------|-----|
+| **Cowork** | Autor de todos los artefactos |
+| **Claude in Chrome** | Abre el HTML, navega el prototipo, graba GIF del flujo para revisión en el chat |
+| **design:design-handoff** | Genera la spec técnica de componentes (estados, tamaños, props) a partir del prototipo aprobado |
+| **design:ux-copy** | Copy de botones y mensajes de la interfaz del juez — alta precisión requerida |
+
+---
+
+*Creado: 2026-04-04 — inicio de INC-4.0*
+*Proceso acordado en sesión Cowork — ver HITO-18*

--- a/docs/design/ux/README.md
+++ b/docs/design/ux/README.md
@@ -5,7 +5,7 @@
 | **Incremento** | INC-4.0 — UX Design |
 | **Sprint** | SP4 — La Plataforma |
 | **Responsable** | Cowork (claude.ai) con input de Victor |
-| **Fecha** | 2026-04-04 |
+| **Fecha** | 2026-04-08 |
 | **DoD** | Todos los artefactos comprometidos en esta carpeta y aprobados por Victor antes de escribir una línea de frontend |
 
 ---
@@ -34,19 +34,37 @@ Ambos se commitean al repo — los prototipos son documentación viva del diseñ
 
 | Artefacto | Estado | Descripción |
 |-----------|--------|-------------|
-| `flujos-por-rol.md` | ⏳ Pendiente | Flujos de usuario por rol: juez, organizador, atleta |
-| `wireframes-juez.md` | ⏳ Pendiente | Pantallas del juez: 6 pasos + amarilla en revisión + BKO + offline |
-| `wireframes-organizador.md` | ⏳ Pendiente | Panel del organizador: torneo, grilla, jueces asignados, auditoría |
-| `wireframes-atleta.md` | ⏳ Pendiente | Portal del atleta: inscripción, anuncios, resultados |
-| `decisiones-frontend.md` | ⏳ Pendiente | Stack final: librería UI, routing, state management, estrategia offline |
+| `flujos-por-rol.md` | ✅ Completo | Flujos de usuario por rol: juez, organizador y atleta |
+| `wireframes-juez.md` | ✅ Completo | Pantallas del juez: 6 pasos + amarilla en revisión + BKO + offline |
+| `wireframes-organizador.md` | ✅ Completo | Panel del organizador: torneo, grilla, jueces asignados, auditoría |
+| `wireframes-atleta.md` | ✅ Completo | Portal del atleta: inscripción, anuncios, grilla y resultados |
+| `wireframes-registro-roles.md` | ✅ Completo | Onboarding, perfil multirol, notificaciones e invitaciones de juez |
+| `wireframes-setup-torneo.md` | ✅ Completo | Flujo de preparación del torneo: disciplinas, grilla y asignación de jueces |
+| `decisiones-frontend.md` | ✅ Completo | Stack final: librería UI, routing, state management y estrategia offline |
+| `decisiones-registro-usuario.md` | ✅ Completo | Decisiones específicas del flujo de registro, roles y certificaciones |
 
 ### Prototipos (HTML — input para validación visual)
 
 | Artefacto | Estado | Descripción |
 |-----------|--------|-------------|
-| `prototipos/prototipo-juez.html` | ⏳ Pendiente | Flujo completo del juez — navegable, mobile-first |
-| `prototipos/prototipo-organizador.html` | ⏳ Pendiente | Panel del organizador — navegable |
-| `prototipos/prototipo-atleta.html` | ⏳ Pendiente | Portal del atleta — navegable |
+| `prototipos/prototipo-juez.html` | ✅ Completo | Flujo completo del juez — navegable, mobile-first |
+| `prototipos/prototipo-organizador.html` | ✅ Completo | Panel del organizador operativo — navegable |
+| `prototipos/prototipo-atleta.html` | ✅ Completo | Portal del atleta — navegable |
+| `prototipos/prototipo-registro-roles.html` | ✅ Completo | Registro, perfil multirol, notificaciones e invitaciones |
+| `prototipos/prototipo-setup-torneo.html` | ✅ Completo | Setup del torneo antes de la operación en vivo |
+
+### Estado del paquete UX
+
+El paquete base de INC-4.0 quedó cubierto con estos bloques:
+
+- autenticación, onboarding y gestión multirol
+- operación del juez en competencia
+- operación del organizador en vivo
+- preparación y publicación del torneo
+- experiencia del atleta pre-competencia y post-competencia
+- decisiones de frontend para iniciar INC-4.1
+
+En otras palabras, esta carpeta ya contiene el set mínimo de contratos UX necesarios para comenzar la implementación del frontend.
 
 ---
 

--- a/docs/design/ux/decisiones-frontend.md
+++ b/docs/design/ux/decisiones-frontend.md
@@ -1,0 +1,295 @@
+# Decisiones de Stack Frontend — AtaraxiaDive
+
+> Artefacto INC-4.0 · Decisiones técnicas que habilitan INC-4.2 (implementación React)
+> Fecha: 2026-04-05
+> Ver también: ADR-003 (React PWA), ADR-010 (sin Docker)
+
+---
+
+## Contexto
+
+INC-4.0 produjo cinco artefactos de UX validados:
+
+- `prototipo-juez.html` + `wireframes-juez.md` — interfaz mobile-first del juez
+- `prototipo-organizador.html` + `wireframes-organizador.md` — panel desktop del organizador en vivo
+- `prototipo-atleta.html` + `wireframes-atleta.md` — portal mobile del atleta
+- `prototipo-registro-roles.html` + `wireframes-registro-roles.md` — onboarding y gestión multirol
+- `prototipo-setup-torneo.html` + `wireframes-setup-torneo.md` — preparación del torneo (pre-ejecución)
+
+Los prototipos son HTML/CSS/JS puros (sin framework) y funcionan como contratos visuales.
+INC-4.2 reimplementa esos prototipos como componentes React con lógica real conectada a la API.
+
+Este documento formaliza las decisiones de stack necesarias para iniciar INC-4.2.
+
+---
+
+## Decisiones
+
+### D-01 — Bundler y scaffolding: Vite + React + TypeScript
+
+**Decisión:** `npm create vite@latest frontend -- --template react-ts`
+
+**Justificación:**
+- HMR instantáneo — crítico para el ciclo de desarrollo iterativo por US
+- Build optimizado por defecto (tree-shaking, code splitting por ruta)
+- TypeScript strict desde el arranque, alineado con mypy en el backend
+- Alternativa descartada: Create React App (abandonado), Next.js (SSR innecesario para PWA offline-first)
+
+**Estructura generada:**
+```
+frontend/
+├── src/
+│   ├── components/   ← componentes compartidos (NavBar, KpiCard, etc.)
+│   ├── pages/        ← una carpeta por rol (juez/, organizador/, atleta/)
+│   ├── hooks/        ← useConnection, useGrilla, useCompetencia
+│   ├── stores/       ← estado global (Zustand)
+│   ├── api/          ← clients HTTP por BC
+│   └── main.tsx
+├── public/
+│   └── manifest.json ← PWA
+├── vite.config.ts
+└── index.html
+```
+
+---
+
+### D-02 — Routing: React Router v6
+
+**Decisión:** React Router DOM v6 con `createBrowserRouter`.
+
+**Rutas planificadas:**
+
+| Ruta | Componente | Rol |
+|------|-----------|-----|
+| `/juez` | `JuezLayout` | Juez |
+| `/juez/disciplinas` | `MisDisciplinas` | Juez |
+| `/juez/grilla` | `GrillaJuez` | Juez |
+| `/juez/performance/:id` | `PasosPerformance` | Juez |
+| `/organizador` | `OrgLayout` | Organizador |
+| `/organizador/dashboard` | `Dashboard` | Organizador |
+| `/organizador/grilla` | `GrillaOrganizador` | Organizador |
+| `/organizador/resultados` | `Resultados` | Organizador |
+| `/organizador/jueces` | `Jueces` | Organizador |
+| `/organizador/torneo` | `GestionTorneo` | Organizador |
+| `/organizador/audit` | `AuditLog` | Organizador |
+| `/` | redirect según rol | — |
+
+**Guards de ruta:** HOC `<RequireRole role="juez|organizador">` que lee el JWT y redirige a `/login` si no autenticado o rol incorrecto.
+
+---
+
+### D-03 — Estado global: Zustand
+
+**Decisión:** Zustand para estado global de sesión y competencia activa.
+
+**Justificación:**
+- API mínima (sin boilerplate Redux)
+- Compatible con React Query para datos del servidor
+- Persistencia sencilla con `zustand/middleware` (persist)
+- Alternativa descartada: Redux Toolkit (overhead innecesario para esta escala), Context API (re-renders)
+
+**Stores planificados:**
+
+| Store | Responsabilidad |
+|-------|----------------|
+| `useAuthStore` | JWT, rol activo, usuario |
+| `useConnectionStore` | estado online/offline, cola de sync |
+| `useCompetenciaStore` | disciplina activa, atleta siguiente, alertas |
+
+---
+
+### D-04 — Fetching y cache: TanStack Query (React Query v5)
+
+**Decisión:** TanStack Query para fetching, cache, y mutaciones.
+
+**Justificación:**
+- Stale-while-revalidate automático (crítico para grilla en tiempo real)
+- Mutations con rollback optimista para el juez (registrar resultado aunque offline)
+- `queryClient.invalidateQueries` al recibir eventos SSE del organizador
+- Alternativa descartada: SWR (menos features para mutaciones complejas), fetch manual (sin cache)
+
+**Endpoints de ejemplo:**
+
+```typescript
+// Grilla del juez
+useQuery({ queryKey: ['grilla', disciplinaId], queryFn: fetchGrilla })
+
+// Registrar resultado (mutación)
+useMutation({ mutationFn: registrarResultado, onSuccess: () => invalidateQueries(['grilla']) })
+```
+
+---
+
+### D-05 — Componentes UI: shadcn/ui + Tailwind CSS
+
+**Decisión:** shadcn/ui sobre Tailwind CSS, con los tokens de color de los prototipos como CSS variables.
+
+**Justificación:**
+- shadcn/ui genera componentes accesibles (Radix UI bajo el capó) directamente en el proyecto — sin dependencia de una librería externa
+- Tailwind permite replicar exactamente el sistema de tokens del prototipo (`bg-slate-900`, `sky-400`, etc.)
+- Alternativa descartada: MUI (theme override costoso), Chakra (bundle pesado), CSS Modules puro (sin componentes accesibles)
+
+**Mapeo tokens → Tailwind:**
+
+| Token prototipo | Variable CSS | Clase Tailwind aprox. |
+|----------------|-------------|----------------------|
+| `--bg` #0f172a | `--color-bg` | `bg-slate-950` |
+| `--surface` #1e293b | `--color-surface` | `bg-slate-800` |
+| `--accent` #38bdf8 | `--color-accent` | `text-sky-400` |
+| `--blanca` #22c55e | `--color-blanca` | `text-green-500` |
+| `--amarilla` #eab308 | `--color-amarilla` | `text-yellow-500` |
+| `--roja` #ef4444 | `--color-roja` | `text-red-500` |
+
+**Tailwind config:** extender `theme.colors` con los tokens exactos para evitar aproximaciones.
+
+---
+
+### D-06 — PWA: vite-plugin-pwa
+
+**Decisión:** `vite-plugin-pwa` con Workbox para service worker y manifest.
+
+**Configuración clave:**
+
+```typescript
+// vite.config.ts
+VitePWA({
+  registerType: 'autoUpdate',
+  workbox: {
+    globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+    runtimeCaching: [{
+      urlPattern: /^https:\/\/.*\/api\//,
+      handler: 'NetworkFirst',
+      options: { cacheName: 'api-cache', networkTimeoutSeconds: 3 }
+    }]
+  },
+  manifest: {
+    name: 'AtaraxiaDive',
+    short_name: 'AtaraxiaDive',
+    theme_color: '#0f172a',
+    display: 'standalone',
+    orientation: 'portrait'   // juez siempre portrait
+  }
+})
+```
+
+**Estrategia de cache:**
+- Assets estáticos: CacheFirst (versión de build)
+- Llamadas API: NetworkFirst con fallback a cache (timeout 3 s)
+- Escrituras (POST/PATCH): encolar si offline, sync al reconectar (ver D-07)
+
+---
+
+### D-07 — Persistencia offline: Dexie.js
+
+**Decisión:** Dexie.js (wrapper sobre IndexedDB) para la cola de sincronización offline.
+
+**Justificación:**
+- API promesa + TypeScript nativo
+- El juez puede operar completamente offline; los resultados se sincronizan al reconectar
+- Alternativa descartada: localStorage (síncrono, limitado a 5 MB), PouchDB (overhead CouchDB)
+
+**Esquema mínimo:**
+
+```typescript
+class AtaraxiaDiveDB extends Dexie {
+  pendingCommands!: Table<PendingCommand>
+
+  constructor() {
+    super('ataraxiadive')
+    this.version(1).stores({
+      pendingCommands: '++id, type, competenciaId, atletaId, createdAt'
+    })
+  }
+}
+
+interface PendingCommand {
+  id?: number
+  type: 'registrar_resultado' | 'asignar_tarjeta' | 'registrar_dns'
+  payload: Record<string, unknown>
+  competenciaId: string
+  atletaId: string
+  createdAt: number
+}
+```
+
+**Hook `useOfflineSync`:** al detectar reconexión (`navigator.onLine` + event `online`), drena la cola en orden FIFO vía la API del BC Competencia.
+
+---
+
+### D-08 — Comunicación en tiempo real: Server-Sent Events (SSE)
+
+**Decisión:** SSE desde el backend FastAPI para notificaciones en tiempo real al organizador.
+
+**Justificación:**
+- Unidireccional servidor → cliente: suficiente para actualizar la grilla y alertas
+- Sin overhead de WebSocket (handshake, bidireccionalidad, librería cliente)
+- FastAPI soporta SSE nativo con `StreamingResponse`
+- El juez no necesita SSE (opera en modo "push → API")
+
+**Endpoint planificado:**
+
+```
+GET /api/competencia/{id}/eventos
+Content-Type: text/event-stream
+```
+
+**Eventos emitidos:**
+
+| Evento | Payload | Receptor |
+|--------|---------|---------|
+| `resultado_registrado` | `{atletaId, rp, tarjeta}` | Organizador |
+| `amarilla_pendiente` | `{atletaId, rp, motivo}` | Organizador |
+| `amarilla_resuelta` | `{atletaId, decision, rpFinal}` | Organizador |
+| `atleta_dns` | `{atletaId}` | Organizador |
+
+**Hook `useCompetenciaStream`:** abre EventSource, escucha eventos, invalida queries de React Query correspondientes.
+
+---
+
+## Resumen de dependencias
+
+```json
+{
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18",
+    "react-router-dom": "^6",
+    "@tanstack/react-query": "^5",
+    "zustand": "^4",
+    "dexie": "^3",
+    "dexie-react-hooks": "^1"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "vite": "^5",
+    "vite-plugin-pwa": "^0.20",
+    "tailwindcss": "^3",
+    "autoprefixer": "^10",
+    "@types/react": "^18"
+  }
+}
+```
+
+**shadcn/ui:** se instala componente a componente con `npx shadcn-ui@latest add <component>` — no es una dependencia de package.json sino código generado.
+
+---
+
+## Criterio de inicio de INC-4.2
+
+INC-4.2 puede iniciarse cuando:
+
+- [x] `wireframes-juez.md` aprobado
+- [x] `wireframes-organizador.md` aprobado
+- [x] `wireframes-atleta.md` aprobado
+- [x] `wireframes-registro-roles.md` aprobado
+- [x] `wireframes-setup-torneo.md` aprobado
+- [x] `decisiones-frontend.md` aprobado (este documento)
+- [ ] INC-4.1 completado (correcciones de dominio CMAS/FAAS — backend)
+- [ ] Branch `feature/inc-4.2-frontend-setup` creada desde `develop`
+- [ ] Scaffold Vite ejecutado y estructura de carpetas verificada
+- [ ] Primera US-IEDD de SP4 especificada en `docs/specs/sp4/`
+
+---
+
+*Artefacto generado: 2026-04-05 — INC-4.0 UX Design*
+*Capa IEDD: 3 — Especificación técnica de soporte para implementación*

--- a/docs/design/ux/decisiones-registro-usuario.md
+++ b/docs/design/ux/decisiones-registro-usuario.md
@@ -1,0 +1,134 @@
+# Decisiones de Diseño — Registro y Roles
+
+> Artefacto INC-4.0 · Decisiones específicas del flujo de registro, identidad multirol e invitaciones
+> Complementa: `wireframes-registro-roles.md`, `prototipo-registro-roles.html`
+> Fecha: 2026-04-08
+
+---
+
+## Contexto
+
+El flujo de registro y gestión de roles en AtaraxiaDive tiene particularidades que no son
+evidentes en los wireframes. Este documento captura las decisiones de diseño tomadas al
+producir `prototipo-registro-roles.html` y las razones detrás de cada una.
+
+---
+
+## Decisiones
+
+### D-RR-01 — El rol de juez no es autoasignable
+
+**Decisión:** no existe botón "Quiero ser juez" en el onboarding. El rol de juez se obtiene
+exclusivamente por invitación de un organizador.
+
+**Justificación:**
+- Evita que cualquier usuario se declare juez sin validación
+- El organizador es responsable de verificar las credenciales del juez antes de invitarlo
+- El dashboard vacío (S-04) explica explícitamente esta restricción con copy informativo
+
+**Implementación:** la pantalla S-04 muestra el camino "Soy juez" como `path-card` deshabilitada
+con texto explicativo — visible pero sin CTA.
+
+---
+
+### D-RR-02 — Las certificaciones de juez son auto-declaradas
+
+**Decisión:** el usuario puede registrar sus certificaciones (organización, nivel, número, fecha)
+sin validación por parte de la plataforma.
+
+**Justificación:**
+- La verificación física de credenciales es responsabilidad del organizador, no de la plataforma
+- La plataforma almacena la declaración y la expone al organizador en el momento de la invitación
+- Un aviso inline explícito en S-09 informa: "Esta certificación es declarada por vos; el organizador
+  puede solicitarte el carnet original antes del torneo"
+
+**Niveles soportados:** 1 estrella (Juez Nacional), 2 estrellas (Juez Continental), 3 estrellas
+(Juez Internacional) — alineado con la nomenclatura CMAS.
+
+---
+
+### D-RR-03 — Los datos deportivos son opcionales al alta
+
+**Decisión:** club, federación y número de licencia no bloquean el registro. Se muestran con
+prompt suave "Completar después" en S-06 Perfil.
+
+**Justificación:**
+- Un usuario puede registrarse para explorar la plataforma antes de decidir si compite
+- Los datos son obligatorios en el flujo de inscripción (S-04 del portal atleta), no en el alta
+- Reduce la fricción del onboarding
+
+**Comportamiento:** campos muestran estado `No completado` con acción `+ Agregar`.
+El flujo de inscripción a un torneo los requiere y redirige a completarlos si faltan.
+
+---
+
+### D-RR-04 — Compatibilidad atleta + juez en el mismo torneo
+
+**Decisión:** un usuario puede ser juez y atleta en el mismo torneo, siempre que no haya
+colisión de disciplinas/andariveles.
+
+**Justificación:**
+- En competencias pequeñas (FAAS regionales) es común que jueces también compitan
+- La pantalla S-08 (Invitación de juez) detecta la coexistencia y la informa explícitamente
+- La compatibilidad se resuelve por disciplina y andarivel asignado, no globalmente
+
+**Implementación:** la card "Compatibilidad de roles" en S-08 muestra si hay solapamiento
+y cómo se resuelve (disciplinas separadas, andariveles distintos).
+
+---
+
+### D-RR-05 — Los roles se materializan por torneo, no son globales
+
+**Decisión:** un usuario no tiene "su rol" a nivel cuenta. Tiene roles dentro de torneos
+específicos. El dashboard (S-05) los agrupa por torneo con badges: `Organizador`, `Juez`, `Atleta`.
+
+**Justificación:**
+- Refleja la realidad del dominio: Victor organiza un torneo, juzga en otro, compite en un tercero
+- Evita el problema de "selector de rol al login" (UX confusa, común en plataformas multirol)
+- El BC Identidad ya maneja roles por torneo en el dominio (rol asignado en contexto de torneo)
+
+**Comportamiento en login:** el usuario ingresa con email + contraseña. El sistema deriva
+la vista de inicio según los torneos activos donde participa, no según un "rol activo" global.
+
+---
+
+### D-RR-06 — Verificación de email es obligatoria antes del primer acceso funcional
+
+**Decisión:** el registro crea la cuenta pero deja al usuario en estado `pendiente_verificacion`.
+Hasta confirmar el email, el acceso está restringido a la pantalla S-03 (Verificar Email).
+
+**Justificación:**
+- Garantiza que el email es válido antes de enviar notificaciones (BC Notificaciones)
+- Previene registros fantasma
+- El flujo de re-envío de email está disponible en S-03
+
+---
+
+### D-RR-07 — La bandeja de notificaciones es unificada por roles
+
+**Decisión:** todas las alertas de todos los roles del usuario llegan a una única bandeja (S-07),
+diferenciadas por tipo e ícono.
+
+**Justificación:**
+- El usuario no tiene que navegar entre vistas de rol para ver sus alertas pendientes
+- Tipos de notificación en el mock: invitación de juez, inscripción confirmada, torneo publicado,
+  resultados disponibles
+- La invitación de juez es el único tipo que requiere acción inline (Aceptar / Rechazar)
+
+---
+
+## Componentes implicados (BC Identidad)
+
+Estas decisiones impactan directamente en el BC Identidad y su API:
+
+| Decisión | Impacto en BC Identidad |
+|----------|------------------------|
+| D-RR-01 | No existe endpoint `POST /usuarios/rol/juez`; el rol emerge de `POST /torneos/{id}/jueces/invitar` |
+| D-RR-02 | `POST /usuarios/certificaciones` — sin validación server-side, solo persistencia |
+| D-RR-05 | `GET /usuarios/me/torneos` devuelve lista con roles por torneo |
+| D-RR-06 | `POST /usuarios/verificar-email` — token enviado por BC Notificaciones |
+
+---
+
+*Artefacto generado: 2026-04-08 — INC-4.0 UX Design*
+*Capa IEDD: 3 — Especificación de decisiones de diseño*

--- a/docs/design/ux/flujos-por-rol.md
+++ b/docs/design/ux/flujos-por-rol.md
@@ -1,0 +1,229 @@
+# Flujos por Rol — AtaraxiaDive SP4
+
+> Artefacto INC-4.0 · Fuente: prototipo validado + Reglamento CMAS 2022/01 (FAAS)
+> Última actualización: 2026-04-05
+
+---
+
+## 1. Rol: Juez
+
+**Contexto de uso:** pileta, manos mojadas, luz solar directa, operación bajo presión de tiempo.
+**Dispositivo:** smartphone (mobile-first, orientación vertical).
+**Restricción crítica:** ≤ 6 toques por performance, botones ≥ 58 px.
+
+### 1.1 Flujo principal — Performance completa
+
+```
+[Login]
+  └── Email + contraseña → INGRESAR
+        │
+[Mis Disciplinas]
+  └── Lista de disciplinas asignadas (DNF / STA / DBF / DYN)
+      ├── ACTIVA  → tap → Grilla de Salida
+      └── PENDIENTE → no habilitada aún
+            │
+[Grilla de Salida]
+  └── Lista ordenada por OT ascendente
+      ├── ✓ BLANCA / ROJA / DNS  → no tappable (ya ejecutó)
+      ├── ⚠ REVISIÓN             → tappable → pantalla de resolución
+      ├── ▶ SIGUIENTE            → tappable (primer pendiente, resaltado)
+      └── PENDIENTE              → tappable (siguientes)
+            │
+[Paso 1 — Llamar atleta]
+  ├── LLAMAR ATLETA → Paso 2
+  └── DNS — No se presenta → pantalla DNS
+            │
+[Paso 2 — Confirmar presencia]
+  ├── PRESENTE → Paso 3
+  └── DNS — No se presenta → pantalla DNS
+            │
+[Paso 3 — Tiempo Oficial]
+  Estado A: muestra OT programado + botón "⏱ TIEMPO OFICIAL"
+  └── Juez presiona en el momento exacto del OT
+        │
+  Estado B: ventana +30s activa (countdown 30→0)
+  ├── Verde 30s–11s · Amarillo 10s–6s · Rojo 5s–1s
+  ├── ▶ ATLETA INICIA (juez presiona cuando ve al atleta sumergirse) → Paso 4
+  └── Si 0s: ventana vencida → REGISTRAR DQ (no inició en ventana) → resultado Roja
+            │
+[Paso 4 — Performance en curso]
+  └── Cronómetro activo desde ATLETA INICIA
+      ├── ⏹ FINALIZAR PERFORMANCE → Paso 5
+      └── ⚡ BKO — Black-out → pantalla BKO
+            │
+[Paso 5 — Registrar RP]
+  └── Selector metros + cm:
+      presets (25/50/75/100/125) + ajuste (−1/+1/+5/+10 m) + numpad cm
+      └── CONFIRMAR MARCA → Paso 6
+            │
+[Paso 6 — Asignar tarjeta]
+  ├── ⬜ TARJETA BLANCA   → resultado Blanca → SIGUIENTE ATLETA
+  ├── 🟨 TARJETA AMARILLA → resultado Amarilla (en revisión)
+  └── 🟥 TARJETA ROJA     → resultado Roja → SIGUIENTE ATLETA
+```
+
+### 1.2 Flujos alternativos
+
+#### DNS — Did Not Start
+```
+[Paso 1 o Paso 2]
+  └── DNS — No se presenta
+        └── Confirmación → CONFIRMAR DNS → resultado DNS → SIGUIENTE ATLETA
+```
+
+#### BKO — Black-out
+```
+[Paso 4 — En curso]
+  └── ⚡ BKO
+        └── Distancia alcanzada (metros + cm, obligatorio)
+              └── CONFIRMAR BKO — TARJETA ROJA → resultado Roja
+```
+> Regla CMAS 1.1.10.3: BKO bajo el agua = tarjeta roja automática. Campo distancia obligatorio.
+
+#### Tarjeta Amarilla — Resolución
+```
+[Resultado Amarilla]  o  [Grilla → fila ⚠ REVISIÓN]
+  └── Deliberación judges (máx 3 minutos — CMAS 1.2.3.1)
+      ├── ⬜ RESOLVER → BLANCA  (con eventual penalización −3m)
+      └── 🟥 RESOLVER → ROJA
+```
+
+#### DQ — No inició en ventana OT+30s
+```
+[Paso 3 — ventana vencida]
+  └── REGISTRAR DQ — No inició en ventana → resultado Roja
+```
+> Diferente al DNS: atleta presente pero no sumergió vías respiratorias antes de OT+30s (CMAS 1.2.1.8).
+
+### 1.3 Flujo offline
+```
+[Cualquier pantalla de performance]
+  └── Pérdida de conexión → badge "Sin conexión" (rojo, parpadeante)
+      └── Acciones se encolan localmente (Dexie.js)
+            └── Al reconectar → sincronización automática en background
+```
+
+---
+
+## 2. Rol: Organizador
+
+**Contexto de uso:** escritorio o tablet, antes y durante el torneo.
+**Dispositivo:** desktop-first (tablet compatible).
+
+### 2.1 Flujo principal — Gestión del torneo
+
+```
+[Login]
+  └── Email + contraseña → rol Organizador → Panel principal
+        │
+[Panel principal]
+  ├── Torneos activos
+  ├── Alertas pendientes (amarillas sin resolver, etc.)
+  └── Accesos rápidos
+        │
+        ├── [Gestión de Torneo]
+        │     ├── Crear / editar torneo (nombre, fecha, sede, disciplinas)
+        │     ├── Configurar disciplinas (DNF, STA, DBF, DYN, SPE)
+        │     └── Publicar / cerrar torneo
+        │
+        ├── [Gestión de Grilla]
+        │     ├── Ver grilla de salida por disciplina
+        │     ├── Ajustar orden de salida
+        │     ├── Modificar OT de atleta (con justificación)
+        │     └── Exportar grilla (PDF)
+        │
+        ├── [Gestión de Jueces]
+        │     ├── Asignar jueces a disciplinas / andariveles
+        │     ├── Ver estado en tiempo real por disciplina
+        │     └── Reasignar ante ausencia
+        │
+        ├── [Resultados en tiempo real]
+        │     ├── Vista por disciplina (ranking parcial)
+        │     ├── Overall ranking
+        │     └── Publicar resultados oficiales
+        │
+        └── [Audit Log]
+              ├── Historial de eventos por performance
+              ├── Filtro por atleta / disciplina / juez
+              └── Hash SHA-256 por registro (integridad)
+```
+
+### 2.2 Flujo — Resolución de incidencia
+```
+[Alertas]
+  └── Tarjeta amarilla sin resolver → tap → detalle de la performance
+        └── Ver video / consultar → Resolver (Blanca o Roja)
+```
+
+---
+
+## 3. Rol: Atleta
+
+**Contexto de uso:** pre-competencia y post-competencia, smartphone.
+**Dispositivo:** mobile-first. Solo lectura durante la competencia.
+
+### 3.1 Flujo principal
+
+```
+[Login]
+  └── Email + contraseña → rol Atleta → Portal atleta
+        │
+[Portal atleta]
+  ├── [Mis inscripciones]
+  │     ├── Torneos disponibles → inscribirse
+  │     ├── Mis inscripciones activas
+  │     └── Cancelar inscripción (dentro del plazo)
+  │
+  ├── [Mis anuncios (AP)]
+  │     ├── Ver disciplinas inscriptas
+  │     ├── Ingresar / modificar AP por disciplina
+  │     └── Confirmar anuncio (cierra cuando el organizador lo habilita)
+  │
+  ├── [Mi grilla]
+  │     ├── OT asignado por disciplina
+  │     ├── Andarivel
+  │     └── Posición en la grilla
+  │
+  └── [Resultados]
+        ├── Mi resultado por disciplina (RP, tarjeta)
+        ├── Ranking de disciplina
+        └── Ranking Overall
+```
+
+### 3.2 Restricciones de acceso
+- El atleta **no puede modificar** el AP una vez que el organizador cierra el período de anuncios.
+- Durante la ejecución de su performance: solo lectura.
+- Los resultados son visibles una vez que el organizador los publica.
+
+---
+
+## 4. Navegación entre roles
+
+Un usuario puede tener múltiples roles (ej: juez + atleta). En ese caso:
+
+```
+[Login]
+  └── Si tiene múltiples roles → pantalla de selección de rol activo
+        ├── Juez   → interfaz del juez
+        ├── Atleta → portal del atleta
+        └── Organizador → panel organizador
+```
+
+---
+
+## 5. Invariantes de dominio relevantes para la UX
+
+| Invariante | Impacto en UI |
+|------------|--------------|
+| No puede haber un PENDIENTE con OT anterior a un ejecutado | Grilla siempre ordenada por OT; completados no tappable |
+| Tarjeta amarilla bloquea CerrarCompetencia | Badge ⚠ visible en grilla y en panel organizador |
+| BKO → tarjeta roja automática, distancia obligatoria | Campo distancia no puede estar vacío en pantalla BKO |
+| Ventana OT: atleta puede iniciar OT hasta OT+30s | Paso 3 muestra countdown activo post-botón TIEMPO OFICIAL |
+| DQ (no inició) ≠ DNS (no se presentó) | Dos acciones distintas con registros y etiquetas distintos |
+| Medición con precisión de 1 cm (CMAS 2.1.4.1) | Selector RP: metros + numpad cm |
+| Penalización general DNF: −3 m (CMAS 1.1.13.1) | Tarjeta amarilla resuelta como blanca puede tener deducción |
+
+---
+
+*Fuentes: Reglamento CMAS Apnea Indoor v2022/01 (FAAS) · prototipo-juez.html validado 2026-04-05*
+*Siguiente artefacto: wireframes-juez.md · wireframes-organizador.md · wireframes-atleta.md*

--- a/docs/design/ux/prototipos/prototipo-atleta.html
+++ b/docs/design/ux/prototipos/prototipo-atleta.html
@@ -1,0 +1,1171 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AtaraxiaDive — Portal del Atleta (Prototipo INC-4.0)</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:       #0f172a;
+  --surface:  #1e293b;
+  --surface2: #334155;
+  --border:   #475569;
+  --text:     #f8fafc;
+  --muted:    #94a3b8;
+  --accent:   #38bdf8;
+  --blanca:   #22c55e;
+  --amarilla: #eab308;
+  --roja:     #ef4444;
+  --r: 12px;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  min-height: 100vh;
+}
+
+/* ── Screens ── */
+.screen { display: none; min-height: 100vh; flex-direction: column; }
+.screen.active { display: flex; }
+
+/* ── Mobile shell (max 430px centrado) ── */
+.shell {
+  flex: 1; display: flex; flex-direction: column;
+  max-width: 430px; width: 100%; margin: 0 auto;
+}
+
+/* ── Top header móvil ── */
+.header {
+  background: var(--surface); border-bottom: 1px solid var(--border);
+  padding: 0 16px; display: flex; align-items: center;
+  height: 52px; gap: 10px; position: sticky; top: 0; z-index: 100;
+}
+.header-brand { font-size: 17px; font-weight: 900; color: var(--accent); letter-spacing: -.5px; }
+.header-back  { font-size: 22px; cursor: pointer; color: var(--muted); padding: 4px; }
+.header-title { flex: 1; font-size: 16px; font-weight: 700; }
+.header-right { margin-left: auto; }
+
+/* ── Bottom tab bar ── */
+.tabbar {
+  background: var(--surface); border-top: 1px solid var(--border);
+  display: flex; height: 56px; position: sticky; bottom: 0; z-index: 100;
+}
+.tab-item {
+  flex: 1; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 3px; cursor: pointer;
+  font-size: 10px; font-weight: 600; color: var(--muted);
+  border: none; background: none; transition: color .15s;
+}
+.tab-item.active { color: var(--accent); }
+.tab-icon { font-size: 20px; }
+
+/* ── Scroll content ── */
+.scroll { flex: 1; overflow-y: auto; padding: 16px; }
+.scroll-nopad { flex: 1; overflow-y: auto; }
+
+/* ── Seccion titulo ── */
+.sec-title {
+  font-size: 12px; font-weight: 700; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .5px; margin-bottom: 8px;
+}
+
+/* ── Hero card (dashboard) ── */
+.hero-card {
+  background: linear-gradient(135deg, rgba(56,189,248,.15) 0%, rgba(56,189,248,.05) 100%);
+  border: 1px solid rgba(56,189,248,.25);
+  border-radius: var(--r); padding: 20px; margin-bottom: 16px;
+}
+.hero-nombre { font-size: 20px; font-weight: 900; }
+.hero-sub    { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+/* ── Cards genéricas ── */
+.card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 16px;
+  margin-bottom: 10px;
+}
+.card-title   { font-size: 15px; font-weight: 800; }
+.card-meta    { font-size: 13px; color: var(--muted); margin-top: 3px; }
+.card.tappable { cursor: pointer; transition: border-color .15s; }
+.card.tappable:hover { border-color: var(--accent); }
+
+/* ── Torneo card ── */
+.torneo-card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 16px;
+  margin-bottom: 10px; cursor: pointer; transition: border-color .15s;
+}
+.torneo-card:hover { border-color: var(--accent); }
+.torneo-nombre { font-size: 16px; font-weight: 800; }
+.torneo-meta   { font-size: 12px; color: var(--muted); margin-top: 3px; line-height: 1.5; }
+
+/* ── Disciplina row ── */
+.disc-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 13px 0; border-top: 1px solid var(--border);
+}
+.disc-icon { font-size: 24px; min-width: 30px; }
+.disc-info { flex: 1; }
+.disc-name { font-size: 14px; font-weight: 700; }
+.disc-sub  { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+/* ── Checkbox disc select ── */
+.disc-checkbox {
+  width: 22px; height: 22px; border-radius: 6px;
+  border: 2px solid var(--border); background: var(--surface2);
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
+  font-size: 14px; transition: background .15s, border-color .15s;
+}
+.disc-checkbox.checked { background: var(--accent); border-color: var(--accent); color: #0f172a; }
+
+/* ── AP input grande ── */
+.ap-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 13px 0; border-top: 1px solid var(--border);
+}
+.ap-label { flex: 1; font-size: 14px; font-weight: 700; }
+.ap-field {
+  display: flex; align-items: center; gap: 6px;
+}
+.ap-input-big {
+  width: 80px; background: var(--surface2); border: 2px solid var(--border);
+  border-radius: 8px; color: var(--accent); font-size: 18px; font-weight: 800;
+  padding: 8px 10px; text-align: center; outline: none;
+}
+.ap-input-big:focus { border-color: var(--accent); }
+.ap-unit { font-size: 14px; color: var(--muted); font-weight: 600; }
+
+/* ── OT display ── */
+.ot-hero {
+  text-align: center; padding: 24px 16px;
+  background: rgba(56,189,248,.06);
+  border: 1px solid rgba(56,189,248,.2);
+  border-radius: var(--r); margin-bottom: 12px;
+}
+.ot-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
+.ot-time  { font-size: 52px; font-weight: 900; color: var(--accent);
+            font-variant-numeric: tabular-nums; line-height: 1; margin: 6px 0; }
+.ot-sub   { font-size: 13px; color: var(--muted); }
+
+/* ── Grilla lista ── */
+.grilla-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
+}
+.grilla-row.yo { background: rgba(56,189,248,.06); border-left: 3px solid var(--accent); }
+.grilla-row.done { opacity: .5; }
+.g-pos  { font-size: 16px; font-weight: 900; color: var(--muted); min-width: 24px; }
+.g-name { flex: 1; font-size: 14px; }
+.g-name .yo-label { font-size: 10px; color: var(--accent); font-weight: 700;
+                    background: rgba(56,189,248,.15); border-radius: 4px;
+                    padding: 1px 5px; margin-left: 5px; }
+.g-ot   { font-size: 13px; color: var(--muted); font-variant-numeric: tabular-nums; }
+
+/* ── Resultado hero ── */
+.result-hero {
+  border-radius: var(--r); padding: 24px; text-align: center; margin-bottom: 12px;
+}
+.result-hero.blanca  { background: rgba(34,197,94,.08); border: 1px solid rgba(34,197,94,.3); }
+.result-hero.amarilla{ background: rgba(234,179,8,.08); border: 1px solid rgba(234,179,8,.3); }
+.result-hero.roja    { background: rgba(239,68,68,.08); border: 1px solid rgba(239,68,68,.3); }
+.result-tarjeta { font-size: 13px; font-weight: 700; margin-bottom: 8px; }
+.result-dist    { font-size: 56px; font-weight: 900; line-height: 1; }
+.result-unit    { font-size: 20px; font-weight: 700; color: var(--muted); }
+.result-pos     { font-size: 14px; color: var(--muted); margin-top: 8px; }
+
+/* ── Ranking list ── */
+.rank-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 11px 16px; border-bottom: 1px solid var(--border);
+}
+.rank-row.yo { background: rgba(56,189,248,.06); border-left: 3px solid var(--accent); }
+.r-pos  { font-size: 18px; font-weight: 900; color: var(--muted); min-width: 28px; }
+.r-pos.gold   { color: #fbbf24; }
+.r-pos.silver { color: #94a3b8; }
+.r-pos.bronze { color: #b45309; }
+.r-name { flex: 1; font-size: 14px; font-weight: 600; }
+.r-dist { font-size: 15px; font-weight: 800; color: var(--accent); }
+
+/* ── Chips ── */
+.chip { display: inline-block; padding: 3px 9px; border-radius: 20px; font-size: 11px; font-weight: 700; }
+.chip-ok    { background: rgba(34,197,94,.15); color: #4ade80; }
+.chip-pend  { background: var(--surface2); color: var(--muted); }
+.chip-warn  { background: rgba(234,179,8,.15); color: #facc15; }
+.chip-roja  { background: rgba(239,68,68,.15); color: #fca5a5; }
+.chip-open  { background: rgba(56,189,248,.15); color: var(--accent); }
+.chip-lock  { background: var(--surface2); color: var(--muted); }
+
+/* ── Badge estado torneo ── */
+.badge { display: inline-block; padding: 3px 10px; border-radius: 20px; font-size: 11px; font-weight: 700; }
+.badge-abierto   { background: rgba(56,189,248,.15); color: var(--accent); }
+.badge-ejecucion { background: rgba(34,197,94,.15); color: #4ade80; }
+.badge-publicado { background: rgba(139,92,246,.2); color: #c4b5fd; }
+
+/* ── Botones ── */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 0 18px; height: 44px; border-radius: 10px;
+  border: none; cursor: pointer; font-weight: 700; font-size: 15px;
+  transition: filter .12s; width: 100%;
+}
+.btn:hover   { filter: brightness(1.1); }
+.btn:active  { filter: brightness(.88); transform: scale(.98); }
+.btn-primary { background: var(--accent); color: #0f172a; }
+.btn-outline { background: transparent; color: var(--text); border: 2px solid var(--border); }
+.btn-ghost   { background: var(--surface2); color: var(--muted); }
+.btn-roja    { background: var(--roja); color: #fff; }
+.btn-sm { height: 34px; font-size: 13px; padding: 0 14px; width: auto; border-radius: 8px; }
+
+/* ── Form ── */
+.field { margin-bottom: 14px; }
+.field label { font-size: 12px; color: var(--muted); display: block; margin-bottom: 4px;
+               text-transform: uppercase; letter-spacing: .3px; }
+.input {
+  width: 100%; background: var(--surface2); border: 2px solid var(--border);
+  border-radius: 8px; color: var(--text); font-size: 15px;
+  padding: 11px 13px; outline: none;
+}
+.input:focus { border-color: var(--accent); }
+select.input { cursor: pointer; }
+
+/* ── Divider ── */
+.divider { height: 1px; background: var(--border); margin: 12px 0; }
+
+/* ── Info box ── */
+.info-box { border-radius: 8px; padding: 11px 13px; font-size: 13px; margin-bottom: 12px; }
+.info-muted    { background: var(--surface2); color: var(--muted); }
+.info-accent   { background: rgba(56,189,248,.06); border: 1px solid rgba(56,189,248,.2); color: var(--accent); }
+.info-amarilla { background: rgba(234,179,8,.06); border: 1px solid rgba(234,179,8,.2); color: #fde047; }
+.info-ok       { background: rgba(34,197,94,.06); border: 1px solid rgba(34,197,94,.2); color: #4ade80; }
+
+/* ── Step bar (inscripción en pasos) ── */
+.step-bar { display: flex; align-items: flex-start; margin-bottom: 20px; }
+.step-item { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 4px; position: relative; }
+.step-item:not(:last-child)::after {
+  content: ''; position: absolute; top: 13px; left: 58%; right: -42%;
+  height: 2px; background: var(--border); z-index: 0;
+}
+.step-item.done::after { background: var(--blanca); }
+.step-num {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--surface2); border: 2px solid var(--border);
+  font-size: 12px; font-weight: 800;
+  display: flex; align-items: center; justify-content: center; z-index: 1;
+}
+.step-item.active .step-num { background: var(--accent); border-color: var(--accent); color: #0f172a; }
+.step-item.done .step-num { background: var(--blanca); border-color: var(--blanca); color: #0f172a; }
+.step-label { font-size: 10px; color: var(--muted); font-weight: 600; text-align: center; }
+.step-item.active .step-label { color: var(--accent); }
+
+/* ── Upload area ── */
+.upload-area {
+  border: 2px dashed var(--border); border-radius: 8px; padding: 16px;
+  text-align: center; cursor: pointer; transition: border-color .15s; margin-bottom: 6px;
+}
+.upload-area:hover { border-color: var(--accent); }
+.upload-area .upload-icon { font-size: 24px; margin-bottom: 6px; }
+.upload-area .upload-text { font-size: 13px; color: var(--muted); }
+.upload-area.uploaded { border-color: var(--blanca); background: rgba(34,197,94,.05); }
+.upload-area.uploaded .upload-text { color: #4ade80; }
+
+/* ── Form tab panels ── */
+.form-tab { display: none; }
+.form-tab.active { display: block; }
+
+/* ── Radio item ── */
+.radio-group { display: flex; flex-direction: column; gap: 8px; }
+.radio-item {
+  display: flex; align-items: center; gap: 12px; padding: 12px;
+  background: var(--surface2); border-radius: 8px; border: 2px solid transparent;
+  cursor: pointer; transition: border-color .15s, background .15s;
+}
+.radio-item.selected { border-color: var(--accent); background: rgba(56,189,248,.06); }
+.radio-dot {
+  width: 18px; height: 18px; border-radius: 50%; border: 2px solid var(--border);
+  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.radio-item.selected .radio-dot { border-color: var(--accent); background: var(--accent); }
+.radio-item.selected .radio-dot::after {
+  content: ''; display: block; width: 7px; height: 7px;
+  border-radius: 50%; background: #0f172a;
+}
+.radio-text { font-size: 14px; font-weight: 600; }
+.radio-sub  { font-size: 12px; color: var(--muted); margin-top: 1px; }
+
+/* ── Login ── */
+.login-wrap {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; padding: 32px 20px;
+}
+.login-box {
+  width: 100%; max-width: 360px; background: var(--surface);
+  border-radius: 14px; border: 1px solid var(--border); padding: 28px;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.login-logo { font-size: 26px; font-weight: 900; color: var(--accent); text-align: center; }
+.login-sub  { font-size: 13px; color: var(--muted); text-align: center; margin-top: -6px; }
+
+/* ── Estado inscripcion ── */
+.insc-estado {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 0; border-top: 1px solid var(--border);
+}
+.insc-disc { font-size: 14px; font-weight: 700; }
+.insc-sub  { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+/* ── Deadline countdown ── */
+.deadline {
+  display: flex; align-items: center; gap: 8px;
+  background: rgba(234,179,8,.08); border: 1px solid rgba(234,179,8,.25);
+  border-radius: 8px; padding: 10px 13px; font-size: 13px; color: #fde047;
+  margin-bottom: 12px;
+}
+</style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════════
+     S-00  LOGIN
+══════════════════════════════════════════ -->
+<div class="screen active" id="s-login">
+  <div class="login-wrap">
+    <div class="login-box">
+      <div class="login-logo">AtaraxiaDive</div>
+      <div class="login-sub">Portal del Atleta</div>
+      <div class="field">
+        <label>Email</label>
+        <input class="input" type="email" value="sofia.ramirez@correo.com">
+      </div>
+      <div class="field" style="margin-bottom:0">
+        <label>Contraseña</label>
+        <input class="input" type="password" value="••••••••">
+      </div>
+      <button class="btn btn-primary" onclick="go('s-portal')">INGRESAR</button>
+      <div style="text-align:center;font-size:13px;color:var(--muted)">
+        Rol activo: <strong style="color:var(--accent)">Atleta</strong>
+      </div>
+      <div style="text-align:center;font-size:13px;color:var(--muted)">
+        ¿No tenés cuenta? <span style="color:var(--accent);cursor:pointer">Registrate</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-01  PORTAL / DASHBOARD
+══════════════════════════════════════════ -->
+<div class="screen" id="s-portal">
+  <div class="shell">
+    <div class="header">
+      <span class="header-brand">AtaraxiaDive</span>
+      <div class="header-right">
+        <span style="font-size:13px;color:var(--muted)">Sofía R.</span>
+      </div>
+    </div>
+    <div class="scroll">
+
+      <!-- Hero -->
+      <div class="hero-card">
+        <div class="hero-nombre">Hola, Sofía 👋</div>
+        <div class="hero-sub">Atleta · Senior F · Club Náutico BA</div>
+      </div>
+
+      <!-- Próximo OT -->
+      <div class="sec-title">Tu próximo OT</div>
+      <div class="card tappable" onclick="go('s-mi-grilla')">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+          <span style="font-size:13px;color:var(--muted)">Copa Litoral 2026 · DNF</span>
+          <span class="badge badge-ejecucion">HOY</span>
+        </div>
+        <div style="font-size:36px;font-weight:900;color:var(--accent);font-variant-numeric:tabular-nums">
+          10:18
+        </div>
+        <div style="font-size:13px;color:var(--muted);margin-top:4px">
+          Andarivel A · Posición #3 de 5 · AP declarado: 58.0 m
+        </div>
+        <div style="margin-top:10px">
+          <span style="font-size:12px;color:var(--accent);font-weight:600">Ver grilla completa →</span>
+        </div>
+      </div>
+
+      <!-- Mis inscripciones activas -->
+      <div class="sec-title" style="margin-top:16px">Mis inscripciones activas</div>
+
+      <div class="card tappable" onclick="go('s-mis-inscripciones')">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between">
+          <div>
+            <div class="card-title">Copa Litoral 2026</div>
+            <div class="card-meta">12–13 jun · Club Rowing Paraná</div>
+          </div>
+          <span class="badge badge-ejecucion">EN EJECUCIÓN</span>
+        </div>
+        <div style="margin-top:10px;display:flex;gap:6px;flex-wrap:wrap">
+          <span class="chip chip-ok">DNF ✓ AP</span>
+          <span class="chip chip-ok">STA ✓ AP</span>
+        </div>
+      </div>
+
+      <div class="card tappable" onclick="go('s-mis-inscripciones')">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between">
+          <div>
+            <div class="card-title">Open Litoral 2026</div>
+            <div class="card-meta">20 jul · Club Náutico Paraná</div>
+          </div>
+          <span class="badge badge-abierto">INSCRIPCIONES</span>
+        </div>
+        <div style="margin-top:10px;display:flex;gap:6px">
+          <span class="chip chip-warn">DNF ⚠ Sin AP</span>
+        </div>
+      </div>
+
+      <!-- Explorar torneos -->
+      <div style="margin-top:16px">
+        <button class="btn btn-outline" onclick="go('s-torneos')">
+          🔍 Explorar torneos disponibles
+        </button>
+      </div>
+
+    </div>
+    <div class="tabbar">
+      <button class="tab-item active" onclick="go('s-portal')">
+        <span class="tab-icon">🏠</span>Inicio
+      </button>
+      <button class="tab-item" onclick="go('s-torneos')">
+        <span class="tab-icon">🏆</span>Torneos
+      </button>
+      <button class="tab-item" onclick="go('s-mis-inscripciones')">
+        <span class="tab-icon">📋</span>Mis inscr.
+      </button>
+      <button class="tab-item" onclick="go('s-mis-resultados')">
+        <span class="tab-icon">📊</span>Resultados
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-02  TORNEOS DISPONIBLES
+══════════════════════════════════════════ -->
+<div class="screen" id="s-torneos">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="go('s-portal')">←</span>
+      <span class="header-title">Torneos</span>
+    </div>
+    <div class="scroll">
+
+      <div class="sec-title">Inscripciones abiertas</div>
+
+      <div class="torneo-card" onclick="go('s-detalle-torneo')">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:6px">
+          <span class="torneo-nombre">Open Litoral 2026</span>
+          <span class="badge badge-abierto">ABIERTO</span>
+        </div>
+        <div class="torneo-meta">
+          20 julio · Club Náutico Paraná<br>
+          DNF · STA · 3 disciplinas · Reglamento CMAS
+        </div>
+        <div style="margin-top:10px;display:flex;align-items:center;justify-content:space-between">
+          <span style="font-size:12px;color:var(--muted)">Cierre: 15 julio</span>
+          <span style="font-size:12px;color:var(--accent);font-weight:600">Ver detalle →</span>
+        </div>
+      </div>
+
+      <div class="torneo-card" onclick="go('s-detalle-torneo')">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:6px">
+          <span class="torneo-nombre">Campeonato Regional NEA 2026</span>
+          <span class="badge badge-abierto">ABIERTO</span>
+        </div>
+        <div class="torneo-meta">
+          15–16 agosto · Club Náutico Corrientes<br>
+          DNF · STA · DYNB · Reglamento CMAS
+        </div>
+        <div style="margin-top:10px;display:flex;align-items:center;justify-content:space-between">
+          <span style="font-size:12px;color:var(--muted)">Cierre: 10 agosto</span>
+          <span style="font-size:12px;color:var(--accent);font-weight:600">Ver detalle →</span>
+        </div>
+      </div>
+
+      <div class="sec-title" style="margin-top:16px">Próximos (inscripciones no abiertas)</div>
+
+      <div class="torneo-card" style="opacity:.6;cursor:default">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:6px">
+          <span class="torneo-nombre">Copa Litoral 2026 — 2da edición</span>
+          <span class="badge" style="background:var(--surface2);color:var(--muted)">PRÓXIMO</span>
+        </div>
+        <div class="torneo-meta">Diciembre 2026 · Fecha por confirmar</div>
+      </div>
+
+    </div>
+    <div class="tabbar">
+      <button class="tab-item" onclick="go('s-portal')">
+        <span class="tab-icon">🏠</span>Inicio
+      </button>
+      <button class="tab-item active" onclick="go('s-torneos')">
+        <span class="tab-icon">🏆</span>Torneos
+      </button>
+      <button class="tab-item" onclick="go('s-mis-inscripciones')">
+        <span class="tab-icon">📋</span>Mis inscr.
+      </button>
+      <button class="tab-item" onclick="go('s-mis-resultados')">
+        <span class="tab-icon">📊</span>Resultados
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-03  DETALLE DEL TORNEO
+══════════════════════════════════════════ -->
+<div class="screen" id="s-detalle-torneo">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="go('s-torneos')">←</span>
+      <span class="header-title">Open Litoral 2026</span>
+    </div>
+    <div class="scroll">
+
+      <div class="card" style="margin-bottom:12px">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:8px">
+          <div>
+            <div class="card-title" style="font-size:17px">Open Litoral 2026</div>
+            <div class="card-meta">20 julio · Club Náutico Paraná · Paraná, Entre Ríos</div>
+          </div>
+          <span class="badge badge-abierto">ABIERTO</span>
+        </div>
+        <div style="font-size:13px;color:var(--muted);line-height:1.6">
+          Reglamento CMAS Apnea Indoor v2022/01 · Cierre de inscripciones: <strong style="color:var(--text)">15 julio</strong>
+        </div>
+      </div>
+
+      <div class="sec-title">Disciplinas disponibles</div>
+
+      <div class="card">
+        <div class="disc-row" style="border-top:none;padding-top:0">
+          <div class="disc-icon">🤽</div>
+          <div class="disc-info">
+            <div class="disc-name">DNF — Dinámica sin aletas</div>
+            <div class="disc-sub">20 jul · 10:00 hs · Andariveles A/B · Intervalo 9 min</div>
+            <div class="disc-sub">Categorías: Senior M/F · Junior M/F · Master M</div>
+          </div>
+        </div>
+        <div class="disc-row">
+          <div class="disc-icon">🧘</div>
+          <div class="disc-info">
+            <div class="disc-name">STA — Apnea estática</div>
+            <div class="disc-sub">20 jul · 15:00 hs · Andarivel A · Intervalo 5 min</div>
+            <div class="disc-sub">Categorías: Senior M/F · Master M</div>
+          </div>
+        </div>
+        <div class="disc-row">
+          <div class="disc-icon">🐬</div>
+          <div class="disc-info">
+            <div class="disc-name">DYNB — Dinámica con bialetas</div>
+            <div class="disc-sub">21 jul · 10:00 hs · Andariveles A/B · Intervalo 9 min</div>
+            <div class="disc-sub">Categorías: Senior M/F · Junior M/F</div>
+          </div>
+        </div>
+      </div>
+
+      <div style="margin-top:8px">
+        <button class="btn btn-primary" onclick="go('s-inscribirse')">
+          Inscribirme en este torneo
+        </button>
+      </div>
+
+    </div>
+    <div class="tabbar">
+      <button class="tab-item" onclick="go('s-portal')"><span class="tab-icon">🏠</span>Inicio</button>
+      <button class="tab-item active" onclick="go('s-torneos')"><span class="tab-icon">🏆</span>Torneos</button>
+      <button class="tab-item" onclick="go('s-mis-inscripciones')"><span class="tab-icon">📋</span>Mis inscr.</button>
+      <button class="tab-item" onclick="go('s-mis-resultados')"><span class="tab-icon">📊</span>Resultados</button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-04  INSCRIBIRSE — 3 PESTAÑAS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-inscribirse">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="go('s-detalle-torneo')">←</span>
+      <span class="header-title">Inscribirme</span>
+    </div>
+    <div class="scroll">
+
+      <!-- Step bar -->
+      <div class="step-bar">
+        <div class="step-item active" id="step-1">
+          <div class="step-num">1</div>
+          <div class="step-label">Personales</div>
+        </div>
+        <div class="step-item" id="step-2">
+          <div class="step-num">2</div>
+          <div class="step-label">Competencia</div>
+        </div>
+        <div class="step-item" id="step-3">
+          <div class="step-num">3</div>
+          <div class="step-label">Requisitos</div>
+        </div>
+      </div>
+
+      <!-- ─── PESTAÑA 1: Datos Personales ─── -->
+      <div class="form-tab active" id="tab-1">
+
+        <div class="info-accent info-box">
+          Verificá tus datos. Están pre-cargados de tu perfil y figurarán en la grilla oficial.
+        </div>
+
+        <div class="field">
+          <label>Correo</label>
+          <input class="input" type="email" value="sofia.ramirez@correo.com" readonly style="opacity:.6">
+        </div>
+        <div class="field">
+          <label>Nombre y Apellido *</label>
+          <input class="input" type="text" value="Sofía Ramírez">
+        </div>
+        <div class="field">
+          <label>Fecha de Nacimiento *</label>
+          <input class="input" type="date" value="1998-03-15">
+        </div>
+        <div class="field">
+          <label>Género *</label>
+          <div class="radio-group">
+            <div class="radio-item selected" onclick="selectRadio(this,'genero')">
+              <div class="radio-dot"></div>
+              <div><div class="radio-text">Mujer</div></div>
+            </div>
+            <div class="radio-item" onclick="selectRadio(this,'genero')">
+              <div class="radio-dot"></div>
+              <div><div class="radio-text">Hombre</div></div>
+            </div>
+          </div>
+        </div>
+        <div class="field">
+          <label>Documento (Tipo: Número) *</label>
+          <div style="display:flex;gap:8px">
+            <select class="input" style="flex:0 0 100px">
+              <option selected>DNI</option>
+              <option>PASAPORTE</option>
+              <option>CI</option>
+            </select>
+            <input class="input" type="text" value="38.742.910" style="flex:1">
+          </div>
+        </div>
+        <div class="field">
+          <label>Teléfono *</label>
+          <input class="input" type="tel" value="+54 9 343 4870001">
+        </div>
+
+        <div style="margin-top:4px">
+          <button class="btn btn-primary" onclick="goTab(2)">Siguiente →</button>
+        </div>
+      </div>
+
+      <!-- ─── PESTAÑA 2: Datos de la Competencia ─── -->
+      <div class="form-tab" id="tab-2">
+
+        <div class="sec-title">Open Litoral 2026 · 20–21 jul</div>
+
+        <div class="field">
+          <label>Disciplinas en las que participaré *</label>
+          <div style="display:flex;flex-direction:column;gap:8px">
+
+            <div class="radio-item selected" id="disc-dnf" onclick="toggleDiscInsc('dnf')">
+              <div class="disc-checkbox checked" style="width:22px;height:22px;border-radius:6px;border:2px solid var(--accent);background:var(--accent);flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:14px;color:#0f172a">✓</div>
+              <div>
+                <div class="radio-text">🤽 DNF — Dinámica sin aletas</div>
+                <div class="radio-sub">20 jul · 10:00 hs · And. A/B</div>
+              </div>
+            </div>
+
+            <div class="radio-item" id="disc-sta" onclick="toggleDiscInsc('sta')">
+              <div class="disc-checkbox" style="width:22px;height:22px;border-radius:6px;border:2px solid var(--border);background:var(--surface);flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:14px"></div>
+              <div>
+                <div class="radio-text">🧘 STA — Apnea estática</div>
+                <div class="radio-sub">20 jul · 15:00 hs · And. A</div>
+              </div>
+            </div>
+
+            <div class="radio-item" id="disc-dynb" onclick="toggleDiscInsc('dynb')">
+              <div class="disc-checkbox" style="width:22px;height:22px;border-radius:6px;border:2px solid var(--border);background:var(--surface);flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:14px"></div>
+              <div>
+                <div class="radio-text">🐬 DYNB — Dinámica con bialetas</div>
+                <div class="radio-sub">21 jul · 10:00 hs · And. A/B</div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="field">
+          <label>Categoría *</label>
+          <div class="info-muted info-box" style="margin-bottom:8px;font-size:12px">
+            📅 Calculada automáticamente desde tu fecha de nacimiento. Revisá antes de enviar.
+          </div>
+          <div class="radio-group">
+            <div class="radio-item" onclick="selectRadio(this,'cat')">
+              <div class="radio-dot"></div>
+              <div><div class="radio-text">Junior</div><div class="radio-sub">Hasta 17 años</div></div>
+            </div>
+            <div class="radio-item selected" onclick="selectRadio(this,'cat')">
+              <div class="radio-dot"></div>
+              <div><div class="radio-text">Senior</div><div class="radio-sub">Desde 18 hasta 49 años</div></div>
+            </div>
+            <div class="radio-item" onclick="selectRadio(this,'cat')">
+              <div class="radio-dot"></div>
+              <div><div class="radio-text">Master</div><div class="radio-sub">Desde 50 años</div></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="field">
+          <label>Nº Brevet FAAS <span style="color:var(--muted);text-transform:none;letter-spacing:0;font-weight:400">(opcional)</span></label>
+          <input class="input" type="text" placeholder="Ej: AR-2024-0412">
+        </div>
+
+        <div style="display:flex;gap:8px;margin-top:4px">
+          <button class="btn btn-ghost" onclick="goTab(1)" style="flex:1">← Anterior</button>
+          <button class="btn btn-primary" onclick="goTab(3)" style="flex:2">Siguiente →</button>
+        </div>
+      </div>
+
+      <!-- ─── PESTAÑA 3: Requisitos ─── -->
+      <div class="form-tab" id="tab-3">
+
+        <div class="info-amarilla info-box">
+          ⚠️ Ambos documentos son obligatorios. Tu inscripción quedará <strong>pendiente de verificación</strong> hasta que el organizador los apruebe.
+        </div>
+
+        <!-- Certificado médico -->
+        <div class="sec-title">Certificado Médico *</div>
+        <div class="card" style="margin-bottom:14px">
+          <div style="font-size:13px;color:var(--muted);line-height:1.6;margin-bottom:12px">
+            Completar el formulario médico oficial y adjuntarlo firmado. Podés descargar el formulario desde el sitio del torneo.
+          </div>
+          <div class="upload-area uploaded" onclick="alert('Simulación: selector de archivo')">
+            <div class="upload-icon">✅</div>
+            <div class="upload-text">certificado_medico_sofia.pdf · 128 KB</div>
+          </div>
+          <div style="font-size:11px;color:var(--muted);margin-top:4px">Formatos: PDF, JPG, PNG · Máx. 5 MB</div>
+        </div>
+
+        <!-- Comprobante de pago -->
+        <div class="sec-title">Comprobante de Pago *</div>
+        <div class="card" style="margin-bottom:14px">
+          <div style="font-size:13px;color:var(--muted);line-height:1.7;margin-bottom:12px">
+            Transferir a:<br>
+            <strong style="color:var(--text)">CVU:</strong> 0000003100002674543142<br>
+            <strong style="color:var(--text)">Referencia:</strong> nombre completo + torneo
+            <div style="margin-top:8px;padding:10px;background:var(--surface2);border-radius:8px;font-size:12px;line-height:1.8">
+              💰 Hasta el <strong style="color:var(--text)">13 jul</strong> → <span style="color:var(--blanca);font-weight:700">$80.000</span><br>
+              💰 Del 14 al 18 jul → <span style="color:var(--amarilla);font-weight:700">$95.000</span>
+            </div>
+          </div>
+          <div class="upload-area" onclick="alert('Simulación: selector de archivo')">
+            <div class="upload-icon">📎</div>
+            <div class="upload-text">Adjuntar comprobante de transferencia</div>
+          </div>
+          <div style="font-size:11px;color:var(--muted);margin-top:4px">Formatos: PDF, JPG, PNG · Máx. 5 MB</div>
+        </div>
+
+        <div style="display:flex;gap:8px;margin-top:4px">
+          <button class="btn btn-ghost" onclick="goTab(2)" style="flex:1">← Anterior</button>
+          <button class="btn btn-primary" onclick="go('s-mis-inscripciones')" style="flex:2">Enviar inscripción</button>
+        </div>
+        <div style="margin-top:8px">
+          <button class="btn btn-ghost" onclick="go('s-detalle-torneo')">Cancelar</button>
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-05  MIS INSCRIPCIONES
+══════════════════════════════════════════ -->
+<div class="screen" id="s-mis-inscripciones">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="go('s-portal')">←</span>
+      <span class="header-title">Mis inscripciones</span>
+    </div>
+    <div class="scroll">
+
+      <!-- Copa Litoral — en ejecución hoy -->
+      <div class="sec-title">En ejecución</div>
+      <div class="card" style="margin-bottom:10px">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:10px">
+          <div>
+            <div class="card-title">Copa Litoral 2026</div>
+            <div class="card-meta">12–13 jun · Club Rowing Paraná</div>
+          </div>
+          <span class="badge badge-ejecucion">HOY</span>
+        </div>
+
+        <div class="insc-estado">
+          <div>
+            <div class="insc-disc">🤽 DNF</div>
+            <div class="insc-sub">AP: 58.0 m · OT: 10:18 · And. A</div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+            <span class="chip chip-lock">AP cerrado</span>
+            <button class="btn btn-sm btn-outline" onclick="go('s-mi-grilla')">Ver grilla</button>
+          </div>
+        </div>
+
+        <div class="insc-estado">
+          <div>
+            <div class="insc-disc">🧘 STA</div>
+            <div class="insc-sub">AP: 3:45 · OT: 10:00 · And. A · 13 jun</div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+            <span class="chip chip-lock">AP cerrado</span>
+            <button class="btn btn-sm btn-outline" onclick="go('s-mi-grilla')">Ver grilla</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Open Litoral — inscripciones abiertas -->
+      <div class="sec-title" style="margin-top:8px">Inscripciones abiertas</div>
+      <div class="card" style="margin-bottom:10px">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:10px">
+          <div>
+            <div class="card-title">Open Litoral 2026</div>
+            <div class="card-meta">20 jul · Club Náutico Paraná</div>
+          </div>
+          <span class="badge badge-abierto">ABIERTO</span>
+        </div>
+
+        <div class="insc-estado">
+          <div>
+            <div class="insc-disc">🤽 DNF</div>
+            <div class="insc-sub" style="color:var(--amarilla)">⚠ Sin AP declarado</div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+            <span class="chip chip-warn">AP pendiente</span>
+            <button class="btn btn-sm btn-primary" onclick="go('s-anunciar-ap')">Declarar AP</button>
+          </div>
+        </div>
+
+        <div style="margin-top:10px;padding-top:10px;border-top:1px solid var(--border)">
+          <div class="deadline">
+            ⏰ Cierre de anuncios: <strong style="margin-left:4px">15 julio · 23:59</strong>
+          </div>
+        </div>
+      </div>
+
+    </div>
+    <div class="tabbar">
+      <button class="tab-item" onclick="go('s-portal')"><span class="tab-icon">🏠</span>Inicio</button>
+      <button class="tab-item" onclick="go('s-torneos')"><span class="tab-icon">🏆</span>Torneos</button>
+      <button class="tab-item active" onclick="go('s-mis-inscripciones')"><span class="tab-icon">📋</span>Mis inscr.</button>
+      <button class="tab-item" onclick="go('s-mis-resultados')"><span class="tab-icon">📊</span>Resultados</button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-06  DECLARAR / MODIFICAR AP
+══════════════════════════════════════════ -->
+<div class="screen" id="s-anunciar-ap">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="go('s-mis-inscripciones')">←</span>
+      <span class="header-title">Declarar AP</span>
+    </div>
+    <div class="scroll">
+
+      <div class="info-accent info-box">
+        Declarás tu <strong>Announced Performance</strong> antes de competir.
+        Podés modificarlo hasta el cierre de anuncios.
+      </div>
+
+      <div class="card" style="margin-bottom:10px">
+        <div style="font-size:13px;color:var(--muted);margin-bottom:12px">
+          Open Litoral 2026 · DNF · 20 jul · 10:00 hs
+        </div>
+
+        <div class="field">
+          <label>AP — Distancia anunciada *</label>
+          <div class="ap-field" style="gap:10px">
+            <input class="ap-input-big" style="width:100px;font-size:28px;height:60px"
+                   value="" placeholder="—" id="ap-metros">
+            <span class="ap-unit" style="font-size:16px">metros</span>
+          </div>
+        </div>
+
+        <div style="font-size:12px;color:var(--muted);line-height:1.6;margin-top:4px">
+          El AP es la distancia que declarás alcanzar. Si realizás exactamente tu AP o más, obtenés tarjeta blanca. Si realizás menos, puede resultar en tarjeta amarilla según el reglamento.
+        </div>
+      </div>
+
+      <div class="deadline">
+        ⏰ Cierre de anuncios: <strong style="margin-left:4px">15 julio · 23:59</strong>
+      </div>
+
+      <button class="btn btn-primary" onclick="go('s-mis-inscripciones')">
+        Guardar AP
+      </button>
+      <div style="margin-top:8px">
+        <button class="btn btn-ghost" onclick="go('s-mis-inscripciones')">Cancelar</button>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-07  MI GRILLA (posición en la competencia)
+══════════════════════════════════════════ -->
+<div class="screen" id="s-mi-grilla">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="go('s-portal')">←</span>
+      <span class="header-title">Mi grilla — DNF</span>
+    </div>
+    <div class="scroll-nopad">
+
+      <!-- Mi OT destacado -->
+      <div style="padding:16px">
+        <div class="ot-hero">
+          <div class="ot-label">Tu Tiempo Oficial</div>
+          <div class="ot-time">10:18</div>
+          <div class="ot-sub">Andarivel A · Posición #3 · Copa Litoral 2026</div>
+          <div style="margin-top:10px;display:flex;gap:8px;justify-content:center">
+            <span class="chip chip-ok">AP: 58.0 m</span>
+            <span class="chip chip-open">Pendiente</span>
+          </div>
+        </div>
+
+        <div class="info-accent info-box">
+          Tenés una ventana de <strong>30 segundos</strong> desde tu OT para iniciar.
+          Comenzá entre las 10:18:00 y las 10:18:30.
+        </div>
+      </div>
+
+      <!-- Lista grilla completa -->
+      <div style="padding:0 16px 6px">
+        <div class="sec-title">Grilla completa — DNF · 12 jun</div>
+      </div>
+
+      <div class="grilla-row done">
+        <div class="g-pos">1</div>
+        <div class="g-name">Ramírez, Sofía <span style="font-size:10px;color:var(--blanca);font-weight:700;background:rgba(34,197,94,.15);border-radius:4px;padding:1px 5px;margin-left:4px">TÚ</span></div>
+        <div style="flex:1"></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-end;gap:3px">
+          <span class="g-ot">10:00 · A</span>
+          <span class="chip chip-ok" style="font-size:10px">BLANCA · 56m</span>
+        </div>
+      </div>
+
+      <div style="padding:8px 16px;background:rgba(34,197,94,.04);border-top:1px solid var(--border);border-bottom:1px solid var(--border)">
+        <div style="font-size:11px;color:var(--blanca);font-weight:700;text-align:center">
+          ✓ Ya competiste · Ver resultado →
+        </div>
+      </div>
+
+      <div class="grilla-row done">
+        <div class="g-pos">1</div>
+        <div class="g-name">Ramírez, Sofía</div>
+        <div style="flex:1"></div>
+        <div class="g-ot">10:00 · A</div>
+      </div>
+      <div class="grilla-row done">
+        <div class="g-pos">2</div>
+        <div class="g-name">Vega, Claudia</div>
+        <div style="flex:1"></div>
+        <div class="g-ot">10:09 · B</div>
+      </div>
+      <div class="grilla-row yo">
+        <div class="g-pos" style="color:var(--accent)">3</div>
+        <div class="g-name">
+          Ramírez, Sofía
+          <span class="yo-label">TÚ</span>
+        </div>
+        <div style="flex:1"></div>
+        <div style="text-align:right">
+          <div class="g-ot" style="color:var(--accent);font-weight:800">10:18 · A</div>
+          <div style="font-size:11px;color:var(--muted)">AP 58.0 m</div>
+        </div>
+      </div>
+      <div class="grilla-row">
+        <div class="g-pos">4</div>
+        <div class="g-name">Torres, Iván</div>
+        <div style="flex:1"></div>
+        <div class="g-ot">10:27 · B</div>
+      </div>
+      <div class="grilla-row">
+        <div class="g-pos">5</div>
+        <div class="g-name">Gómez, Federico</div>
+        <div style="flex:1"></div>
+        <div class="g-ot">10:36 · A</div>
+      </div>
+
+      <div style="padding:16px;margin-top:4px">
+        <button class="btn btn-outline btn-sm" style="width:100%" onclick="go('s-mis-resultados')">
+          Ver mis resultados →
+        </button>
+      </div>
+
+    </div>
+    <div class="tabbar">
+      <button class="tab-item" onclick="go('s-portal')"><span class="tab-icon">🏠</span>Inicio</button>
+      <button class="tab-item" onclick="go('s-torneos')"><span class="tab-icon">🏆</span>Torneos</button>
+      <button class="tab-item active" onclick="go('s-mis-inscripciones')"><span class="tab-icon">📋</span>Mis inscr.</button>
+      <button class="tab-item" onclick="go('s-mis-resultados')"><span class="tab-icon">📊</span>Resultados</button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-08  MIS RESULTADOS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-mis-resultados">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="go('s-portal')">←</span>
+      <span class="header-title">Mis resultados</span>
+    </div>
+    <div class="scroll">
+
+      <!-- Torneo activo -->
+      <div class="sec-title">Copa Litoral 2026</div>
+
+      <!-- DNF — resultado publicado -->
+      <div class="result-hero blanca" style="margin-bottom:10px">
+        <div class="result-tarjeta" style="color:#4ade80">⬜ TARJETA BLANCA · DNF</div>
+        <div class="result-dist" style="color:#4ade80">56<span class="result-unit">m</span></div>
+        <div class="result-pos">AP declarado: 58.0 m · Diferencia: −2.0 m</div>
+        <div style="margin-top:8px">
+          <span class="chip chip-ok">✓ Performance válida</span>
+        </div>
+      </div>
+
+      <!-- Ranking DNF -->
+      <div class="card" style="padding:0;overflow:hidden;margin-bottom:16px">
+        <div style="padding:12px 16px;background:var(--surface2)">
+          <div style="font-size:12px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4px">
+            Ranking DNF — Junior F
+          </div>
+        </div>
+        <div class="rank-row">
+          <div class="r-pos gold">1</div>
+          <div class="r-name">Morales, Lucía</div>
+          <div class="r-dist">62.0 m</div>
+          <span class="chip chip-ok" style="font-size:10px">BLANCA</span>
+        </div>
+        <div class="rank-row yo">
+          <div class="r-pos silver">2</div>
+          <div class="r-name">
+            Ramírez, Sofía
+            <span style="font-size:10px;color:var(--accent);font-weight:700;
+                         background:rgba(56,189,248,.15);border-radius:4px;
+                         padding:1px 5px;margin-left:4px">TÚ</span>
+          </div>
+          <div class="r-dist">56.0 m</div>
+          <span class="chip chip-ok" style="font-size:10px">BLANCA</span>
+        </div>
+        <div class="rank-row">
+          <div class="r-pos bronze">3</div>
+          <div class="r-name">Vega, Claudia</div>
+          <div class="r-dist">54.5 m</div>
+          <span class="chip chip-ok" style="font-size:10px">BLANCA</span>
+        </div>
+        <div style="padding:10px 16px;font-size:12px;color:var(--muted);border-top:1px solid var(--border)">
+          Ranking parcial · 2 de 5 atletas completados
+        </div>
+      </div>
+
+      <!-- STA — pendiente -->
+      <div class="card" style="margin-bottom:16px">
+        <div style="display:flex;align-items:center;gap:12px">
+          <div style="font-size:28px">🧘</div>
+          <div style="flex:1">
+            <div style="font-size:15px;font-weight:800">STA — 13 jun</div>
+            <div style="font-size:13px;color:var(--muted);margin-top:2px">OT: 10:00 · AP: 3:45 · And. A</div>
+          </div>
+          <span class="chip chip-pend">Pendiente</span>
+        </div>
+        <div class="info-muted info-box" style="margin-top:12px;margin-bottom:0">
+          Tu resultado estará disponible después de competir el 13 de junio.
+        </div>
+      </div>
+
+      <!-- Overall -->
+      <div class="sec-title">Ranking general (Overall)</div>
+      <div class="card">
+        <div class="empty" style="padding:24px 0">
+          <div style="font-size:28px;margin-bottom:8px">🏆</div>
+          <div style="font-size:14px;color:var(--muted)">
+            Disponible al finalizar todas las disciplinas del torneo
+          </div>
+        </div>
+      </div>
+
+    </div>
+    <div class="tabbar">
+      <button class="tab-item" onclick="go('s-portal')"><span class="tab-icon">🏠</span>Inicio</button>
+      <button class="tab-item" onclick="go('s-torneos')"><span class="tab-icon">🏆</span>Torneos</button>
+      <button class="tab-item" onclick="go('s-mis-inscripciones')"><span class="tab-icon">📋</span>Mis inscr.</button>
+      <button class="tab-item active" onclick="go('s-mis-resultados')"><span class="tab-icon">📊</span>Resultados</button>
+    </div>
+  </div>
+</div>
+
+<script>
+function go(id) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  const t = document.getElementById(id);
+  if (t) { t.classList.add('active'); window.scrollTo(0, 0); }
+}
+
+/* Navegar entre pestañas del formulario de inscripción */
+function goTab(n) {
+  [1,2,3].forEach(i => {
+    document.getElementById('tab-' + i).classList.toggle('active', i === n);
+    const si = document.getElementById('step-' + i);
+    si.classList.remove('active', 'done');
+    if (i === n) si.classList.add('active');
+    else if (i < n) si.classList.add('done');
+  });
+  window.scrollTo(0, 0);
+}
+
+/* Toggle selección de disciplina en formulario de inscripción */
+function toggleDiscInsc(disc) {
+  const el = document.getElementById('disc-' + disc);
+  const cb = el.querySelector('.disc-checkbox');
+  const isChecked = cb.classList.contains('checked');
+  if (isChecked) {
+    cb.classList.remove('checked');
+    cb.textContent = '';
+    cb.style.border = '2px solid var(--border)';
+    cb.style.background = 'var(--surface)';
+    cb.style.color = '';
+    el.classList.remove('selected');
+  } else {
+    cb.classList.add('checked');
+    cb.textContent = '✓';
+    cb.style.border = '2px solid var(--accent)';
+    cb.style.background = 'var(--accent)';
+    cb.style.color = '#0f172a';
+    el.classList.add('selected');
+  }
+}
+
+/* Selección de radio (género, categoría) */
+function selectRadio(el, name) {
+  el.closest('.radio-group').querySelectorAll('.radio-item').forEach(r => r.classList.remove('selected'));
+  el.classList.add('selected');
+}
+</script>
+</body>
+</html>

--- a/docs/design/ux/prototipos/prototipo-juez.html
+++ b/docs/design/ux/prototipos/prototipo-juez.html
@@ -1,0 +1,1198 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+<title>AtaraxiaDive — Interfaz del Juez (Prototipo INC-4.0)</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+
+  :root {
+    --bg:        #0f172a;
+    --surface:   #1e293b;
+    --surface2:  #334155;
+    --border:    #475569;
+    --text:      #f8fafc;
+    --muted:     #94a3b8;
+    --accent:    #38bdf8;
+    --blanca:    #22c55e;
+    --amarilla:  #eab308;
+    --roja:      #ef4444;
+    --dns:       #64748b;
+    --r: 14px;
+    --btn-h: 58px;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    display: flex;
+    justify-content: center;
+    min-height: 100vh;
+  }
+
+  /* ── Contenedor mobile ── */
+  #app {
+    width: 100%;
+    max-width: 390px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* ── Screens ── */
+  .screen {
+    display: none;
+    flex-direction: column;
+    flex: 1;
+    padding: 0 0 24px;
+    animation: fadeIn .18s ease;
+  }
+  .screen.active { display: flex; }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+
+  /* ── Header ── */
+  .header {
+    background: var(--surface);
+    padding: 16px 20px 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border);
+    position: sticky; top: 0; z-index: 10;
+  }
+  .header-title { font-size: 17px; font-weight: 700; }
+  .header-sub   { font-size: 13px; color: var(--muted); margin-top: 2px; }
+  .back-btn {
+    background: none; border: none; color: var(--accent);
+    font-size: 15px; font-weight: 600; cursor: pointer; padding: 4px 0;
+  }
+
+  /* ── Offline badge ── */
+  .conn-badge {
+    display: flex; align-items: center; gap: 5px;
+    font-size: 12px; font-weight: 600; padding: 3px 9px;
+    border-radius: 20px; letter-spacing: .3px;
+  }
+  .conn-badge.online  { background: rgba(34,197,94,.15); color: #4ade80; }
+  .conn-badge.offline { background: rgba(239,68,68,.15);  color: #f87171; }
+  .conn-dot { width: 7px; height: 7px; border-radius: 50%; }
+  .online  .conn-dot { background: #4ade80; }
+  .offline .conn-dot { background: #f87171; animation: blink 1.2s infinite; }
+  @keyframes blink { 0%,100%{opacity:1} 50%{opacity:.3} }
+
+  /* ── Pasos indicator ── */
+  .steps {
+    display: flex; gap: 6px; justify-content: center;
+    padding: 14px 20px 4px;
+  }
+  .step-dot {
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--surface2);
+    transition: background .2s;
+  }
+  .step-dot.done    { background: var(--blanca); }
+  .step-dot.current { background: var(--accent); }
+
+  /* ── Atleta card ── */
+  .atleta-card {
+    background: var(--surface);
+    border-radius: var(--r);
+    margin: 16px 20px 0;
+    padding: 16px 18px;
+    border: 1px solid var(--border);
+  }
+  .atleta-nombre { font-size: 22px; font-weight: 800; }
+  .atleta-meta   { display: flex; gap: 12px; margin-top: 8px; flex-wrap: wrap; }
+  .atleta-chip {
+    background: var(--surface2); border-radius: 8px;
+    padding: 4px 10px; font-size: 13px; font-weight: 600;
+  }
+  .atleta-chip.ap  { color: var(--accent); }
+  .atleta-chip.pos { color: var(--muted); }
+
+  /* ── Action label ── */
+  .action-label {
+    font-size: 14px; color: var(--muted); font-weight: 500;
+    margin: 20px 20px 6px;
+    text-transform: uppercase; letter-spacing: .6px;
+  }
+
+  /* ── Botones principales ── */
+  .btn {
+    display: flex; align-items: center; justify-content: center; gap: 10px;
+    min-height: var(--btn-h); border-radius: var(--r);
+    border: none; cursor: pointer; font-weight: 700;
+    font-size: 17px; letter-spacing: .2px;
+    transition: filter .12s, transform .08s;
+    width: 100%;
+  }
+  .btn:active { filter: brightness(.88); transform: scale(.98); }
+  .btn-primary { background: var(--accent); color: #0f172a; }
+  .btn-blanca  { background: var(--blanca); color: #fff; }
+  .btn-amarilla{ background: var(--amarilla); color: #0f172a; }
+  .btn-roja    { background: var(--roja);   color: #fff; }
+  .btn-dns     { background: var(--dns);    color: #fff; font-size: 15px; }
+  .btn-outline {
+    background: transparent; color: var(--text);
+    border: 2px solid var(--border); font-size: 15px;
+  }
+  .btn-ghost   { background: var(--surface2); color: var(--muted); font-size: 14px; min-height: 48px; }
+
+  .btn-row { display: flex; gap: 12px; }
+  .btn-row .btn { flex: 1; }
+
+  /* ── Zona de botones ── */
+  .actions { padding: 0 20px; display: flex; flex-direction: column; gap: 12px; margin-top: 6px; }
+
+  /* ── Cronómetro ── */
+  .cronometro {
+    text-align: center;
+    margin: 24px 20px 0;
+    background: var(--surface);
+    border-radius: var(--r);
+    padding: 24px;
+    border: 1px solid var(--border);
+  }
+  .crono-label { font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: .6px; }
+  .crono-time  { font-size: 52px; font-weight: 800; font-variant-numeric: tabular-nums; margin: 8px 0 4px; letter-spacing: -1px; }
+  .crono-time.running { color: var(--blanca); }
+  .crono-time.waiting { color: var(--accent); }
+
+  /* ── Input marca ── */
+  .marca-input-wrap {
+    margin: 20px 20px 0;
+    background: var(--surface);
+    border-radius: var(--r);
+    padding: 20px;
+    border: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .marca-label { font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: .6px; }
+  .marca-input {
+    background: var(--surface2); border: 2px solid var(--border);
+    border-radius: 10px; color: var(--text);
+    font-size: 36px; font-weight: 800; text-align: center;
+    padding: 12px; width: 100%; outline: none;
+    font-variant-numeric: tabular-nums;
+  }
+  .marca-input:focus { border-color: var(--accent); }
+  .marca-hint { font-size: 12px; color: var(--muted); text-align: center; }
+
+  /* ── Lista disciplinas ── */
+  .disc-list { padding: 16px 20px 0; display: flex; flex-direction: column; gap: 10px; }
+  .disc-card {
+    background: var(--surface); border-radius: var(--r);
+    padding: 16px 18px; border: 1px solid var(--border);
+    cursor: pointer; display: flex; align-items: center;
+    justify-content: space-between;
+    transition: border-color .15s;
+    min-height: var(--btn-h);
+  }
+  .disc-card:hover, .disc-card:active { border-color: var(--accent); }
+  .disc-nombre { font-size: 20px; font-weight: 800; }
+  .disc-hora   { font-size: 14px; color: var(--muted); margin-top: 3px; }
+  .disc-badge  {
+    padding: 4px 12px; border-radius: 20px;
+    font-size: 12px; font-weight: 700; letter-spacing: .4px;
+  }
+  .disc-badge.activa  { background: rgba(34,197,94,.15); color: #4ade80; }
+  .disc-badge.pend    { background: var(--surface2); color: var(--muted); }
+
+  /* ── Lista atletas grilla ── */
+  .grilla-list { padding: 12px 20px 0; display: flex; flex-direction: column; gap: 8px; }
+  .grilla-row {
+    background: var(--surface); border-radius: var(--r);
+    padding: 14px 16px; border: 1px solid var(--border);
+    cursor: pointer; display: flex; align-items: center; gap: 14px;
+    transition: border-color .15s; min-height: var(--btn-h);
+  }
+  .grilla-row:hover, .grilla-row:active { border-color: var(--accent); }
+  .grilla-row.done  { opacity: .45; cursor: default; border-color: var(--border); }
+  .grilla-row.dns   { opacity: .55; cursor: default; }
+  .grilla-pos  { font-size: 20px; font-weight: 800; color: var(--muted); min-width: 28px; text-align: center; }
+  .grilla-info { flex: 1; }
+  .grilla-nombre { font-size: 16px; font-weight: 700; }
+  .grilla-ot     { font-size: 13px; color: var(--muted); margin-top: 2px; }
+  .grilla-ap     { font-size: 14px; font-weight: 600; color: var(--accent); }
+  .grilla-estado { font-size: 12px; font-weight: 700; padding: 3px 10px; border-radius: 10px; white-space: nowrap; }
+  .estado-ok    { background: rgba(34,197,94,.15);  color: #4ade80; }
+  .estado-dns   { background: rgba(100,116,139,.2); color: var(--muted); }
+  .estado-pend  { background: var(--surface2); color: var(--muted); }
+  .estado-rev   { background: rgba(234,179,8,.15); color: #facc15; }
+
+  /* ── Resultado final ── */
+  .result-hero {
+    margin: 24px 20px 0;
+    background: var(--surface);
+    border-radius: var(--r);
+    padding: 28px 20px;
+    text-align: center;
+    border: 1px solid var(--border);
+  }
+  .result-icon { font-size: 48px; margin-bottom: 10px; }
+  .result-label{ font-size: 26px; font-weight: 800; }
+  .result-marca{ font-size: 18px; color: var(--muted); margin-top: 6px; }
+
+  /* ── Alerta ── */
+  .alerta {
+    margin: 16px 20px 0;
+    background: rgba(234,179,8,.1);
+    border: 1px solid rgba(234,179,8,.4);
+    border-radius: var(--r);
+    padding: 14px 16px;
+    font-size: 14px; color: #fde047; line-height: 1.5;
+  }
+  .alerta-roja {
+    background: rgba(239,68,68,.1);
+    border-color: rgba(239,68,68,.4);
+    color: #fca5a5;
+  }
+
+  /* ── Login ── */
+  .login-wrap {
+    flex: 1; display: flex; flex-direction: column;
+    justify-content: center; padding: 40px 28px;
+    gap: 20px;
+  }
+  .login-logo  { font-size: 32px; font-weight: 900; color: var(--accent); text-align: center; letter-spacing: -1px; }
+  .login-sub   { font-size: 14px; color: var(--muted); text-align: center; margin-top: -12px; }
+  .input-field {
+    background: var(--surface); border: 2px solid var(--border);
+    border-radius: var(--r); color: var(--text);
+    font-size: 16px; padding: 14px 16px; width: 100%; outline: none;
+  }
+  .input-field:focus { border-color: var(--accent); }
+  .input-label { font-size: 13px; color: var(--muted); margin-bottom: 4px; letter-spacing: .3px; }
+
+  /* ── BKO ── */
+  .bko-warn {
+    margin: 20px 20px 0;
+    background: rgba(239,68,68,.12); border: 2px solid var(--roja);
+    border-radius: var(--r); padding: 16px; text-align: center;
+  }
+  .bko-title { font-size: 20px; font-weight: 800; color: var(--roja); }
+  .bko-desc  { font-size: 14px; color: var(--muted); margin-top: 6px; }
+
+  /* ── Revisión amarilla ── */
+  .rev-badge {
+    margin: 16px 20px 0;
+    background: rgba(234,179,8,.12); border: 1px solid var(--amarilla);
+    border-radius: var(--r); padding: 14px 16px;
+    display: flex; align-items: center; gap: 12px;
+  }
+  .rev-icon  { font-size: 28px; }
+  .rev-text  { font-size: 15px; font-weight: 700; color: #fde047; }
+  .rev-sub   { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+  /* ── Separador ── */
+  .sep { height: 1px; background: var(--border); margin: 16px 20px; }
+
+  /* ── Scroll ── */
+  .scroll-area { flex: 1; overflow-y: auto; }
+
+  /* ── Paso label ── */
+  .paso-label {
+    font-size: 12px; font-weight: 600; color: var(--muted);
+    text-align: center; letter-spacing: .5px; margin-top: 20px;
+    text-transform: uppercase;
+  }
+
+  /* ── Siguiente indicator ── */
+  .grilla-row.siguiente { border-color: var(--accent); background: rgba(56,189,248,.06); }
+  .estado-sig { background: rgba(56,189,248,.2); color: var(--accent); }
+
+  /* ── Display combinado m + cm ── */
+  .rp-display-row {
+    display: flex; align-items: baseline; justify-content: center;
+    gap: 6px; padding: 14px 0 6px;
+  }
+  .rp-m-val {
+    font-size: 58px; font-weight: 900; color: var(--accent);
+    font-variant-numeric: tabular-nums; letter-spacing: -2px; line-height: 1;
+  }
+  .rp-m-unit { font-size: 22px; color: var(--muted); font-weight: 600; }
+  .rp-sep { font-size: 44px; color: var(--border); font-weight: 200; margin: 0 2px; line-height: 1; }
+  .rp-cm-val {
+    font-size: 44px; font-weight: 800; color: var(--border);
+    font-variant-numeric: tabular-nums; letter-spacing: -1px;
+    min-width: 56px; text-align: center; line-height: 1;
+    transition: color .15s;
+  }
+  .rp-cm-val.has-value { color: var(--text); }
+  .rp-cm-unit { font-size: 18px; color: var(--muted); font-weight: 600; }
+
+  /* ── Presets y ajuste metros ── */
+  .preset-row { display: flex; gap: 7px; margin-top: 8px; }
+  .preset-btn {
+    flex: 1; min-height: 54px; background: var(--surface2);
+    border: 2px solid var(--border); border-radius: 10px;
+    color: var(--text); font-size: 15px; font-weight: 700;
+    cursor: pointer; transition: border-color .12s, background .12s;
+  }
+  .preset-btn:active { background: var(--accent); color: #0f172a; border-color: var(--accent); }
+  .preset-btn.selected { border-color: var(--accent); color: var(--accent); background: rgba(56,189,248,.1); }
+  .m-adj-row { display: flex; gap: 8px; margin-top: 8px; }
+  .m-adj-btn {
+    flex: 1; min-height: 52px; background: var(--surface2);
+    border: 2px solid var(--border); border-radius: 10px;
+    font-size: 16px; font-weight: 700; cursor: pointer; color: var(--text);
+  }
+  .m-adj-btn.neg { color: #f87171; border-color: rgba(239,68,68,.3); }
+  .m-adj-btn.pos { color: #4ade80; border-color: rgba(34,197,94,.3); }
+  .m-adj-btn:active { filter: brightness(.75); transform: scale(.97); }
+
+  /* ── Numpad centímetros ── */
+  .numpad {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    gap: 8px; margin-top: 8px;
+  }
+  .np-btn {
+    min-height: 58px; background: var(--surface2);
+    border: 2px solid var(--border); border-radius: 10px;
+    font-size: 24px; font-weight: 700; cursor: pointer; color: var(--text);
+    transition: background .1s, border-color .1s;
+  }
+  .np-btn:active { background: var(--accent); color: #0f172a; border-color: var(--accent); transform: scale(.96); }
+  .np-zero { grid-column: 1 / 3; }
+  .np-del  { background: rgba(239,68,68,.08); color: #f87171; border-color: rgba(239,68,68,.25); font-size: 20px; }
+  .np-del:active { background: #ef4444; color: #fff; }
+</style>
+</head>
+<body>
+<div id="app">
+
+<!-- ══════════════════════════════════════════
+     S-00  LOGIN
+══════════════════════════════════════════ -->
+<div class="screen active" id="s-login">
+  <div class="login-wrap">
+    <div>
+      <div class="login-logo">AtaraxiaDive</div>
+      <div class="login-sub">Gestión de torneos de apnea</div>
+    </div>
+    <div>
+      <div class="input-label">Email</div>
+      <input class="input-field" type="email" value="carlos.mendez@juez.com" placeholder="tu@email.com">
+    </div>
+    <div>
+      <div class="input-label">Contraseña</div>
+      <input class="input-field" type="password" value="••••••••" placeholder="Contraseña">
+    </div>
+    <div class="actions" style="margin-top:4px; padding:0;">
+      <button class="btn btn-primary" onclick="go('s-disciplinas')">INGRESAR</button>
+    </div>
+    <div style="text-align:center; font-size:13px; color:var(--muted);">Rol activo: <strong style="color:var(--accent)">Juez</strong></div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-01  MIS DISCIPLINAS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-disciplinas">
+  <div class="header">
+    <div>
+      <div class="header-title">Mis disciplinas</div>
+      <div class="header-sub">Carlos Méndez · Torneo BA 2026</div>
+    </div>
+    <div id="conn1" class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+  </div>
+  <div class="disc-list">
+    <div class="disc-card" onclick="go('s-grilla')">
+      <div>
+        <div class="disc-nombre">DNF</div>
+        <div class="disc-hora">14:00 · 12 atletas · Andarivel A/B</div>
+      </div>
+      <div class="disc-badge activa">ACTIVA</div>
+    </div>
+    <div class="disc-card" onclick="alert('Disciplina aún no iniciada')">
+      <div>
+        <div class="disc-nombre">STA</div>
+        <div class="disc-hora">16:30 · 8 atletas · Andarivel A</div>
+      </div>
+      <div class="disc-badge pend">PENDIENTE</div>
+    </div>
+  </div>
+  <div style="margin:24px 20px 0; padding:14px 16px; background:var(--surface); border-radius:var(--r); border:1px solid var(--border);">
+    <div style="font-size:13px;color:var(--muted);">Torneo</div>
+    <div style="font-size:16px;font-weight:700;margin-top:4px;">Apnea Indoor Buenos Aires 2026</div>
+    <div style="font-size:13px;color:var(--muted);margin-top:4px;">4 de abril · Club Náutico BA</div>
+  </div>
+  <div style="flex:1"></div>
+  <div class="actions">
+    <button class="btn btn-ghost" onclick="go('s-login')">Cerrar sesión</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-02  GRILLA DE SALIDA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-grilla">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-disciplinas')">← Disciplinas</button>
+    <div style="text-align:right">
+      <div class="header-title">DNF</div>
+      <div class="header-sub">EN EJECUCIÓN</div>
+    </div>
+  </div>
+  <div class="scroll-area">
+    <div style="padding:12px 20px 4px; display:flex; justify-content:space-between; align-items:center;">
+      <div style="font-size:13px;color:var(--muted);">12 atletas · Intervalo 9 min</div>
+      <div id="conn2" class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+    </div>
+    <div class="grilla-list">
+      <!-- Atleta 1 — BLANCA (OT más temprano, ya ejecutó) -->
+      <div class="grilla-row done">
+        <div class="grilla-pos">1</div>
+        <div class="grilla-info">
+          <div class="grilla-nombre">García, Martina</div>
+          <div class="grilla-ot">OT 14:00 · And. A</div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-end;gap:5px">
+          <div class="grilla-ap">65.0 m</div>
+          <div class="grilla-estado estado-ok">✓ BLANCA</div>
+        </div>
+      </div>
+      <!-- Atleta 2 — en revisión (amarilla, OT ya pasó — tappable) -->
+      <div class="grilla-row" onclick="go('s-revision')">
+        <div class="grilla-pos">2</div>
+        <div class="grilla-info">
+          <div class="grilla-nombre">López, Andrés</div>
+          <div class="grilla-ot">OT 14:09 · And. B</div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-end;gap:5px">
+          <div class="grilla-ap">72.0 m</div>
+          <div class="grilla-estado estado-rev">⚠ REVISIÓN</div>
+        </div>
+      </div>
+      <!-- Atleta 3 — SIGUIENTE (primer pendiente, OT 14:18) -->
+      <div class="grilla-row siguiente" onclick="go('s-paso1')">
+        <div class="grilla-pos">3</div>
+        <div class="grilla-info">
+          <div class="grilla-nombre">Ramírez, Sofía</div>
+          <div class="grilla-ot">OT 14:18 · And. A</div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-end;gap:5px">
+          <div class="grilla-ap">58.0 m</div>
+          <div class="grilla-estado estado-sig">▶ SIGUIENTE</div>
+        </div>
+      </div>
+      <!-- Atleta 4 — pendiente (OT posterior) -->
+      <div class="grilla-row" onclick="go('s-paso1')">
+        <div class="grilla-pos">4</div>
+        <div class="grilla-info">
+          <div class="grilla-nombre">Torres, Iván</div>
+          <div class="grilla-ot">OT 14:27 · And. B</div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-end;gap:5px">
+          <div class="grilla-ap">80.0 m</div>
+          <div class="grilla-estado estado-pend">PENDIENTE</div>
+        </div>
+      </div>
+      <!-- Atleta 5 — pendiente (OT posterior) -->
+      <div class="grilla-row" onclick="go('s-paso1')">
+        <div class="grilla-pos">5</div>
+        <div class="grilla-info">
+          <div class="grilla-nombre">Vega, Claudia</div>
+          <div class="grilla-ot">OT 14:36 · And. A</div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-end;gap:5px">
+          <div class="grilla-ap">61.5 m</div>
+          <div class="grilla-estado estado-pend">PENDIENTE</div>
+        </div>
+      </div>
+    </div>
+    <div style="height:16px"></div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-03  PASO 1 — LLAMAR ATLETA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-paso1">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-grilla')">← Grilla</button>
+    <div style="text-align:right">
+      <div class="header-title">DNF · 14:00</div>
+      <div class="header-sub">Performance #1</div>
+    </div>
+  </div>
+  <div class="steps">
+    <div class="step-dot current"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+      <div class="atleta-chip pos">#1 · And. A</div>
+      <div class="atleta-chip pos">OT 14:00</div>
+    </div>
+  </div>
+  <div class="paso-label">Paso 1 de 6</div>
+  <div class="actions" style="margin-top:16px">
+    <button class="btn btn-primary" onclick="go('s-paso2')">📢 LLAMAR ATLETA</button>
+    <div class="sep" style="margin:4px 0"></div>
+    <button class="btn btn-dns" onclick="go('s-dns')">DNS — No se presenta</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-04  PASO 2 — CONFIRMAR PRESENCIA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-paso2">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-paso1')">← Atrás</button>
+    <div style="text-align:right">
+      <div class="header-title">DNF · 14:00</div>
+      <div class="header-sub">Atleta llamado</div>
+    </div>
+  </div>
+  <div class="steps">
+    <div class="step-dot done"></div>
+    <div class="step-dot current"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+      <div class="atleta-chip pos">#1 · And. A</div>
+    </div>
+  </div>
+  <div style="margin: 20px 20px 0; font-size:15px; color:var(--muted);">¿El atleta se presenta en el andarivel?</div>
+  <div class="paso-label">Paso 2 de 6</div>
+  <div class="actions" style="margin-top:16px">
+    <button class="btn btn-primary" onclick="go('s-paso3')">✓ PRESENTE</button>
+    <div class="sep" style="margin:4px 0"></div>
+    <button class="btn btn-dns" onclick="go('s-dns')">DNS — No se presenta</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-05  PASO 3 — INICIAR PERFORMANCE (OT)
+══════════════════════════════════════════ -->
+<div class="screen" id="s-paso3">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-paso2')">← Atrás</button>
+    <div style="text-align:right">
+      <div class="header-title">DNF · 14:00</div>
+      <div class="header-sub">Confirmado</div>
+    </div>
+  </div>
+  <div class="steps">
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot current"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+      <div class="atleta-chip pos">OT 14:00:00</div>
+    </div>
+  </div>
+
+  <!-- Banner con OT programado -->
+  <div style="margin:16px 20px 0; background:var(--surface); border:1px solid var(--border); border-radius:var(--r); padding:14px 16px; text-align:center;">
+    <div style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.6px;">Hora de salida programada</div>
+    <div style="font-size:32px;font-weight:900;color:var(--text);margin:4px 0;font-variant-numeric:tabular-nums;">14:00:00</div>
+    <div id="ot-estado-label" style="font-size:12px;color:var(--muted);">Presioná cuando llegue el Tiempo Oficial</div>
+  </div>
+
+  <!-- Countdown +30s — oculto hasta que el juez presione TIEMPO OFICIAL -->
+  <div id="ot-window-panel" style="display:none; margin:12px 20px 0; background:rgba(56,189,248,.06); border:2px solid var(--accent); border-radius:var(--r); padding:16px 20px; text-align:center;">
+    <div style="font-size:11px;color:var(--accent);text-transform:uppercase;letter-spacing:.8px;font-weight:700;">⏱ Ventana activa — el atleta puede sumergirse</div>
+    <div id="ot-countdown" style="font-size:80px;font-weight:900;color:var(--blanca);font-variant-numeric:tabular-nums;letter-spacing:-4px;line-height:1.1;">30</div>
+    <div style="font-size:12px;color:var(--muted);">segundos restantes · máx OT +30s</div>
+  </div>
+
+  <div class="paso-label">Paso 3 de 6</div>
+  <div class="actions" style="margin-top:16px; gap:12px;">
+
+    <!-- Botón principal: TIEMPO OFICIAL (estado inicial) -->
+    <button id="btn-tiempo-oficial" class="btn btn-primary" style="font-size:19px;min-height:66px;" onclick="marcarTiempoOficial()">⏱ TIEMPO OFICIAL</button>
+
+    <!-- Botón ATLETA INICIA — oculto hasta que corra la ventana -->
+    <button id="btn-atleta-inicia" class="btn" style="font-size:19px;min-height:66px;background:var(--blanca);color:#fff;display:none;" onclick="atletaInicia()">▶ ATLETA INICIA</button>
+
+    <!-- DQ por ventana vencida — oculto -->
+    <div id="dq-ventana" style="display:none; flex-direction:column; gap:10px;">
+      <div class="alerta alerta-roja" style="margin:0;">⏱ Ventana de +30s vencida. El atleta no inició en el tiempo reglamentario.</div>
+      <button class="btn btn-roja" onclick="go('s-resultado-roja')">REGISTRAR DQ — No inició en ventana</button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-06  PASO 4 — PERFORMANCE EN CURSO
+══════════════════════════════════════════ -->
+<div class="screen" id="s-paso4">
+  <div class="header">
+    <div>
+      <div class="header-title">DNF — EN CURSO</div>
+      <div class="header-sub">García, Martina</div>
+    </div>
+    <div id="conn4" class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+  </div>
+  <div class="steps">
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot current"></div>
+    <div class="step-dot"></div>
+    <div class="step-dot"></div>
+  </div>
+  <div class="cronometro">
+    <div class="crono-label">Tiempo en curso</div>
+    <div class="crono-time running" id="timer-display">00:00</div>
+    <div style="font-size:13px;color:var(--muted);">Cronómetro activo</div>
+  </div>
+  <div class="atleta-card" style="margin-top:14px">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+      <div class="atleta-chip pos">And. A</div>
+    </div>
+  </div>
+  <div class="paso-label">Paso 4 de 6</div>
+  <div class="actions" style="margin-top:16px">
+    <button class="btn btn-primary" onclick="go('s-paso5'); stopTimer()">⏹ FINALIZAR PERFORMANCE</button>
+    <div class="sep" style="margin:4px 0"></div>
+    <button class="btn btn-roja" style="min-height:52px;font-size:15px" onclick="go('s-bko'); stopTimer()">⚡ BKO — Black-out</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-07  PASO 5 — REGISTRAR MARCA (RP)
+══════════════════════════════════════════ -->
+<div class="screen" id="s-paso5">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-paso4')">← Atrás</button>
+    <div style="text-align:right">
+      <div class="header-title">DNF · Resultado</div>
+      <div class="header-sub">García, Martina</div>
+    </div>
+  </div>
+  <div class="steps">
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot current"></div>
+    <div class="step-dot"></div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+    </div>
+  </div>
+  <div class="marca-input-wrap">
+    <div class="marca-label">Distancia realizada (RP)</div>
+    <!-- Display m + cm -->
+    <div class="rp-display-row">
+      <span class="rp-m-val" id="rp-meters">0</span>
+      <span class="rp-m-unit">m</span>
+      <span class="rp-sep">·</span>
+      <span class="rp-cm-val" id="rp-cm">--</span>
+      <span class="rp-cm-unit">cm</span>
+    </div>
+    <!-- Metros: presets -->
+    <div class="marca-label">Metros — selección rápida</div>
+    <div class="preset-row">
+      <button class="preset-btn" onclick="rpSetM(25)">25</button>
+      <button class="preset-btn" onclick="rpSetM(50)">50</button>
+      <button class="preset-btn" onclick="rpSetM(75)">75</button>
+      <button class="preset-btn" onclick="rpSetM(100)">100</button>
+      <button class="preset-btn" onclick="rpSetM(125)">125</button>
+    </div>
+    <!-- Metros: ajuste fino -->
+    <div class="m-adj-row">
+      <button class="m-adj-btn neg" onclick="rpAdjM(-1)">−1</button>
+      <button class="m-adj-btn pos" onclick="rpAdjM(1)">+1</button>
+      <button class="m-adj-btn pos" onclick="rpAdjM(5)">+5</button>
+      <button class="m-adj-btn pos" onclick="rpAdjM(10)">+10</button>
+    </div>
+    <!-- Centímetros: numpad -->
+    <div class="marca-label" style="margin-top:12px">Centímetros</div>
+    <div class="numpad">
+      <button class="np-btn" onclick="rpCmAdd('7')">7</button>
+      <button class="np-btn" onclick="rpCmAdd('8')">8</button>
+      <button class="np-btn" onclick="rpCmAdd('9')">9</button>
+      <button class="np-btn" onclick="rpCmAdd('4')">4</button>
+      <button class="np-btn" onclick="rpCmAdd('5')">5</button>
+      <button class="np-btn" onclick="rpCmAdd('6')">6</button>
+      <button class="np-btn" onclick="rpCmAdd('1')">1</button>
+      <button class="np-btn" onclick="rpCmAdd('2')">2</button>
+      <button class="np-btn" onclick="rpCmAdd('3')">3</button>
+      <button class="np-btn np-zero" onclick="rpCmAdd('0')">0</button>
+      <button class="np-btn np-del"  onclick="rpCmDel()">⌫</button>
+    </div>
+  </div>
+  <div class="paso-label">Paso 5 de 6</div>
+  <div class="actions" style="margin-top:16px">
+    <button class="btn btn-primary" onclick="go('s-paso6')">CONFIRMAR MARCA</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-08  PASO 6 — ASIGNAR TARJETA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-paso6">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-paso5')">← Atrás</button>
+    <div style="text-align:right">
+      <div class="header-title">DNF · Tarjeta</div>
+      <div class="header-sub">García, Martina</div>
+    </div>
+  </div>
+  <div class="steps">
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot done"></div>
+    <div class="step-dot current"></div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+      <div class="atleta-chip" style="color:var(--blanca)">RP: 58.3 m</div>
+    </div>
+  </div>
+  <div class="paso-label">Paso 6 de 6 — Asignar tarjeta</div>
+  <div class="actions" style="margin-top:16px; gap:14px">
+    <button class="btn btn-blanca" style="font-size:19px" onclick="go('s-resultado-blanca')">⬜ TARJETA BLANCA</button>
+    <button class="btn btn-amarilla" style="font-size:19px" onclick="go('s-resultado-amarilla')">🟨 TARJETA AMARILLA</button>
+    <button class="btn btn-roja"    style="font-size:19px" onclick="go('s-resultado-roja')">🟥 TARJETA ROJA</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-09  RESULTADO — BLANCA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-resultado-blanca">
+  <div class="header">
+    <div><div class="header-title">Performance completada</div></div>
+  </div>
+  <div class="result-hero">
+    <div class="result-icon">⬜</div>
+    <div class="result-label" style="color:var(--blanca)">TARJETA BLANCA</div>
+    <div class="result-marca">García, Martina · 58.3 m</div>
+    <div style="font-size:13px;color:var(--muted);margin-top:8px">Performance válida · AP: 65.0 m</div>
+  </div>
+  <div class="actions" style="margin-top:24px">
+    <button class="btn btn-primary" onclick="go('s-grilla')">SIGUIENTE ATLETA →</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-10  RESULTADO — AMARILLA (REVISIÓN)
+══════════════════════════════════════════ -->
+<div class="screen" id="s-resultado-amarilla">
+  <div class="header">
+    <div><div class="header-title">Tarjeta en revisión</div></div>
+  </div>
+  <div class="rev-badge">
+    <div class="rev-icon">🟨</div>
+    <div>
+      <div class="rev-text">TARJETA AMARILLA — EN REVISIÓN</div>
+      <div class="rev-sub">Debe resolverse antes de cerrar la disciplina</div>
+    </div>
+  </div>
+  <div class="atleta-card" style="margin-top:14px">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+      <div class="atleta-chip" style="color:var(--blanca)">RP: 58.3 m</div>
+    </div>
+  </div>
+  <div class="alerta">⚠ La competencia no puede cerrarse mientras existan tarjetas amarillas sin resolver.</div>
+  <div class="action-label" style="margin-top:20px">Resolver revisión</div>
+  <div class="actions">
+    <button class="btn btn-blanca" onclick="go('s-resultado-blanca')">⬜ RESOLVER → BLANCA</button>
+    <button class="btn btn-roja"   onclick="go('s-resultado-roja')">🟥 RESOLVER → ROJA</button>
+  </div>
+  <div class="sep"></div>
+  <div class="actions" style="margin-top:0">
+    <button class="btn btn-ghost" onclick="go('s-grilla')">Volver a la grilla (queda en revisión)</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-11  RESULTADO — ROJA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-resultado-roja">
+  <div class="header">
+    <div><div class="header-title">Performance completada</div></div>
+  </div>
+  <div class="result-hero">
+    <div class="result-icon">🟥</div>
+    <div class="result-label" style="color:var(--roja)">TARJETA ROJA</div>
+    <div class="result-marca">García, Martina · Descalificada</div>
+  </div>
+  <div class="actions" style="margin-top:24px">
+    <button class="btn btn-primary" onclick="go('s-grilla')">SIGUIENTE ATLETA →</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-12  BKO — BLACK-OUT
+══════════════════════════════════════════ -->
+<div class="screen" id="s-bko">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-paso4'); startTimer()">← Atrás</button>
+    <div style="text-align:right">
+      <div class="header-title">BKO — Black-out</div>
+      <div class="header-sub">Tarjeta roja automática</div>
+    </div>
+  </div>
+  <div class="bko-warn">
+    <div class="bko-title">⚡ BLACK-OUT DETECTADO</div>
+    <div class="bko-desc">Se asigna tarjeta ROJA automáticamente</div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+    </div>
+  </div>
+  <div class="alerta alerta-roja">El campo de distancia alcanzada es <strong>obligatorio</strong> para registrar el BKO.</div>
+  <div class="marca-input-wrap">
+    <div class="marca-label">Distancia alcanzada antes del BKO</div>
+    <div class="rp-display-row">
+      <span class="rp-m-val" id="bko-meters">0</span>
+      <span class="rp-m-unit">m</span>
+      <span class="rp-sep">·</span>
+      <span class="rp-cm-val" id="bko-cm">--</span>
+      <span class="rp-cm-unit">cm</span>
+    </div>
+    <div class="marca-label">Metros</div>
+    <div class="preset-row">
+      <button class="preset-btn" onclick="bkoSetM(25)">25</button>
+      <button class="preset-btn" onclick="bkoSetM(50)">50</button>
+      <button class="preset-btn" onclick="bkoSetM(75)">75</button>
+      <button class="preset-btn" onclick="bkoSetM(100)">100</button>
+      <button class="preset-btn" onclick="bkoSetM(125)">125</button>
+    </div>
+    <div class="m-adj-row">
+      <button class="m-adj-btn neg" onclick="bkoAdjM(-1)">−1</button>
+      <button class="m-adj-btn pos" onclick="bkoAdjM(1)">+1</button>
+      <button class="m-adj-btn pos" onclick="bkoAdjM(5)">+5</button>
+      <button class="m-adj-btn pos" onclick="bkoAdjM(10)">+10</button>
+    </div>
+    <div class="marca-label" style="margin-top:12px">Centímetros</div>
+    <div class="numpad">
+      <button class="np-btn" onclick="bkoCmAdd('7')">7</button>
+      <button class="np-btn" onclick="bkoCmAdd('8')">8</button>
+      <button class="np-btn" onclick="bkoCmAdd('9')">9</button>
+      <button class="np-btn" onclick="bkoCmAdd('4')">4</button>
+      <button class="np-btn" onclick="bkoCmAdd('5')">5</button>
+      <button class="np-btn" onclick="bkoCmAdd('6')">6</button>
+      <button class="np-btn" onclick="bkoCmAdd('1')">1</button>
+      <button class="np-btn" onclick="bkoCmAdd('2')">2</button>
+      <button class="np-btn" onclick="bkoCmAdd('3')">3</button>
+      <button class="np-btn np-zero" onclick="bkoCmAdd('0')">0</button>
+      <button class="np-btn np-del"  onclick="bkoCmDel()">⌫</button>
+    </div>
+    <div class="marca-hint">Estimación del juez</div>
+  </div>
+  <div class="actions" style="margin-top:16px">
+    <button class="btn btn-roja" style="font-size:17px" onclick="go('s-resultado-roja')">CONFIRMAR BKO — TARJETA ROJA</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-13  DNS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-dns">
+  <div class="header">
+    <button class="back-btn" onclick="history.back ? go('s-paso1') : go('s-paso1')">← Atrás</button>
+    <div style="text-align:right">
+      <div class="header-title">DNS</div>
+      <div class="header-sub">Did Not Start</div>
+    </div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">García, Martina</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 65.0 m</div>
+      <div class="atleta-chip pos">#1 · And. A · OT 14:00</div>
+    </div>
+  </div>
+  <div class="alerta">El atleta no se presentó al OT programado. Se registrará DNS.</div>
+  <div class="actions" style="margin-top:20px">
+    <button class="btn btn-dns" onclick="go('s-resultado-dns')">CONFIRMAR DNS</button>
+    <button class="btn btn-outline" onclick="go('s-paso1')">Cancelar</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-14  RESULTADO DNS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-resultado-dns">
+  <div class="header">
+    <div><div class="header-title">DNS registrado</div></div>
+  </div>
+  <div class="result-hero">
+    <div class="result-icon">—</div>
+    <div class="result-label" style="color:var(--muted)">DNS</div>
+    <div class="result-marca">García, Martina · No se presentó</div>
+  </div>
+  <div class="actions" style="margin-top:24px">
+    <button class="btn btn-primary" onclick="go('s-grilla')">SIGUIENTE ATLETA →</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-15  TARJETA AMARILLA desde GRILLA (revisión pendiente)
+══════════════════════════════════════════ -->
+<div class="screen" id="s-revision">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-grilla')">← Grilla</button>
+    <div style="text-align:right">
+      <div class="header-title">En revisión</div>
+      <div class="header-sub">DNF #2</div>
+    </div>
+  </div>
+  <div class="rev-badge" style="margin-top:20px">
+    <div class="rev-icon">🟨</div>
+    <div>
+      <div class="rev-text">TARJETA AMARILLA — PENDIENTE</div>
+      <div class="rev-sub">Requiere resolución antes del cierre</div>
+    </div>
+  </div>
+  <div class="atleta-card">
+    <div class="atleta-nombre">López, Andrés</div>
+    <div class="atleta-meta">
+      <div class="atleta-chip ap">AP: 72.0 m</div>
+      <div class="atleta-chip" style="color:var(--blanca)">RP: 66.0 m</div>
+      <div class="atleta-chip pos">#2 · And. B</div>
+    </div>
+  </div>
+  <div class="alerta">⚠ La disciplina DNF no puede cerrarse hasta resolver esta tarjeta.</div>
+  <div class="action-label" style="margin-top:20px">Resolver revisión</div>
+  <div class="actions">
+    <button class="btn btn-blanca" onclick="go('s-grilla')">⬜ RESOLVER → BLANCA</button>
+    <button class="btn btn-roja"   onclick="go('s-grilla')">🟥 RESOLVER → ROJA</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-16  OFFLINE DEMO
+══════════════════════════════════════════ -->
+<div class="screen" id="s-offline-demo">
+  <div class="header">
+    <button class="back-btn" onclick="go('s-paso4')">← Volver</button>
+    <div id="conn-offline" class="conn-badge offline"><div class="conn-dot"></div>Sin conexión</div>
+  </div>
+  <div class="alerta" style="margin-top:20px">
+    📵 <strong>Modo offline activo.</strong><br>
+    Las acciones se guardan localmente y se sincronizarán al reconectar.
+  </div>
+  <div style="margin:16px 20px 0; background:var(--surface); border-radius:var(--r); padding:16px; border:1px solid var(--border);">
+    <div style="font-size:13px;color:var(--muted);text-transform:uppercase;letter-spacing:.5px;">Cola de sincronización</div>
+    <div style="margin-top:10px;display:flex;flex-direction:column;gap:8px;">
+      <div style="display:flex;justify-content:space-between;font-size:14px;">
+        <span>Performance #3 — Blanca</span><span style="color:var(--amarilla)">⏳ pendiente</span>
+      </div>
+      <div style="display:flex;justify-content:space-between;font-size:14px;">
+        <span>Performance #4 — DNS</span><span style="color:var(--amarilla)">⏳ pendiente</span>
+      </div>
+    </div>
+  </div>
+  <div class="actions" style="margin-top:20px">
+    <button class="btn btn-primary" onclick="simulateSync()">SIMULAR RECONEXIÓN</button>
+  </div>
+  <div id="sync-ok" style="display:none;margin:16px 20px 0;background:rgba(34,197,94,.1);border:1px solid var(--blanca);border-radius:var(--r);padding:14px;text-align:center;color:var(--blanca);font-weight:700;">
+    ✓ 2 eventos sincronizados correctamente
+  </div>
+</div>
+
+</div><!-- #app -->
+
+<script>
+// ── Navegación ──────────────────────────────────────────
+function go(screenId) {
+  clearInterval(otInterval); // cancela ventana OT si navegamos fuera
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  const target = document.getElementById(screenId);
+  if (target) target.classList.add('active');
+  window.scrollTo(0, 0);
+  if (screenId === 's-paso3') resetOtPanel();
+}
+
+// ── Cronómetro ──────────────────────────────────────────
+let timerInterval = null;
+let timerSeconds  = 0;
+
+function startTimer() {
+  timerSeconds = 0;
+  clearInterval(timerInterval);
+  timerInterval = setInterval(() => {
+    timerSeconds++;
+    const m = String(Math.floor(timerSeconds / 60)).padStart(2, '0');
+    const s = String(timerSeconds % 60).padStart(2, '0');
+    const el = document.getElementById('timer-display');
+    if (el) el.textContent = `${m}:${s}`;
+  }, 1000);
+}
+
+function stopTimer() {
+  clearInterval(timerInterval);
+}
+
+// ── Simulación offline ──────────────────────────────────
+function simulateSync() {
+  const badges = document.querySelectorAll('.conn-badge');
+  badges.forEach(b => { b.className = 'conn-badge online'; b.innerHTML = '<div class="conn-dot"></div>En línea'; });
+  document.getElementById('sync-ok').style.display = 'block';
+  setTimeout(() => go('s-grilla'), 1800);
+}
+
+// ── Ventana OT (+30s) ─────────────────────────────────
+let otInterval = null;
+let otSeconds  = 30;
+
+function resetOtPanel() {
+  // Restaura paso3 a estado inicial (antes de presionar TIEMPO OFICIAL)
+  otSeconds = 30;
+  clearInterval(otInterval);
+  const countEl  = document.getElementById('ot-countdown');
+  const panelEl  = document.getElementById('ot-window-panel');
+  const btnTO    = document.getElementById('btn-tiempo-oficial');
+  const btnIA    = document.getElementById('btn-atleta-inicia');
+  const dqEl     = document.getElementById('dq-ventana');
+  const labelEl  = document.getElementById('ot-estado-label');
+  if (countEl)  { countEl.textContent = '30'; countEl.style.color = 'var(--blanca)'; }
+  if (panelEl)  panelEl.style.display = 'none';
+  if (btnTO)    { btnTO.style.display = 'flex'; btnTO.disabled = false; btnTO.style.opacity = '1'; }
+  if (btnIA)    btnIA.style.display = 'none';
+  if (dqEl)     dqEl.style.display = 'none';
+  if (labelEl)  { labelEl.textContent = 'Presioná cuando llegue el Tiempo Oficial'; labelEl.style.color = 'var(--muted)'; }
+}
+
+function marcarTiempoOficial() {
+  // El juez presiona cuando llega el OT → arranca la ventana de +30s
+  const panelEl  = document.getElementById('ot-window-panel');
+  const btnTO    = document.getElementById('btn-tiempo-oficial');
+  const btnIA    = document.getElementById('btn-atleta-inicia');
+  const countEl  = document.getElementById('ot-countdown');
+  const labelEl  = document.getElementById('ot-estado-label');
+
+  // Ocultar botón TO, mostrar panel y botón ATLETA INICIA
+  if (btnTO)   { btnTO.style.display = 'none'; }
+  if (panelEl) panelEl.style.display = 'block';
+  if (btnIA)   btnIA.style.display = 'flex';
+  if (labelEl) { labelEl.textContent = '✓ Tiempo Oficial marcado'; labelEl.style.color = 'var(--blanca)'; }
+
+  // Arrancar countdown
+  otSeconds = 30;
+  clearInterval(otInterval);
+  otInterval = setInterval(() => {
+    otSeconds--;
+    if (countEl) {
+      countEl.textContent = otSeconds;
+      if (otSeconds <= 10 && otSeconds > 5) countEl.style.color = 'var(--amarilla)';
+      if (otSeconds <= 5  && otSeconds > 0) countEl.style.color = 'var(--roja)';
+    }
+    if (otSeconds <= 0) {
+      clearInterval(otInterval);
+      if (countEl) { countEl.textContent = '0'; countEl.style.color = 'var(--roja)'; }
+      if (btnIA)   { btnIA.disabled = true; btnIA.style.opacity = '.3'; }
+      const dqEl = document.getElementById('dq-ventana');
+      if (dqEl)    dqEl.style.display = 'flex';
+    }
+  }, 1000);
+}
+
+function atletaInicia() {
+  clearInterval(otInterval);
+  go('s-paso4');
+  startTimer();
+}
+
+// ── Demo: botón offline desde grilla ───────────────────
+// Click largo en el header de grilla abre demo offline
+document.getElementById('s-grilla')?.querySelector('.header')
+  ?.addEventListener('dblclick', () => go('s-offline-demo'));
+
+// ── Selector de marca RP (metros + centímetros) ────────
+let rpM = 0;      // metros enteros
+let rpCm = '';    // buffer de cm: '' | '4' | '43'
+
+function rpSetM(val) {
+  rpM = Math.max(0, val);
+  document.querySelectorAll('#s-paso5 .preset-btn').forEach(b =>
+    b.classList.toggle('selected', parseInt(b.textContent) === rpM));
+  rpRefresh();
+}
+function rpAdjM(d) { rpSetM(rpM + d); }
+
+function rpCmAdd(digit) {
+  rpCm = (rpCm + digit).slice(-2); // máx 2 dígitos, desplaza hacia izquierda
+  rpRefresh();
+}
+function rpCmDel() {
+  rpCm = rpCm.slice(0, -1);
+  rpRefresh();
+}
+function rpRefresh() {
+  const mEl = document.getElementById('rp-meters');
+  const cmEl = document.getElementById('rp-cm');
+  if (mEl) mEl.textContent = rpM;
+  if (cmEl) {
+    cmEl.textContent = rpCm === '' ? '--' : rpCm.padStart(2, '0');
+    cmEl.classList.toggle('has-value', rpCm !== '');
+  }
+}
+
+// ── Selector de distancia BKO ─────────────────────────
+let bkoM = 0;
+let bkoCm = '';
+
+function bkoSetM(val) {
+  bkoM = Math.max(0, val);
+  document.querySelectorAll('#s-bko .preset-btn').forEach(b =>
+    b.classList.toggle('selected', parseInt(b.textContent) === bkoM));
+  bkoRefresh();
+}
+function bkoAdjM(d) { bkoSetM(bkoM + d); }
+
+function bkoCmAdd(digit) {
+  bkoCm = (bkoCm + digit).slice(-2);
+  bkoRefresh();
+}
+function bkoCmDel() {
+  bkoCm = bkoCm.slice(0, -1);
+  bkoRefresh();
+}
+function bkoRefresh() {
+  const mEl = document.getElementById('bko-meters');
+  const cmEl = document.getElementById('bko-cm');
+  if (mEl) mEl.textContent = bkoM;
+  if (cmEl) {
+    cmEl.textContent = bkoCm === '' ? '--' : bkoCm.padStart(2, '0');
+    cmEl.classList.toggle('has-value', bkoCm !== '');
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/ux/prototipos/prototipo-organizador.html
+++ b/docs/design/ux/prototipos/prototipo-organizador.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+/<!DOCTYPE html>
 <html lang="es">
 <head>
 <meta charset="UTF-8">

--- a/docs/design/ux/prototipos/prototipo-organizador.html
+++ b/docs/design/ux/prototipos/prototipo-organizador.html
@@ -1,0 +1,927 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AtaraxiaDive — Panel Organizador (Prototipo INC-4.0)</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:       #0f172a;
+  --surface:  #1e293b;
+  --surface2: #334155;
+  --border:   #475569;
+  --text:     #f8fafc;
+  --muted:    #94a3b8;
+  --accent:   #38bdf8;
+  --blanca:   #22c55e;
+  --amarilla: #eab308;
+  --roja:     #ef4444;
+  --dns:      #64748b;
+  --r: 10px;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  min-height: 100vh;
+}
+
+/* ── Screens ── */
+.screen { display: none; min-height: 100vh; flex-direction: column; }
+.screen.active { display: flex; }
+
+/* ── Top navbar ── */
+.navbar {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  position: sticky; top: 0; z-index: 100;
+  height: 56px;
+}
+.navbar-brand {
+  font-size: 18px; font-weight: 900; color: var(--accent);
+  letter-spacing: -.5px; margin-right: 32px; white-space: nowrap;
+}
+.nav-items { display: flex; gap: 2px; flex: 1; }
+.nav-item {
+  padding: 0 14px; height: 56px; display: flex; align-items: center;
+  font-size: 13px; font-weight: 600; color: var(--muted);
+  cursor: pointer; border-bottom: 2px solid transparent;
+  transition: color .15s, border-color .15s; white-space: nowrap;
+  background: none; border-top: none; border-left: none; border-right: none;
+}
+.nav-item:hover { color: var(--text); }
+.nav-item.active { color: var(--accent); border-bottom-color: var(--accent); }
+.navbar-right { display: flex; align-items: center; gap: 12px; margin-left: auto; }
+.conn-badge {
+  display: flex; align-items: center; gap: 5px;
+  font-size: 12px; font-weight: 600; padding: 3px 9px;
+  border-radius: 20px;
+}
+.conn-badge.online { background: rgba(34,197,94,.15); color: #4ade80; }
+.conn-dot { width: 7px; height: 7px; border-radius: 50%; background: #4ade80; }
+.navbar-user { font-size: 13px; color: var(--muted); }
+
+/* ── Content area ── */
+.content {
+  flex: 1; max-width: 1100px; width: 100%;
+  margin: 0 auto; padding: 28px 24px;
+}
+
+/* ── Page title ── */
+.page-title { font-size: 22px; font-weight: 800; margin-bottom: 4px; }
+.page-sub   { font-size: 13px; color: var(--muted); margin-bottom: 24px; }
+
+/* ── KPI cards ── */
+.kpi-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 24px; }
+.kpi-card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 18px 20px;
+}
+.kpi-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
+.kpi-value { font-size: 36px; font-weight: 900; margin-top: 4px; font-variant-numeric: tabular-nums; }
+.kpi-sub   { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+/* ── Sección con título ── */
+.section-title {
+  font-size: 13px; font-weight: 700; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .5px;
+  margin-bottom: 10px;
+}
+
+/* ── Alerta card ── */
+.alert-card {
+  border-radius: var(--r); padding: 14px 16px;
+  display: flex; align-items: center; gap: 12px;
+  cursor: pointer; transition: filter .12s;
+  margin-bottom: 8px;
+}
+.alert-card:hover { filter: brightness(1.1); }
+.alert-amarilla { background: rgba(234,179,8,.1); border: 1px solid rgba(234,179,8,.4); }
+.alert-icon { font-size: 22px; }
+.alert-text { flex: 1; }
+.alert-title { font-size: 14px; font-weight: 700; color: #fde047; }
+.alert-desc  { font-size: 12px; color: var(--muted); margin-top: 2px; }
+.alert-action { font-size: 12px; color: var(--accent); font-weight: 600; }
+
+/* ── Estado disciplina ── */
+.disc-status {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 20px;
+  margin-bottom: 24px;
+}
+.disc-status-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; }
+.disc-name { font-size: 20px; font-weight: 800; }
+.badge-activa { background: rgba(34,197,94,.15); color: #4ade80; padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 700; }
+.badge-pend   { background: var(--surface2); color: var(--muted); padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 700; }
+.badge-cerrada{ background: rgba(56,189,248,.15); color: var(--accent); padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 700; }
+.progress-bar {
+  background: var(--surface2); border-radius: 4px; height: 8px;
+  margin: 10px 0 6px; overflow: hidden;
+}
+.progress-fill { height: 100%; background: var(--blanca); border-radius: 4px; transition: width .3s; }
+.progress-label { font-size: 12px; color: var(--muted); }
+
+/* ── Tabla grilla ── */
+.table-wrap { background: var(--surface); border-radius: var(--r); border: 1px solid var(--border); overflow: hidden; }
+table { width: 100%; border-collapse: collapse; }
+thead th {
+  background: var(--surface2); padding: 10px 14px;
+  font-size: 11px; font-weight: 700; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .4px; text-align: left;
+}
+tbody tr { border-top: 1px solid var(--border); transition: background .1s; }
+tbody tr:hover { background: rgba(255,255,255,.03); }
+tbody tr.row-done { opacity: .5; }
+tbody tr.row-siguiente { background: rgba(56,189,248,.05); }
+tbody td { padding: 11px 14px; font-size: 14px; }
+.td-pos    { font-weight: 800; color: var(--muted); width: 36px; }
+.td-nombre { font-weight: 600; }
+.td-ot     { color: var(--muted); font-size: 13px; }
+.td-ap     { color: var(--accent); font-weight: 600; }
+.td-rp     { font-weight: 700; }
+.chip {
+  display: inline-block; padding: 3px 10px; border-radius: 20px;
+  font-size: 11px; font-weight: 700;
+}
+.chip-blanca   { background: rgba(34,197,94,.15); color: #4ade80; }
+.chip-amarilla { background: rgba(234,179,8,.15); color: #facc15; }
+.chip-roja     { background: rgba(239,68,68,.15); color: #fca5a5; }
+.chip-dns      { background: rgba(100,116,139,.2); color: var(--muted); }
+.chip-sig      { background: rgba(56,189,248,.2); color: var(--accent); }
+.chip-pend     { background: var(--surface2); color: var(--muted); }
+.chip-juez     { background: rgba(139,92,246,.2); color: #c4b5fd; font-size: 11px; }
+.row-action { cursor: pointer; }
+.row-action:hover td { background: rgba(255,255,255,.03); }
+
+/* ── Botones ── */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 0 18px; height: 38px; border-radius: 8px;
+  border: none; cursor: pointer; font-weight: 700; font-size: 14px;
+  transition: filter .12s;
+}
+.btn:hover { filter: brightness(1.1); }
+.btn:active { filter: brightness(.88); transform: scale(.98); }
+.btn-primary { background: var(--accent); color: #0f172a; }
+.btn-outline { background: transparent; color: var(--text); border: 2px solid var(--border); }
+.btn-roja    { background: var(--roja); color: #fff; }
+.btn-blanca  { background: var(--blanca); color: #fff; }
+.btn-ghost   { background: var(--surface2); color: var(--muted); }
+.btn-sm { height: 30px; padding: 0 12px; font-size: 12px; }
+
+/* ── Two-col layout ── */
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.three-col { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
+
+/* ── Detail panel (para modal) ── */
+.detail-panel {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 20px;
+}
+.detail-panel h3 { font-size: 16px; font-weight: 800; margin-bottom: 14px; }
+
+/* ── Ranking list ── */
+.rank-row {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 0; border-top: 1px solid var(--border);
+}
+.rank-pos  { font-size: 22px; font-weight: 900; color: var(--muted); min-width: 32px; }
+.rank-pos.gold   { color: #fbbf24; }
+.rank-pos.silver { color: #94a3b8; }
+.rank-pos.bronze { color: #b45309; }
+.rank-name { flex: 1; font-weight: 600; }
+.rank-dist { font-size: 16px; font-weight: 800; color: var(--accent); }
+
+/* ── Form elements ── */
+.field { margin-bottom: 16px; }
+.field label { font-size: 12px; color: var(--muted); display: block; margin-bottom: 4px; text-transform: uppercase; letter-spacing: .3px; }
+.input {
+  width: 100%; background: var(--surface2); border: 2px solid var(--border);
+  border-radius: 8px; color: var(--text); font-size: 14px;
+  padding: 10px 12px; outline: none;
+}
+.input:focus { border-color: var(--accent); }
+select.input { cursor: pointer; }
+
+/* ── Audit log ── */
+.log-item {
+  display: flex; gap: 14px; padding: 12px 0;
+  border-top: 1px solid var(--border); font-size: 13px;
+}
+.log-time  { color: var(--muted); white-space: nowrap; min-width: 58px; }
+.log-event { flex: 1; }
+.log-actor { color: var(--accent); font-weight: 600; }
+.log-hash  { font-size: 11px; color: var(--border); font-family: monospace; margin-top: 2px; }
+
+/* ── Login ── */
+.login-wrap {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 20px; padding: 40px;
+}
+.login-box {
+  width: 100%; max-width: 380px;
+  background: var(--surface); border-radius: 14px;
+  border: 1px solid var(--border); padding: 32px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.login-logo { font-size: 28px; font-weight: 900; color: var(--accent); text-align: center; }
+.login-sub  { font-size: 13px; color: var(--muted); text-align: center; margin-top: -8px; }
+
+/* ── Jueces ── */
+.juez-card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 16px 18px;
+  display: flex; align-items: center; gap: 14px;
+  margin-bottom: 8px;
+}
+.juez-avatar {
+  width: 40px; height: 40px; border-radius: 50%;
+  background: var(--surface2); display: flex; align-items: center;
+  justify-content: center; font-weight: 800; font-size: 16px; color: var(--accent);
+}
+.juez-info { flex: 1; }
+.juez-nombre { font-weight: 700; font-size: 15px; }
+.juez-assign { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+/* ── Disciplinas list (gestión torneo) ── */
+.disc-card-mgmt {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 16px 18px;
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 8px;
+}
+.disc-card-mgmt .disc-info h4 { font-size: 16px; font-weight: 800; }
+.disc-card-mgmt .disc-info p  { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+/* ── Empty state ── */
+.empty { text-align: center; padding: 48px 20px; color: var(--muted); }
+.empty-icon { font-size: 40px; margin-bottom: 12px; }
+.empty-text { font-size: 15px; }
+</style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════════
+     S-00  LOGIN
+══════════════════════════════════════════ -->
+<div class="screen active" id="s-login">
+  <div class="login-wrap">
+    <div class="login-box">
+      <div class="login-logo">AtaraxiaDive</div>
+      <div class="login-sub">Panel de Organización</div>
+      <div class="field">
+        <label>Email</label>
+        <input class="input" type="email" value="organizer@ataraxiadive.com">
+      </div>
+      <div class="field" style="margin-bottom:0">
+        <label>Contraseña</label>
+        <input class="input" type="password" value="••••••••">
+      </div>
+      <button class="btn btn-primary" style="width:100%;height:44px;font-size:15px" onclick="go('s-dashboard')">INGRESAR</button>
+      <div style="text-align:center;font-size:13px;color:var(--muted)">Rol activo: <strong style="color:var(--accent)">Organizador</strong></div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-01  DASHBOARD — PANEL PRINCIPAL
+══════════════════════════════════════════ -->
+<div class="screen" id="s-dashboard">
+  <nav class="navbar">
+    <span class="navbar-brand">AtaraxiaDive</span>
+    <div class="nav-items">
+      <button class="nav-item active" onclick="go('s-dashboard')">📊 Panel</button>
+      <button class="nav-item" onclick="go('s-grilla')">📋 Grilla</button>
+      <button class="nav-item" onclick="go('s-resultados')">🏆 Resultados</button>
+      <button class="nav-item" onclick="go('s-jueces')">👥 Jueces</button>
+      <button class="nav-item" onclick="go('s-torneo')">📝 Torneo</button>
+      <button class="nav-item" onclick="go('s-audit')">🔍 Audit Log</button>
+    </div>
+    <div class="navbar-right">
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+      <div class="navbar-user">Roberto Silva</div>
+    </div>
+  </nav>
+  <div class="content">
+    <div class="page-title">Apnea Indoor Buenos Aires 2026</div>
+    <div class="page-sub">5 de abril · Club Náutico BA · Organizador: Roberto Silva</div>
+
+    <!-- KPIs -->
+    <div class="kpi-grid">
+      <div class="kpi-card">
+        <div class="kpi-label">Atletas totales</div>
+        <div class="kpi-value">28</div>
+        <div class="kpi-sub">3 disciplinas</div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-label">Completados</div>
+        <div class="kpi-value" style="color:var(--blanca)">2</div>
+        <div class="kpi-sub">de 12 en DNF</div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-label">En revisión</div>
+        <div class="kpi-value" style="color:var(--amarilla)">1</div>
+        <div class="kpi-sub">tarjeta amarilla</div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-label">Tiempo estimado</div>
+        <div class="kpi-value" style="color:var(--accent)">83'</div>
+        <div class="kpi-sub">para fin de DNF</div>
+      </div>
+    </div>
+
+    <div class="two-col">
+      <div>
+        <!-- Disciplina activa -->
+        <div class="section-title">Disciplina en ejecución</div>
+        <div class="disc-status">
+          <div class="disc-status-header">
+            <div>
+              <div class="disc-name">DNF — Dinámica sin aletas</div>
+              <div style="font-size:13px;color:var(--muted);margin-top:2px">14:00 hs · Andariveles A y B · 12 atletas</div>
+            </div>
+            <span class="badge-activa">EN EJECUCIÓN</span>
+          </div>
+          <div class="progress-bar">
+            <div class="progress-fill" style="width:17%"></div>
+          </div>
+          <div class="progress-label">2 de 12 atletas completados (17%)</div>
+          <div style="display:flex;gap:10px;margin-top:14px">
+            <button class="btn btn-outline btn-sm" onclick="go('s-grilla')">Ver grilla completa</button>
+            <button class="btn btn-roja btn-sm" onclick="alert('Acción: Cerrar disciplina DNF')">Cerrar disciplina</button>
+          </div>
+        </div>
+
+        <!-- Otras disciplinas -->
+        <div class="section-title">Otras disciplinas del torneo</div>
+        <div class="disc-card-mgmt">
+          <div class="disc-info">
+            <h4>STA — Apnea Estática</h4>
+            <p>16:30 hs · 8 atletas · Andarivel A</p>
+          </div>
+          <span class="badge-pend">PENDIENTE</span>
+        </div>
+        <div class="disc-card-mgmt">
+          <div class="disc-info">
+            <h4>DBF — Dinámica con bialetas</h4>
+            <p>18:00 hs · 8 atletas · Andarivel A</p>
+          </div>
+          <span class="badge-pend">PENDIENTE</span>
+        </div>
+      </div>
+
+      <div>
+        <!-- Alertas -->
+        <div class="section-title">Alertas activas</div>
+        <div class="alert-card alert-amarilla" onclick="go('s-grilla')">
+          <div class="alert-icon">🟨</div>
+          <div class="alert-text">
+            <div class="alert-title">Tarjeta amarilla sin resolver</div>
+            <div class="alert-desc">López, Andrés · DNF #2 · OT 14:09 · RP 66.0 m</div>
+          </div>
+          <div class="alert-action">Resolver →</div>
+        </div>
+
+        <!-- Próximos atletas -->
+        <div class="section-title" style="margin-top:20px">Próximos en DNF</div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>#</th><th>Atleta</th><th>OT</th><th>AP</th><th>Estado</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="row-siguiente">
+                <td class="td-pos">3</td>
+                <td class="td-nombre">Ramírez, Sofía</td>
+                <td class="td-ot">14:18</td>
+                <td class="td-ap">58.0 m</td>
+                <td><span class="chip chip-sig">▶ SIGUIENTE</span></td>
+              </tr>
+              <tr>
+                <td class="td-pos">4</td>
+                <td class="td-nombre">Torres, Iván</td>
+                <td class="td-ot">14:27</td>
+                <td class="td-ap">80.0 m</td>
+                <td><span class="chip chip-pend">PENDIENTE</span></td>
+              </tr>
+              <tr>
+                <td class="td-pos">5</td>
+                <td class="td-nombre">Vega, Claudia</td>
+                <td class="td-ot">14:36</td>
+                <td class="td-ap">61.5 m</td>
+                <td><span class="chip chip-pend">PENDIENTE</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-02  GRILLA DE SALIDA (COMPLETA)
+══════════════════════════════════════════ -->
+<div class="screen" id="s-grilla">
+  <nav class="navbar">
+    <span class="navbar-brand">AtaraxiaDive</span>
+    <div class="nav-items">
+      <button class="nav-item" onclick="go('s-dashboard')">📊 Panel</button>
+      <button class="nav-item active" onclick="go('s-grilla')">📋 Grilla</button>
+      <button class="nav-item" onclick="go('s-resultados')">🏆 Resultados</button>
+      <button class="nav-item" onclick="go('s-jueces')">👥 Jueces</button>
+      <button class="nav-item" onclick="go('s-torneo')">📝 Torneo</button>
+      <button class="nav-item" onclick="go('s-audit')">🔍 Audit Log</button>
+    </div>
+    <div class="navbar-right">
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+    </div>
+  </nav>
+  <div class="content">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
+      <div class="page-title">Grilla — DNF</div>
+      <div style="display:flex;gap:10px">
+        <button class="btn btn-outline btn-sm" onclick="alert('Exportar grilla PDF')">↓ Exportar PDF</button>
+        <button class="btn btn-ghost btn-sm" onclick="go('s-dashboard')">← Panel</button>
+      </div>
+    </div>
+    <div class="page-sub">En ejecución · 12 atletas · Intervalo 9 min · Andariveles A y B</div>
+
+    <!-- Filtro -->
+    <div style="display:flex;gap:10px;margin-bottom:16px;flex-wrap:wrap">
+      <button class="btn btn-outline btn-sm" style="border-color:var(--accent);color:var(--accent)">Todos (12)</button>
+      <button class="btn btn-ghost btn-sm">Pendientes (9)</button>
+      <button class="btn btn-ghost btn-sm">Completados (2)</button>
+      <button class="btn btn-ghost btn-sm" style="color:var(--amarilla)">⚠ Revisión (1)</button>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>#</th><th>Atleta</th><th>Cat.</th><th>OT</th><th>And.</th><th>AP</th><th>RP</th><th>Juez</th><th>Estado</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="row-done">
+            <td class="td-pos">1</td>
+            <td class="td-nombre">García, Martina</td>
+            <td style="color:var(--muted);font-size:13px">Senior F</td>
+            <td class="td-ot">14:00</td>
+            <td style="font-size:13px;color:var(--muted)">A</td>
+            <td class="td-ap">65.0 m</td>
+            <td class="td-rp">65.0 m</td>
+            <td><span class="chip chip-juez">C. Méndez</span></td>
+            <td><span class="chip chip-blanca">✓ BLANCA</span></td>
+            <td><button class="btn btn-ghost btn-sm" onclick="go('s-audit')">Log</button></td>
+          </tr>
+          <tr class="row-action" onclick="go('s-detalle-amarilla')">
+            <td class="td-pos">2</td>
+            <td class="td-nombre">López, Andrés</td>
+            <td style="color:var(--muted);font-size:13px">Senior M</td>
+            <td class="td-ot">14:09</td>
+            <td style="font-size:13px;color:var(--muted)">B</td>
+            <td class="td-ap">72.0 m</td>
+            <td class="td-rp">66.0 m</td>
+            <td><span class="chip chip-juez">C. Méndez</span></td>
+            <td><span class="chip chip-amarilla">⚠ REVISIÓN</span></td>
+            <td><button class="btn btn-outline btn-sm" style="border-color:var(--amarilla);color:var(--amarilla)" onclick="event.stopPropagation();go('s-detalle-amarilla')">Resolver</button></td>
+          </tr>
+          <tr class="row-siguiente row-action" onclick="go('s-dashboard')">
+            <td class="td-pos">3</td>
+            <td class="td-nombre">Ramírez, Sofía</td>
+            <td style="color:var(--muted);font-size:13px">Junior F</td>
+            <td class="td-ot">14:18</td>
+            <td style="font-size:13px;color:var(--muted)">A</td>
+            <td class="td-ap">58.0 m</td>
+            <td class="td-rp">—</td>
+            <td><span class="chip chip-juez">C. Méndez</span></td>
+            <td><span class="chip chip-sig">▶ SIGUIENTE</span></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td class="td-pos">4</td>
+            <td class="td-nombre">Torres, Iván</td>
+            <td style="color:var(--muted);font-size:13px">Master M</td>
+            <td class="td-ot">14:27</td>
+            <td style="font-size:13px;color:var(--muted)">B</td>
+            <td class="td-ap">80.0 m</td>
+            <td class="td-rp">—</td>
+            <td><span class="chip chip-juez">A. Ruiz</span></td>
+            <td><span class="chip chip-pend">PENDIENTE</span></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td class="td-pos">5</td>
+            <td class="td-nombre">Vega, Claudia</td>
+            <td style="color:var(--muted);font-size:13px">Senior F</td>
+            <td class="td-ot">14:36</td>
+            <td style="font-size:13px;color:var(--muted)">A</td>
+            <td class="td-ap">61.5 m</td>
+            <td class="td-rp">—</td>
+            <td><span class="chip chip-juez">C. Méndez</span></td>
+            <td><span class="chip chip-pend">PENDIENTE</span></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td class="td-pos" colspan="9" style="color:var(--muted);font-size:12px;padding:10px 14px;">
+              + 7 atletas más · OT 14:45 → 16:21
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-03  DETALLE AMARILLA — RESOLUCIÓN
+══════════════════════════════════════════ -->
+<div class="screen" id="s-detalle-amarilla">
+  <nav class="navbar">
+    <span class="navbar-brand">AtaraxiaDive</span>
+    <div class="nav-items">
+      <button class="nav-item" onclick="go('s-dashboard')">📊 Panel</button>
+      <button class="nav-item active" onclick="go('s-grilla')">📋 Grilla</button>
+      <button class="nav-item" onclick="go('s-resultados')">🏆 Resultados</button>
+      <button class="nav-item" onclick="go('s-jueces')">👥 Jueces</button>
+      <button class="nav-item" onclick="go('s-torneo')">📝 Torneo</button>
+      <button class="nav-item" onclick="go('s-audit')">🔍 Audit Log</button>
+    </div>
+    <div class="navbar-right">
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+    </div>
+  </nav>
+  <div class="content">
+    <div style="display:flex;align-items:center;gap:12px;margin-bottom:20px">
+      <button class="btn btn-ghost btn-sm" onclick="go('s-grilla')">← Grilla</button>
+      <div class="page-title" style="margin-bottom:0">Resolución — Tarjeta Amarilla</div>
+    </div>
+
+    <div class="two-col">
+      <div>
+        <div class="detail-panel">
+          <h3>Performance en revisión</h3>
+          <div style="display:flex;flex-direction:column;gap:10px;font-size:14px;">
+            <div style="display:flex;justify-content:space-between"><span style="color:var(--muted)">Atleta</span><strong>López, Andrés</strong></div>
+            <div style="display:flex;justify-content:space-between"><span style="color:var(--muted)">Disciplina</span><span>DNF — #2</span></div>
+            <div style="display:flex;justify-content:space-between"><span style="color:var(--muted)">OT</span><span>14:09 · Andarivel B</span></div>
+            <div style="display:flex;justify-content:space-between"><span style="color:var(--muted)">AP declarado</span><span style="color:var(--accent);font-weight:700">72.0 m</span></div>
+            <div style="display:flex;justify-content:space-between"><span style="color:var(--muted)">RP medido</span><span style="font-weight:700">66.0 m</span></div>
+            <div style="display:flex;justify-content:space-between"><span style="color:var(--muted)">Juez</span><span>Carlos Méndez</span></div>
+            <div style="display:flex;justify-content:space-between"><span style="color:var(--muted)">Motivo revisión</span><span style="color:var(--amarilla)">Protocolo superficie dudoso</span></div>
+          </div>
+        </div>
+
+        <div class="detail-panel" style="margin-top:14px;">
+          <h3>Penalización aplicable (CMAS 1.1.13)</h3>
+          <div style="font-size:13px;color:var(--muted);line-height:1.6;">
+            En caso de resolver como <strong style="color:var(--blanca)">BLANCA</strong> con penalización general:
+            se restan <strong>3 metros</strong> a la distancia realizada.<br><br>
+            RP efectivo con penalización: <strong style="color:var(--accent)">63.0 m</strong>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="detail-panel">
+          <h3>Resolución</h3>
+          <div style="background:rgba(234,179,8,.08);border:1px solid rgba(234,179,8,.3);border-radius:8px;padding:12px;margin-bottom:16px;font-size:13px;color:#fde047;">
+            ⚠ Los jueces tienen máximo <strong>3 minutos</strong> para dar la decisión final (CMAS 1.2.3.1).
+          </div>
+          <div class="field">
+            <label>Decisión</label>
+            <select class="input">
+              <option>Seleccionar resolución...</option>
+              <option>BLANCA — Performance válida (sin penalización)</option>
+              <option>BLANCA con penalización — RP: 63.0 m (−3 m)</option>
+              <option>ROJA — Descalificada (DQ)</option>
+            </select>
+          </div>
+          <div class="field">
+            <label>Observaciones</label>
+            <textarea class="input" rows="3" style="resize:vertical" placeholder="Motivo de la decisión..."></textarea>
+          </div>
+          <div style="display:flex;gap:10px;margin-top:4px">
+            <button class="btn btn-blanca" style="flex:1" onclick="go('s-grilla')">⬜ CONFIRMAR BLANCA</button>
+            <button class="btn btn-roja"   style="flex:1" onclick="go('s-grilla')">🟥 CONFIRMAR ROJA</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-04  RESULTADOS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-resultados">
+  <nav class="navbar">
+    <span class="navbar-brand">AtaraxiaDive</span>
+    <div class="nav-items">
+      <button class="nav-item" onclick="go('s-dashboard')">📊 Panel</button>
+      <button class="nav-item" onclick="go('s-grilla')">📋 Grilla</button>
+      <button class="nav-item active" onclick="go('s-resultados')">🏆 Resultados</button>
+      <button class="nav-item" onclick="go('s-jueces')">👥 Jueces</button>
+      <button class="nav-item" onclick="go('s-torneo')">📝 Torneo</button>
+      <button class="nav-item" onclick="go('s-audit')">🔍 Audit Log</button>
+    </div>
+    <div class="navbar-right">
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+    </div>
+  </nav>
+  <div class="content">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
+      <div class="page-title">Resultados</div>
+      <button class="btn btn-primary btn-sm" onclick="alert('Publicar resultados oficiales')">Publicar resultados</button>
+    </div>
+    <div class="page-sub">DNF — Ranking parcial · 2 de 12 atletas completados</div>
+
+    <div class="two-col">
+      <div>
+        <div class="section-title">Ranking DNF — Parcial</div>
+        <div class="detail-panel">
+          <div class="rank-row">
+            <div class="rank-pos gold">1</div>
+            <div class="rank-name">García, Martina<br><span style="font-size:12px;color:var(--muted)">Senior F</span></div>
+            <div class="rank-dist">65.0 m</div>
+            <span class="chip chip-blanca" style="margin-left:8px">BLANCA</span>
+          </div>
+          <div class="rank-row" style="opacity:.7">
+            <div class="rank-pos" style="color:var(--muted)">—</div>
+            <div class="rank-name">López, Andrés<br><span style="font-size:12px;color:var(--muted)">Senior M</span></div>
+            <div class="rank-dist" style="color:var(--muted)">66.0 m</div>
+            <span class="chip chip-amarilla" style="margin-left:8px">EN REVISIÓN</span>
+          </div>
+          <div style="padding:16px 0;color:var(--muted);font-size:13px;border-top:1px solid var(--border);margin-top:8px;">
+            10 atletas pendientes de ejecución…
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="section-title">Overall ranking</div>
+        <div class="detail-panel">
+          <div class="empty">
+            <div class="empty-icon">🏆</div>
+            <div class="empty-text">Disponible al cerrar todas las disciplinas</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-05  JUECES
+══════════════════════════════════════════ -->
+<div class="screen" id="s-jueces">
+  <nav class="navbar">
+    <span class="navbar-brand">AtaraxiaDive</span>
+    <div class="nav-items">
+      <button class="nav-item" onclick="go('s-dashboard')">📊 Panel</button>
+      <button class="nav-item" onclick="go('s-grilla')">📋 Grilla</button>
+      <button class="nav-item" onclick="go('s-resultados')">🏆 Resultados</button>
+      <button class="nav-item active" onclick="go('s-jueces')">👥 Jueces</button>
+      <button class="nav-item" onclick="go('s-torneo')">📝 Torneo</button>
+      <button class="nav-item" onclick="go('s-audit')">🔍 Audit Log</button>
+    </div>
+    <div class="navbar-right">
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+    </div>
+  </nav>
+  <div class="content">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
+      <div class="page-title">Jueces asignados</div>
+      <button class="btn btn-outline btn-sm" onclick="alert('Agregar juez')">+ Agregar juez</button>
+    </div>
+    <div class="page-sub">DNF — 2 jueces activos · 2 andariveles</div>
+
+    <div class="section-title">En línea</div>
+    <div class="juez-card">
+      <div class="juez-avatar">CM</div>
+      <div class="juez-info">
+        <div class="juez-nombre">Carlos Méndez</div>
+        <div class="juez-assign">DNF · Andarivel A — Atletas 1, 3, 5, 7, 9, 11</div>
+      </div>
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+      <button class="btn btn-ghost btn-sm">Reasignar</button>
+    </div>
+    <div class="juez-card">
+      <div class="juez-avatar">AR</div>
+      <div class="juez-info">
+        <div class="juez-nombre">Ana Ruiz</div>
+        <div class="juez-assign">DNF · Andarivel B — Atletas 2, 4, 6, 8, 10, 12</div>
+      </div>
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+      <button class="btn btn-ghost btn-sm">Reasignar</button>
+    </div>
+
+    <div class="section-title" style="margin-top:20px">Pendientes (disciplinas futuras)</div>
+    <div class="juez-card" style="opacity:.6">
+      <div class="juez-avatar" style="background:var(--surface2);color:var(--muted)">MP</div>
+      <div class="juez-info">
+        <div class="juez-nombre">Marcos Pérez</div>
+        <div class="juez-assign">STA · 16:30 hs — Aún no iniciada</div>
+      </div>
+      <span style="font-size:12px;color:var(--muted)">Sin conexión</span>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-06  GESTIÓN DEL TORNEO
+══════════════════════════════════════════ -->
+<div class="screen" id="s-torneo">
+  <nav class="navbar">
+    <span class="navbar-brand">AtaraxiaDive</span>
+    <div class="nav-items">
+      <button class="nav-item" onclick="go('s-dashboard')">📊 Panel</button>
+      <button class="nav-item" onclick="go('s-grilla')">📋 Grilla</button>
+      <button class="nav-item" onclick="go('s-resultados')">🏆 Resultados</button>
+      <button class="nav-item" onclick="go('s-jueces')">👥 Jueces</button>
+      <button class="nav-item active" onclick="go('s-torneo')">📝 Torneo</button>
+      <button class="nav-item" onclick="go('s-audit')">🔍 Audit Log</button>
+    </div>
+    <div class="navbar-right">
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+    </div>
+  </nav>
+  <div class="content">
+    <div class="page-title">Gestión del Torneo</div>
+    <div class="page-sub">Apnea Indoor Buenos Aires 2026</div>
+
+    <div class="two-col">
+      <div>
+        <div class="section-title">Datos generales</div>
+        <div class="detail-panel">
+          <div class="field">
+            <label>Nombre del torneo</label>
+            <input class="input" value="Apnea Indoor Buenos Aires 2026">
+          </div>
+          <div class="field">
+            <label>Fecha</label>
+            <input class="input" type="date" value="2026-04-05">
+          </div>
+          <div class="field">
+            <label>Sede</label>
+            <input class="input" value="Club Náutico BA">
+          </div>
+          <div class="field" style="margin-bottom:0">
+            <label>Estado</label>
+            <select class="input">
+              <option>En ejecución</option>
+              <option>Inscripciones abiertas</option>
+              <option>Finalizado</option>
+            </select>
+          </div>
+          <button class="btn btn-primary" style="margin-top:16px">Guardar cambios</button>
+        </div>
+      </div>
+      <div>
+        <div class="section-title">Disciplinas</div>
+        <div class="disc-card-mgmt">
+          <div class="disc-info">
+            <h4>DNF</h4>
+            <p>14:00 · 12 atletas · And. A/B · 9 min intervalo</p>
+          </div>
+          <span class="badge-activa">ACTIVA</span>
+        </div>
+        <div class="disc-card-mgmt">
+          <div class="disc-info">
+            <h4>STA</h4>
+            <p>16:30 · 8 atletas · And. A · 5 min intervalo</p>
+          </div>
+          <span class="badge-pend">PENDIENTE</span>
+        </div>
+        <div class="disc-card-mgmt">
+          <div class="disc-info">
+            <h4>DBF</h4>
+            <p>18:00 · 8 atletas · And. A · 9 min intervalo</p>
+          </div>
+          <span class="badge-pend">PENDIENTE</span>
+        </div>
+        <button class="btn btn-outline btn-sm" style="margin-top:8px" onclick="alert('Agregar disciplina')">+ Agregar disciplina</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-07  AUDIT LOG
+══════════════════════════════════════════ -->
+<div class="screen" id="s-audit">
+  <nav class="navbar">
+    <span class="navbar-brand">AtaraxiaDive</span>
+    <div class="nav-items">
+      <button class="nav-item" onclick="go('s-dashboard')">📊 Panel</button>
+      <button class="nav-item" onclick="go('s-grilla')">📋 Grilla</button>
+      <button class="nav-item" onclick="go('s-resultados')">🏆 Resultados</button>
+      <button class="nav-item" onclick="go('s-jueces')">👥 Jueces</button>
+      <button class="nav-item" onclick="go('s-torneo')">📝 Torneo</button>
+      <button class="nav-item active" onclick="go('s-audit')">🔍 Audit Log</button>
+    </div>
+    <div class="navbar-right">
+      <div class="conn-badge online"><div class="conn-dot"></div>En línea</div>
+    </div>
+  </nav>
+  <div class="content">
+    <div class="page-title">Audit Log</div>
+    <div class="page-sub">Historial de eventos · Integridad SHA-256</div>
+
+    <div style="display:flex;gap:10px;margin-bottom:20px;flex-wrap:wrap">
+      <select class="input" style="width:auto;min-width:160px">
+        <option>Todas las disciplinas</option>
+        <option>DNF</option><option>STA</option><option>DBF</option>
+      </select>
+      <select class="input" style="width:auto;min-width:160px">
+        <option>Todos los atletas</option>
+        <option>García, Martina</option>
+        <option>López, Andrés</option>
+      </select>
+      <select class="input" style="width:auto;min-width:160px">
+        <option>Todos los jueces</option>
+        <option>Carlos Méndez</option>
+        <option>Ana Ruiz</option>
+      </select>
+    </div>
+
+    <div class="table-wrap" style="padding:0 20px">
+      <div class="log-item">
+        <div class="log-time">14:19</div>
+        <div class="log-event">
+          <span class="chip chip-amarilla" style="margin-right:6px">AMARILLA</span>
+          <span>Tarjeta amarilla asignada · <span class="log-actor">López, Andrés</span> · DNF #2 · RP 66.0 m</span>
+          <div class="log-hash">sha256: a3f9c2d1... · Juez: C. Méndez</div>
+        </div>
+      </div>
+      <div class="log-item">
+        <div class="log-time">14:17</div>
+        <div class="log-event">
+          <span class="chip chip-blanca" style="margin-right:6px">RP</span>
+          <span>Resultado registrado · <span class="log-actor">López, Andrés</span> · 66.0 m</span>
+          <div class="log-hash">sha256: 7b2e4f8a... · Juez: C. Méndez</div>
+        </div>
+      </div>
+      <div class="log-item">
+        <div class="log-time">14:09</div>
+        <div class="log-event">
+          <span class="chip chip-sig" style="margin-right:6px;background:rgba(56,189,248,.2);color:var(--accent)">OT</span>
+          <span>Tiempo Oficial marcado · <span class="log-actor">López, Andrés</span> · Andarivel B</span>
+          <div class="log-hash">sha256: 1d6c9e3b... · Juez: C. Méndez</div>
+        </div>
+      </div>
+      <div class="log-item">
+        <div class="log-time">14:07</div>
+        <div class="log-event">
+          <span class="chip chip-blanca" style="margin-right:6px">BLANCA</span>
+          <span>Tarjeta blanca asignada · <span class="log-actor">García, Martina</span> · DNF #1 · RP 65.0 m</span>
+          <div class="log-hash">sha256: 4e1a7c5f... · Juez: C. Méndez</div>
+        </div>
+      </div>
+      <div class="log-item">
+        <div class="log-time">14:05</div>
+        <div class="log-event">
+          <span class="chip chip-blanca" style="margin-right:6px">RP</span>
+          <span>Resultado registrado · <span class="log-actor">García, Martina</span> · 65.0 m</span>
+          <div class="log-hash">sha256: 9c3d2a1e... · Juez: C. Méndez</div>
+        </div>
+      </div>
+      <div class="log-item">
+        <div class="log-time">14:00</div>
+        <div class="log-event">
+          <span class="chip chip-sig" style="margin-right:6px;background:rgba(56,189,248,.2);color:var(--accent)">OT</span>
+          <span>Tiempo Oficial marcado · <span class="log-actor">García, Martina</span> · Andarivel A</span>
+          <div class="log-hash">sha256: 2f8b6e4d... · Juez: C. Méndez</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+function go(screenId) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  const target = document.getElementById(screenId);
+  if (target) target.classList.add('active');
+  window.scrollTo(0, 0);
+  // Sync navbar active state
+  const navMap = {
+    's-dashboard': 0, 's-grilla': 1, 's-detalle-amarilla': 1,
+    's-resultados': 2, 's-jueces': 3, 's-torneo': 4, 's-audit': 5
+  };
+  document.querySelectorAll('.nav-item').forEach((btn, i) => {
+    btn.classList.toggle('active', i === navMap[screenId]);
+  });
+}
+</script>
+</body>
+</html>

--- a/docs/design/ux/prototipos/prototipo-registro-roles.html
+++ b/docs/design/ux/prototipos/prototipo-registro-roles.html
@@ -1,0 +1,1147 @@
+/<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AtaraxiaDive — Registro y Roles (Prototipo INC-4.0)</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:       #0f172a;
+  --surface:  #1e293b;
+  --surface2: #334155;
+  --border:   #475569;
+  --text:     #f8fafc;
+  --muted:    #94a3b8;
+  --accent:   #38bdf8;
+  --blanca:   #22c55e;
+  --amarilla: #eab308;
+  --roja:     #ef4444;
+  --r: 12px;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  min-height: 100vh;
+}
+
+/* ── Screens ── */
+.screen { display: none; min-height: 100vh; flex-direction: column; }
+.screen.active { display: flex; }
+
+/* ── Mobile shell ── */
+.shell {
+  flex: 1; display: flex; flex-direction: column;
+  max-width: 430px; width: 100%; margin: 0 auto;
+}
+
+/* ── Top header ── */
+.header {
+  background: var(--surface); border-bottom: 1px solid var(--border);
+  padding: 0 16px; display: flex; align-items: center;
+  height: 52px; gap: 10px; position: sticky; top: 0; z-index: 100;
+}
+.header-brand { font-size: 17px; font-weight: 900; color: var(--accent); letter-spacing: -.5px; }
+.header-back  { font-size: 22px; cursor: pointer; color: var(--muted); padding: 4px; }
+.header-title { flex: 1; font-size: 16px; font-weight: 700; }
+.header-right { margin-left: auto; font-size: 13px; color: var(--accent); cursor: pointer; }
+
+/* ── Bottom tab bar ── */
+.tabbar {
+  background: var(--surface); border-top: 1px solid var(--border);
+  display: flex; height: 56px; position: sticky; bottom: 0; z-index: 100;
+}
+.tab-item {
+  flex: 1; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 3px; cursor: pointer;
+  font-size: 10px; font-weight: 600; color: var(--muted);
+  border: none; background: none; transition: color .15s;
+}
+.tab-item.active { color: var(--accent); }
+.tab-icon { font-size: 20px; }
+
+/* ── Scroll content ── */
+.scroll { flex: 1; overflow-y: auto; padding: 16px; }
+
+/* ── Section title ── */
+.sec-title {
+  font-size: 11px; font-weight: 700; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .5px; margin-bottom: 10px; margin-top: 20px;
+}
+.sec-title:first-child { margin-top: 0; }
+
+/* ── Cards ── */
+.card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 16px;
+  margin-bottom: 10px;
+}
+.card.tappable { cursor: pointer; transition: border-color .15s; }
+.card.tappable:hover { border-color: var(--accent); }
+.card-title   { font-size: 15px; font-weight: 800; }
+.card-meta    { font-size: 12px; color: var(--muted); margin-top: 3px; line-height: 1.5; }
+
+/* ── Forms ── */
+.form-group { margin-bottom: 14px; }
+.form-label { font-size: 12px; font-weight: 600; color: var(--muted); margin-bottom: 6px; display: block; }
+.form-input {
+  width: 100%; background: var(--surface2); border: 1px solid var(--border);
+  border-radius: 8px; padding: 12px 14px; color: var(--text); font-size: 15px;
+  outline: none; transition: border-color .15s;
+}
+.form-input:focus { border-color: var(--accent); }
+.form-input::placeholder { color: var(--muted); }
+.form-select {
+  width: 100%; background: var(--surface2); border: 1px solid var(--border);
+  border-radius: 8px; padding: 12px 14px; color: var(--text); font-size: 15px;
+  outline: none; appearance: none; cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%2394a3b8' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 14px center;
+}
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.form-hint { font-size: 11px; color: var(--muted); margin-top: 5px; }
+
+/* ── Buttons ── */
+.btn {
+  width: 100%; padding: 14px; border-radius: 10px; font-size: 16px;
+  font-weight: 700; border: none; cursor: pointer; transition: opacity .15s;
+}
+.btn:hover { opacity: .9; }
+.btn-primary { background: var(--accent); color: #0f172a; }
+.btn-secondary {
+  background: transparent; color: var(--accent);
+  border: 1.5px solid var(--accent); margin-top: 10px;
+}
+.btn-ghost { background: var(--surface2); color: var(--text); margin-top: 10px; }
+.btn-danger { background: var(--roja); color: #fff; margin-top: 10px; }
+.btn-sm {
+  padding: 8px 16px; font-size: 13px; border-radius: 8px; border: none;
+  cursor: pointer; font-weight: 700; transition: opacity .15s;
+}
+.btn-sm:hover { opacity: .85; }
+.btn-sm.accept { background: var(--blanca); color: #0f172a; }
+.btn-sm.reject { background: transparent; color: var(--muted); border: 1px solid var(--border); }
+
+/* ── Brand splash ── */
+.brand-splash {
+  display: flex; flex-direction: column; align-items: center;
+  justify-content: center; padding: 48px 32px 24px;
+}
+.brand-logo { font-size: 38px; font-weight: 900; color: var(--accent); letter-spacing: -1px; }
+.brand-sub { font-size: 14px; color: var(--muted); margin-top: 6px; text-align: center; }
+.brand-divider { width: 40px; height: 3px; background: var(--accent); border-radius: 2px; margin: 20px auto; }
+
+/* ── Progress steps ── */
+.progress-steps {
+  display: flex; align-items: center; gap: 0; padding: 16px 20px; margin-bottom: 4px;
+}
+.step-dot {
+  width: 28px; height: 28px; border-radius: 50%; font-size: 12px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--surface2); border: 2px solid var(--border); color: var(--muted);
+  flex-shrink: 0;
+}
+.step-dot.active { background: var(--accent); border-color: var(--accent); color: #0f172a; }
+.step-dot.done   { background: var(--blanca); border-color: var(--blanca); color: #0f172a; }
+.step-line { flex: 1; height: 2px; background: var(--border); }
+.step-line.done { background: var(--blanca); }
+
+/* ── Role badge ── */
+.role-badge {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 10px; border-radius: 20px; font-size: 11px; font-weight: 700;
+}
+.role-badge.org  { background: rgba(56,189,248,.15); color: var(--accent); border: 1px solid rgba(56,189,248,.3); }
+.role-badge.juez { background: rgba(234,179,8,.15); color: var(--amarilla); border: 1px solid rgba(234,179,8,.3); }
+.role-badge.atleta { background: rgba(34,197,94,.15); color: var(--blanca); border: 1px solid rgba(34,197,94,.3); }
+
+/* ── Torneo row con roles ── */
+.torneo-row {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 14px 0; border-bottom: 1px solid var(--border);
+}
+.torneo-row:last-child { border-bottom: none; }
+.torneo-nombre { font-size: 15px; font-weight: 700; }
+.torneo-meta   { font-size: 12px; color: var(--muted); }
+.torneo-roles  { display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* ── Perfil avatar ── */
+.avatar-section {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 24px 0 16px;
+}
+.avatar {
+  width: 72px; height: 72px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), #818cf8);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 28px; font-weight: 900; color: #0f172a;
+}
+.avatar-name { font-size: 20px; font-weight: 800; margin-top: 10px; }
+.avatar-email { font-size: 13px; color: var(--muted); }
+
+/* ── Info row ── */
+.info-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 0; border-bottom: 1px solid var(--border);
+}
+.info-row:last-child { border-bottom: none; }
+.info-label { font-size: 13px; color: var(--muted); }
+.info-value { font-size: 13px; font-weight: 600; }
+.info-edit  { font-size: 13px; color: var(--accent); cursor: pointer; }
+.info-empty { font-size: 13px; color: var(--muted); font-style: italic; }
+
+/* ── Cert card ── */
+.cert-card {
+  background: var(--surface2); border-radius: 10px;
+  border: 1px solid var(--border); padding: 12px 14px;
+  margin-bottom: 8px; display: flex; align-items: center; gap: 12px;
+}
+.cert-org  { font-size: 11px; font-weight: 700; color: var(--accent); letter-spacing: .5px; }
+.cert-level { font-size: 14px; font-weight: 800; }
+.cert-num  { font-size: 11px; color: var(--muted); }
+.cert-stars { font-size: 16px; }
+
+/* ── Notificación card ── */
+.notif-card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 14px;
+  margin-bottom: 10px; cursor: pointer; transition: border-color .15s;
+}
+.notif-card.unread { border-left: 3px solid var(--accent); }
+.notif-card:hover { border-color: var(--accent); }
+.notif-header { display: flex; align-items: flex-start; gap: 10px; }
+.notif-icon { font-size: 22px; min-width: 28px; }
+.notif-body { flex: 1; }
+.notif-title { font-size: 14px; font-weight: 700; line-height: 1.3; }
+.notif-sub   { font-size: 12px; color: var(--muted); margin-top: 3px; }
+.notif-time  { font-size: 11px; color: var(--muted); white-space: nowrap; }
+.notif-actions { display: flex; gap: 8px; margin-top: 12px; }
+
+/* ── Invitación detalle ── */
+.inv-hero {
+  background: linear-gradient(135deg, rgba(234,179,8,.12) 0%, rgba(234,179,8,.04) 100%);
+  border: 1px solid rgba(234,179,8,.25); border-radius: var(--r);
+  padding: 20px; margin-bottom: 16px; text-align: center;
+}
+.inv-emoji { font-size: 36px; }
+.inv-title { font-size: 18px; font-weight: 900; margin-top: 8px; }
+.inv-sub   { font-size: 13px; color: var(--muted); margin-top: 4px; }
+
+/* ── Empty state ── */
+.empty-state {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 40px 20px; text-align: center; gap: 8px;
+}
+.empty-icon  { font-size: 48px; }
+.empty-title { font-size: 18px; font-weight: 800; }
+.empty-sub   { font-size: 14px; color: var(--muted); line-height: 1.5; }
+
+/* ── Caminos card (primer acceso) ── */
+.path-card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 18px;
+  margin-bottom: 10px; cursor: pointer; transition: border-color .15s;
+  display: flex; align-items: center; gap: 14px;
+}
+.path-card:hover { border-color: var(--accent); }
+.path-icon { font-size: 30px; min-width: 36px; }
+.path-text {}
+.path-title { font-size: 15px; font-weight: 800; }
+.path-sub   { font-size: 12px; color: var(--muted); margin-top: 3px; line-height: 1.4; }
+.path-arrow { margin-left: auto; font-size: 18px; color: var(--muted); }
+
+/* ── Link text ── */
+.link-text { color: var(--accent); cursor: pointer; font-weight: 600; }
+.center    { text-align: center; }
+.mt-16     { margin-top: 16px; }
+.mt-8      { margin-top: 8px; }
+.text-sm   { font-size: 13px; color: var(--muted); }
+
+/* ── Checkbox ── */
+.check-row {
+  display: flex; align-items: flex-start; gap: 10px;
+  margin-bottom: 14px;
+}
+.check-box {
+  width: 20px; height: 20px; border-radius: 5px; flex-shrink: 0; margin-top: 1px;
+  border: 2px solid var(--border); background: var(--surface2);
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
+  font-size: 13px; transition: background .15s, border-color .15s;
+}
+.check-box.checked { background: var(--accent); border-color: var(--accent); color: #0f172a; }
+.check-label { font-size: 13px; color: var(--muted); line-height: 1.5; }
+
+/* ── Pill selector (género) ── */
+.pill-group { display: flex; gap: 8px; }
+.pill {
+  flex: 1; padding: 10px; border-radius: 8px; border: 1.5px solid var(--border);
+  background: var(--surface2); color: var(--muted); font-size: 14px; font-weight: 600;
+  cursor: pointer; text-align: center; transition: all .15s;
+}
+.pill.selected { border-color: var(--accent); background: rgba(56,189,248,.12); color: var(--accent); }
+
+/* ── Summary resumen roles ── */
+.roles-summary {
+  display: flex; gap: 16px; padding: 14px 0; flex-wrap: wrap;
+}
+.roles-count { display: flex; flex-direction: column; align-items: center; gap: 2px; }
+.roles-count-num { font-size: 24px; font-weight: 900; }
+.roles-count-label { font-size: 11px; color: var(--muted); font-weight: 600; }
+
+/* ── Selección nivel cert ── */
+.level-options { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+.level-opt {
+  padding: 12px 14px; border-radius: 10px; border: 1.5px solid var(--border);
+  background: var(--surface2); cursor: pointer; display: flex; align-items: center;
+  gap: 10px; transition: all .15s;
+}
+.level-opt.selected { border-color: var(--accent); background: rgba(56,189,248,.1); }
+.level-opt-stars { font-size: 16px; }
+.level-opt-text  { font-size: 14px; font-weight: 700; }
+.level-opt-sub   { font-size: 11px; color: var(--muted); }
+.level-opt-radio {
+  margin-left: auto; width: 18px; height: 18px; border-radius: 50%;
+  border: 2px solid var(--border); display: flex; align-items: center; justify-content: center;
+}
+.level-opt.selected .level-opt-radio { border-color: var(--accent); }
+.level-opt.selected .level-opt-radio::after {
+  content: ''; width: 8px; height: 8px; border-radius: 50%; background: var(--accent);
+}
+
+/* ── Nav index (desktop helper) ── */
+.nav-index {
+  position: fixed; top: 16px; left: 16px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r); padding: 12px; z-index: 999;
+  max-width: 200px;
+}
+.nav-index h4 { font-size: 11px; font-weight: 700; color: var(--muted); text-transform: uppercase; margin-bottom: 8px; }
+.nav-btn {
+  display: block; width: 100%; text-align: left;
+  padding: 6px 8px; font-size: 12px; border-radius: 6px;
+  background: none; border: none; color: var(--muted); cursor: pointer;
+  transition: background .15s, color .15s;
+}
+.nav-btn:hover { background: var(--surface2); color: var(--text); }
+.nav-btn.active-screen { color: var(--accent); font-weight: 700; }
+</style>
+</head>
+<body>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- NAV INDEX (helper de navegación) -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="nav-index">
+  <h4>Pantallas</h4>
+  <button class="nav-btn" onclick="show('s-login')">1. Login</button>
+  <button class="nav-btn" onclick="show('s-register')">2. Registro</button>
+  <button class="nav-btn" onclick="show('s-verify')">3. Verificar email</button>
+  <button class="nav-btn" onclick="show('s-dashboard-empty')">4. Dashboard vacío</button>
+  <button class="nav-btn" onclick="show('s-dashboard-roles')">5. Dashboard con roles</button>
+  <button class="nav-btn" onclick="show('s-perfil')">6. Mi Perfil</button>
+  <button class="nav-btn" onclick="show('s-notificaciones')">7. Notificaciones</button>
+  <button class="nav-btn" onclick="show('s-invitacion')">8. Invitación juez</button>
+  <button class="nav-btn" onclick="show('s-agregar-cert')">9. Agregar certificación</button>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-1: LOGIN -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen active" id="s-login">
+  <div class="shell">
+    <div class="brand-splash">
+      <div class="brand-logo">AtaraxiaDive</div>
+      <div class="brand-sub">Gestión de torneos de apnea</div>
+      <div class="brand-divider"></div>
+    </div>
+    <div class="scroll" style="padding-top:0">
+      <div class="form-group">
+        <label class="form-label">Email</label>
+        <input class="form-input" type="email" placeholder="tu@email.com" value="carlos.mendez@email.com">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Contraseña</label>
+        <input class="form-input" type="password" placeholder="••••••••" value="••••••••">
+      </div>
+      <div class="center mt-8 mb-4" style="margin-bottom:16px">
+        <span class="link-text" style="font-size:13px">Olvidé mi contraseña</span>
+      </div>
+      <button class="btn btn-primary" onclick="show('s-dashboard-roles')">Iniciar sesión</button>
+      <div class="center mt-16">
+        <span class="text-sm">¿No tenés cuenta? </span>
+        <span class="link-text" onclick="show('s-register')">Crear cuenta</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-2: REGISTRO -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-register">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="show('s-login')">‹</span>
+      <span class="header-title">Crear cuenta</span>
+    </div>
+
+    <!-- Progress -->
+    <div class="progress-steps">
+      <div class="step-dot active">1</div>
+      <div class="step-line"></div>
+      <div class="step-dot">2</div>
+      <div class="step-line"></div>
+      <div class="step-dot">3</div>
+    </div>
+
+    <div class="scroll">
+      <p class="text-sm" style="margin-bottom:20px">Paso 1 de 3 — <strong style="color:var(--text)">Datos personales</strong></p>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label class="form-label">Nombre</label>
+          <input class="form-input" type="text" placeholder="Carlos">
+        </div>
+        <div class="form-group">
+          <label class="form-label">Apellido</label>
+          <input class="form-input" type="text" placeholder="Méndez">
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Email</label>
+        <input class="form-input" type="email" placeholder="tu@email.com">
+        <p class="form-hint">Necesitarás confirmar este email.</p>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Fecha de nacimiento</label>
+        <input class="form-input" type="date" value="1990-07-15">
+        <p class="form-hint">Necesaria para determinar tu categoría de competición.</p>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Género</label>
+        <div class="pill-group">
+          <div class="pill selected" onclick="selectPill(this)">Masculino</div>
+          <div class="pill" onclick="selectPill(this)">Femenino</div>
+        </div>
+      </div>
+
+      <button class="btn btn-primary" onclick="show('s-register-2')">Siguiente →</button>
+      <div class="center mt-16">
+        <span class="text-sm">¿Ya tenés cuenta? </span>
+        <span class="link-text" onclick="show('s-login')">Iniciar sesión</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-2b: REGISTRO PASO 2 -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-register-2">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="show('s-register')">‹</span>
+      <span class="header-title">Crear cuenta</span>
+    </div>
+
+    <div class="progress-steps">
+      <div class="step-dot done">✓</div>
+      <div class="step-line done"></div>
+      <div class="step-dot active">2</div>
+      <div class="step-line"></div>
+      <div class="step-dot">3</div>
+    </div>
+
+    <div class="scroll">
+      <p class="text-sm" style="margin-bottom:20px">Paso 2 de 3 — <strong style="color:var(--text)">Acceso</strong></p>
+
+      <div class="form-group">
+        <label class="form-label">Contraseña</label>
+        <input class="form-input" type="password" placeholder="Mínimo 8 caracteres">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Confirmar contraseña</label>
+        <input class="form-input" type="password" placeholder="Repetir contraseña">
+      </div>
+
+      <div style="background:var(--surface2); border-radius:8px; padding:12px; margin-bottom:16px;">
+        <p style="font-size:12px; color:var(--muted); line-height:1.5;">
+          La contraseña debe tener al menos 8 caracteres, incluir una mayúscula y un número.
+        </p>
+      </div>
+
+      <button class="btn btn-primary" onclick="show('s-register-3')">Siguiente →</button>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-2c: REGISTRO PASO 3 -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-register-3">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="show('s-register-2')">‹</span>
+      <span class="header-title">Crear cuenta</span>
+    </div>
+
+    <div class="progress-steps">
+      <div class="step-dot done">✓</div>
+      <div class="step-line done"></div>
+      <div class="step-dot done">✓</div>
+      <div class="step-line done"></div>
+      <div class="step-dot active">3</div>
+    </div>
+
+    <div class="scroll">
+      <p class="text-sm" style="margin-bottom:20px">Paso 3 de 3 — <strong style="color:var(--text)">Confirmación</strong></p>
+
+      <div class="card" style="margin-bottom:16px;">
+        <div class="info-row">
+          <span class="info-label">Nombre</span>
+          <span class="info-value">Carlos Méndez</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Email</span>
+          <span class="info-value">carlos.mendez@email.com</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Fecha de nac.</span>
+          <span class="info-value">15/07/1990</span>
+        </div>
+        <div class="info-row" style="border-bottom:none">
+          <span class="info-label">Género</span>
+          <span class="info-value">Masculino</span>
+        </div>
+      </div>
+
+      <div class="check-row">
+        <div class="check-box checked" onclick="toggleCheck(this)">✓</div>
+        <span class="check-label">Acepto los <span class="link-text">Términos de uso</span> y la <span class="link-text">Política de privacidad</span>.</span>
+      </div>
+
+      <div class="check-row">
+        <div class="check-box" onclick="toggleCheck(this)"></div>
+        <span class="check-label">Quiero recibir notificaciones sobre torneos y novedades (opcional).</span>
+      </div>
+
+      <button class="btn btn-primary" onclick="show('s-verify')">Crear mi cuenta</button>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-3: VERIFICAR EMAIL -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-verify">
+  <div class="shell">
+    <div class="header">
+      <div class="header-brand">AtaraxiaDive</div>
+    </div>
+    <div class="scroll" style="display:flex; flex-direction:column; align-items:center; justify-content:center; min-height:80vh; text-align:center;">
+      <div style="font-size:64px; margin-bottom:20px;">📧</div>
+      <h2 style="font-size:22px; font-weight:900; margin-bottom:8px;">Revisá tu email</h2>
+      <p style="font-size:14px; color:var(--muted); line-height:1.6; max-width:280px; margin-bottom:28px;">
+        Te enviamos un email a <strong style="color:var(--text)">carlos.mendez@email.com</strong>. Hacé clic en el enlace para confirmar tu cuenta.
+      </p>
+      <button class="btn btn-primary" style="max-width:280px" onclick="show('s-dashboard-empty')">Ya confirmé mi email</button>
+      <p class="text-sm mt-16">¿No llegó? <span class="link-text">Reenviar email</span></p>
+      <p class="text-sm mt-8">¿Email incorrecto? <span class="link-text" onclick="show('s-register')">Volver</span></p>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-4: DASHBOARD VACÍO (primer acceso) -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-dashboard-empty">
+  <div class="shell">
+    <div class="header">
+      <div class="header-brand">AtaraxiaDive</div>
+      <div class="header-right" onclick="show('s-notificaciones')">🔔</div>
+    </div>
+
+    <div class="scroll">
+      <!-- Bienvenida -->
+      <div style="padding: 20px 0 16px; border-bottom: 1px solid var(--border); margin-bottom:20px;">
+        <div style="font-size:13px; color:var(--muted)">Bienvenido,</div>
+        <div style="font-size:22px; font-weight:900; margin-top:2px;">Carlos Méndez</div>
+        <div style="font-size:13px; color:var(--muted); margin-top:4px;">Todavía no tenés ningún torneo activo.</div>
+      </div>
+
+      <div class="sec-title">¿Cómo querés empezar?</div>
+
+      <div class="path-card" onclick="alert('→ Flujo crear torneo (prototipo-organizador.html)')">
+        <div class="path-icon">🏆</div>
+        <div class="path-text">
+          <div class="path-title">Crear un torneo</div>
+          <div class="path-sub">Organizás el evento. Configurás disciplinas, grilla y jueces.</div>
+        </div>
+        <div class="path-arrow">›</div>
+      </div>
+
+      <div class="path-card" onclick="alert('→ Flujo inscripción atleta (prototipo-atleta.html)')">
+        <div class="path-icon">🤿</div>
+        <div class="path-text">
+          <div class="path-title">Inscribirme a un torneo</div>
+          <div class="path-sub">Buscá un torneo abierto y declarás tus APs por disciplina.</div>
+        </div>
+        <div class="path-arrow">›</div>
+      </div>
+
+      <div class="path-card" style="opacity:.65; cursor:default;">
+        <div class="path-icon">⚖️</div>
+        <div class="path-text">
+          <div class="path-title">Soy juez</div>
+          <div class="path-sub">Un organizador debe invitarte. Recibirás una notificación cuando te asignen a un torneo.</div>
+        </div>
+      </div>
+
+      <div style="background:var(--surface2); border-radius:10px; padding:14px; margin-top:8px;">
+        <p style="font-size:12px; color:var(--muted); line-height:1.5;">
+          💡 Una misma persona puede organizar torneos, juzgar y competir. Tus roles son independientes por torneo.
+        </p>
+      </div>
+    </div>
+
+    <div class="tabbar">
+      <button class="tab-item active" onclick="show('s-dashboard-empty')">
+        <span class="tab-icon">🏠</span>Inicio
+      </button>
+      <button class="tab-item" onclick="show('s-dashboard-roles')">
+        <span class="tab-icon">🏆</span>Torneos
+      </button>
+      <button class="tab-item" onclick="show('s-notificaciones')">
+        <span class="tab-icon">🔔</span>Alertas
+      </button>
+      <button class="tab-item" onclick="show('s-perfil')">
+        <span class="tab-icon">👤</span>Perfil
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-5: DASHBOARD CON ROLES ACTIVOS -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-dashboard-roles">
+  <div class="shell">
+    <div class="header">
+      <div class="header-brand">AtaraxiaDive</div>
+      <div class="header-right" onclick="show('s-notificaciones')">🔔 <span style="background:var(--roja);border-radius:50%;width:8px;height:8px;display:inline-block;margin-left:-4px;vertical-align:top;"></span></div>
+    </div>
+
+    <div class="scroll">
+      <!-- Resumen de roles -->
+      <div style="padding: 16px 0 12px; border-bottom: 1px solid var(--border); margin-bottom:16px;">
+        <div style="font-size:13px; color:var(--muted)">Hola de nuevo,</div>
+        <div style="font-size:20px; font-weight:900; margin-top:2px;">Carlos Méndez</div>
+        <div class="roles-summary" style="margin-top:14px;">
+          <div class="roles-count">
+            <span class="roles-count-num" style="color:var(--accent)">2</span>
+            <span class="roles-count-label">Organizando</span>
+          </div>
+          <div style="width:1px; background:var(--border);"></div>
+          <div class="roles-count">
+            <span class="roles-count-num" style="color:var(--amarilla)">1</span>
+            <span class="roles-count-label">Juzgando</span>
+          </div>
+          <div style="width:1px; background:var(--border);"></div>
+          <div class="roles-count">
+            <span class="roles-count-num" style="color:var(--blanca)">2</span>
+            <span class="roles-count-label">Compitiendo</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Torneos activos -->
+      <div class="sec-title">Próximos torneos</div>
+      <div class="card">
+
+        <!-- Torneo 1: org + atleta -->
+        <div class="torneo-row">
+          <div>
+            <div class="torneo-nombre">Nacional de Apnea Buenos Aires 2026</div>
+            <div class="torneo-meta">28–30 Ago · Club Náutico Tigre</div>
+          </div>
+          <div class="torneo-roles">
+            <span class="role-badge org">🏆 Organizador</span>
+          </div>
+        </div>
+
+        <!-- Torneo 2: juez + atleta -->
+        <div class="torneo-row">
+          <div>
+            <div class="torneo-nombre">Copa Mar del Plata 2026</div>
+            <div class="torneo-meta">12 Oct · Club de Pesca MDP</div>
+          </div>
+          <div class="torneo-roles">
+            <span class="role-badge juez">⚖️ Juez</span>
+            <span class="role-badge atleta">🤿 Atleta</span>
+          </div>
+        </div>
+
+        <!-- Torneo 3: atleta -->
+        <div class="torneo-row">
+          <div>
+            <div class="torneo-nombre">Interclub Patagonia 2026</div>
+            <div class="torneo-meta">3 Nov · Bariloche</div>
+          </div>
+          <div class="torneo-roles">
+            <span class="role-badge atleta">🤿 Atleta</span>
+          </div>
+        </div>
+
+        <!-- Torneo 4: org -->
+        <div class="torneo-row">
+          <div>
+            <div class="torneo-nombre">Selectivo FAAS 2026</div>
+            <div class="torneo-meta">Nov 2026 · Córdoba (en organización)</div>
+          </div>
+          <div class="torneo-roles">
+            <span class="role-badge org">🏆 Organizador</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <button class="btn btn-secondary" style="margin-top:4px">+ Inscribirme a otro torneo</button>
+    </div>
+
+    <div class="tabbar">
+      <button class="tab-item active">
+        <span class="tab-icon">🏠</span>Inicio
+      </button>
+      <button class="tab-item">
+        <span class="tab-icon">🏆</span>Torneos
+      </button>
+      <button class="tab-item" onclick="show('s-notificaciones')">
+        <span class="tab-icon">🔔</span>Alertas
+      </button>
+      <button class="tab-item" onclick="show('s-perfil')">
+        <span class="tab-icon">👤</span>Perfil
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-6: MI PERFIL -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-perfil">
+  <div class="shell">
+    <div class="header">
+      <div class="header-brand">AtaraxiaDive</div>
+      <div class="header-right">Editar</div>
+    </div>
+
+    <div class="scroll">
+      <!-- Avatar -->
+      <div class="avatar-section">
+        <div class="avatar">CM</div>
+        <div class="avatar-name">Carlos Méndez</div>
+        <div class="avatar-email">carlos.mendez@email.com</div>
+      </div>
+
+      <!-- Datos de cuenta -->
+      <div class="sec-title">Datos de cuenta</div>
+      <div class="card">
+        <div class="info-row">
+          <span class="info-label">Nombre</span>
+          <span class="info-value">Carlos Méndez</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Email</span>
+          <span class="info-value">carlos.mendez@email.com</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Fecha de nac.</span>
+          <span class="info-value">15/07/1990</span>
+        </div>
+        <div class="info-row" style="border-bottom:none">
+          <span class="info-label">Género</span>
+          <span class="info-value">Masculino</span>
+        </div>
+      </div>
+
+      <!-- Datos deportivos -->
+      <div class="sec-title">Datos deportivos</div>
+      <div style="background:rgba(56,189,248,.07); border:1px dashed rgba(56,189,248,.3); border-radius:var(--r); padding:12px 14px; margin-bottom:10px;">
+        <p style="font-size:12px; color:var(--muted); line-height:1.5;">
+          💡 Completar estos datos es opcional pero necesario para competir. El organizador puede pedirlos al inscribirte.
+        </p>
+      </div>
+      <div class="card">
+        <div class="info-row">
+          <span class="info-label">Club</span>
+          <span class="info-empty">No completado</span>
+          <span class="info-edit">+ Agregar</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Federación</span>
+          <span class="info-empty">No completado</span>
+          <span class="info-edit">+ Agregar</span>
+        </div>
+        <div class="info-row" style="border-bottom:none">
+          <span class="info-label">Nro. de licencia</span>
+          <span class="info-empty">No completado</span>
+          <span class="info-edit">+ Agregar</span>
+        </div>
+      </div>
+
+      <!-- Certificaciones de juez -->
+      <div class="sec-title">Certificaciones de juez</div>
+      <div style="background:rgba(234,179,8,.07); border:1px dashed rgba(234,179,8,.3); border-radius:var(--r); padding:12px 14px; margin-bottom:10px;">
+        <p style="font-size:12px; color:var(--muted); line-height:1.5;">
+          Si tenés habilitación para juzgar, registrá tu certificación. Los organizadores pueden consultarla al asignarte como juez.
+        </p>
+      </div>
+
+      <!-- Cert existente -->
+      <div class="cert-card">
+        <div>
+          <div class="cert-org">CMAS</div>
+          <div class="cert-level">Juez Nacional <span class="cert-stars">★★☆</span></div>
+          <div class="cert-num">Nro. AR-2019-047 · Vence 12/2026</div>
+        </div>
+      </div>
+
+      <button class="btn btn-secondary" onclick="show('s-agregar-cert')">+ Agregar otra certificación</button>
+
+      <!-- Seguridad -->
+      <div class="sec-title">Seguridad</div>
+      <div class="card">
+        <div class="info-row">
+          <span class="info-label">Contraseña</span>
+          <span class="info-edit">Cambiar</span>
+        </div>
+        <div class="info-row" style="border-bottom:none">
+          <span class="info-label">Sesiones activas</span>
+          <span class="info-edit">Ver</span>
+        </div>
+      </div>
+
+      <button class="btn btn-ghost" style="margin-top:8px; color:var(--roja);">Cerrar sesión</button>
+    </div>
+
+    <div class="tabbar">
+      <button class="tab-item" onclick="show('s-dashboard-roles')">
+        <span class="tab-icon">🏠</span>Inicio
+      </button>
+      <button class="tab-item">
+        <span class="tab-icon">🏆</span>Torneos
+      </button>
+      <button class="tab-item" onclick="show('s-notificaciones')">
+        <span class="tab-icon">🔔</span>Alertas
+      </button>
+      <button class="tab-item active">
+        <span class="tab-icon">👤</span>Perfil
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-7: NOTIFICACIONES -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-notificaciones">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="show('s-dashboard-roles')">‹</span>
+      <span class="header-title">Notificaciones</span>
+    </div>
+
+    <div class="scroll">
+      <div class="sec-title">Nuevas</div>
+
+      <!-- Invitación juez -->
+      <div class="notif-card unread" onclick="show('s-invitacion')">
+        <div class="notif-header">
+          <div class="notif-icon">⚖️</div>
+          <div class="notif-body">
+            <div class="notif-title">Te invitaron como juez</div>
+            <div class="notif-sub">Ana Rodríguez te invitó a juzgar en <strong>Copa Mar del Plata 2026</strong>.</div>
+          </div>
+          <div class="notif-time">hace 2h</div>
+        </div>
+        <div class="notif-actions">
+          <button class="btn-sm accept" onclick="event.stopPropagation(); acceptInvitation()">Aceptar</button>
+          <button class="btn-sm reject">Rechazar</button>
+        </div>
+      </div>
+
+      <!-- Inscripción confirmada -->
+      <div class="notif-card unread">
+        <div class="notif-header">
+          <div class="notif-icon">✅</div>
+          <div class="notif-body">
+            <div class="notif-title">Inscripción confirmada</div>
+            <div class="notif-sub">Tu inscripción a <strong>Interclub Patagonia 2026</strong> fue aprobada.</div>
+          </div>
+          <div class="notif-time">ayer</div>
+        </div>
+      </div>
+
+      <div class="sec-title">Anteriores</div>
+
+      <!-- Torneo publicado -->
+      <div class="notif-card">
+        <div class="notif-header">
+          <div class="notif-icon">🏆</div>
+          <div class="notif-body">
+            <div class="notif-title">Torneo publicado</div>
+            <div class="notif-sub"><strong>Nacional BA 2026</strong> está visible públicamente. Las inscripciones están abiertas.</div>
+          </div>
+          <div class="notif-time">3 días</div>
+        </div>
+      </div>
+
+      <!-- Ranking publicado -->
+      <div class="notif-card">
+        <div class="notif-header">
+          <div class="notif-icon">🥉</div>
+          <div class="notif-body">
+            <div class="notif-title">Resultados disponibles</div>
+            <div class="notif-sub">Copa Litoral 2025 — Quedaste 3º en STA Masculino.</div>
+          </div>
+          <div class="notif-time">hace 5 días</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tabbar">
+      <button class="tab-item" onclick="show('s-dashboard-roles')">
+        <span class="tab-icon">🏠</span>Inicio
+      </button>
+      <button class="tab-item">
+        <span class="tab-icon">🏆</span>Torneos
+      </button>
+      <button class="tab-item active">
+        <span class="tab-icon">🔔</span>Alertas
+      </button>
+      <button class="tab-item" onclick="show('s-perfil')">
+        <span class="tab-icon">👤</span>Perfil
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-8: INVITACIÓN DETALLE -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-invitacion">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="show('s-notificaciones')">‹</span>
+      <span class="header-title">Invitación de juez</span>
+    </div>
+
+    <div class="scroll">
+      <!-- Hero -->
+      <div class="inv-hero">
+        <div class="inv-emoji">⚖️</div>
+        <div class="inv-title">Copa Mar del Plata 2026</div>
+        <div class="inv-sub">Ana Rodríguez te invita a juzgar este torneo</div>
+      </div>
+
+      <!-- Detalles del torneo -->
+      <div class="sec-title">Torneo</div>
+      <div class="card">
+        <div class="info-row">
+          <span class="info-label">Fecha</span>
+          <span class="info-value">12 octubre 2026</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Sede</span>
+          <span class="info-value">Club de Pesca MDP</span>
+        </div>
+        <div class="info-row" style="border-bottom:none">
+          <span class="info-label">Organizador</span>
+          <span class="info-value">Ana Rodríguez</span>
+        </div>
+      </div>
+
+      <!-- Tu rol -->
+      <div class="sec-title">Tu rol</div>
+      <div class="card">
+        <div class="info-row">
+          <span class="info-label">Función</span>
+          <span class="role-badge juez">⚖️ Juez</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Disciplinas</span>
+          <span class="info-value">STA, DYN, DNF</span>
+        </div>
+        <div class="info-row" style="border-bottom:none">
+          <span class="info-label">Andarivel asignado</span>
+          <span class="info-value">A determinar</span>
+        </div>
+      </div>
+
+      <!-- Compatibilidad -->
+      <div class="sec-title">Compatibilidad de roles</div>
+      <div style="background:rgba(34,197,94,.08); border:1px solid rgba(34,197,94,.25); border-radius:var(--r); padding:14px; margin-bottom:16px;">
+        <div style="display:flex; align-items:flex-start; gap:10px;">
+          <span style="font-size:18px;">✅</span>
+          <div>
+            <div style="font-size:14px; font-weight:700; color:var(--blanca);">Podés juzgar y competir en este torneo</div>
+            <div style="font-size:12px; color:var(--muted); margin-top:4px; line-height:1.5;">
+              Tu inscripción como atleta en STA no colisiona con tu función de juez en STA — judgarás andariveles en los que no compitas. El organizador confirmará el detalle.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Cert detectada -->
+      <div class="sec-title">Tu certificación</div>
+      <div class="cert-card" style="border-color: rgba(234,179,8,.4);">
+        <div>
+          <div class="cert-org">CMAS</div>
+          <div class="cert-level">Juez Nacional <span class="cert-stars">★★☆</span></div>
+          <div class="cert-num">Nro. AR-2019-047 · Vence 12/2026</div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <button class="btn btn-primary" onclick="acceptInvitation()">Aceptar invitación</button>
+      <button class="btn btn-ghost" onclick="show('s-notificaciones')">Rechazar</button>
+
+      <p class="text-sm center mt-16">Si aceptás, Ana Rodríguez recibirá una confirmación. Podrás retirarte antes del inicio del torneo.</p>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<!-- S-9: AGREGAR CERTIFICACIÓN -->
+<!-- ════════════════════════════════════════════════ -->
+<div class="screen" id="s-agregar-cert">
+  <div class="shell">
+    <div class="header">
+      <span class="header-back" onclick="show('s-perfil')">‹</span>
+      <span class="header-title">Agregar certificación</span>
+    </div>
+
+    <div class="scroll">
+      <div class="sec-title">Organización</div>
+      <div class="form-group">
+        <select class="form-select" onchange="updateLevels(this)">
+          <option value="">Seleccionar organización…</option>
+          <option value="cmas">CMAS</option>
+          <option value="aida">AIDA</option>
+          <option value="faas">FAAS</option>
+        </select>
+      </div>
+
+      <div class="sec-title">Nivel</div>
+      <div class="level-options">
+        <div class="level-opt" onclick="selectLevel(this)">
+          <span class="level-opt-stars">★☆☆</span>
+          <div>
+            <div class="level-opt-text">Juez Nacional — 1 estrella</div>
+            <div class="level-opt-sub">Torneos locales y nacionales</div>
+          </div>
+          <div class="level-opt-radio"></div>
+        </div>
+        <div class="level-opt selected" onclick="selectLevel(this)">
+          <span class="level-opt-stars">★★☆</span>
+          <div>
+            <div class="level-opt-text">Juez Continental — 2 estrellas</div>
+            <div class="level-opt-sub">Torneos continentales</div>
+          </div>
+          <div class="level-opt-radio"></div>
+        </div>
+        <div class="level-opt" onclick="selectLevel(this)">
+          <span class="level-opt-stars">★★★</span>
+          <div>
+            <div class="level-opt-text">Juez Internacional — 3 estrellas</div>
+            <div class="level-opt-sub">Campeonatos mundiales y continentales CMAS</div>
+          </div>
+          <div class="level-opt-radio"></div>
+        </div>
+      </div>
+
+      <div class="sec-title" style="margin-top:24px;">Datos del certificado</div>
+      <div class="form-group">
+        <label class="form-label">Número de certificación</label>
+        <input class="form-input" type="text" placeholder="Ej: AR-2019-047">
+      </div>
+      <div class="form-row">
+        <div class="form-group">
+          <label class="form-label">Fecha de emisión</label>
+          <input class="form-input" type="month" value="2019-05">
+        </div>
+        <div class="form-group">
+          <label class="form-label">Vencimiento</label>
+          <input class="form-input" type="month" value="2026-12">
+        </div>
+      </div>
+
+      <div style="background:var(--surface2); border-radius:10px; padding:12px 14px; margin-bottom:16px;">
+        <p style="font-size:12px; color:var(--muted); line-height:1.5;">
+          Esta información es declarada por vos. El organizador es responsable de verificarla si su torneo lo requiere.
+        </p>
+      </div>
+
+      <button class="btn btn-primary" onclick="show('s-perfil')">Guardar certificación</button>
+      <button class="btn btn-ghost" onclick="show('s-perfil')">Cancelar</button>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════════ -->
+<script>
+function show(id) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+  // Scroll to top
+  const scroll = document.getElementById(id).querySelector('.scroll');
+  if (scroll) scroll.scrollTop = 0;
+  // Update nav
+  document.querySelectorAll('.nav-btn').forEach(b => {
+    b.classList.toggle('active-screen', b.getAttribute('onclick')?.includes(id));
+  });
+}
+
+function selectPill(el) {
+  el.closest('.pill-group').querySelectorAll('.pill').forEach(p => p.classList.remove('selected'));
+  el.classList.add('selected');
+}
+
+function toggleCheck(el) {
+  el.classList.toggle('checked');
+  el.textContent = el.classList.contains('checked') ? '✓' : '';
+}
+
+function selectLevel(el) {
+  el.closest('.level-options').querySelectorAll('.level-opt').forEach(o => o.classList.remove('selected'));
+  el.classList.add('selected');
+}
+
+function acceptInvitation() {
+  // Simular aceptación
+  const overlay = document.createElement('div');
+  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:9999;';
+  overlay.innerHTML = `
+    <div style="background:#1e293b;border-radius:16px;padding:32px 24px;text-align:center;max-width:280px;border:1px solid #475569;">
+      <div style="font-size:48px;margin-bottom:12px;">✅</div>
+      <div style="font-size:18px;font-weight:900;margin-bottom:8px;">Invitación aceptada</div>
+      <div style="font-size:13px;color:#94a3b8;line-height:1.5;margin-bottom:20px;">
+        Ana Rodríguez será notificada. Copa Mar del Plata 2026 aparecerá en tu dashboard como juez.
+      </div>
+      <button onclick="this.closest('div[style]').remove(); show('s-dashboard-roles')"
+        style="background:#38bdf8;color:#0f172a;border:none;border-radius:10px;padding:12px 24px;font-size:15px;font-weight:700;cursor:pointer;width:100%;">
+        Ver mis torneos
+      </button>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+}
+</script>
+</body>
+</html>

--- a/docs/design/ux/prototipos/prototipo-setup-torneo.html
+++ b/docs/design/ux/prototipos/prototipo-setup-torneo.html
@@ -1,0 +1,1060 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AtaraxiaDive — Setup del Torneo (Prototipo INC-4.0 v2)</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:       #0f172a;
+  --surface:  #1e293b;
+  --surface2: #334155;
+  --border:   #475569;
+  --text:     #f8fafc;
+  --muted:    #94a3b8;
+  --accent:   #38bdf8;
+  --blanca:   #22c55e;
+  --amarilla: #eab308;
+  --roja:     #ef4444;
+  --r: 10px;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  min-height: 100vh;
+}
+
+.screen { display: none; min-height: 100vh; flex-direction: column; }
+.screen.active { display: flex; }
+
+/* ── Topbar ── */
+.topbar {
+  background: var(--surface); border-bottom: 1px solid var(--border);
+  padding: 0 24px; display: flex; align-items: center; height: 56px;
+  gap: 12px; position: sticky; top: 0; z-index: 100;
+}
+.topbar-brand { font-size: 18px; font-weight: 900; color: var(--accent); letter-spacing: -.5px; }
+
+/* ── Content ── */
+.content { flex: 1; max-width: 1100px; width: 100%; margin: 0 auto; padding: 28px 24px; }
+
+/* ── Titulos ── */
+.page-title { font-size: 22px; font-weight: 800; margin-bottom: 4px; }
+.page-sub   { font-size: 13px; color: var(--muted); margin-bottom: 24px; }
+.section-title {
+  font-size: 13px; font-weight: 700; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .5px; margin-bottom: 10px;
+}
+
+/* ── Botones ── */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 0 18px; height: 38px; border-radius: 8px;
+  border: none; cursor: pointer; font-weight: 700; font-size: 14px;
+  transition: filter .12s;
+}
+.btn:hover   { filter: brightness(1.1); }
+.btn:active  { filter: brightness(.88); transform: scale(.98); }
+.btn-primary { background: var(--accent); color: #0f172a; }
+.btn-outline { background: transparent; color: var(--text); border: 2px solid var(--border); }
+.btn-ghost   { background: var(--surface2); color: var(--muted); }
+.btn-sm  { height: 30px; padding: 0 12px; font-size: 12px; }
+.btn-lg  { height: 48px; padding: 0 28px; font-size: 16px; }
+.btn:disabled { opacity: .35; cursor: not-allowed; filter: none; }
+
+/* ── Badges ── */
+.badge { display: inline-block; padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 700; }
+.badge-borrador   { background: var(--surface2); color: var(--muted); }
+.badge-abierto    { background: rgba(56,189,248,.15); color: var(--accent); }
+.badge-ejecucion  { background: rgba(34,197,94,.15); color: #4ade80; }
+.badge-finalizado { background: rgba(100,116,139,.2); color: var(--muted); }
+
+/* ── Chips ── */
+.chip { display: inline-block; padding: 3px 10px; border-radius: 20px; font-size: 11px; font-weight: 700; }
+.chip-ok   { background: rgba(34,197,94,.15); color: #4ade80; }
+.chip-pend { background: var(--surface2); color: var(--muted); }
+.chip-warn { background: rgba(234,179,8,.15); color: #facc15; }
+
+/* ── Login ── */
+.login-wrap {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; padding: 40px;
+}
+.login-box {
+  width: 100%; max-width: 380px; background: var(--surface);
+  border-radius: 14px; border: 1px solid var(--border); padding: 32px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.login-logo { font-size: 28px; font-weight: 900; color: var(--accent); text-align: center; }
+.login-sub  { font-size: 13px; color: var(--muted); text-align: center; margin-top: -8px; }
+
+/* ── Forms ── */
+.field { margin-bottom: 16px; }
+.field label { font-size: 12px; color: var(--muted); display: block; margin-bottom: 4px;
+               text-transform: uppercase; letter-spacing: .3px; }
+.input {
+  width: 100%; background: var(--surface2); border: 2px solid var(--border);
+  border-radius: 8px; color: var(--text); font-size: 14px;
+  padding: 10px 12px; outline: none;
+}
+.input:focus { border-color: var(--accent); }
+select.input { cursor: pointer; }
+textarea.input { resize: vertical; cursor: text; }
+
+/* ── Panels ── */
+.panel {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 22px; margin-bottom: 16px;
+}
+.panel h3 { font-size: 16px; font-weight: 800; margin-bottom: 14px; }
+
+/* ── Torneo card ── */
+.torneo-card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 20px 22px;
+  display: flex; align-items: center; gap: 16px;
+  margin-bottom: 12px; cursor: pointer; transition: border-color .15s;
+}
+.torneo-card:hover { border-color: var(--accent); }
+.torneo-info   { flex: 1; }
+.torneo-nombre { font-size: 17px; font-weight: 800; }
+.torneo-meta   { font-size: 13px; color: var(--muted); margin-top: 3px; }
+.torneo-action { font-size: 13px; color: var(--accent); font-weight: 600; }
+
+/* ── Checklist de preparacion ── */
+.disc-steps {
+  background: var(--surface2); border-radius: 8px;
+  padding: 14px 16px; margin-bottom: 10px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.disc-step { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+.disc-step-icon { font-size: 16px; min-width: 22px; }
+.disc-step-text { flex: 1; }
+.disc-step-action { font-size: 12px; color: var(--accent); font-weight: 600; cursor: pointer; }
+.disc-step-action:hover { text-decoration: underline; }
+.disc-step-action.locked { color: var(--muted); cursor: not-allowed; text-decoration: none; }
+
+/* ── Disciplina card ── */
+.disc-card {
+  background: var(--surface); border-radius: var(--r);
+  border: 1px solid var(--border); padding: 18px 20px;
+  display: flex; align-items: center; gap: 16px;
+  margin-bottom: 10px; cursor: pointer; transition: border-color .15s;
+}
+.disc-card:hover { border-color: var(--accent); }
+.disc-info   { flex: 1; }
+.disc-nombre { font-size: 16px; font-weight: 800; }
+.disc-meta   { font-size: 13px; color: var(--muted); margin-top: 3px; }
+
+/* ── Tabla ── */
+.table-wrap { background: var(--surface); border-radius: var(--r); border: 1px solid var(--border); overflow: hidden; }
+table { width: 100%; border-collapse: collapse; }
+thead th {
+  background: var(--surface2); padding: 10px 14px;
+  font-size: 11px; font-weight: 700; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .4px; text-align: left;
+}
+tbody tr { border-top: 1px solid var(--border); }
+tbody tr:hover { background: rgba(255,255,255,.02); }
+tbody td { padding: 11px 14px; font-size: 14px; }
+.td-pos   { font-weight: 800; color: var(--muted); width: 36px; }
+.td-name  { font-weight: 600; }
+.td-ot    { font-variant-numeric: tabular-nums; color: var(--accent); font-weight: 700; }
+.td-muted { color: var(--muted); font-size: 13px; }
+
+/* ── AP inline editable ── */
+.ap-input {
+  width: 90px; background: var(--surface2); border: 2px solid var(--border);
+  border-radius: 6px; color: var(--accent); font-size: 13px; font-weight: 700;
+  padding: 5px 8px; text-align: center; outline: none;
+}
+.ap-input:focus { border-color: var(--accent); }
+
+/* ── Judge select en grilla ── */
+.juez-select {
+  background: var(--surface2); border: 2px solid var(--border);
+  border-radius: 6px; color: var(--text); font-size: 13px;
+  padding: 5px 8px; outline: none; cursor: pointer; min-width: 155px;
+}
+.juez-select:focus { border-color: var(--accent); }
+.juez-select.asignado { border-color: rgba(34,197,94,.5); color: #4ade80; }
+.juez-select.pendiente { border-color: var(--amarilla); }
+
+/* ── Layouts ── */
+.two-col   { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.three-col { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
+
+/* ── Info boxes ── */
+.info-box { border-radius: var(--r); padding: 12px 16px; font-size: 13px; margin-bottom: 14px; }
+.info-amarilla { background: rgba(234,179,8,.06); border: 1px solid rgba(234,179,8,.2); color: #fde047; }
+.info-accent   { background: rgba(56,189,248,.06); border: 1px solid rgba(56,189,248,.2); color: var(--accent); }
+.info-muted    { background: var(--surface2); border: 1px solid var(--border); color: var(--muted); }
+
+/* ── Grilla ok header ── */
+.grilla-ok {
+  display: flex; align-items: center; gap: 14px;
+  background: rgba(56,189,248,.06); border: 1px solid rgba(56,189,248,.2);
+  border-radius: var(--r); padding: 16px 20px; margin-bottom: 16px;
+}
+.grilla-ok h3 { font-size: 17px; font-weight: 800; color: var(--accent); }
+.grilla-ok p  { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+/* ── Stepper ── */
+.stepper { display: flex; align-items: center; margin-bottom: 24px; }
+.step { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 700; color: var(--muted); }
+.step-num { width: 26px; height: 26px; border-radius: 50%; background: var(--surface2);
+            display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 800; }
+.step.active .step-num { background: var(--accent); color: #0f172a; }
+.step.active { color: var(--text); }
+.step.done .step-num { background: var(--blanca); color: #fff; }
+.step-line { flex: 1; height: 2px; background: var(--border); margin: 0 6px; min-width: 20px; }
+.step-line.done { background: var(--blanca); }
+
+/* ── Checkbox group ── */
+.checkbox-group { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 6px; }
+.cb-label {
+  display: flex; align-items: center; gap: 7px;
+  background: var(--surface2); border: 2px solid var(--border);
+  border-radius: 8px; padding: 7px 12px; cursor: pointer;
+  font-size: 13px; font-weight: 600; transition: border-color .12s;
+}
+.cb-label:hover { border-color: var(--accent); }
+.cb-label input { accent-color: var(--accent); width: 15px; height: 15px; }
+
+/* ── Check item global ── */
+.check-item {
+  display: flex; align-items: center; gap: 14px;
+  background: var(--surface2); border-radius: 8px; padding: 14px 16px;
+  border: 2px solid transparent; margin-bottom: 6px;
+}
+.check-item.done   { border-color: rgba(34,197,94,.3); background: rgba(34,197,94,.04); }
+.check-item.clickable { cursor: pointer; transition: border-color .15s; }
+.check-item.clickable:hover { border-color: var(--accent); }
+</style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════════
+     S-00  LOGIN
+══════════════════════════════════════════ -->
+<div class="screen active" id="s-login">
+  <div class="login-wrap">
+    <div class="login-box">
+      <div class="login-logo">AtaraxiaDive</div>
+      <div class="login-sub">Panel de Organización</div>
+      <div class="field">
+        <label>Email</label>
+        <input class="input" type="email" value="organizer@ataraxiadive.com">
+      </div>
+      <div class="field" style="margin-bottom:0">
+        <label>Contraseña</label>
+        <input class="input" type="password" value="••••••••">
+      </div>
+      <button class="btn btn-primary" style="width:100%;height:44px;font-size:15px"
+              onclick="go('s-torneos')">INGRESAR</button>
+      <div style="text-align:center;font-size:13px;color:var(--muted)">
+        Rol activo: <strong style="color:var(--accent)">Organizador</strong>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-01  MIS TORNEOS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-torneos">
+  <div class="topbar">
+    <span class="topbar-brand">AtaraxiaDive</span>
+    <div style="flex:1"></div>
+    <span style="font-size:13px;color:var(--muted)">Roberto Silva</span>
+    <button class="btn btn-primary btn-sm" onclick="go('s-crear-torneo')">+ Nuevo torneo</button>
+  </div>
+  <div class="content">
+    <div class="page-title">Mis torneos</div>
+    <div class="page-sub">Todos los torneos organizados por esta cuenta</div>
+
+    <div class="section-title">En ejecución</div>
+    <div class="torneo-card" onclick="alert('→ Panel de organización en tiempo real')">
+      <div style="font-size:32px">🏊</div>
+      <div class="torneo-info">
+        <div class="torneo-nombre">Apnea Indoor Buenos Aires 2026</div>
+        <div class="torneo-meta">5 abr · Club Náutico BA · 3 disciplinas · 28 atletas</div>
+      </div>
+      <span class="badge badge-ejecucion">EN EJECUCIÓN</span>
+      <div class="torneo-action">Ir al panel →</div>
+    </div>
+
+    <div class="section-title" style="margin-top:20px">En preparación</div>
+    <div class="torneo-card" onclick="go('s-prep')">
+      <div style="font-size:32px">📋</div>
+      <div class="torneo-info">
+        <div class="torneo-nombre">Copa Litoral 2026</div>
+        <div class="torneo-meta">12–13 jun · Club Rowing Paraná · 2 disciplinas · 8 atletas inscriptos</div>
+      </div>
+      <span class="badge badge-abierto">INSCRIPCIONES ABIERTAS</span>
+      <div class="torneo-action">Configurar →</div>
+    </div>
+
+    <div class="section-title" style="margin-top:20px">Finalizados</div>
+    <div class="torneo-card" style="opacity:.55;cursor:default">
+      <div style="font-size:32px">🏆</div>
+      <div class="torneo-info">
+        <div class="torneo-nombre">Open Paraná 2025</div>
+        <div class="torneo-meta">15 nov 2025 · Club Náutico Paraná · 2 disciplinas · 22 atletas</div>
+      </div>
+      <span class="badge badge-finalizado">FINALIZADO</span>
+      <div class="torneo-action" style="color:var(--muted)">Ver resultados →</div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-02  CREAR TORNEO
+══════════════════════════════════════════ -->
+<div class="screen" id="s-crear-torneo">
+  <div class="topbar">
+    <button class="btn btn-ghost btn-sm" onclick="go('s-torneos')">← Mis torneos</button>
+    <span class="topbar-brand" style="margin-left:12px">Nuevo torneo</span>
+  </div>
+  <div class="content" style="max-width:680px">
+
+    <div class="stepper">
+      <div class="step active"><div class="step-num">1</div><span>Datos del torneo</span></div>
+      <div class="step-line"></div>
+      <div class="step"><div class="step-num">2</div><span>Disciplinas</span></div>
+      <div class="step-line"></div>
+      <div class="step"><div class="step-num">3</div><span>Por disciplina</span></div>
+    </div>
+
+    <div class="panel">
+      <h3>Identificación del torneo</h3>
+      <div class="field">
+        <label>Nombre del torneo *</label>
+        <input class="input" value="Copa Litoral 2026">
+      </div>
+      <div class="two-col">
+        <div class="field">
+          <label>Fecha de inicio *</label>
+          <input class="input" type="date" value="2026-06-12">
+        </div>
+        <div class="field">
+          <label>Fecha de fin *</label>
+          <input class="input" type="date" value="2026-06-13">
+        </div>
+      </div>
+      <div class="two-col">
+        <div class="field">
+          <label>Sede *</label>
+          <input class="input" value="Club Rowing Paraná">
+        </div>
+        <div class="field">
+          <label>Ciudad</label>
+          <input class="input" value="Paraná, Entre Ríos">
+        </div>
+      </div>
+      <div class="field" style="margin-bottom:0">
+        <label>Reglamento</label>
+        <select class="input">
+          <option selected>CMAS Apnea Indoor v2022/01 (FAAS)</option>
+          <option>AIDA Indoor Rules 2023</option>
+          <option>Reglamento personalizado</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h3>Estado de inscripciones</h3>
+      <div class="field" style="margin-bottom:0">
+        <label>Estado inicial</label>
+        <select class="input">
+          <option>Borrador (no visible para atletas)</option>
+          <option selected>Inscripciones abiertas</option>
+        </select>
+      </div>
+    </div>
+
+    <div style="display:flex;justify-content:flex-end;gap:10px">
+      <button class="btn btn-outline" onclick="go('s-torneos')">Cancelar</button>
+      <button class="btn btn-primary btn-lg" onclick="go('s-disciplinas-lista')">
+        Continuar — Disciplinas →
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-03  TORNEO EN PREPARACIÓN (checklist global)
+══════════════════════════════════════════ -->
+<div class="screen" id="s-prep">
+  <div class="topbar">
+    <button class="btn btn-ghost btn-sm" onclick="go('s-torneos')">← Mis torneos</button>
+    <span class="topbar-brand" style="margin-left:12px">Copa Litoral 2026</span>
+    <span class="badge badge-abierto" style="margin-left:12px">INSCRIPCIONES ABIERTAS</span>
+  </div>
+  <div class="content">
+    <div class="page-title" style="margin-bottom:2px">Preparación del torneo</div>
+    <div class="page-sub">12–13 jun · Club Rowing Paraná · Completá la configuración de cada disciplina</div>
+
+    <div class="two-col">
+      <div>
+        <!-- Datos basicos -->
+        <div class="section-title">Torneo</div>
+        <div class="check-item done clickable" style="margin-bottom:16px" onclick="go('s-crear-torneo')">
+          <div style="font-size:20px">✅</div>
+          <div style="flex:1">
+            <div style="font-weight:700;font-size:14px">Datos básicos completos</div>
+            <div style="font-size:12px;color:var(--muted);margin-top:2px">Copa Litoral 2026 · 12–13 jun · Club Rowing Paraná</div>
+          </div>
+          <span style="font-size:12px;color:var(--accent)">Editar</span>
+        </div>
+
+        <!-- DNF — progreso parcial -->
+        <div class="section-title">DNF — Dinámica sin aletas · 12 jun</div>
+        <div class="disc-steps">
+          <div class="disc-step">
+            <div class="disc-step-icon">✅</div>
+            <div class="disc-step-text">Parámetros · 10:00 hs · And. A/B · 9 min intervalo</div>
+            <span class="disc-step-action" onclick="go('s-conf-disciplina')">Editar</span>
+          </div>
+          <div class="disc-step">
+            <div class="disc-step-icon">⚠️</div>
+            <div class="disc-step-text" style="color:var(--amarilla)">Inscriptos: 4 con AP · 1 sin AP</div>
+            <span class="disc-step-action" onclick="go('s-inscriptos')">Ver</span>
+          </div>
+          <div class="disc-step">
+            <div class="disc-step-icon">⚪</div>
+            <div class="disc-step-text" style="color:var(--muted)">Grilla de salida — No generada</div>
+            <span class="disc-step-action" onclick="go('s-grilla-preview')">Generar</span>
+          </div>
+          <div class="disc-step">
+            <div class="disc-step-icon">🔒</div>
+            <div class="disc-step-text" style="color:var(--muted)">Jueces — Disponible después de generar la grilla</div>
+            <span class="disc-step-action locked">Bloqueado</span>
+          </div>
+        </div>
+
+        <!-- STA — completa -->
+        <div class="section-title" style="margin-top:6px">STA — Apnea estática · 13 jun</div>
+        <div class="disc-steps">
+          <div class="disc-step">
+            <div class="disc-step-icon">✅</div>
+            <div class="disc-step-text">Parámetros · 10:00 hs · And. A · 5 min intervalo</div>
+            <span class="disc-step-action" onclick="go('s-conf-disciplina')">Editar</span>
+          </div>
+          <div class="disc-step">
+            <div class="disc-step-icon">✅</div>
+            <div class="disc-step-text">Inscriptos: 3 atletas · todos con AP</div>
+            <span class="disc-step-action" onclick="go('s-inscriptos')">Ver</span>
+          </div>
+          <div class="disc-step">
+            <div class="disc-step-icon">✅</div>
+            <div class="disc-step-text">Grilla generada · 3 atletas · OT 10:00–10:10</div>
+            <span class="disc-step-action" onclick="go('s-grilla-preview')">Ver</span>
+          </div>
+          <div class="disc-step">
+            <div class="disc-step-icon">✅</div>
+            <div class="disc-step-text">Jueces asignados · 3 competidores cubiertos</div>
+            <span class="disc-step-action" onclick="go('s-asignar-jueces')">Ver</span>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="section-title">Estado general</div>
+        <div class="panel" style="margin-bottom:12px">
+          <div style="display:flex;flex-direction:column;gap:10px;font-size:14px">
+            <div style="display:flex;justify-content:space-between">
+              <span style="color:var(--muted)">Disciplinas</span><strong>2</strong>
+            </div>
+            <div style="display:flex;justify-content:space-between">
+              <span style="color:var(--muted)">Atletas inscriptos</span><strong>8</strong>
+            </div>
+            <div style="display:flex;justify-content:space-between">
+              <span style="color:var(--muted)">Grillas generadas</span>
+              <strong style="color:var(--amarilla)">1 de 2</strong>
+            </div>
+            <div style="display:flex;justify-content:space-between">
+              <span style="color:var(--muted)">Disciplinas con jueces</span>
+              <strong style="color:var(--amarilla)">1 de 2</strong>
+            </div>
+          </div>
+        </div>
+
+        <div class="info-amarilla info-box">
+          ⚠ <strong>DNF:</strong> generá la grilla y asigná los jueces para poder publicar.
+        </div>
+
+        <button class="btn btn-primary btn-lg" style="width:100%" disabled>
+          Publicar torneo
+        </button>
+        <div style="font-size:12px;color:var(--muted);text-align:center;margin-top:8px">
+          Disponible cuando todas las disciplinas tengan grilla y jueces asignados
+        </div>
+
+        <button class="btn btn-outline btn-sm" style="width:100%;margin-top:12px"
+                onclick="go('s-disciplinas-lista')">
+          + Agregar disciplina
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-04  LISTA DE DISCIPLINAS
+══════════════════════════════════════════ -->
+<div class="screen" id="s-disciplinas-lista">
+  <div class="topbar">
+    <button class="btn btn-ghost btn-sm" onclick="go('s-prep')">← Preparación</button>
+    <span class="topbar-brand" style="margin-left:12px">Disciplinas</span>
+  </div>
+  <div class="content">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
+      <div class="page-title">Disciplinas del torneo</div>
+      <button class="btn btn-primary btn-sm" onclick="go('s-conf-disciplina')">+ Agregar disciplina</button>
+    </div>
+    <div class="page-sub">Copa Litoral 2026 · 12–13 jun</div>
+
+    <div class="disc-card" onclick="go('s-conf-disciplina')">
+      <div style="font-size:30px">🤽</div>
+      <div class="disc-info">
+        <div class="disc-nombre">DNF — Dinámica sin aletas</div>
+        <div class="disc-meta">12 jun · 10:00 hs · And. A y B · Intervalo 9 min · 5 inscriptos</div>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+        <span class="chip chip-warn">Grilla pendiente</span>
+        <button class="btn btn-ghost btn-sm"
+                onclick="event.stopPropagation();go('s-conf-disciplina')">Editar</button>
+      </div>
+    </div>
+
+    <div class="disc-card" onclick="go('s-conf-disciplina')">
+      <div style="font-size:30px">🧘</div>
+      <div class="disc-info">
+        <div class="disc-nombre">STA — Apnea estática</div>
+        <div class="disc-meta">13 jun · 10:00 hs · And. A · Intervalo 5 min · 3 inscriptos</div>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+        <span class="chip chip-ok">Completa ✓</span>
+        <button class="btn btn-ghost btn-sm"
+                onclick="event.stopPropagation();go('s-conf-disciplina')">Editar</button>
+      </div>
+    </div>
+
+    <div class="disc-card" style="border-style:dashed;justify-content:center;color:var(--muted)"
+         onclick="go('s-conf-disciplina')">
+      <span style="font-size:22px">+</span>
+      <span style="font-size:14px;font-weight:700">Agregar otra disciplina</span>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-05  CONFIGURAR DISCIPLINA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-conf-disciplina">
+  <div class="topbar">
+    <button class="btn btn-ghost btn-sm" onclick="go('s-disciplinas-lista')">← Disciplinas</button>
+    <span class="topbar-brand" style="margin-left:12px">Configurar disciplina</span>
+  </div>
+  <div class="content" style="max-width:700px">
+    <div class="panel">
+      <h3>Tipo, fecha y horario</h3>
+      <div class="two-col">
+        <div class="field">
+          <label>Tipo de disciplina *</label>
+          <select class="input">
+            <option selected>DNF — Dinámica sin aletas</option>
+            <option>STA — Apnea estática</option>
+            <option>DYN — Dinámica con aletas mono</option>
+            <option>DYNB — Dinámica con bialetas</option>
+          </select>
+        </div>
+        <div class="field">
+          <label>Fecha de la competencia *</label>
+          <input class="input" type="date" value="2026-06-12">
+        </div>
+      </div>
+      <div class="two-col">
+        <div class="field" style="margin-bottom:0">
+          <label>Hora de inicio *</label>
+          <input class="input" type="time" value="10:00">
+        </div>
+        <div class="field" style="margin-bottom:0">
+          <label>Intervalo entre atletas (min) *</label>
+          <input class="input" type="number" value="9" min="1" max="30">
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h3>Andariveles habilitados *</h3>
+      <div class="checkbox-group">
+        <label class="cb-label"><input type="checkbox" checked> A</label>
+        <label class="cb-label"><input type="checkbox" checked> B</label>
+        <label class="cb-label"><input type="checkbox"> C</label>
+        <label class="cb-label"><input type="checkbox"> D</label>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h3>Categorías habilitadas</h3>
+      <div class="checkbox-group">
+        <label class="cb-label"><input type="checkbox" checked> Senior M</label>
+        <label class="cb-label"><input type="checkbox" checked> Senior F</label>
+        <label class="cb-label"><input type="checkbox" checked> Junior M</label>
+        <label class="cb-label"><input type="checkbox" checked> Junior F</label>
+        <label class="cb-label"><input type="checkbox" checked> Master M</label>
+        <label class="cb-label"><input type="checkbox"> Master F</label>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h3>Criterio de ordenamiento de grilla</h3>
+      <div class="field" style="margin-bottom:0">
+        <select class="input">
+          <option selected>AP ascendente — menor distancia sale primero (CMAS default)</option>
+          <option>AP descendente — mayor distancia sale primero</option>
+          <option>Orden de inscripción</option>
+        </select>
+      </div>
+    </div>
+
+    <div style="display:flex;justify-content:flex-end;gap:10px">
+      <button class="btn btn-outline" onclick="go('s-disciplinas-lista')">Cancelar</button>
+      <button class="btn btn-primary" onclick="go('s-disciplinas-lista')">Guardar disciplina</button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-06  INSCRIPTOS — SOLO LECTURA + CORRECCIÓN
+══════════════════════════════════════════ -->
+<div class="screen" id="s-inscriptos">
+  <div class="topbar">
+    <button class="btn btn-ghost btn-sm" onclick="go('s-prep')">← Preparación</button>
+    <span class="topbar-brand" style="margin-left:12px">Inscriptos — DNF</span>
+  </div>
+  <div class="content">
+    <div class="page-title" style="margin-bottom:2px">Atletas inscriptos en DNF</div>
+    <div class="page-sub">Copa Litoral 2026 · 12 jun · Vista de solo lectura con corrección de datos</div>
+
+    <div class="info-muted info-box">
+      ℹ Los atletas se inscriben y declaran su AP desde su propio perfil. Aquí podés
+      <strong style="color:var(--text)">corregir datos incorrectos</strong> (AP, categoría)
+      antes de generar la grilla. No es posible agregar ni dar de baja atletas desde esta vista.
+    </div>
+
+    <div class="table-wrap" style="margin-bottom:12px">
+      <table>
+        <thead>
+          <tr>
+            <th>#</th><th>Atleta</th><th>Cat.</th><th>Club</th>
+            <th>AP declarado</th><th>Estado</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="td-pos">1</td>
+            <td class="td-name">Ramírez, Sofía</td>
+            <td class="td-muted">Junior F</td>
+            <td class="td-muted">Club Náutico BA</td>
+            <td><input class="ap-input" value="58.0 m" title="Corregir AP si está incorrecto"></td>
+            <td><span class="chip chip-ok">✓ Con AP</span></td>
+          </tr>
+          <tr>
+            <td class="td-pos">2</td>
+            <td class="td-name">Torres, Iván</td>
+            <td class="td-muted">Master M</td>
+            <td class="td-muted">Apnea Litoral</td>
+            <td><input class="ap-input" value="80.0 m"></td>
+            <td><span class="chip chip-ok">✓ Con AP</span></td>
+          </tr>
+          <tr>
+            <td class="td-pos">3</td>
+            <td class="td-name">Vega, Claudia</td>
+            <td class="td-muted">Senior F</td>
+            <td class="td-muted">Freediving Rosario</td>
+            <td><input class="ap-input" value="61.5 m"></td>
+            <td><span class="chip chip-ok">✓ Con AP</span></td>
+          </tr>
+          <tr>
+            <td class="td-pos">4</td>
+            <td class="td-name">Gómez, Federico</td>
+            <td class="td-muted">Senior M</td>
+            <td class="td-muted">Apnea Litoral</td>
+            <td><input class="ap-input" value="95.0 m"></td>
+            <td><span class="chip chip-ok">✓ Con AP</span></td>
+          </tr>
+          <tr>
+            <td class="td-pos">5</td>
+            <td class="td-name">Flores, Martín</td>
+            <td class="td-muted">Junior M</td>
+            <td class="td-muted">Club Náutico BA</td>
+            <td><input class="ap-input" placeholder="Sin AP" style="color:var(--amarilla)"></td>
+            <td><span class="chip chip-warn">⚠ Sin AP</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="info-amarilla info-box">
+      ⚠ <strong>Flores, Martín</strong> no declaró AP. Podés ingresar una corrección
+      o aguardar a que el atleta lo declare antes del inicio de la disciplina.
+    </div>
+
+    <div style="display:flex;justify-content:flex-end;gap:10px">
+      <button class="btn btn-outline" onclick="go('s-prep')">Volver</button>
+      <button class="btn btn-primary" onclick="go('s-prep')">Guardar correcciones</button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-07  PREVIEW Y CONFIRMAR GRILLA
+══════════════════════════════════════════ -->
+<div class="screen" id="s-grilla-preview">
+  <div class="topbar">
+    <button class="btn btn-ghost btn-sm" onclick="go('s-prep')">← Preparación</button>
+    <span class="topbar-brand" style="margin-left:12px">Generar grilla — DNF</span>
+  </div>
+  <div class="content">
+    <div class="grilla-ok">
+      <div style="font-size:40px">📋</div>
+      <div>
+        <h3>Grilla calculada — lista para confirmar</h3>
+        <p>5 atletas · 2 andariveles · Orden AP ascendente · Intervalo 9 min</p>
+      </div>
+    </div>
+
+    <div class="two-col" style="margin-bottom:20px">
+      <div>
+        <div class="section-title">Grilla de salida · DNF · 12 jun · 10:00 hs</div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>#</th><th>Atleta</th><th>OT</th><th>And.</th><th>AP</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="td-pos">1</td><td class="td-name">Ramírez, Sofía</td>
+                <td class="td-ot">10:00</td><td class="td-muted">A</td>
+                <td style="color:var(--accent);font-weight:600">58.0 m</td>
+              </tr>
+              <tr>
+                <td class="td-pos">2</td><td class="td-name">Vega, Claudia</td>
+                <td class="td-ot">10:09</td><td class="td-muted">B</td>
+                <td style="color:var(--accent);font-weight:600">61.5 m</td>
+              </tr>
+              <tr>
+                <td class="td-pos">3</td><td class="td-name">Flores, Martín</td>
+                <td class="td-ot">10:18</td><td class="td-muted">A</td>
+                <td style="color:var(--amarilla);font-weight:600">Sin AP</td>
+              </tr>
+              <tr>
+                <td class="td-pos">4</td><td class="td-name">Torres, Iván</td>
+                <td class="td-ot">10:27</td><td class="td-muted">B</td>
+                <td style="color:var(--accent);font-weight:600">80.0 m</td>
+              </tr>
+              <tr>
+                <td class="td-pos">5</td><td class="td-name">Gómez, Federico</td>
+                <td class="td-ot">10:36</td><td class="td-muted">A</td>
+                <td style="color:var(--accent);font-weight:600">95.0 m</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div style="font-size:12px;color:var(--muted);margin-top:6px">
+          Orden AP asc · Alternancia A→B→A→B→A
+        </div>
+      </div>
+      <div>
+        <div class="section-title">Validaciones</div>
+        <div class="panel">
+          <div style="display:flex;flex-direction:column;gap:10px;font-size:14px">
+            <div style="display:flex;gap:10px;align-items:center">
+              <span style="color:var(--blanca)">✓</span>
+              <span>5 atletas con OT y andarivel asignados</span>
+            </div>
+            <div style="display:flex;gap:10px;align-items:center">
+              <span style="color:var(--blanca)">✓</span>
+              <span>OT sin solapamiento (9 min entre atletas)</span>
+            </div>
+            <div style="display:flex;gap:10px;align-items:center">
+              <span style="color:var(--blanca)">✓</span>
+              <span>Alternancia A/B balanceada</span>
+            </div>
+            <div style="display:flex;gap:10px;align-items:center">
+              <span style="color:var(--amarilla)">⚠</span>
+              <span style="color:var(--amarilla)">Flores, Martín sin AP declarado</span>
+            </div>
+          </div>
+          <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--border);
+                      font-size:12px;color:var(--muted)">
+            Podés confirmar la grilla con atletas sin AP. El atleta puede declararlo
+            hasta el inicio de la disciplina.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;justify-content:space-between;align-items:center">
+      <div style="display:flex;gap:10px">
+        <button class="btn btn-outline" onclick="go('s-prep')">← Volver</button>
+        <button class="btn btn-ghost" onclick="alert('Exportar grilla como PDF')">↓ PDF</button>
+      </div>
+      <button class="btn btn-primary btn-lg" onclick="go('s-asignar-jueces')">
+        Confirmar grilla — Asignar jueces →
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-08  ASIGNAR JUECES POR COMPETIDOR
+══════════════════════════════════════════ -->
+<div class="screen" id="s-asignar-jueces">
+  <div class="topbar">
+    <button class="btn btn-ghost btn-sm" onclick="go('s-grilla-preview')">← Grilla</button>
+    <span class="topbar-brand" style="margin-left:12px">Asignar jueces — DNF</span>
+  </div>
+  <div class="content">
+    <div class="page-title" style="margin-bottom:2px">Asignación de jueces por competidor</div>
+    <div class="page-sub">
+      DNF · 12 jun · Grilla confirmada · Los jueces rotan entre andariveles y competidores
+    </div>
+
+    <div class="info-accent info-box">
+      ℹ Asigná un juez a cada fila de la grilla. El mismo juez puede aparecer en varias filas
+      según la rotación acordada entre los jueces.
+    </div>
+
+    <div class="two-col" style="margin-bottom:16px">
+      <div>
+        <div class="section-title">Grilla — asignación de jueces</div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>#</th><th>Atleta</th><th>OT</th><th>And.</th><th>Juez</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="td-pos">1</td>
+                <td class="td-name">Ramírez, Sofía</td>
+                <td class="td-ot">10:00</td>
+                <td class="td-muted">A</td>
+                <td>
+                  <select class="juez-select asignado" onchange="onJuezChange(this)">
+                    <option value="">— Sin asignar —</option>
+                    <option selected>Carlos Méndez</option>
+                    <option>Ana Ruiz</option>
+                    <option>Marcos Pérez</option>
+                  </select>
+                </td>
+              </tr>
+              <tr>
+                <td class="td-pos">2</td>
+                <td class="td-name">Vega, Claudia</td>
+                <td class="td-ot">10:09</td>
+                <td class="td-muted">B</td>
+                <td>
+                  <select class="juez-select asignado" onchange="onJuezChange(this)">
+                    <option value="">— Sin asignar —</option>
+                    <option>Carlos Méndez</option>
+                    <option selected>Ana Ruiz</option>
+                    <option>Marcos Pérez</option>
+                  </select>
+                </td>
+              </tr>
+              <tr>
+                <td class="td-pos">3</td>
+                <td class="td-name">Flores, Martín</td>
+                <td class="td-ot">10:18</td>
+                <td class="td-muted">A</td>
+                <td>
+                  <select class="juez-select pendiente" onchange="onJuezChange(this)">
+                    <option value="" selected>— Sin asignar —</option>
+                    <option>Carlos Méndez</option>
+                    <option>Ana Ruiz</option>
+                    <option>Marcos Pérez</option>
+                  </select>
+                </td>
+              </tr>
+              <tr>
+                <td class="td-pos">4</td>
+                <td class="td-name">Torres, Iván</td>
+                <td class="td-ot">10:27</td>
+                <td class="td-muted">B</td>
+                <td>
+                  <select class="juez-select asignado" onchange="onJuezChange(this)">
+                    <option value="">— Sin asignar —</option>
+                    <option selected>Carlos Méndez</option>
+                    <option>Ana Ruiz</option>
+                    <option>Marcos Pérez</option>
+                  </select>
+                </td>
+              </tr>
+              <tr>
+                <td class="td-pos">5</td>
+                <td class="td-name">Gómez, Federico</td>
+                <td class="td-ot">10:36</td>
+                <td class="td-muted">A</td>
+                <td>
+                  <select class="juez-select asignado" onchange="onJuezChange(this)">
+                    <option value="">— Sin asignar —</option>
+                    <option>Carlos Méndez</option>
+                    <option selected>Ana Ruiz</option>
+                    <option>Marcos Pérez</option>
+                  </select>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div style="margin-top:10px">
+          <button class="btn btn-ghost btn-sm" onclick="completarPendientes()">
+            Completar filas pendientes con…
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <div class="section-title">Jueces disponibles</div>
+        <div class="panel" style="margin-bottom:12px">
+          <div style="display:flex;flex-direction:column;gap:10px">
+            <div style="display:flex;align-items:center;gap:12px;padding:10px;
+                        background:var(--surface2);border-radius:8px">
+              <div style="width:36px;height:36px;border-radius:50%;background:var(--surface);
+                          display:flex;align-items:center;justify-content:center;
+                          font-weight:800;color:var(--accent);font-size:14px">CM</div>
+              <div style="flex:1">
+                <div style="font-weight:700;font-size:14px">Carlos Méndez</div>
+                <div style="font-size:12px;color:var(--muted)">Licencia CMAS</div>
+              </div>
+              <span class="chip chip-ok" style="font-size:10px">Filas #1 #4</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:12px;padding:10px;
+                        background:var(--surface2);border-radius:8px">
+              <div style="width:36px;height:36px;border-radius:50%;background:var(--surface);
+                          display:flex;align-items:center;justify-content:center;
+                          font-weight:800;color:var(--accent);font-size:14px">AR</div>
+              <div style="flex:1">
+                <div style="font-weight:700;font-size:14px">Ana Ruiz</div>
+                <div style="font-size:12px;color:var(--muted)">Licencia CMAS</div>
+              </div>
+              <span class="chip chip-ok" style="font-size:10px">Filas #2 #5</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:12px;padding:10px;
+                        background:var(--surface2);border-radius:8px;opacity:.65">
+              <div style="width:36px;height:36px;border-radius:50%;background:var(--surface);
+                          display:flex;align-items:center;justify-content:center;
+                          font-weight:800;color:var(--muted);font-size:14px">MP</div>
+              <div style="flex:1">
+                <div style="font-weight:700;font-size:14px">Marcos Pérez</div>
+                <div style="font-size:12px;color:var(--muted)">Licencia CMAS</div>
+              </div>
+              <span class="chip chip-pend" style="font-size:10px">Sin filas</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="info-amarilla info-box">
+          ⚠ <strong>Fila #3 (Flores, Martín)</strong> sin juez asignado.
+        </div>
+
+        <div style="padding:14px;background:var(--surface2);border-radius:var(--r);
+                    font-size:13px;color:var(--muted);line-height:1.6">
+          <strong style="color:var(--text)">Rotación del ejemplo:</strong><br>
+          Méndez → And. A (filas 1, 3, 5)<br>
+          Ruiz → And. B (filas 2, 4)<br>
+          Ajustá libremente según disponibilidad.
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;justify-content:space-between;align-items:center">
+      <button class="btn btn-outline" onclick="go('s-grilla-preview')">← Grilla</button>
+      <button class="btn btn-primary btn-lg" onclick="go('s-listo')">
+        Confirmar asignación →
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     S-09  TORNEO PUBLICADO
+══════════════════════════════════════════ -->
+<div class="screen" id="s-listo">
+  <div class="topbar">
+    <span class="topbar-brand">AtaraxiaDive</span>
+    <div style="flex:1"></div>
+    <span style="font-size:13px;color:var(--muted)">Roberto Silva</span>
+  </div>
+  <div class="content" style="max-width:680px;text-align:center;padding-top:60px">
+    <div style="font-size:64px;margin-bottom:16px">🎉</div>
+    <div style="font-size:28px;font-weight:900;margin-bottom:8px">¡Torneo publicado!</div>
+    <div style="font-size:15px;color:var(--muted);margin-bottom:32px">
+      Copa Litoral 2026 · Atletas y jueces ya pueden ver las grillas de salida
+    </div>
+
+    <div class="three-col" style="margin-bottom:32px;text-align:left">
+      <div style="background:var(--surface);border:1px solid var(--border);
+                  border-radius:var(--r);padding:20px;text-align:center">
+        <div style="font-size:32px;font-weight:900;color:var(--accent)">8</div>
+        <div style="font-size:13px;color:var(--muted)">Atletas</div>
+      </div>
+      <div style="background:var(--surface);border:1px solid var(--border);
+                  border-radius:var(--r);padding:20px;text-align:center">
+        <div style="font-size:32px;font-weight:900;color:var(--blanca)">2</div>
+        <div style="font-size:13px;color:var(--muted)">Disciplinas</div>
+      </div>
+      <div style="background:var(--surface);border:1px solid var(--border);
+                  border-radius:var(--r);padding:20px;text-align:center">
+        <div style="font-size:32px;font-weight:900">3</div>
+        <div style="font-size:13px;color:var(--muted)">Jueces</div>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:10px;max-width:380px;margin:0 auto">
+      <button class="btn btn-primary btn-lg" style="width:100%"
+              onclick="alert('→ Panel de organización en tiempo real')">
+        Ir al panel de organización →
+      </button>
+      <button class="btn btn-outline" style="width:100%" onclick="go('s-torneos')">
+        ← Volver a mis torneos
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+function go(id) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  const t = document.getElementById(id);
+  if (t) { t.classList.add('active'); window.scrollTo(0, 0); }
+}
+
+function onJuezChange(sel) {
+  sel.classList.remove('asignado', 'pendiente');
+  sel.style.borderColor = '';
+  if (sel.value) {
+    sel.classList.add('asignado');
+  } else {
+    sel.classList.add('pendiente');
+  }
+}
+
+function completarPendientes() {
+  const sel = document.querySelectorAll('.juez-select.pendiente');
+  sel.forEach(s => {
+    s.value = 'Carlos Méndez';
+    onJuezChange(s);
+  });
+}
+</script>
+</body>
+</html>

--- a/docs/design/ux/wireframes-atleta.md
+++ b/docs/design/ux/wireframes-atleta.md
@@ -1,0 +1,497 @@
+# Wireframes — Portal del Atleta
+
+> Artefacto INC-4.0 · Especificación formal derivada de `prototipo-atleta.html` validado
+> Fuente reglamentaria: CMAS Apnea Indoor v2022/01 (FAAS)
+> Última actualización: 2026-04-08
+
+---
+
+## Principios de diseño
+
+| Principio | Valor |
+|-----------|-------|
+| Tema | Dark (fondo #0f172a) |
+| Ancho máximo | 430 px (mobile-first) |
+| Altura de header | 52 px sticky |
+| Altura de tab bar | 56 px sticky |
+| Fuente | System UI (-apple-system, BlinkMacSystemFont) |
+| Contexto de uso | Pre-competencia y consulta post-competencia desde smartphone |
+
+**Tokens de color** (compartidos con juez y organizador):
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| `--bg` | `#0f172a` | Fondo general |
+| `--surface` | `#1e293b` | Cards, headers, tab bar |
+| `--surface2` | `#334155` | Inputs, chips neutrales, botones ghost |
+| `--border` | `#475569` | Bordes generales |
+| `--accent` | `#38bdf8` | Acción principal, OT, links |
+| `--blanca` | `#22c55e` | Estado válido, confirmaciones |
+| `--amarilla` | `#eab308` | Alertas, AP pendiente, deadlines |
+| `--roja` | `#ef4444` | Error, rechazo, cancelación crítica |
+| `--muted` | `#94a3b8` | Texto secundario |
+
+---
+
+## Navegación base
+
+La experiencia del atleta usa shell móvil con:
+
+- `header` superior sticky
+- `scroll` central
+- `tabbar` inferior sticky con 4 tabs
+
+**Tabs persistentes:**
+
+```
+[🏠 Inicio] [🏆 Torneos] [📋 Mis inscr.] [📊 Resultados]
+```
+
+| Tab | Destino |
+|-----|---------|
+| Inicio | S-01 Portal |
+| Torneos | S-02 Torneos |
+| Mis inscr. | S-05 Mis inscripciones |
+| Resultados | S-08 Mis resultados |
+
+**Regla de navegación:** las pantallas de detalle usan flecha `←` para volver, pero conservan la tab bar para salto directo.
+
+---
+
+## Pantallas
+
+### S-00 — Login
+
+**Propósito:** autenticación del atleta.
+
+**Layout:** caja centrada de 360 px máximo.
+
+**Componentes:**
+- Logo "AtaraxiaDive" (accent, 26 px, 900)
+- Subtítulo "Portal del Atleta"
+- Campo Email
+- Campo Contraseña
+- Botón `INGRESAR` (btn-primary, ancho completo, 44 px)
+- Label "Rol activo: Atleta"
+- Link secundario `Registrate`
+
+**Acción:**
+- `INGRESAR` → S-01 Portal
+
+---
+
+### S-01 — Portal / Dashboard
+
+**Propósito:** home resumida del atleta con próximo OT y accesos a sus torneos activos.
+
+**Componentes:**
+- Header simple con marca + nombre abreviado del atleta
+- `hero-card` con saludo, categoría y club
+- Card "Tu próximo OT"
+- Sección "Mis inscripciones activas"
+- CTA `Explorar torneos disponibles`
+
+#### Card "Tu próximo OT"
+
+Contenido:
+- torneo + disciplina
+- badge `HOY`
+- hora OT en tipografía destacada
+- andarivel + posición + AP declarado
+- link "Ver grilla completa →"
+
+**Acción:** tap card → S-07 Mi grilla
+
+#### Sección "Mis inscripciones activas"
+
+Cada card muestra:
+- nombre del torneo
+- fecha + sede
+- badge de estado
+- chips por disciplina
+
+**Estados mockeados:**
+
+| Torneo | Estado | Chips |
+|--------|--------|-------|
+| Copa Litoral 2026 | `EN EJECUCIÓN` | `DNF ✓ AP`, `STA ✓ AP` |
+| Open Litoral 2026 | `INSCRIPCIONES` | `DNF ⚠ Sin AP` |
+
+**Acciones:**
+- Tap card → S-05 Mis inscripciones
+- `Explorar torneos disponibles` → S-02 Torneos
+
+---
+
+### S-02 — Torneos Disponibles
+
+**Propósito:** discovery de torneos publicados y visualización de estado de inscripción.
+
+**Header:** `←` + título "Torneos".
+
+**Secciones:**
+- `Inscripciones abiertas`
+- `Próximos (inscripciones no abiertas)`
+
+#### Torneo abierto (`torneo-card`)
+
+Muestra:
+- nombre
+- badge `ABIERTO`
+- fecha + sede
+- resumen de disciplinas
+- deadline de cierre
+- link "Ver detalle →"
+
+**Acción:** tap → S-03 Detalle del torneo
+
+#### Torneo próximo
+
+Muestra:
+- nombre
+- badge neutro `PRÓXIMO`
+- fecha por confirmar
+
+**Regla UX:** cards futuras aparecen con menor prominencia visual y sin CTA.
+
+---
+
+### S-03 — Detalle del Torneo
+
+**Propósito:** informar condiciones del torneo antes de iniciar la inscripción.
+
+**Header:** `←` + nombre del torneo.
+
+**Componentes:**
+- Card resumen del torneo
+- Sección "Disciplinas disponibles"
+- Botón `Inscribirme en este torneo`
+
+#### Card resumen
+
+Campos visibles:
+- nombre
+- fecha
+- sede + ciudad
+- badge `ABIERTO`
+- reglamento aplicable
+- fecha de cierre de inscripciones
+
+#### Lista de disciplinas
+
+Cada `disc-row` muestra:
+- ícono de disciplina
+- nombre largo
+- fecha + hora + andariveles + intervalo
+- categorías habilitadas
+
+**Acción principal:**
+- `Inscribirme en este torneo` → S-04 Inscribirme
+
+---
+
+### S-04 — Inscribirme (wizard de 3 pasos)
+
+**Propósito:** registrar participación del atleta en un torneo y adjuntar requisitos obligatorios.
+
+**Header:** `←` + título "Inscribirme".
+
+**Indicador:** `step-bar` de 3 pasos:
+- `1 Personales`
+- `2 Competencia`
+- `3 Requisitos`
+
+#### Paso 1 — Datos Personales
+
+**Objetivo:** verificar y completar información civil del atleta.
+
+**Componentes:**
+- Caja informativa: datos pre-cargados desde el perfil
+- Campo `Correo` readonly
+- Campo `Nombre y Apellido *`
+- Campo `Fecha de Nacimiento *`
+- Grupo radio `Género *`
+- Campo compuesto `Documento (Tipo + Número) *`
+- Campo `Teléfono *`
+- Botón `Siguiente →`
+
+**Acción:** `Siguiente →` activa paso 2
+
+#### Paso 2 — Datos de la Competencia
+
+**Objetivo:** definir disciplinas y categoría competitiva.
+
+**Componentes:**
+- Label contextual con torneo y fechas
+- Selector múltiple de disciplinas (`toggleDiscInsc`)
+- Caja informativa de categoría calculada por fecha de nacimiento
+- Grupo radio `Categoría *`
+- Campo `Nº Brevet FAAS` opcional
+- Botones `← Anterior` y `Siguiente →`
+
+**Disciplinas mockeadas:**
+- DNF
+- STA
+- DYNB
+
+**Regla UX:** la selección de disciplina se comporta como checklist visual dentro de `radio-item`.
+
+#### Paso 3 — Requisitos
+
+**Objetivo:** adjuntar documentación antes de enviar la inscripción.
+
+**Componentes:**
+- Aviso reglamentario: inscripción queda `pendiente de verificación`
+- Bloque `Certificado Médico *`
+- Bloque `Comprobante de Pago *`
+- Botones `← Anterior`, `Enviar inscripción`, `Cancelar`
+
+**Certificado médico:**
+- texto explicativo
+- `upload-area`
+- helper de formatos y peso máximo
+
+**Comprobante de pago:**
+- datos de transferencia
+- pricing por fecha con dos tramos
+- `upload-area`
+- helper de formatos y peso máximo
+
+**Acciones:**
+- `Enviar inscripción` → S-05 Mis inscripciones
+- `Cancelar` → S-03 Detalle del torneo
+
+**Invariante:** ambos archivos son obligatorios para completar la inscripción.
+
+---
+
+### S-05 — Mis Inscripciones
+
+**Propósito:** concentrar el estado de participación del atleta por torneo y disciplina.
+
+**Header:** `←` + título "Mis inscripciones".
+
+**Secciones del mock:**
+- `En ejecución`
+- `Inscripciones abiertas`
+
+#### Torneo en ejecución
+
+Cada fila `insc-estado` muestra:
+- disciplina
+- AP
+- OT
+- andarivel
+- chip `AP cerrado`
+- botón `Ver grilla`
+
+**Acción:** `Ver grilla` → S-07 Mi grilla
+
+#### Torneo con inscripciones abiertas
+
+La fila muestra:
+- disciplina
+- estado `⚠ Sin AP declarado`
+- chip `AP pendiente`
+- botón `Declarar AP`
+
+Debajo del listado:
+- `deadline` con fecha y hora de cierre de anuncios
+
+**Acción:** `Declarar AP` → S-06 Declarar AP
+
+**Regla de negocio visible:** una vez cerrado el período de anuncios, el atleta solo visualiza `AP cerrado`.
+
+---
+
+### S-06 — Declarar / Modificar AP
+
+**Propósito:** cargar o editar la `Announced Performance` antes del cierre.
+
+**Header:** `←` + título "Declarar AP".
+
+**Componentes:**
+- Caja informativa explicando el concepto de AP
+- Card de contexto con torneo, disciplina y horario
+- Campo destacado `AP — Distancia anunciada *`
+- `deadline` de cierre de anuncios
+- Botón `Guardar AP`
+- Botón `Cancelar`
+
+**Campo principal:**
+- input grande centrado
+- unidad `metros`
+- color accent
+
+**Acciones:**
+- `Guardar AP` → S-05 Mis inscripciones
+- `Cancelar` → S-05 Mis inscripciones
+
+**Restricción:** el AP se expresa en metros para disciplinas dinámicas; el comportamiento para estática requiere un input de tiempo en implementación real.
+
+---
+
+### S-07 — Mi Grilla
+
+**Propósito:** mostrar OT, posición y orden completo de salida en la disciplina.
+
+**Header:** `←` + título "Mi grilla — [DISCIPLINA]".
+
+**Componentes:**
+- `ot-hero` con horario oficial destacado
+- chips de AP y estado
+- caja informativa con ventana OT+30s
+- lista completa `grilla-row`
+- botón `Ver mis resultados →`
+
+#### Hero OT
+
+Campos:
+- label "Tu Tiempo Oficial"
+- hora OT en 52 px
+- andarivel + posición + torneo
+- chips `AP: ...` y estado actual
+
+#### Lista de grilla
+
+Cada fila muestra:
+- posición
+- nombre atleta
+- marca `TÚ` cuando corresponde
+- OT + andarivel
+- opcionalmente chip de resultado si ya compitió
+
+**Estados observados:**
+
+| Estado de fila | Estilo |
+|----------------|--------|
+| `done` | opacidad reducida |
+| `yo` | fondo accent tenue + borde izquierdo accent |
+| normal | pendiente futura |
+
+**Acciones:**
+- `Ver mis resultados →` → S-08 Mis resultados
+
+**Nota de consistencia:** el mock incluye una fila histórica "ya competiste" y luego la grilla activa; en implementación debería resolverse como un único estado consistente según fase del torneo.
+
+---
+
+### S-08 — Mis Resultados
+
+**Propósito:** exponer resultados publicados por disciplina y ranking parcial.
+
+**Header:** `←` + título "Mis resultados".
+
+**Secciones del mock:**
+- torneo activo
+- resultado publicado por disciplina
+- ranking por disciplina
+- disciplinas pendientes
+- ranking general
+
+#### Resultado publicado (`result-hero`)
+
+Muestra:
+- tipo de tarjeta
+- disciplina
+- distancia principal
+- AP declarado
+- diferencia contra AP
+- chip de validez
+
+**Estados visuales soportados por componente:**
+
+| Estado | Clase |
+|--------|-------|
+| Blanca | `result-hero blanca` |
+| Amarilla | `result-hero amarilla` |
+| Roja | `result-hero roja` |
+
+#### Ranking de disciplina
+
+Card con:
+- header de ranking
+- filas `rank-row`
+- distinción visual para top 3
+- resalte del atleta actual (`yo`)
+- pie "Ranking parcial"
+
+#### Resultado pendiente
+
+Card de disciplina futura con:
+- OT
+- AP
+- andarivel
+- chip `Pendiente`
+- caja informativa de disponibilidad posterior
+
+#### Ranking general (Overall)
+
+Estado vacío:
+- ícono trofeo
+- texto "Disponible al finalizar todas las disciplinas del torneo"
+
+**Regla de negocio visible:** el overall no aparece hasta cerrar el torneo o hasta que existan resultados suficientes para publicarlo.
+
+---
+
+## Diagrama de navegación
+
+```text
+S-00 Login
+  └─► S-01 Portal
+        ├─► S-02 Torneos
+        │     └─► S-03 Detalle del torneo
+        │           └─► S-04 Inscribirme
+        │                 └─► S-05 Mis inscripciones
+        ├─► S-05 Mis inscripciones
+        │     ├─► S-06 Declarar AP
+        │     └─► S-07 Mi grilla
+        ├─► S-07 Mi grilla
+        │     └─► S-08 Mis resultados
+        └─► S-08 Mis resultados
+
+Tab bar persistente en S-01, S-02, S-05, S-07 y S-08
+```
+
+---
+
+## Componentes React identificados
+
+| Componente | Props clave | Pantallas |
+|-----------|-------------|-----------|
+| `AthleteShell` | `title`, `showBack`, `activeTab` | S-01 a S-08 |
+| `BottomTabBar` | `activeTab` | S-01, S-02, S-05, S-07, S-08 |
+| `HeroCard` | `name`, `categoria`, `club` | S-01 |
+| `TorneoCard` | `torneo`, `estado`, `disciplinas`, `onOpen` | S-01, S-02 |
+| `DisciplinaRow` | `disciplina`, `horario`, `categorias` | S-03 |
+| `InscripcionStepper` | `currentStep` | S-04 |
+| `DisciplinaToggleCard` | `selected`, `disciplina`, `onToggle` | S-04 |
+| `UploadArea` | `label`, `acceptedFormats`, `uploadedFile` | S-04 |
+| `InscripcionEstadoRow` | `disciplina`, `ap`, `ot`, `status`, `action` | S-05 |
+| `DeadlineBanner` | `label`, `deadline` | S-05, S-06 |
+| `ApInputCard` | `disciplina`, `unidad`, `value`, `onChange` | S-06 |
+| `OtHero` | `ot`, `andarivel`, `posicion`, `ap`, `estado` | S-07 |
+| `GrillaRow` | `pos`, `nombre`, `ot`, `andarivel`, `isSelf`, `estado` | S-07 |
+| `ResultHero` | `tarjeta`, `disciplina`, `valor`, `ap`, `diferencia` | S-08 |
+| `RankingRow` | `pos`, `nombre`, `marca`, `estado`, `isSelf` | S-08 |
+
+---
+
+## Invariantes de negocio formalizados
+
+| ID | Regla | Fuente |
+|----|-------|--------|
+| INV-ATL-01 | El atleta solo puede declarar o modificar AP antes del cierre de anuncios | Flujo de atleta |
+| INV-ATL-02 | Una inscripción enviada con requisitos pendientes queda en estado de verificación | Prototipo S-04 |
+| INV-ATL-03 | El OT y la posición de grilla son de solo lectura para el atleta | Dominio competencia |
+| INV-ATL-04 | La grilla se ordena por OT ascendente y resalta al atleta actual | Dominio competencia |
+| INV-ATL-05 | Los resultados se muestran una vez publicados por organización | Flujo de atleta |
+| INV-ATL-06 | El ranking overall permanece oculto o vacío hasta finalizar las disciplinas relevantes | Prototipo S-08 |
+| INV-ATL-07 | La categoría competitiva se deriva de la fecha de nacimiento y debe poder revisarse antes del envío | Prototipo S-04 |
+| INV-ATL-08 | Certificado médico y comprobante de pago son obligatorios para completar la inscripción | Prototipo S-04 |
+
+---
+
+*Artefacto generado: 2026-04-08 — INC-4.0 UX Design*
+*Capa IEDD: 3b — Especificación interactiva*

--- a/docs/design/ux/wireframes-juez.md
+++ b/docs/design/ux/wireframes-juez.md
@@ -1,0 +1,425 @@
+# Wireframes — Interfaz del Juez
+
+> Artefacto INC-4.0 · Especificación formal derivada de `prototipo-juez.html` validado
+> Fuente reglamentaria: CMAS Apnea Indoor v2022/01 (FAAS)
+> Última actualización: 2026-04-05
+
+---
+
+## Principios de diseño
+
+| Principio | Valor |
+|-----------|-------|
+| Tema | Dark (fondo #0f172a) |
+| Ancho máximo | 390 px (mobile-first) |
+| Altura mínima de botón | 58 px |
+| Fuente | System UI (-apple-system, BlinkMacSystemFont) |
+| Contraste | Alto — operable bajo luz solar directa y manos mojadas |
+| Toque máximo por performance | 6 acciones principales |
+
+**Tokens de color:**
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| `--bg` | `#0f172a` | Fondo general |
+| `--surface` | `#1e293b` | Cards, headers |
+| `--surface2` | `#334155` | Botones secundarios, inputs |
+| `--accent` | `#38bdf8` | Acción principal, OT |
+| `--blanca` | `#22c55e` | Tarjeta blanca, ATLETA INICIA |
+| `--amarilla` | `#eab308` | Tarjeta amarilla, alerta |
+| `--roja` | `#ef4444` | Tarjeta roja, DQ, BKO |
+| `--dns` | `#64748b` | DNS |
+| `--muted` | `#94a3b8` | Texto secundario |
+
+---
+
+## Pantallas
+
+### S-00 — Login
+
+**Propósito:** autenticación del juez.
+
+**Componentes:**
+- Logo "AtaraxiaDive" (accent, 32 px, bold)
+- Campo Email (pre-llenado en prototipo)
+- Campo Contraseña
+- Botón `INGRESAR` (btn-primary, ancho completo)
+- Label "Rol activo: Juez"
+
+**Acción:**
+- `INGRESAR` → S-01 Mis Disciplinas
+
+---
+
+### S-01 — Mis Disciplinas
+
+**Propósito:** selección de la disciplina a juzgar.
+
+**Componentes:**
+- Header: nombre del juez + nombre del torneo
+- Badge conexión (online/offline)
+- Lista de disciplinas asignadas (`disc-card`)
+- Card torneo (nombre, fecha, sede)
+- Botón `Cerrar sesión`
+
+**Estados de disc-card:**
+
+| Estado | Badge | Acción al tap |
+|--------|-------|---------------|
+| ACTIVA | verde | → S-02 Grilla |
+| PENDIENTE | gris | deshabilitado |
+
+---
+
+### S-02 — Grilla de Salida
+
+**Propósito:** vista general de todos los atletas de la disciplina, ordenada por OT ascendente.
+
+**Componentes:**
+- Header: nombre disciplina + estado (EN EJECUCIÓN)
+- Botón `← Disciplinas`
+- Label: cantidad de atletas + intervalo
+- Badge conexión
+- Lista `grilla-row` ordenada por OT
+
+**Estados de grilla-row:**
+
+| Estado | Estilo | Tappable | Destino |
+|--------|--------|----------|---------|
+| ✓ BLANCA | opacidad 45% | No | — |
+| ✓ ROJA | opacidad 45% | No | — |
+| DNS | opacidad 55% | No | — |
+| ⚠ REVISIÓN | borde amarillo | Sí | S-15 Revisión |
+| ▶ SIGUIENTE | borde accent, fondo accent/6% | Sí | S-03 Paso 1 |
+| PENDIENTE | normal | Sí | S-03 Paso 1 |
+
+**Invariante:** ningún atleta PENDIENTE puede tener OT anterior al último atleta ejecutado.
+
+**Datos por fila:**
+- Posición (#)
+- Apellido, Nombre
+- OT + Andarivel
+- AP (metros, color accent)
+- Badge de estado
+
+---
+
+### S-03 — Paso 1: Llamar Atleta
+
+**Propósito:** el juez anuncia al atleta que debe dirigirse a la zona de inicio.
+
+**Componentes:**
+- Indicador de pasos (6 puntos, punto 1 activo)
+- Card atleta: nombre, AP, posición, andarivel, OT
+- Label "Paso 1 de 6"
+- Botón `📢 LLAMAR ATLETA` (btn-primary)
+- Botón `DNS — No se presenta` (btn-dns)
+
+**Acciones:**
+- `LLAMAR ATLETA` → S-04 Paso 2
+- `DNS` → S-13 DNS
+
+---
+
+### S-04 — Paso 2: Confirmar Presencia
+
+**Propósito:** verificar que el atleta llegó al andarivel.
+
+**Componentes:**
+- Indicador pasos (paso 2 activo, paso 1 completado)
+- Card atleta
+- Texto "¿El atleta se presenta en el andarivel?"
+- Label "Paso 2 de 6"
+- Botón `✓ PRESENTE` (btn-primary)
+- Botón `DNS — No se presenta` (btn-dns)
+
+**Acciones:**
+- `PRESENTE` → S-05 Paso 3
+- `DNS` → S-13 DNS
+
+---
+
+### S-05 — Paso 3: Tiempo Oficial
+
+**Propósito:** gestionar la ventana de inicio OT±30s conforme CMAS 1.2.1.8.
+
+**Componentes:**
+- Indicador pasos (paso 3 activo)
+- Card atleta
+- Panel OT: horario programado (ej: 14:00:00), label estado
+- Botón `⏱ TIEMPO OFICIAL` (btn-primary, 66 px altura) — **Estado A**
+- Panel ventana activa (oculto en Estado A, visible en Estado B):
+  - Label "⏱ Ventana activa — el atleta puede sumergirse"
+  - Countdown numérico grande (30→0)
+  - Colores: verde 30s–11s · amarillo 10s–6s · rojo 5s–1s
+- Botón `▶ ATLETA INICIA` (btn-blanca/verde, oculto en Estado A) — **Estado B**
+- Panel DQ (oculto hasta que countdown = 0):
+  - Alerta roja "Ventana de +30s vencida"
+  - Botón `REGISTRAR DQ — No inició en ventana` (btn-roja)
+
+**Estados:**
+
+| Estado | Trigger | Visible |
+|--------|---------|---------|
+| A — Esperando OT | entrada a la pantalla | Botón TIEMPO OFICIAL |
+| B — Ventana activa | tap TIEMPO OFICIAL | Panel ventana + countdown + ATLETA INICIA |
+| C — Vencida | countdown = 0 | Botón ATLETA INICIA deshabilitado + panel DQ |
+
+**Acciones:**
+- `TIEMPO OFICIAL` → arranca countdown 30s (Estado A → B)
+- `ATLETA INICIA` → para countdown → S-06 Paso 4 + inicia cronómetro de performance
+- `REGISTRAR DQ` → S-11 Resultado Roja
+
+**Regla CMAS:** el atleta puede iniciar desde OT hasta OT+30s. Antes del OT → DQ (salida en falso). Después de OT+30s → DQ (no inició en ventana).
+
+---
+
+### S-06 — Paso 4: Performance en Curso
+
+**Propósito:** monitorear la performance activa.
+
+**Componentes:**
+- Header: "DNF — EN CURSO" + nombre atleta
+- Badge conexión
+- Indicador pasos (paso 4 activo)
+- Cronómetro activo (MM:SS, color verde, fuente 52 px)
+- Card atleta: nombre, AP, andarivel
+- Label "Paso 4 de 6"
+- Botón `⏹ FINALIZAR PERFORMANCE` (btn-primary)
+- Botón `⚡ BKO — Black-out` (btn-roja, 52 px altura)
+
+**Acciones:**
+- `FINALIZAR PERFORMANCE` → para cronómetro → S-07 Paso 5
+- `BKO` → para cronómetro → S-12 BKO
+
+---
+
+### S-07 — Paso 5: Registrar RP
+
+**Propósito:** ingresar la distancia realizada por el atleta con precisión de 1 cm (CMAS 2.1.4.1).
+
+**Componentes:**
+- Indicador pasos (paso 5 activo)
+- Card atleta: nombre, AP
+- Display RP: `[metros] m · [cm] cm`
+  - Metros: fuente 58 px, color accent
+  - Separador `·`
+  - Centímetros: fuente 44 px, color muted si vacío / texto si ingresado
+- Sección Metros:
+  - Label "Metros — selección rápida"
+  - Presets: `25 | 50 | 75 | 100 | 125` (54 px altura)
+  - Ajuste: `−1 | +1 | +5 | +10` (52 px altura)
+- Sección Centímetros:
+  - Label "Centímetros"
+  - Numpad 3×3 + fila 0+⌫:
+    ```
+    7  8  9
+    4  5  6
+    1  2  3
+    0  0  ⌫
+    ```
+  - Botones numpad: 58 px altura, fondo surface2
+  - `0` ocupa 2 columnas; `⌫` ocupa 1 (rojo suave)
+- Label "Paso 5 de 6"
+- Botón `CONFIRMAR MARCA` (btn-primary)
+
+**Comportamiento numpad cm:**
+- Máximo 2 dígitos (rango 00–99)
+- Ingreso: cada dígito nuevo desplaza hacia la izquierda (`"4"` → `"04"`, luego `"3"` → `"43"`)
+- Display muestra `"--"` hasta que se ingresa el primer dígito
+- `⌫` elimina el último dígito
+
+**Acciones:**
+- Preset → setea metros, resetea selección previa
+- `±m` → ajusta metros (no afecta cm)
+- Numpad → ingresa cm dígito a dígito
+- `CONFIRMAR MARCA` → S-08 Paso 6
+
+---
+
+### S-08 — Paso 6: Asignar Tarjeta
+
+**Propósito:** el juez asigna el resultado de la performance.
+
+**Componentes:**
+- Indicador pasos (paso 6 activo, todos anteriores completados)
+- Card atleta: nombre, AP, RP confirmado
+- Label "Paso 6 de 6 — Asignar tarjeta"
+- Botón `⬜ TARJETA BLANCA` (btn-blanca, 19 px)
+- Botón `🟨 TARJETA AMARILLA` (btn-amarilla, 19 px)
+- Botón `🟥 TARJETA ROJA` (btn-roja, 19 px)
+
+**Acciones:**
+- `BLANCA` → S-09 Resultado Blanca
+- `AMARILLA` → S-10 Resultado Amarilla (en revisión)
+- `ROJA` → S-11 Resultado Roja
+
+---
+
+### S-09 — Resultado: Tarjeta Blanca
+
+**Componentes:**
+- Header "Performance completada"
+- Hero card: ⬜ icono, "TARJETA BLANCA" (color blanca/verde), nombre + RP, nota AP
+- Botón `SIGUIENTE ATLETA →` (btn-primary)
+
+**Acción:** → S-02 Grilla
+
+---
+
+### S-10 — Resultado: Tarjeta Amarilla (En Revisión)
+
+**Propósito:** gestionar la deliberación post-performance (CMAS 1.2.3.1 — máx 3 minutos).
+
+**Componentes:**
+- Header "Tarjeta en revisión"
+- Badge amarillo "🟨 TARJETA AMARILLA — EN REVISIÓN"
+- Sub-label "Debe resolverse antes de cerrar la disciplina"
+- Card atleta: nombre, AP, RP
+- Alerta amarilla: "La competencia no puede cerrarse mientras existan tarjetas amarillas sin resolver"
+- Label "Resolver revisión"
+- Botón `⬜ RESOLVER → BLANCA` (btn-blanca)
+- Botón `🟥 RESOLVER → ROJA` (btn-roja)
+- Botón `Volver a la grilla (queda en revisión)` (btn-ghost)
+
+**Acciones:**
+- `RESOLVER → BLANCA` → S-09 Resultado Blanca
+- `RESOLVER → ROJA` → S-11 Resultado Roja
+- `Volver a la grilla` → S-02 Grilla (fila queda con badge ⚠ REVISIÓN)
+
+---
+
+### S-11 — Resultado: Tarjeta Roja
+
+**Componentes:**
+- Header "Performance completada"
+- Hero card: 🟥 icono, "TARJETA ROJA" (color roja), nombre + "Descalificada"
+- Botón `SIGUIENTE ATLETA →` (btn-primary)
+
+**Acción:** → S-02 Grilla
+
+---
+
+### S-12 — BKO: Black-out
+
+**Propósito:** registrar pérdida de conciencia — tarjeta roja automática (CMAS 1.1.10).
+
+**Componentes:**
+- Header "BKO — Black-out" + "Tarjeta roja automática"
+- Panel rojo: "⚡ BLACK-OUT DETECTADO — Se asigna tarjeta ROJA automáticamente"
+- Card atleta
+- Alerta roja: "El campo de distancia alcanzada es **obligatorio**"
+- Selector distancia (igual que S-07, con prefijo `bko-`):
+  - Display `[metros] m · [cm] cm`
+  - Presets metros + ajuste ±1/+5/+10
+  - Numpad cm
+- Botón `CONFIRMAR BKO — TARJETA ROJA` (btn-roja)
+
+**Restricción:** botón deshabilitado si metros = 0 y cm = "--" (distancia obligatoria).
+
+**Acción:** → S-11 Resultado Roja
+
+---
+
+### S-13 — DNS: Did Not Start
+
+**Propósito:** registrar que el atleta no se presentó al OT.
+
+**Componentes:**
+- Header "DNS — Did Not Start"
+- Card atleta: nombre, AP, posición, andarivel, OT
+- Alerta amarilla: "El atleta no se presentó al OT programado. Se registrará DNS."
+- Botón `CONFIRMAR DNS` (btn-dns)
+- Botón `Cancelar` (btn-outline) — regresa al paso de origen
+
+**Acciones:**
+- `CONFIRMAR DNS` → S-14 Resultado DNS
+- `Cancelar` → S-03 Paso 1
+
+---
+
+### S-14 — Resultado DNS
+
+**Componentes:**
+- Header "DNS registrado"
+- Hero card: "—" icono, "DNS" (color muted), nombre + "No se presentó"
+- Botón `SIGUIENTE ATLETA →` (btn-primary)
+
+**Acción:** → S-02 Grilla
+
+---
+
+### S-15 — Revisión desde Grilla (Amarilla pendiente)
+
+**Propósito:** resolver una tarjeta amarilla que quedó pendiente de sesiones anteriores.
+
+**Componentes:**
+- Header "En revisión" + "DNF #N"
+- Badge "🟨 TARJETA AMARILLA — PENDIENTE"
+- Sub-label "Requiere resolución antes del cierre"
+- Card atleta: nombre, AP, RP, posición
+- Alerta: "La disciplina no puede cerrarse hasta resolver esta tarjeta"
+- Botón `⬜ RESOLVER → BLANCA`
+- Botón `🟥 RESOLVER → ROJA`
+
+**Acciones:** → S-02 Grilla (con estado actualizado)
+
+---
+
+### S-16 — Demo Offline
+
+**Propósito:** demostrar el comportamiento offline-first.
+
+**Componentes:**
+- Badge "Sin conexión" (rojo, parpadeante)
+- Alerta azul "📵 Modo offline activo — acciones guardadas localmente"
+- Panel "Cola de sincronización" (lista de eventos pendientes)
+- Botón `SIMULAR RECONEXIÓN`
+- Panel confirmación sync (aparece post-reconexión)
+
+**Acceso:** doble-tap en el header de la grilla (modo demo).
+
+---
+
+## Flujo completo — resumen visual
+
+```
+S-00 Login
+  └── S-01 Mis Disciplinas
+        └── S-02 Grilla de Salida ←─────────────────────────┐
+              ├── S-15 Revisión (amarilla pendiente) ────────┤
+              └── S-03 Paso 1 Llamar                        │
+                    ├── S-13 DNS → S-14 Resultado DNS ───────┤
+                    └── S-04 Paso 2 Confirmar                │
+                          ├── S-13 DNS → S-14 Resultado DNS ─┤
+                          └── S-05 Paso 3 Tiempo Oficial     │
+                                ├── DQ ventana → S-11 ───────┤
+                                └── S-06 Paso 4 En Curso     │
+                                      ├── S-12 BKO → S-11 ──┤
+                                      └── S-07 Paso 5 RP     │
+                                            └── S-08 Paso 6  │
+                                                  ├── S-09 ──┤
+                                                  ├── S-10 ──┤
+                                                  └── S-11 ──┘
+```
+
+---
+
+## Componentes reutilizables para implementación React
+
+| Componente | Pantallas | Props clave |
+|------------|-----------|-------------|
+| `StepIndicator` | S-03 a S-08 | `total=6, current=N` |
+| `AtletaCard` | S-03 a S-08, S-12, S-13 | `nombre, ap, rp?, pos, andarivel, ot?` |
+| `ConnectionBadge` | S-01, S-02, S-06 | `online: boolean` |
+| `GrillaRow` | S-02 | `atleta, estado, onClick?` |
+| `RpSelector` | S-07, S-12 | `id, onValue(m, cm)` |
+| `NumpadCm` | S-07, S-12 | `id, value, onChange` |
+| `OtWindow` | S-05 | `otTime, onInicia, onDq` |
+| `ResultHero` | S-09, S-11, S-14 | `tipo, nombre, rp?` |
+| `AlertaRevision` | S-10, S-15 | `atleta, onBlanca, onRoja` |
+
+---
+
+*Prototipo de referencia: `docs/design/ux/prototipos/prototipo-juez.html`*
+*Próximo artefacto: `prototipo-organizador.html` + `wireframes-organizador.md`*

--- a/docs/design/ux/wireframes-organizador.md
+++ b/docs/design/ux/wireframes-organizador.md
@@ -1,0 +1,411 @@
+# Wireframes — Interfaz del Organizador
+
+> Artefacto INC-4.0 · Especificación formal derivada de `prototipo-organizador.html` validado
+> Fuente reglamentaria: CMAS Apnea Indoor v2022/01 (FAAS)
+> Última actualización: 2026-04-05
+
+---
+
+## Principios de diseño
+
+| Principio | Valor |
+|-----------|-------|
+| Tema | Dark (fondo #0f172a) |
+| Ancho máximo de contenido | 1100 px (desktop-first) |
+| Altura de navbar | 56 px sticky |
+| Fuente | System UI (-apple-system, BlinkMacSystemFont) |
+| Layout | Two-column (50/50) para secciones de detalle |
+| Contraste | Alto — legible en sala de competencia con luz variable |
+
+**Tokens de color** (compartidos con el juez):
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| `--bg` | `#0f172a` | Fondo general |
+| `--surface` | `#1e293b` | Cards, panels, navbar |
+| `--surface2` | `#334155` | Inputs, botones ghost, encabezados de tabla |
+| `--border` | `#475569` | Bordes generales |
+| `--accent` | `#38bdf8` | Acción principal, link activo nav, AP |
+| `--blanca` | `#22c55e` | Tarjeta blanca, progreso |
+| `--amarilla` | `#eab308` | Tarjeta amarilla, alertas |
+| `--roja` | `#ef4444` | Tarjeta roja, DQ, cierre forzado |
+| `--dns` | `#64748b` | DNS |
+| `--muted` | `#94a3b8` | Texto secundario, labels |
+
+---
+
+## Navegación principal
+
+La aplicación del organizador es de pantalla única con navegación por tabs en la barra superior. La navbar es sticky (siempre visible al hacer scroll).
+
+**Estructura de la navbar:**
+
+```
+[AtaraxiaDive]  [📊 Panel]  [📋 Grilla]  [🏆 Resultados]  [👥 Jueces]  [📝 Torneo]  [🔍 Audit Log]  →  [● En línea]  [Nombre usuario]
+```
+
+| Elemento | Comportamiento |
+|----------|---------------|
+| Marca (izquierda) | Decorativo — no navega |
+| Nav items | Tab activo con borde inferior accent + color accent |
+| Badge conexión | Verde "En línea" / Rojo "Sin conexión" |
+| Nombre usuario | Solo informativo |
+
+**Invariante de navegación:** cada pantalla reusa la misma navbar con el item correspondiente marcado como `active`. La función `go(screenId)` sincroniza el estado activo automáticamente mediante el mapa `navMap`.
+
+---
+
+## Pantallas
+
+### S-00 — Login
+
+**Propósito:** autenticación del organizador.
+
+**Layout:** centrado vertical y horizontal, caja de 380 px máximo.
+
+**Componentes:**
+- Logo "AtaraxiaDive" (accent, 28 px, 900 weight)
+- Subtítulo "Panel de Organización" (muted)
+- Campo Email
+- Campo Contraseña
+- Botón `INGRESAR` (btn-primary, ancho completo, 44 px alto)
+- Label "Rol activo: **Organizador**"
+
+**Acción:**
+- `INGRESAR` → S-01 Dashboard
+
+---
+
+### S-01 — Dashboard (Panel Principal)
+
+**Propósito:** vista ejecutiva del estado del torneo en ejecución. Punto de entrada tras login.
+
+**Layout:** KPI strip + two-column (disciplina activa | alertas + próximos).
+
+#### KPI strip (4 columnas)
+
+| KPI | Valor mock | Color valor |
+|-----|-----------|-------------|
+| Atletas totales | 28 | default |
+| Completados | 2 de 12 en DNF | `--blanca` |
+| En revisión | 1 tarjeta amarilla | `--amarilla` |
+| Tiempo estimado | 83' para fin de DNF | `--accent` |
+
+#### Columna izquierda — Disciplina en ejecución
+
+Componente `disc-status` con:
+- Nombre disciplina + horario + andariveles + cantidad atletas
+- Badge de estado: `EN EJECUCIÓN` (verde) / `PENDIENTE` (gris) / `CERRADA` (accent)
+- Barra de progreso horizontal (fill `--blanca`, proporcional a completados/total)
+- Label de progreso: "N de M atletas completados (X%)"
+- Botones: `Ver grilla completa` (outline) → S-02 · `Cerrar disciplina` (roja, requiere confirmación)
+
+Sección "Otras disciplinas del torneo": lista de `disc-card-mgmt` con disciplinas no activas, solo informativas (badge PENDIENTE, sin acción habilitada).
+
+#### Columna derecha — Alertas activas
+
+Cada alerta es un `alert-card` con:
+- Ícono + título + descripción (atleta, disciplina, OT, RP)
+- Botón/texto "Resolver →" (accent)
+- Tap en la card navega a S-03 (detalle amarilla)
+
+**Invariante UX:** si no hay alertas activas, mostrar empty state "Sin alertas".
+
+Sección "Próximos en DNF": tabla compacta con columnas `#, Atleta, OT, AP, Estado`. El siguiente en ejecutar muestra fila `row-siguiente` (fondo accent tenue + chip "▶ SIGUIENTE").
+
+---
+
+### S-02 — Grilla de Salida (Completa)
+
+**Propósito:** vista exhaustiva de todos los atletas de la disciplina activa. Permite supervisar el progreso y acceder a resoluciones de amarilla.
+
+**Header de página:**
+- Título "Grilla — [DISCIPLINA]" + botones `↓ Exportar PDF` y `← Panel`
+- Subtítulo: estado + cantidad atletas + intervalo + andariveles
+
+**Filtros rápidos (pill buttons):**
+
+| Filtro | Estilo cuando activo |
+|--------|---------------------|
+| Todos (N) | outline accent |
+| Pendientes (N) | ghost |
+| Completados (N) | ghost |
+| ⚠ Revisión (N) | ghost amarilla |
+
+**Tabla principal — columnas:**
+
+| Columna | Ancho | Descripción |
+|---------|-------|-------------|
+| `#` | 36 px | Posición en grilla (orden OT) |
+| Atleta | auto | Apellido, Nombre (font-weight 600) |
+| Cat. | auto | Categoría (Senior M/F, Junior, Master) — muted sm |
+| OT | auto | Hora del OT — muted 13 px |
+| And. | auto | Andarivel A / B — muted |
+| AP | auto | Distancia anunciada — accent bold |
+| RP | auto | Distancia realizada — bold / "—" si pendiente |
+| Juez | auto | Chip `chip-juez` con nombre abreviado |
+| Estado | auto | Chip de estado (ver tabla de chips) |
+| Acciones | auto | Botón contextual según estado |
+
+**Chips de estado en grilla:**
+
+| Estado | Clase CSS | Texto |
+|--------|-----------|-------|
+| Completado | `chip-blanca` | ✓ BLANCA |
+| En revisión | `chip-amarilla` | ⚠ REVISIÓN |
+| Siguiente | `chip-sig` | ▶ SIGUIENTE |
+| Pendiente | `chip-pend` | PENDIENTE |
+| DNS | `chip-dns` | DNS |
+| DQ | `chip-roja` | ROJA |
+
+**Estilos de fila:**
+
+| Condición | Clase | Efecto |
+|-----------|-------|--------|
+| Atleta completado | `row-done` | opacity 0.5 |
+| Siguiente atleta | `row-siguiente` | fondo accent tenue |
+| Fila con acción | `row-action` | cursor pointer, hover sutil |
+
+**Botones contextuales (columna acciones):**
+
+| Estado atleta | Botón | Destino |
+|--------------|-------|---------|
+| BLANCA | `Log` (ghost sm) | S-07 Audit Log |
+| REVISIÓN | `Resolver` (outline amarilla sm) | S-03 Detalle Amarilla |
+| SIGUIENTE / PENDIENTE | — | sin botón |
+
+**Invariante de orden:** filas ordenadas por OT ascendente. Ningún atleta pendiente puede tener OT anterior a un atleta completado.
+
+---
+
+### S-03 — Detalle Amarilla — Resolución
+
+**Propósito:** interfaz para que el organizador (junto con los jueces) resuelva formalmente una tarjeta amarilla pendiente.
+
+**Acceso:** desde S-01 (alerta) o S-02 (botón "Resolver").
+
+**Header:** `← Grilla` + título "Resolución — Tarjeta Amarilla".
+
+**Layout:** two-column.
+
+#### Columna izquierda — Datos de la performance
+
+Panel `detail-panel` con filas label/valor:
+
+| Campo | Valor mock |
+|-------|-----------|
+| Atleta | López, Andrés |
+| Disciplina | DNF — #2 |
+| OT | 14:09 · Andarivel B |
+| AP declarado | 72.0 m (accent bold) |
+| RP medido | 66.0 m |
+| Juez | Carlos Méndez |
+| Motivo revisión | Protocolo superficie dudoso (amarilla) |
+
+Panel inferior — Penalización aplicable (CMAS 1.1.13.1):
+- Texto informativo: "En caso de resolver como BLANCA con penalización general: se restan **3 metros** a la distancia realizada."
+- RP efectivo con penalización: **63.0 m** (accent)
+
+#### Columna derecha — Formulario de resolución
+
+Aviso reglamentario (fondo amarilla tenue):
+> ⚠ Los jueces tienen máximo **3 minutos** para dar la decisión final (CMAS 1.2.3.1).
+
+Campo **Decisión** (select):
+- `Seleccionar resolución...` (placeholder)
+- `BLANCA — Performance válida (sin penalización)`
+- `BLANCA con penalización — RP: 63.0 m (−3 m)`
+- `ROJA — Descalificada (DQ)`
+
+Campo **Observaciones** (textarea, 3 filas, resize vertical): motivo de la decisión.
+
+Botones de acción (lado a lado, ancho completo):
+- `⬜ CONFIRMAR BLANCA` (btn-blanca) → S-02 Grilla
+- `🟥 CONFIRMAR ROJA` (btn-roja) → S-02 Grilla
+
+**Invariante de negocio:** la resolución es irreversible desde la UI del organizador. El audit log registra el evento con SHA-256. No se puede dejar en estado REVISIÓN indefinidamente (bloquea el cierre de disciplina).
+
+---
+
+### S-04 — Resultados
+
+**Propósito:** vista de rankings parciales por disciplina y ranking overall (disponible al cerrar todas las disciplinas).
+
+**Header:** título "Resultados" + botón `Publicar resultados` (btn-primary sm).
+
+**Subtítulo:** disciplina activa + estado del ranking (parcial/final) + progreso.
+
+**Layout:** two-column.
+
+#### Columna izquierda — Ranking por disciplina (parcial)
+
+Lista de `rank-row`:
+
+| Elemento | Descripción |
+|----------|-------------|
+| `rank-pos` | Posición numérica (1, 2, 3…); colores oro/plata/bronce para el podio |
+| `rank-name` | Apellido, Nombre + Categoría (muted sm) |
+| `rank-dist` | Distancia RP (accent, 16 px bold) |
+| Chip estado | BLANCA / EN REVISIÓN / DQ / DNS |
+
+Atletas en revisión aparecen con opacity 0.7 y sin posición asignada (guión "—").
+
+Mensaje de cierre: "N atletas pendientes de ejecución…" en muted.
+
+#### Columna derecha — Overall Ranking
+
+Estado vacío mientras no estén cerradas todas las disciplinas:
+- Ícono 🏆 + texto "Disponible al cerrar todas las disciplinas"
+
+Una vez disponible: misma estructura de `rank-row` usando puntos CMAS o distancia acumulada según reglamento del torneo.
+
+**Invariante:** botón "Publicar resultados" sólo debe estar habilitado cuando todas las disciplinas estén cerradas y no haya amarillas pendientes (en el prototipo es siempre visible por simplicidad).
+
+---
+
+### S-05 — Jueces
+
+**Propósito:** monitoreo del estado de conexión de los jueces y gestión de asignaciones por andarivel.
+
+**Header:** título "Jueces asignados" + botón `+ Agregar juez` (outline sm).
+
+**Subtítulo:** disciplina activa + cantidad de jueces en línea + andariveles.
+
+**Sección "En línea":**
+
+Cada `juez-card` contiene:
+- Avatar con iniciales (circle, accent sobre surface2)
+- Nombre completo
+- Disciplina + andarivel + lista de atletas asignados (posiciones impares/pares)
+- Badge de conexión `online` (verde)
+- Botón `Reasignar` (ghost sm)
+
+**Sección "Pendientes (disciplinas futuras)":**
+
+Misma estructura con opacity 0.6, avatar en surface2/muted, sin badge online → texto "Sin conexión".
+
+**Invariante:** un juez solo puede estar asignado a un andarivel a la vez. La reasignación no está implementada en el prototipo (muestra `alert()`).
+
+---
+
+### S-06 — Gestión del Torneo
+
+**Propósito:** edición de datos generales del torneo y gestión de disciplinas.
+
+**Layout:** two-column.
+
+#### Columna izquierda — Datos generales
+
+Panel `detail-panel` con formulario:
+
+| Campo | Tipo | Valor mock |
+|-------|------|-----------|
+| Nombre del torneo | text input | Apnea Indoor Buenos Aires 2026 |
+| Fecha | date input | 2026-04-05 |
+| Sede | text input | Club Náutico BA |
+| Estado | select | En ejecución / Inscripciones abiertas / Finalizado |
+
+Botón `Guardar cambios` (btn-primary).
+
+#### Columna derecha — Disciplinas
+
+Lista de `disc-card-mgmt` por cada disciplina:
+
+| Campo mostrado | Ejemplo |
+|---------------|---------|
+| Nombre corto | DNF |
+| Detalle | 14:00 · 12 atletas · And. A/B · 9 min intervalo |
+| Badge estado | ACTIVA (blanca) / PENDIENTE (gris) |
+
+Botón `+ Agregar disciplina` (outline sm) al pie de la lista.
+
+**Invariante:** no se puede editar una disciplina en estado ACTIVA (bloqueado en prototipo con badge visual; implementar validación en API).
+
+---
+
+### S-07 — Audit Log
+
+**Propósito:** trazabilidad completa de eventos del torneo con integridad verificable mediante hash SHA-256.
+
+**Header:** título "Audit Log" + subtítulo "Historial de eventos · Integridad SHA-256".
+
+**Filtros (dropdowns en línea):**
+- Disciplina: Todas / DNF / STA / DBF
+- Atleta: Todos / lista
+- Juez: Todos / lista
+
+**Lista de eventos (`log-item`):**
+
+Cada entrada contiene:
+- `log-time`: hora del evento (HH:MM), muted, ancho fijo
+- Chip de tipo de evento (reutiliza chips de grilla: AMARILLA, BLANCA, ROJA, etc.)
+- Descripción del evento con atleta destacado (`log-actor`, accent bold)
+- `log-hash`: `sha256: XXXXXXXX…` + "Juez: Nombre" — monospace, color border
+
+**Eventos registrados en el mock (orden cronológico inverso):**
+
+| Hora | Tipo | Descripción |
+|------|------|-------------|
+| 14:19 | AMARILLA | Tarjeta amarilla asignada · López, Andrés · DNF #2 · RP 66.0 m |
+| 14:17 | RP | Resultado registrado · López, Andrés · 66.0 m |
+| 14:09 | OT | Tiempo Oficial marcado · López, Andrés · Andarivel B |
+| 14:07 | BLANCA | Tarjeta blanca asignada · García, Martina · DNF #1 · RP 65.0 m |
+| 14:05 | RP | Resultado registrado · García, Martina · 65.0 m |
+| 14:00 | OT | Tiempo Oficial marcado · García, Martina · Andarivel A |
+
+---
+
+## Diagrama de navegación
+
+```
+S-00 Login
+  └─► S-01 Dashboard
+        ├─► S-02 Grilla ──────────► S-03 Detalle Amarilla ──► S-02
+        │     └─► S-07 Audit Log                               │
+        ├─► S-03 Detalle Amarilla (desde alerta) ──────────────┘
+        ├─► S-04 Resultados
+        ├─► S-05 Jueces
+        ├─► S-06 Torneo
+        └─► S-07 Audit Log
+
+Navbar siempre visible → acceso directo a cualquier sección desde cualquier pantalla
+```
+
+---
+
+## Componentes React identificados
+
+| Componente | Props clave | Pantallas |
+|-----------|------------|-----------|
+| `NavBar` | `activeSection`, `user`, `connectionStatus` | todas (S-01 → S-07) |
+| `KpiCard` | `label`, `value`, `sub`, `color` | S-01 |
+| `DisciplinaStatus` | `disciplina`, `completados`, `total`, `estado` | S-01 |
+| `AlertaCard` | `tipo`, `atleta`, `disciplina`, `ot`, `rp`, `onResolve` | S-01 |
+| `GrillaTable` | `atletas[]`, `filtro`, `onResolve`, `onViewLog` | S-02 |
+| `GrillaRow` | `atleta`, `estado`, `onAction` | S-02 |
+| `DetalleAmarilla` | `performance`, `onConfirmarBlanca`, `onConfirmarRoja` | S-03 |
+| `RankRow` | `pos`, `nombre`, `categoria`, `distancia`, `estado` | S-04 |
+| `JuezCard` | `juez`, `disciplina`, `andarivel`, `online` | S-05 |
+| `DiscCard` | `disciplina`, `estado`, `readonly` | S-01, S-06 |
+| `LogItem` | `hora`, `tipo`, `descripcion`, `actor`, `hash` | S-07 |
+| `ConnectionBadge` | `status` | todas |
+
+---
+
+## Invariantes de negocio formalizados
+
+| ID | Regla | Fuente |
+|----|-------|--------|
+| INV-ORG-01 | Solo una disciplina puede estar en estado ACTIVA simultáneamente | Diseño dominio |
+| INV-ORG-02 | No se puede cerrar una disciplina con amarillas pendientes de resolución | Diseño dominio |
+| INV-ORG-03 | La resolución de amarilla tiene máximo 3 min de deliberación | CMAS 1.2.3.1 |
+| INV-ORG-04 | Penalización general DNF = −3 m sobre RP medido | CMAS 1.1.13.1 |
+| INV-ORG-05 | El Overall Ranking solo se publica al cerrar todas las disciplinas | Diseño dominio |
+| INV-ORG-06 | Todo evento queda registrado con SHA-256 en el audit log | ADR-005, Event Sourcing |
+| INV-ORG-07 | El orden de la grilla es por OT ascendente; no admite reordenamiento manual | Diseño dominio |
+| INV-ORG-08 | Una disciplina ACTIVA no es editable desde S-06 | Diseño dominio |
+
+---
+
+*Artefacto generado: 2026-04-05 — INC-4.0 UX Design*
+*Capa IEDD: 3b — Especificación interactiva*

--- a/docs/design/ux/wireframes-registro-roles.md
+++ b/docs/design/ux/wireframes-registro-roles.md
@@ -1,0 +1,433 @@
+# Wireframes — Registro y Roles
+
+> Artefacto INC-4.0 · Especificación formal derivada de `prototipo-registro-roles.html` validado
+> Fuente funcional: onboarding, perfil multirol e invitaciones de juez
+> Última actualización: 2026-04-08
+
+---
+
+## Principios de diseño
+
+| Principio | Valor |
+|-----------|-------|
+| Tema | Dark (fondo #0f172a) |
+| Ancho máximo | 430 px (mobile-first) |
+| Altura de header | 52 px sticky |
+| Altura de tab bar | 56 px sticky |
+| Fuente | System UI (-apple-system, BlinkMacSystemFont) |
+| Contexto | Onboarding y gestión de identidad multirol desde smartphone |
+
+**Tokens de color**:
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| `--bg` | `#0f172a` | Fondo general |
+| `--surface` | `#1e293b` | Cards, headers, overlays |
+| `--surface2` | `#334155` | Inputs, estados neutros |
+| `--border` | `#475569` | Bordes y divisores |
+| `--accent` | `#38bdf8` | CTA, rol organizador, navegación activa |
+| `--blanca` | `#22c55e` | Éxito, atleta, confirmaciones |
+| `--amarilla` | `#eab308` | Juez, advertencias, certificaciones |
+| `--roja` | `#ef4444` | Notificación crítica, rechazo |
+| `--muted` | `#94a3b8` | Texto secundario |
+
+---
+
+## Navegación base
+
+El flujo combina dos shells:
+
+- shell de autenticación y formularios sin tab bar
+- shell autenticada con `tabbar` inferior
+
+**Tabs en shell autenticada:**
+
+```
+[🏠 Inicio] [🏆 Torneos] [🔔 Alertas] [👤 Perfil]
+```
+
+**Regla principal:** los roles no se seleccionan globalmente al entrar; se materializan por torneo y se resumen en dashboard, notificaciones y perfil.
+
+---
+
+## Pantallas
+
+### S-01 — Login
+
+**Propósito:** acceso para usuarios existentes y entrada al registro.
+
+**Componentes:**
+- splash de marca `AtaraxiaDive`
+- subtítulo "Gestión de torneos de apnea"
+- campo `Email`
+- campo `Contraseña`
+- link `Olvidé mi contraseña`
+- botón `Iniciar sesión`
+- link `Crear cuenta`
+
+**Acciones:**
+- `Iniciar sesión` → S-05 Dashboard con roles
+- `Crear cuenta` → S-02 Registro paso 1
+
+---
+
+### S-02 — Registro Paso 1: Datos personales
+
+**Propósito:** crear identidad básica del usuario.
+
+**Header:** `‹` + título "Crear cuenta".
+
+**Indicador:** progreso de 3 pasos, paso 1 activo.
+
+**Componentes:**
+- campos `Nombre`, `Apellido`
+- campo `Email`
+- helper "Necesitarás confirmar este email"
+- campo `Fecha de nacimiento`
+- helper sobre categoría de competición
+- selector tipo pill `Género`
+- botón `Siguiente →`
+- link `Iniciar sesión`
+
+**Acción:** `Siguiente →` → S-02b
+
+---
+
+### S-02b — Registro Paso 2: Acceso
+
+**Propósito:** definir credenciales.
+
+**Indicador:** paso 1 completado, paso 2 activo.
+
+**Componentes:**
+- campo `Contraseña`
+- campo `Confirmar contraseña`
+- caja informativa con reglas mínimas de password
+- botón `Siguiente →`
+
+**Regla UX:** el requisito de complejidad se presenta inline antes de validación server-side.
+
+**Acción:** `Siguiente →` → S-02c
+
+---
+
+### S-02c — Registro Paso 3: Confirmación
+
+**Propósito:** revisar datos y aceptar términos.
+
+**Indicador:** paso 3 activo, pasos previos completos.
+
+**Componentes:**
+- card resumen con nombre, email, fecha de nacimiento y género
+- checkbox obligatorio `Términos de uso / Política de privacidad`
+- checkbox opcional de notificaciones
+- botón `Crear mi cuenta`
+
+**Acción:** `Crear mi cuenta` → S-03 Verificar email
+
+**Invariante:** sin aceptación de términos no debe completarse el alta.
+
+---
+
+### S-03 — Verificar Email
+
+**Propósito:** estado intermedio post-registro.
+
+**Componentes:**
+- icono de email
+- título "Revisá tu email"
+- copy con el correo destino
+- botón `Ya confirmé mi email`
+- links `Reenviar email` y `Volver`
+
+**Acciones:**
+- `Ya confirmé mi email` → S-04 Dashboard vacío
+- `Volver` → S-02 Registro paso 1
+
+---
+
+### S-04 — Dashboard vacío
+
+**Propósito:** primer acceso sin torneos ni roles activos.
+
+**Header:** marca + acceso a notificaciones.
+
+**Componentes:**
+- bloque de bienvenida
+- sección "¿Cómo querés empezar?"
+- `path-card` para crear torneo
+- `path-card` para inscribirse como atleta
+- `path-card` deshabilitada para juez
+- caja informativa sobre coexistencia de roles
+- tab bar activa en `Inicio`
+
+**Caminos visibles:**
+
+| Camino | Estado | Destino |
+|--------|--------|---------|
+| Crear un torneo | activo | prototipo organizador |
+| Inscribirme a un torneo | activo | prototipo atleta |
+| Soy juez | informativo | sin CTA |
+
+**Regla de negocio visible:** el rol juez solo se obtiene por invitación de un organizador.
+
+---
+
+### S-05 — Dashboard con roles activos
+
+**Propósito:** resumir torneos y roles del usuario una vez que ya participa en el ecosistema.
+
+**Header:** marca + campana con punto rojo.
+
+**Componentes:**
+- saludo al usuario
+- resumen de conteos por rol
+- lista `Próximos torneos`
+- CTA `+ Inscribirme a otro torneo`
+
+#### Resumen de roles
+
+Contadores mockeados:
+- `2 Organizando`
+- `1 Juzgando`
+- `2 Compitiendo`
+
+#### Lista de torneos
+
+Cada `torneo-row` muestra:
+- nombre del torneo
+- fecha + sede
+- badges de rol por torneo
+
+**Combinaciones soportadas:**
+
+| Caso | Badges |
+|------|--------|
+| Solo organizador | `🏆 Organizador` |
+| Juez + atleta | `⚖️ Juez`, `🤿 Atleta` |
+| Solo atleta | `🤿 Atleta` |
+
+**Regla UX:** la vista es agregada por torneo, no por rol aislado.
+
+---
+
+### S-06 — Mi Perfil
+
+**Propósito:** editar identidad de cuenta, datos deportivos y certificaciones.
+
+**Header:** marca + acción `Editar`.
+
+**Secciones:**
+- avatar y datos básicos
+- `Datos de cuenta`
+- `Datos deportivos`
+- `Certificaciones de juez`
+- `Seguridad`
+
+#### Datos de cuenta
+
+Filas de solo lectura:
+- nombre
+- email
+- fecha de nacimiento
+- género
+
+#### Datos deportivos
+
+Campos:
+- club
+- federación
+- número de licencia
+
+Estado mockeado:
+- todos `No completado`
+- acción `+ Agregar`
+
+**Regla UX:** son opcionales al crear la cuenta, pero necesarios para competir.
+
+#### Certificaciones de juez
+
+Elementos:
+- aviso contextual de uso por organizadores
+- `cert-card` existente
+- botón `+ Agregar otra certificación`
+
+#### Seguridad
+
+Opciones:
+- `Cambiar` contraseña
+- `Ver` sesiones activas
+- botón `Cerrar sesión`
+
+**Acciones:**
+- `+ Agregar otra certificación` → S-09 Agregar certificación
+
+---
+
+### S-07 — Notificaciones
+
+**Propósito:** bandeja unificada de eventos relevantes por rol.
+
+**Header:** `‹` + título "Notificaciones".
+
+**Secciones:**
+- `Nuevas`
+- `Anteriores`
+
+#### Tipos de notificación presentes en el mock
+
+| Tipo | Ejemplo | Acción |
+|------|---------|--------|
+| Invitación a juez | "Te invitaron como juez" | abrir detalle o aceptar/rechazar |
+| Inscripción confirmada | aprobación de atleta | informativa |
+| Torneo publicado | apertura organizador | informativa |
+| Resultados disponibles | ranking / puesto | informativa |
+
+#### Notificación de invitación
+
+Elementos:
+- icono `⚖️`
+- título
+- subtítulo con organizador y torneo
+- timestamp
+- acciones inline `Aceptar` / `Rechazar`
+
+**Acciones:**
+- tap card → S-08 Invitación detalle
+- `Aceptar` → aceptación rápida + dashboard actualizado
+
+---
+
+### S-08 — Invitación de juez
+
+**Propósito:** permitir aceptar formalmente una invitación a un torneo como juez.
+
+**Header:** `‹` + título "Invitación de juez".
+
+**Componentes:**
+- `inv-hero` con torneo e invitante
+- card `Torneo`
+- card `Tu rol`
+- bloque `Compatibilidad de roles`
+- `cert-card` detectada
+- botones `Aceptar invitación` y `Rechazar`
+
+#### Información del torneo
+
+Campos:
+- fecha
+- sede
+- organizador
+
+#### Tu rol
+
+Campos:
+- función
+- disciplinas
+- andarivel asignado
+
+#### Compatibilidad de roles
+
+Caso mockeado:
+- usuario puede competir y juzgar en el mismo torneo
+- la no colisión se resuelve por andarivel o asignación específica
+
+#### Certificación detectada
+
+Se destaca la credencial existente del usuario para respaldar la invitación.
+
+**Acciones:**
+- `Aceptar invitación` → modal de éxito + S-05 Dashboard con roles
+- `Rechazar` → S-07 Notificaciones
+
+**Invariante:** una invitación de juez debe hacer visible el rol solamente dentro del torneo correspondiente, no como rol global permanente.
+
+---
+
+### S-09 — Agregar certificación
+
+**Propósito:** registrar credenciales auto-declaradas de juez.
+
+**Header:** `‹` + título "Agregar certificación".
+
+**Componentes:**
+- select `Organización`
+- selector visual `Nivel`
+- campos `Número de certificación`, `Fecha de emisión`, `Vencimiento`
+- caja informativa sobre autodeclaración
+- botones `Guardar certificación` y `Cancelar`
+
+#### Niveles mockeados
+
+| Nivel | Etiqueta |
+|------|----------|
+| 1 estrella | Juez Nacional |
+| 2 estrellas | Juez Continental |
+| 3 estrellas | Juez Internacional |
+
+**Acciones:**
+- `Guardar certificación` → S-06 Perfil
+- `Cancelar` → S-06 Perfil
+
+**Regla UX:** la plataforma almacena la certificación declarada, pero la verificación final queda en manos del organizador.
+
+---
+
+## Diagrama de navegación
+
+```text
+S-01 Login
+  ├─► S-02 Registro
+  │     ├─► S-02b
+  │     ├─► S-02c
+  │     └─► S-03 Verificar email
+  │           └─► S-04 Dashboard vacío
+  └─► S-05 Dashboard con roles
+        ├─► S-06 Perfil
+        │     └─► S-09 Agregar certificación
+        ├─► S-07 Notificaciones
+        │     └─► S-08 Invitación de juez
+        └─► Flujos externos
+              ├─► Portal atleta
+              └─► Panel organizador
+```
+
+---
+
+## Componentes React identificados
+
+| Componente | Props clave | Pantallas |
+|-----------|-------------|-----------|
+| `AuthShell` | `title`, `showBack`, `step` | S-01 a S-03 |
+| `ProgressSteps` | `currentStep`, `totalSteps` | S-02, S-02b, S-02c |
+| `PillSelector` | `options`, `value`, `onChange` | S-02 |
+| `CheckRow` | `checked`, `label`, `required` | S-02c |
+| `AppShell` | `activeTab`, `notificationsCount` | S-04 a S-09 |
+| `PathCard` | `icon`, `title`, `sub`, `disabled`, `onClick` | S-04 |
+| `RolesSummary` | `organizing`, `judging`, `competing` | S-05 |
+| `TorneoRoleRow` | `torneo`, `roles[]` | S-05 |
+| `ProfileInfoRow` | `label`, `value`, `action` | S-06 |
+| `CertificationCard` | `org`, `nivel`, `numero`, `vence` | S-06, S-08 |
+| `NotificationCard` | `tipo`, `titulo`, `subtitulo`, `time`, `actions` | S-07 |
+| `InvitationHero` | `torneo`, `organizador` | S-08 |
+| `LevelOptionCard` | `nivel`, `selected`, `onSelect` | S-09 |
+
+---
+
+## Invariantes de negocio formalizados
+
+| ID | Regla | Fuente |
+|----|-------|--------|
+| INV-RR-01 | Un usuario puede coexistir como organizador, juez y atleta en distintos torneos | Prototipo S-04/S-05 |
+| INV-RR-02 | El rol de juez no se autoasigna; solo se obtiene por invitación | Prototipo S-04 |
+| INV-RR-03 | La compatibilidad atleta+juez se resuelve por disciplina/andarivel y debe informarse explícitamente | Prototipo S-08 |
+| INV-RR-04 | Las certificaciones de juez son auto-declaradas y requieren validación externa si el torneo lo exige | Prototipo S-06/S-09 |
+| INV-RR-05 | Los datos deportivos son opcionales al alta, pero necesarios para competir | Prototipo S-06 |
+| INV-RR-06 | La aceptación de términos es obligatoria para crear la cuenta | Prototipo S-02c |
+| INV-RR-07 | La cuenta debe verificarse por email antes del primer acceso funcional | Prototipo S-03 |
+| INV-RR-08 | Las notificaciones agrupan eventos de distintos roles en una sola bandeja | Prototipo S-07 |
+
+---
+
+*Artefacto generado: 2026-04-08 — INC-4.0 UX Design*
+*Capa IEDD: 3b — Especificación interactiva*

--- a/docs/design/ux/wireframes-setup-torneo.md
+++ b/docs/design/ux/wireframes-setup-torneo.md
@@ -1,0 +1,496 @@
+# Wireframes — Setup del Torneo
+
+> Artefacto INC-4.0 · Especificación formal derivada de `prototipo-setup-torneo.html` validado
+> Fuente funcional: configuración del torneo antes de operación en vivo
+> Última actualización: 2026-04-08
+
+---
+
+## Principios de diseño
+
+| Principio | Valor |
+|-----------|-------|
+| Tema | Dark (fondo #0f172a) |
+| Ancho máximo de contenido | 1100 px |
+| Altura de topbar | 56 px sticky |
+| Fuente | System UI (-apple-system, BlinkMacSystemFont) |
+| Contexto | Organizador en desktop/tablet durante preparación del torneo |
+
+**Tokens de color**:
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| `--bg` | `#0f172a` | Fondo general |
+| `--surface` | `#1e293b` | Panels, cards, tablas |
+| `--surface2` | `#334155` | Inputs, estados neutros |
+| `--border` | `#475569` | Bordes generales |
+| `--accent` | `#38bdf8` | Acción principal, estado abierto |
+| `--blanca` | `#22c55e` | Estado listo/completo |
+| `--amarilla` | `#eab308` | Pendientes y advertencias |
+| `--roja` | `#ef4444` | Fallo crítico o acción destructiva |
+| `--muted` | `#94a3b8` | Texto secundario |
+
+---
+
+## Flujo general
+
+Este artefacto modela el setup previo a la publicación/ejecución:
+
+```text
+Datos del torneo
+  → Disciplinas
+    → Configuración por disciplina
+      → Revisión de inscriptos
+        → Generación de grilla
+          → Asignación de jueces
+            → Torneo listo/publicado
+```
+
+**Regla central:** no se puede publicar un torneo hasta que cada disciplina tenga parámetros, grilla y jueces asignados.
+
+---
+
+## Pantallas
+
+### S-00 — Login
+
+**Propósito:** autenticación del organizador antes del setup.
+
+**Componentes:**
+- logo "AtaraxiaDive"
+- subtítulo "Panel de Organización"
+- campo `Email`
+- campo `Contraseña`
+- botón `INGRESAR`
+- label `Rol activo: Organizador`
+
+**Acción:** `INGRESAR` → S-01 Mis torneos
+
+---
+
+### S-01 — Mis torneos
+
+**Propósito:** entry point para torneos en ejecución, preparación o finalizados.
+
+**Topbar:** marca + usuario + botón `+ Nuevo torneo`.
+
+**Secciones:**
+- `En ejecución`
+- `En preparación`
+- `Finalizados`
+
+#### Torneo card
+
+Cada `torneo-card` muestra:
+- icono contextual
+- nombre del torneo
+- fecha + sede + cantidad de disciplinas/atletas
+- badge de estado
+- CTA textual
+
+**Estados mockeados:**
+
+| Estado | Badge | CTA |
+|--------|-------|-----|
+| En ejecución | `EN EJECUCIÓN` | `Ir al panel →` |
+| En preparación | `INSCRIPCIONES ABIERTAS` | `Configurar →` |
+| Finalizado | `FINALIZADO` | `Ver resultados →` |
+
+**Acciones:**
+- `+ Nuevo torneo` → S-02 Crear torneo
+- tap torneo en preparación → S-03 Preparación
+
+---
+
+### S-02 — Crear torneo
+
+**Propósito:** registrar los datos marco del torneo.
+
+**Topbar:** `← Mis torneos` + "Nuevo torneo".
+
+**Stepper:** 3 pasos:
+- `1 Datos del torneo`
+- `2 Disciplinas`
+- `3 Por disciplina`
+
+**Panels:**
+- `Identificación del torneo`
+- `Estado de inscripciones`
+
+#### Identificación del torneo
+
+Campos:
+- nombre del torneo
+- fecha de inicio
+- fecha de fin
+- sede
+- ciudad
+- reglamento
+
+#### Estado de inscripciones
+
+Campo:
+- select `Estado inicial`
+
+Opciones mockeadas:
+- `Borrador (no visible para atletas)`
+- `Inscripciones abiertas`
+
+**Acciones:**
+- `Cancelar` → S-01 Mis torneos
+- `Continuar — Disciplinas →` → S-04 Lista de disciplinas
+
+---
+
+### S-03 — Preparación del torneo
+
+**Propósito:** vista de checklist global y control de readiness del torneo.
+
+**Topbar:** `← Mis torneos` + nombre torneo + badge `INSCRIPCIONES ABIERTAS`.
+
+**Layout:** dos columnas.
+
+#### Columna izquierda
+
+Elementos:
+- bloque `Torneo` con check de datos básicos
+- checklist por disciplina (`disc-steps`)
+
+Cada disciplina expone 4 hitos:
+- parámetros
+- inscriptos
+- grilla
+- jueces
+
+**Estados soportados:**
+
+| Estado | Ícono | Significado |
+|--------|-------|-------------|
+| completo | `✅` | hito resuelto |
+| pendiente advertencia | `⚠️` | requiere atención |
+| vacío | `⚪` | no generado |
+| bloqueado | `🔒` | depende de otro paso |
+
+#### Columna derecha
+
+Elementos:
+- panel `Estado general`
+- `info-box` amarilla con cuello de botella
+- botón `Publicar torneo`
+- helper explicando por qué está deshabilitado
+- CTA `+ Agregar disciplina`
+
+#### Métricas mockeadas
+
+| Métrica | Valor |
+|---------|-------|
+| Disciplinas | 2 |
+| Atletas inscriptos | 8 |
+| Grillas generadas | 1 de 2 |
+| Disciplinas con jueces | 1 de 2 |
+
+**Acciones:**
+- `Editar` datos básicos → S-02
+- `Editar` parámetros → S-05
+- `Ver` inscriptos → S-06
+- `Generar/Ver` grilla → S-07
+- `Ver` jueces → S-08
+- `+ Agregar disciplina` → S-04
+
+**Regla UX:** `Publicar torneo` permanece disabled hasta que todas las disciplinas completen grilla y asignación de jueces.
+
+---
+
+### S-04 — Lista de disciplinas
+
+**Propósito:** administrar el conjunto de disciplinas del torneo.
+
+**Topbar:** `← Preparación` + título "Disciplinas".
+
+**Componentes:**
+- título de página + botón `+ Agregar disciplina`
+- cards de disciplina
+- card dashed de alta rápida
+
+#### Card de disciplina
+
+Muestra:
+- ícono
+- nombre largo
+- fecha + hora + andariveles + intervalo + inscriptos
+- chip de estado
+- botón `Editar`
+
+**Estados mockeados:**
+- `Grilla pendiente`
+- `Completa ✓`
+
+**Acciones:**
+- tap card o `Editar` → S-05 Configurar disciplina
+- `+ Agregar disciplina` → S-05
+
+---
+
+### S-05 — Configurar disciplina
+
+**Propósito:** definir los parámetros operativos de una disciplina.
+
+**Topbar:** `← Disciplinas` + título "Configurar disciplina".
+
+**Panels:**
+- `Tipo, fecha y horario`
+- `Andariveles habilitados`
+- `Categorías habilitadas`
+- `Criterio de ordenamiento de grilla`
+
+#### Tipo, fecha y horario
+
+Campos:
+- tipo de disciplina
+- fecha de competencia
+- hora de inicio
+- intervalo entre atletas
+
+#### Andariveles habilitados
+
+Checklist de calles A/B/C/D.
+
+#### Categorías habilitadas
+
+Checklist de categorías:
+- Senior M/F
+- Junior M/F
+- Master M/F
+
+#### Criterio de ordenamiento
+
+Opciones mockeadas:
+- `AP ascendente — menor distancia sale primero (CMAS default)`
+- `AP descendente`
+- `Orden de inscripción`
+
+**Acciones:**
+- `Cancelar` → S-04
+- `Guardar disciplina` → S-04
+
+**Invariante:** la disciplina debe tener al menos un andarivel y una categoría habilitada.
+
+---
+
+### S-06 — Inscriptos (solo lectura + corrección)
+
+**Propósito:** revisar atletas de una disciplina y corregir datos previos a la grilla.
+
+**Topbar:** `← Preparación` + "Inscriptos — [DISCIPLINA]".
+
+**Componentes:**
+- título + subtítulo
+- info-box de alcance
+- tabla de inscriptos
+- advertencia por AP faltante
+- botones `Volver` y `Guardar correcciones`
+
+#### Tabla
+
+Columnas:
+- `#`
+- atleta
+- categoría
+- club
+- AP declarado
+- estado
+
+**Comportamiento permitido:**
+- editar AP inline
+- revisar categoría
+- no alta ni baja de atletas desde esta vista
+
+**Estados de fila:**
+- `✓ Con AP`
+- `⚠ Sin AP`
+
+**Acciones:**
+- `Guardar correcciones` → S-03 Preparación
+
+**Regla de negocio visible:** el organizador corrige datos incorrectos, pero no reemplaza el flujo de inscripción del atleta.
+
+---
+
+### S-07 — Preview y confirmar grilla
+
+**Propósito:** validar el orden de salida antes de fijarlo.
+
+**Topbar:** `← Preparación` + "Generar grilla — [DISCIPLINA]".
+
+**Header visual:** `grilla-ok` con resumen de cálculo.
+
+**Layout:** dos columnas.
+
+#### Columna izquierda — Grilla calculada
+
+Tabla con columnas:
+- posición
+- atleta
+- OT
+- andarivel
+- AP
+
+Pie informativo:
+- criterio `AP asc`
+- alternancia de andariveles
+
+#### Columna derecha — Validaciones
+
+Checklist de validaciones:
+- atletas con OT y andarivel
+- ausencia de solapamiento
+- alternancia balanceada
+- advertencia por atleta sin AP
+
+**Acciones:**
+- `← Volver` → S-03
+- `↓ PDF` → exportación
+- `Confirmar grilla — Asignar jueces →` → S-08
+
+**Regla importante:** el mock permite confirmar una grilla aun con atletas sin AP declarado.
+
+---
+
+### S-08 — Asignar jueces por competidor
+
+**Propósito:** vincular un juez a cada fila de la grilla ya confirmada.
+
+**Topbar:** `← Grilla` + "Asignar jueces — [DISCIPLINA]".
+
+**Layout:** dos columnas.
+
+#### Columna izquierda — Grilla con selector de juez
+
+Tabla con columnas:
+- `#`
+- atleta
+- OT
+- andarivel
+- juez
+
+El campo `juez-select` soporta:
+- `— Sin asignar —`
+- lista de jueces disponibles
+
+**Estados visuales:**
+
+| Estado | Clase |
+|--------|-------|
+| asignado | `asignado` |
+| pendiente | `pendiente` |
+
+CTA secundaria:
+- `Completar filas pendientes con…`
+
+#### Columna derecha — Jueces disponibles
+
+Lista de tarjetas-resumen con:
+- avatar/iniciales
+- nombre
+- licencia
+- chip con filas cubiertas
+
+Más:
+- alerta por fila sin juez
+- caja explicativa de rotación
+
+**Acciones:**
+- cambio en select actualiza estado visual
+- `Confirmar asignación →` → S-09 Torneo publicado
+- `← Grilla` → S-07
+
+**Regla UX:** el mismo juez puede aparecer en varias filas según rotación acordada.
+
+---
+
+### S-09 — Torneo publicado
+
+**Propósito:** estado final de setup exitoso.
+
+**Topbar:** marca + usuario.
+
+**Componentes:**
+- icono celebración
+- título "¡Torneo publicado!"
+- subtítulo con impacto
+- tres KPI cards
+- botón `Ir al panel de organización →`
+- botón `← Volver a mis torneos`
+
+#### KPI mockeados
+
+| KPI | Valor |
+|-----|-------|
+| Atletas | 8 |
+| Disciplinas | 2 |
+| Jueces | 3 |
+
+**Acciones:**
+- `Ir al panel de organización →` → panel operativo
+- `← Volver a mis torneos` → S-01
+
+---
+
+## Diagrama de navegación
+
+```text
+S-00 Login
+  └─► S-01 Mis torneos
+        ├─► S-02 Crear torneo
+        │     └─► S-04 Lista de disciplinas
+        ├─► S-03 Preparación del torneo
+        │     ├─► S-02 Crear torneo
+        │     ├─► S-05 Configurar disciplina
+        │     ├─► S-06 Inscriptos
+        │     ├─► S-07 Preview grilla
+        │     │     └─► S-08 Asignar jueces
+        │     │           └─► S-09 Torneo publicado
+        │     └─► S-04 Lista de disciplinas
+        └─► Panel en vivo / resultados
+```
+
+---
+
+## Componentes React identificados
+
+| Componente | Props clave | Pantallas |
+|-----------|-------------|-----------|
+| `OrganizerTopbar` | `title`, `user`, `backAction` | S-01 a S-09 |
+| `TournamentCard` | `torneo`, `estado`, `actionLabel`, `onOpen` | S-01 |
+| `SetupStepper` | `currentStep`, `steps[]` | S-02 |
+| `SetupPanel` | `title`, `children` | S-02, S-05, S-07, S-08 |
+| `PreparationChecklist` | `disciplina`, `steps[]` | S-03 |
+| `StatusMetricPanel` | `metrics[]`, `blockingMessage` | S-03 |
+| `DisciplinaCard` | `disciplina`, `status`, `onEdit` | S-04 |
+| `CheckboxChipGroup` | `options`, `selected`, `onToggle` | S-05 |
+| `EditableAthletesTable` | `rows`, `onApChange` | S-06 |
+| `GridPreviewTable` | `rows`, `sortRule`, `lanes` | S-07 |
+| `ValidationList` | `items[]` | S-07 |
+| `JudgeAssignmentTable` | `rows`, `judges`, `onAssign` | S-08 |
+| `JudgeAvailabilityCard` | `judge`, `assignedRows` | S-08 |
+| `PublishSuccessPanel` | `torneo`, `metrics`, `onOpenDashboard` | S-09 |
+
+---
+
+## Invariantes de negocio formalizados
+
+| ID | Regla | Fuente |
+|----|-------|--------|
+| INV-ST-01 | Un torneo no se publica hasta que todas las disciplinas tengan grilla y jueces asignados | Prototipo S-03 |
+| INV-ST-02 | La asignación de jueces se habilita recién después de confirmar la grilla | Prototipo S-03/S-08 |
+| INV-ST-03 | El organizador puede corregir AP/categoría antes de generar grilla, pero no dar de alta/baja atletas en esa vista | Prototipo S-06 |
+| INV-ST-04 | La grilla debe validar OT sin solapamiento y distribución por andariveles | Prototipo S-07 |
+| INV-ST-05 | El criterio por defecto de ordenamiento es AP ascendente según CMAS | Prototipo S-05/S-07 |
+| INV-ST-06 | Puede confirmarse una grilla con atletas sin AP declarado, manteniendo la advertencia visible | Prototipo S-07 |
+| INV-ST-07 | Un mismo juez puede cubrir múltiples filas según la rotación acordada | Prototipo S-08 |
+| INV-ST-08 | El estado inicial del torneo puede ser borrador o inscripciones abiertas | Prototipo S-02 |
+
+---
+
+*Artefacto generado: 2026-04-08 — INC-4.0 UX Design*
+*Capa IEDD: 3b — Especificación interactiva*

--- a/docs/dominio/06-brechas-reglamento.md
+++ b/docs/dominio/06-brechas-reglamento.md
@@ -1,0 +1,370 @@
+# Brechas entre el Reglamento CMAS/FAAS y la aplicación actual
+
+> **Fuente:** Reglamento CMAS Apnea Indoor v2022/01 — Traducción FAAS (versión en uso 2025)
+> **Fecha de análisis:** 2026-04-05
+> **Propósito:** Registro de funcionalidad definida en el reglamento oficial que no está
+> contemplada actualmente en AtaraxiaDive. Cada brecha incluye la descripción de la regla
+> y la diferencia funcional respecto al estado actual. No implica decisión de implementar.
+
+---
+
+## Cómo leer este documento
+
+Cada brecha describe:
+- **Qué dice el reglamento** — la regla oficial con referencia al artículo
+- **Qué hace la aplicación hoy** — el comportamiento actual
+- **La diferencia** — qué funcionalidad faltaría para cumplir el reglamento
+
+Las brechas están agrupadas por tema y ordenadas por impacto funcional.
+
+---
+
+## 1. Protocolo de Superficie — validación post-performance (§1.2.2)
+
+### Qué dice el reglamento
+
+Cuando el atleta termina su performance y sale a la superficie, no basta con que haya
+completado la distancia o el tiempo. El resultado solo es válido si el atleta completa el
+**Protocolo de Superficie** dentro de los 20 segundos posteriores a la emersión. Este
+protocolo consiste en:
+
+1. Mantener la cabeza fuera del agua (vías respiratorias y nivel de las orejas sobre la
+   superficie, de forma continua).
+2. Realizar el **signo OK** convencional de buceo (dos dedos formando un círculo) en
+   dirección al Juez Principal, ubicado en el borde de la pileta.
+3. No recibir ningún tipo de ayuda externa, no apoyarse en la línea del carril ni en ninguna
+   parte del cuerpo de otra persona.
+
+Si el atleta no puede completar este protocolo en 20 segundos, o necesita ayuda durante
+ese período, es descalificado — incluso si la performance en sí fue perfecta. El juez
+tiene hasta 3 minutos para deliberar y mostrar la tarjeta correspondiente.
+
+### Qué hace la aplicación hoy
+
+El flujo del juez va directamente de "Finalizar Performance" a "Registrar RP" y luego
+a "Asignar Tarjeta". No existe ningún paso entre la finalización de la performance y la
+asignación de la tarjeta que represente la observación y validación del protocolo de
+superficie.
+
+### La diferencia
+
+Hoy el juez asigna la tarjeta basándose solo en lo que ocurrió bajo el agua. El
+reglamento requiere que la tarjeta refleje también lo que ocurrió en superficie durante
+los 20 segundos post-emersión. Una performance correcta bajo el agua puede resultar
+en tarjeta roja si el protocolo de superficie falla. Esta brecha afecta directamente al
+flujo principal del juez.
+
+---
+
+## 2. Dos tipos de Black-out con consecuencias distintas (§1.1.10)
+
+### Qué dice el reglamento
+
+El reglamento distingue explícitamente dos situaciones de pérdida de consciencia:
+
+**Black-out en superficie (§1.1.10.2):** el atleta pierde la consciencia después de
+emerger, durante o después del protocolo de superficie. Consecuencias:
+- Descalificado del evento.
+- Debe ser examinado por un médico.
+- El médico **puede autorizar** que compita al día siguiente.
+
+**Black-out bajo el agua (§1.1.10.3):** el atleta pierde la consciencia durante la
+performance, antes de emerger. Consecuencias:
+- Descalificado del evento.
+- **No puede competir al día siguiente** bajo ninguna circunstancia.
+- Solo puede volver a competir el día subsiguiente, y únicamente con aprobación médica.
+
+### Qué hace la aplicación hoy
+
+La aplicación modela un único evento de Black-out (BKO) que siempre resulta en
+tarjeta roja automática. No distingue dónde ocurrió ni registra ningún tipo de
+inhabilitación temporal del atleta para competir en días sucesivos.
+
+### La diferencia
+
+Hay dos diferencias funcionales. La primera es informativa: el registro del BKO debería
+indicar si ocurrió en superficie o bajo el agua, ya que esto cambia la gravedad del
+evento y tiene implicancias médicas. La segunda es operativa: el organizador necesita
+saber si un atleta que sufrió un BKO puede o no inscribirse en las disciplinas del día
+siguiente, lo que hoy no es posible determinar desde la aplicación.
+
+---
+
+## 3. Penalizaciones técnicas generales — más allá de la tarjeta amarilla (§1.1.13)
+
+### Qué dice el reglamento
+
+Una "penalización general" es una sanción que se aplica cuando el atleta comete una
+infracción técnica específica durante la performance, pero que no invalida el intento
+completo. Para las disciplinas dinámicas, la penalización general consiste en restar
+3 metros a la distancia realizada.
+
+Las situaciones que generan penalización general son:
+- **Sin contacto con la pared al iniciar (§2.2.1.4):** el atleta inicia la fase de apnea
+  sin estar tocando la pared de la piscina.
+- **Cuerpo completo fuera del carril (§2.2.2.2):** si todo el cuerpo del atleta sale
+  del carril de competencia (las desviaciones parciales están permitidas).
+- **Asistente no retira a 3 minutos del OT (§2.1.6.2):** si el asistente personal del
+  atleta permanece en la zona de competencia después de la llamada de 3 minutos.
+- **Patada de delfín en evento de bialetas (§1.1.3.3):** en disciplinas con bialetas
+  (DBF), se aplica una penalización general por cada ciclo de patada de delfín
+  realizado fuera de las zonas permitidas (los 3 metros al inicio y en los giros).
+
+Las penalizaciones generales pueden acumularse.
+
+### Qué hace la aplicación hoy
+
+La aplicación conoce la penalización de −3 metros únicamente en el contexto de la
+tarjeta amarilla resuelta como blanca (donde la penalización puede aplicarse como
+parte de la deliberación). No existe una forma de registrar una penalización técnica
+separada de la asignación de tarjeta.
+
+### La diferencia
+
+Hoy la única forma de reflejar una penalización es a través de la tarjeta amarilla,
+que requiere deliberación y puede resultar en blanca o roja. Pero las penalizaciones
+técnicas del reglamento son independientes de la tarjeta: el atleta puede recibir
+tarjeta blanca y aun así tener −3 metros en su distancia final por haber salido del
+carril. Son dos mecanismos distintos que hoy la app trata como uno solo.
+
+---
+
+## 4. Categorías de competencia — sistema completo con Masters (§1.1.7)
+
+### Qué dice el reglamento
+
+Las competencias oficiales organizan a los atletas en categorías por edad y género.
+El sistema de categorías es:
+
+| Categoría | Rango de edad |
+|-----------|--------------|
+| Junior | 15–17 años |
+| Senior | 18–49 años |
+| Masters 50-54 | 50–54 años |
+| Masters 55-59 | 55–59 años |
+| Masters 60-64 | 60–64 años |
+| Masters 65-70 | 65–70 años |
+| Masters 70+ | 70 años o más |
+
+Reglas adicionales:
+- La edad se calcula como: `año de la temporada - año de nacimiento` (no la edad exacta
+  al día de la competencia).
+- Un atleta de categoría Masters puede optar por competir en la categoría Senior.
+  Si en ese contexto bate un récord Masters, el récord se homologa igualmente.
+
+### Qué hace la aplicación hoy
+
+La aplicación registra el género del atleta, pero no implementa el sistema de
+categorías. Los rankings actuales agrupan por disciplina y género, sin distinción de
+categoría etaria.
+
+### La diferencia
+
+En un torneo oficial, los rankings y podios se determinan dentro de cada categoría
+por separado. Un atleta Senior y un atleta Masters 50-54 pueden competir juntos en
+la misma grilla de salida pero se clasifican en tablas distintas. La aplicación hoy
+produce un único ranking por disciplina y género sin esta subdivisión. Tampoco
+gestiona la opción de un atleta Masters de competir en la categoría Senior.
+
+---
+
+## 5. Subdisciplinas de velocidad-resistencia — SPE no es una sola disciplina (§1.1.8.7)
+
+### Qué dice el reglamento
+
+Las disciplinas de velocidad-resistencia no son una sola prueba sino cuatro variantes
+definidas por la distancia total:
+
+| Nombre | Distancia | Tipo |
+|--------|-----------|------|
+| Velocidad 2×50m | 100 m (2 largos de 50m) | Velocidad |
+| Velocidad 4×50m | 200 m (4 largos de 50m) | Velocidad |
+| Resistencia 8×50m | 400 m (8 largos de 50m) | Resistencia |
+| Resistencia 16×50m | 800 m (16 largos de 50m) | Resistencia |
+
+En todas ellas el atleta alterna apnea activa con recuperación pasiva en los extremos
+de la pileta. Los récords se homologan por variante separadamente.
+
+### Qué hace la aplicación hoy
+
+La disciplina `SPE` (velocidad/resistencia) está definida como una sola disciplina,
+sin distinción de variante ni distancia total.
+
+### La diferencia
+
+Un torneo puede incluir, por ejemplo, `2×50m` y `8×50m` como dos eventos distintos,
+cada uno con su propia grilla de salida y su propio ranking. Hoy la aplicación no puede
+representar esto: solo puede tener una instancia de SPE por torneo, y esa instancia no
+especifica cuántos largos son.
+
+---
+
+## 6. Orden de la grilla de salida — regla invertida para velocidad-resistencia (§1.2.4.3)
+
+### Qué dice el reglamento
+
+El orden de salida en competencias de apnea sigue esta regla:
+
+- **DNF, DYN, DBF, STA:** los atletas con menor performance declarada (AP/PB)
+  compiten primero, los de mayor performance al final. Esto es para que los atletas
+  más fuertes compitan al final, cuando el ambiente es más cargado de expectativa.
+- **SPE (velocidad-resistencia):** el orden es **inverso**: primero los de mayor tiempo
+  declarado (más lentos), al final los más rápidos.
+
+La razón de la inversión para SPE es que en esta disciplina el resultado es un tiempo
+(menor es mejor), por lo que la lógica se aplica al revés.
+
+### Qué hace la aplicación hoy
+
+La grilla de salida se genera y puede ordenarse, pero no implementa esta regla de
+ordenamiento automático basado en el tipo de disciplina y el AP declarado.
+
+### La diferencia
+
+En un torneo oficial, la grilla de salida no es arbitraria: tiene un orden definido por
+el reglamento. El organizador puede ajustar el orden, pero el punto de partida debe
+ser el orden reglamentario. Hoy la aplicación no genera ese orden automáticamente.
+
+---
+
+## 7. Protocolo del juez durante la apnea estática — señales táctiles (§3.2.1)
+
+### Qué dice el reglamento
+
+Durante una performance de apnea estática (STA), el atleta permanece inmóvil bajo
+el agua y no hay forma visual de saber si está bien. El reglamento establece un
+protocolo de control de seguridad obligatorio: el juez de superficie debe comunicarse
+con el atleta mediante **contacto táctil** a intervalos específicos calculados desde el
+AP declarado:
+
+- A `AP − 1 minuto`
+- A `AP − 30 segundos`
+- A `AP − 15 segundos`
+- En el momento del `AP`
+- A partir de ahí, cada **15 segundos** si el atleta continúa
+
+El atleta y el juez acuerdan antes del intento la señal y la respuesta esperada. Si el
+atleta no responde a la señal del juez, el juez repite el toque. Si persiste la no
+respuesta, el juez interrumpe el intento y extrae al atleta (BKO).
+
+### Qué hace la aplicación hoy
+
+El flujo del juez para STA es el mismo que para las disciplinas dinámicas: cronómetro
+activo, botón de finalizar, posibilidad de registrar BKO. No existe ninguna guía o
+registro de las señales táctiles obligatorias.
+
+### La diferencia
+
+El protocolo de señales táctiles es una responsabilidad del juez con consecuencias
+de seguridad. La aplicación podría asistir al juez mostrando los momentos en que debe
+contactar al atleta, calculados automáticamente desde el AP declarado. Hoy esa
+información no está disponible en la interfaz durante la performance.
+
+---
+
+## 8. Inicio del cronómetro en apnea estática — momento diferente (§3.1.3.1)
+
+### Qué dice el reglamento
+
+En la disciplina estática (STA), el cronómetro **no arranca en el Tiempo Oficial**.
+Arranca en el momento exacto en que el atleta **sumerge sus vías respiratorias** por
+debajo de la superficie del agua, lo que puede ocurrir en cualquier momento dentro
+de la ventana OT hasta OT+30s.
+
+El resultado (tiempo realizado, RT) es el tiempo efectivo de apnea desde la inmersión
+de vías respiratorias hasta la emersión.
+
+### Qué hace la aplicación hoy
+
+El flujo del juez activa el cronómetro cuando el juez presiona el botón "ATLETA INICIA"
+en el Paso 3, lo que conceptualmente ocurre cuando el atleta se sumerge. Para las
+disciplinas dinámicas esto es equivalente. Para STA, sin embargo, el cronómetro que
+mide el resultado es el de la inmersión de vías respiratorias, no el inicio del movimiento.
+
+### La diferencia
+
+En la práctica el flujo puede ser el mismo si el juez presiona el botón en el momento
+exacto de la inmersión de las vías respiratorias. Pero el reglamento es preciso: el
+resultado de STA se mide desde las vías respiratorias, y el botón actual dice "ATLETA
+INICIA" (que en dinámica significa el inicio del movimiento, no necesariamente de la
+apnea). La distinción es sutil pero relevante para la exactitud del registro.
+
+---
+
+## 9. "Salida en falso" en velocidad-resistencia — nombre y tratamiento específico (§4.2.1.3)
+
+### Qué dice el reglamento
+
+En las disciplinas de velocidad-resistencia (SPE), si un atleta comienza a nadar antes
+de su Tiempo Oficial, el evento se denomina específicamente **"Salida en falso"**
+(False Start). El atleta es descalificado del intento.
+
+En las disciplinas dinámicas, la misma situación se llama simplemente DQ por inicio
+anticipado (§1.2.1.9), sin nombre específico.
+
+### Qué hace la aplicación hoy
+
+La aplicación registra DQ para el caso en que el atleta no inicia dentro de la ventana
+OT+30s. No hay un tipo específico de DQ para el inicio anticipado, ni una etiqueta
+diferenciada para SPE.
+
+### La diferencia
+
+Es principalmente una diferencia de nomenclatura y registro. El reglamento reconoce
+la "Salida en falso" como un resultado específico de SPE. Para el audit log y para
+estadísticas, sería importante distinguir entre "no inició en ventana" (llegó tarde) y
+"inició antes del OT" (salida en falso), ya que son infracciones distintas con causas
+distintas.
+
+---
+
+## 10. Conducta antideportiva — sanciones que trascienden el evento (Anexo FAAS)
+
+### Qué dice el reglamento
+
+El Anexo FAAS establece que la comisión de apnea tiene potestad para sancionar la
+conducta antideportiva con medidas que van más allá de la descalificación del evento.
+Las sanciones pueden incluir:
+
+- Prohibición de competir en fechas futuras del mismo torneo.
+- Prohibición de participar en competencias internacionales.
+
+La sanción puede aplicarse al deportista, al entrenador, o a toda la escuela/club.
+La conducta antideportiva no necesita estar explícitamente detallada en el reglamento
+para ser sancionada.
+
+### Qué hace la aplicación hoy
+
+Las únicas consecuencias que la aplicación puede registrar son las que ocurren dentro
+de una performance: tarjeta blanca, amarilla, roja, DNS, o DQ. No existe ningún
+mecanismo para registrar sanciones que afecten la participación futura del atleta.
+
+### La diferencia
+
+Una sanción por conducta antideportiva afecta al atleta en múltiples torneos y en el
+tiempo. Hoy no hay manera de que el organizador registre este tipo de sanción en la
+plataforma, ni de que el sistema impida la inscripción de un atleta sancionado. Esta
+brecha es principalmente administrativa y de gestión de federación, no de gestión
+de performance individual.
+
+---
+
+## Tabla resumen
+
+| # | Brecha | Artículo | Prioridad funcional |
+|---|--------|----------|-------------------|
+| 1 | Protocolo de superficie — 20s + signo OK post-performance | §1.2.2 | Alta |
+| 2 | Dos tipos de BKO con consecuencias distintas | §1.1.10 | Alta |
+| 3 | Penalizaciones técnicas independientes de la tarjeta | §1.1.13, §2.2.1.4, §2.2.2.2, §2.1.6.2 | Media |
+| 4 | Sistema completo de categorías con Masters | §1.1.7 | Media |
+| 5 | SPE tiene 4 variantes de distancia distintas | §1.1.8.7 | Media |
+| 6 | Orden de grilla por tipo de disciplina (invertido en SPE) | §1.2.4.3 | Media |
+| 7 | Señales táctiles del juez durante STA | §3.2.1.4 | Baja |
+| 8 | Inicio de cronómetro STA — inmersión de vías respiratorias | §3.1.3.1 | Baja |
+| 9 | "Salida en falso" como resultado específico de SPE | §4.2.1.3 | Baja |
+| 10 | Conducta antideportiva — sanciones multi-torneo | Anexo FAAS | Baja |
+
+---
+
+*Análisis realizado sobre: Reglamento CMAS Apnea Indoor Versión 2022/01 — Traducción FAAS*
+*Archivo fuente: `data/datos_prueba/REGLAS INTERNACIONALES APNEA INDOOR FAAS-CMAS Versión 2025.pdf`*

--- a/docs/dominio/06-brechas-reglamento.md
+++ b/docs/dominio/06-brechas-reglamento.md
@@ -19,152 +19,94 @@ Las brechas están agrupadas por tema y ordenadas por impacto funcional.
 
 ---
 
-## 1. Protocolo de Superficie — validación post-performance (§1.2.2)
+## 1. Motivo de la tarjeta roja — CRUD de causas (§1.2.2, §1.1.10, §1.1.14)
 
 ### Qué dice el reglamento
 
-Cuando el atleta termina su performance y sale a la superficie, no basta con que haya
-completado la distancia o el tiempo. El resultado solo es válido si el atleta completa el
-**Protocolo de Superficie** dentro de los 20 segundos posteriores a la emersión. Este
-protocolo consiste en:
-
-1. Mantener la cabeza fuera del agua (vías respiratorias y nivel de las orejas sobre la
-   superficie, de forma continua).
-2. Realizar el **signo OK** convencional de buceo (dos dedos formando un círculo) en
-   dirección al Juez Principal, ubicado en el borde de la pileta.
-3. No recibir ningún tipo de ayuda externa, no apoyarse en la línea del carril ni en ninguna
-   parte del cuerpo de otra persona.
-
-Si el atleta no puede completar este protocolo en 20 segundos, o necesita ayuda durante
-ese período, es descalificado — incluso si la performance en sí fue perfecta. El juez
-tiene hasta 3 minutos para deliberar y mostrar la tarjeta correspondiente.
+Una tarjeta roja puede emitirse por múltiples causas distintas: Black-out, no seguir el
+protocolo de superficie (signo OK, mantener cabeza fuera del agua, no apoyarse en el
+carril), o infracciones técnicas que implican descalificación directa. El reglamento
+trata cada causa como un evento diferente con sus propias consecuencias (por ejemplo,
+el BKO tiene implicancias para los días siguientes del torneo; el fallo de protocolo de
+superficie no).
 
 ### Qué hace la aplicación hoy
 
-El flujo del juez va directamente de "Finalizar Performance" a "Registrar RP" y luego
-a "Asignar Tarjeta". No existe ningún paso entre la finalización de la performance y la
-asignación de la tarjeta que represente la observación y validación del protocolo de
-superficie.
+Cuando el juez asigna tarjeta roja, la aplicación solo registra el resultado final
+(tarjeta roja) sin capturar el motivo. La excepción es el BKO, que tiene su propia
+pantalla dedicada. Las demás causas de descalificación no se distinguen entre sí.
 
-### La diferencia
+### La diferencia — decisión de diseño
 
-Hoy el juez asigna la tarjeta basándose solo en lo que ocurrió bajo el agua. El
-reglamento requiere que la tarjeta refleje también lo que ocurrió en superficie durante
-los 20 segundos post-emersión. Una performance correcta bajo el agua puede resultar
-en tarjeta roja si el protocolo de superficie falla. Esta brecha afecta directamente al
-flujo principal del juez.
+El flujo del juez **no cambia**: se registra la performance, se asigna la tarjeta.
+Lo que se agrega es que al seleccionar tarjeta roja se abre una selección de motivo
+obligatoria con las causas posibles. Las causas son configurables (CRUD) dado que
+el reglamento puede evolucionar o variar según la federación. Causas iniciales:
+
+- Black-out (BKO) — ya existe como flujo separado, se integra aquí
+- No siguió protocolo de superficie
+- Penalización / infracción técnica
+
+Esto convierte el BKO en un motivo de tarjeta roja dentro de un mecanismo unificado,
+en lugar de un flujo paralelo. El registro queda más completo y permite estadísticas
+por causa de descalificación.
 
 ---
 
 ## 2. Dos tipos de Black-out con consecuencias distintas (§1.1.10)
 
-### Qué dice el reglamento
-
-El reglamento distingue explícitamente dos situaciones de pérdida de consciencia:
-
-**Black-out en superficie (§1.1.10.2):** el atleta pierde la consciencia después de
-emerger, durante o después del protocolo de superficie. Consecuencias:
-- Descalificado del evento.
-- Debe ser examinado por un médico.
-- El médico **puede autorizar** que compita al día siguiente.
-
-**Black-out bajo el agua (§1.1.10.3):** el atleta pierde la consciencia durante la
-performance, antes de emerger. Consecuencias:
-- Descalificado del evento.
-- **No puede competir al día siguiente** bajo ninguna circunstancia.
-- Solo puede volver a competir el día subsiguiente, y únicamente con aprobación médica.
-
-### Qué hace la aplicación hoy
-
-La aplicación modela un único evento de Black-out (BKO) que siempre resulta en
-tarjeta roja automática. No distingue dónde ocurrió ni registra ningún tipo de
-inhabilitación temporal del atleta para competir en días sucesivos.
-
-### La diferencia
-
-Hay dos diferencias funcionales. La primera es informativa: el registro del BKO debería
-indicar si ocurrió en superficie o bajo el agua, ya que esto cambia la gravedad del
-evento y tiene implicancias médicas. La segunda es operativa: el organizador necesita
-saber si un atleta que sufrió un BKO puede o no inscribirse en las disciplinas del día
-siguiente, lo que hoy no es posible determinar desde la aplicación.
+> **Decisión:** esta brecha queda resuelta por la brecha #1. Los dos tipos de BKO
+> (superficie y bajo el agua) son motivos de tarjeta roja dentro del CRUD de causas.
+> BKO superficie y BKO subacuático son entradas distintas en esa lista, con sus
+> respectivas descripciones de consecuencias para el organizador.
+> No requiere tratamiento separado.
 
 ---
 
-## 3. Penalizaciones técnicas generales — más allá de la tarjeta amarilla (§1.1.13)
+## 3. Penalizaciones técnicas — concepto de "Tarjeta Blanca con penalizaciones" (§1.1.13)
 
 ### Qué dice el reglamento
 
-Una "penalización general" es una sanción que se aplica cuando el atleta comete una
-infracción técnica específica durante la performance, pero que no invalida el intento
-completo. Para las disciplinas dinámicas, la penalización general consiste en restar
-3 metros a la distancia realizada.
+Una "penalización general" se aplica cuando el atleta comete una infracción técnica
+durante la performance que no invalida el intento pero sí reduce el resultado. Para
+disciplinas dinámicas: −3 metros por infracción. Las penalizaciones se acumulan
+(dos infracciones = −6 metros). Las situaciones que las generan:
 
-Las situaciones que generan penalización general son:
-- **Sin contacto con la pared al iniciar (§2.2.1.4):** el atleta inicia la fase de apnea
-  sin estar tocando la pared de la piscina.
-- **Cuerpo completo fuera del carril (§2.2.2.2):** si todo el cuerpo del atleta sale
-  del carril de competencia (las desviaciones parciales están permitidas).
-- **Asistente no retira a 3 minutos del OT (§2.1.6.2):** si el asistente personal del
-  atleta permanece en la zona de competencia después de la llamada de 3 minutos.
-- **Patada de delfín en evento de bialetas (§1.1.3.3):** en disciplinas con bialetas
-  (DBF), se aplica una penalización general por cada ciclo de patada de delfín
-  realizado fuera de las zonas permitidas (los 3 metros al inicio y en los giros).
-
-Las penalizaciones generales pueden acumularse.
+- Sin contacto con la pared al iniciar (§2.2.1.4)
+- Cuerpo completo fuera del carril (§2.2.2.2)
+- Asistente no retira de la zona a 3 min del OT (§2.1.6.2)
+- Patada de delfín en evento de bialetas — por cada ciclo (§1.1.3.3)
 
 ### Qué hace la aplicación hoy
 
-La aplicación conoce la penalización de −3 metros únicamente en el contexto de la
-tarjeta amarilla resuelta como blanca (donde la penalización puede aplicarse como
-parte de la deliberación). No existe una forma de registrar una penalización técnica
-separada de la asignación de tarjeta.
+El modelo actual tiene tres resultados posibles: Blanca, Amarilla (en revisión) y Roja.
+La penalización de −3m existe solo como parte de la resolución de una tarjeta amarilla.
+No existe el concepto de una performance válida con penalizaciones aplicadas
+directamente por el juez, sin pasar por el proceso de deliberación de la amarilla.
 
-### La diferencia
+### La diferencia — decisión de diseño
 
-Hoy la única forma de reflejar una penalización es a través de la tarjeta amarilla,
-que requiere deliberación y puede resultar en blanca o roja. Pero las penalizaciones
-técnicas del reglamento son independientes de la tarjeta: el atleta puede recibir
-tarjeta blanca y aun así tener −3 metros en su distancia final por haber salido del
-carril. Son dos mecanismos distintos que hoy la app trata como uno solo.
+Se necesita un nuevo resultado: **Tarjeta Blanca con penalizaciones**. Su lógica:
+
+- La performance es válida (el atleta completó el intento y el protocolo de superficie).
+- El juez registra una o más infracciones técnicas al momento de asignar la tarjeta.
+- Cada infracción aplica −3m (dinámica) o el equivalente según la disciplina.
+- El RP final para el ranking = distancia medida − suma de penalizaciones.
+- La tarjeta mostrada al atleta es **Blanca**, pero el registro interno incluye
+  las infracciones y el RP penalizado.
+
+Esto es distinto de la tarjeta amarilla: no hay deliberación, no hay resolución
+posterior. El juez constata la infracción en el momento y la aplica directamente.
+La tarjeta amarilla queda reservada para los casos donde hay duda sobre si el
+resultado es válido o no (requiere revisión por los jueces antes de decidir).
 
 ---
 
 ## 4. Categorías de competencia — sistema completo con Masters (§1.1.7)
 
-### Qué dice el reglamento
-
-Las competencias oficiales organizan a los atletas en categorías por edad y género.
-El sistema de categorías es:
-
-| Categoría | Rango de edad |
-|-----------|--------------|
-| Junior | 15–17 años |
-| Senior | 18–49 años |
-| Masters 50-54 | 50–54 años |
-| Masters 55-59 | 55–59 años |
-| Masters 60-64 | 60–64 años |
-| Masters 65-70 | 65–70 años |
-| Masters 70+ | 70 años o más |
-
-Reglas adicionales:
-- La edad se calcula como: `año de la temporada - año de nacimiento` (no la edad exacta
-  al día de la competencia).
-- Un atleta de categoría Masters puede optar por competir en la categoría Senior.
-  Si en ese contexto bate un récord Masters, el récord se homologa igualmente.
-
-### Qué hace la aplicación hoy
-
-La aplicación registra el género del atleta, pero no implementa el sistema de
-categorías. Los rankings actuales agrupan por disciplina y género, sin distinción de
-categoría etaria.
-
-### La diferencia
-
-En un torneo oficial, los rankings y podios se determinan dentro de cada categoría
-por separado. Un atleta Senior y un atleta Masters 50-54 pueden competir juntos en
-la misma grilla de salida pero se clasifican en tablas distintas. La aplicación hoy
-produce un único ranking por disciplina y género sin esta subdivisión. Tampoco
-gestiona la opción de un atleta Masters de competir en la categoría Senior.
+> **Decisión:** fuera de alcance. No se distinguirán subcategorías Masters por ahora.
+> La aplicación manejará Junior, Senior y Masters como categoría única sin subdivisión
+> etaria. Si en el futuro se necesita, se incorpora como extensión del BC Registro.
 
 ---
 
@@ -175,27 +117,30 @@ gestiona la opción de un atleta Masters de competir en la categoría Senior.
 Las disciplinas de velocidad-resistencia no son una sola prueba sino cuatro variantes
 definidas por la distancia total:
 
-| Nombre | Distancia | Tipo |
-|--------|-----------|------|
-| Velocidad 2×50m | 100 m (2 largos de 50m) | Velocidad |
-| Velocidad 4×50m | 200 m (4 largos de 50m) | Velocidad |
-| Resistencia 8×50m | 400 m (8 largos de 50m) | Resistencia |
-| Resistencia 16×50m | 800 m (16 largos de 50m) | Resistencia |
+| Nombre | Largos | Distancia total | Tipo |
+|--------|--------|-----------------|------|
+| SPE 2×50m | 2 | 100 m | Velocidad |
+| SPE 4×50m | 4 | 200 m | Velocidad |
+| SPE 8×50m | 8 | 400 m | Resistencia |
+| SPE 16×50m | 16 | 800 m | Resistencia |
 
-En todas ellas el atleta alterna apnea activa con recuperación pasiva en los extremos
-de la pileta. Los récords se homologan por variante separadamente.
+En todas el atleta alterna apnea activa con recuperación pasiva en cada extremo.
+El resultado es un tiempo (menor es mejor). Los récords se homologan por variante.
 
 ### Qué hace la aplicación hoy
 
-La disciplina `SPE` (velocidad/resistencia) está definida como una sola disciplina,
-sin distinción de variante ni distancia total.
+La disciplina `SPE` está definida como una sola disciplina sin distinción de variante.
+Un torneo solo puede tener una instancia de SPE, sin especificar cuántos largos son.
 
-### La diferencia
+### La diferencia — decisión de incorporar
 
-Un torneo puede incluir, por ejemplo, `2×50m` y `8×50m` como dos eventos distintos,
-cada uno con su propia grilla de salida y su propio ranking. Hoy la aplicación no puede
-representar esto: solo puede tener una instancia de SPE por torneo, y esa instancia no
-especifica cuántos largos son.
+Se incorporan las cuatro variantes como subdisciplinas de SPE. Cada variante es un
+evento independiente dentro del torneo: tiene su propia grilla de salida, su propio
+ranking y su propio conjunto de performances. Un torneo puede incluir `SPE 2×50m` y
+`SPE 8×50m` simultáneamente como dos eventos distintos.
+
+El modelo de disciplina pasa de `tipo = SPE` a `tipo = SPE, variante = 2x50 | 4x50 | 8x50 | 16x50`.
+El resultado de SPE siempre es un tiempo, no una distancia.
 
 ---
 
@@ -216,49 +161,27 @@ La razón de la inversión para SPE es que en esta disciplina el resultado es un
 
 ### Qué hace la aplicación hoy
 
-La grilla de salida se genera y puede ordenarse, pero no implementa esta regla de
-ordenamiento automático basado en el tipo de disciplina y el AP declarado.
+La grilla de salida se genera y puede ordenarse, pero no implementa la regla de
+ordenamiento automático basada en el tipo de disciplina y el AP declarado.
 
-### La diferencia
+### La diferencia — decisión de incorporar
 
-En un torneo oficial, la grilla de salida no es arbitraria: tiene un orden definido por
-el reglamento. El organizador puede ajustar el orden, pero el punto de partida debe
-ser el orden reglamentario. Hoy la aplicación no genera ese orden automáticamente.
+La generación de la grilla debe aplicar el orden reglamentario como punto de partida:
+
+- **DNF, DYN, DBF, STA:** orden ascendente por AP — menor performance declarada
+  primero, mayor al final.
+- **SPE (todas las variantes):** orden descendente por AP — mayor tiempo declarado
+  primero (los más lentos), menor tiempo al final (los más rápidos).
+
+El organizador puede ajustar el orden manualmente después de la generación, pero
+el orden inicial que produce el sistema debe cumplir el reglamento.
 
 ---
 
 ## 7. Protocolo del juez durante la apnea estática — señales táctiles (§3.2.1)
 
-### Qué dice el reglamento
-
-Durante una performance de apnea estática (STA), el atleta permanece inmóvil bajo
-el agua y no hay forma visual de saber si está bien. El reglamento establece un
-protocolo de control de seguridad obligatorio: el juez de superficie debe comunicarse
-con el atleta mediante **contacto táctil** a intervalos específicos calculados desde el
-AP declarado:
-
-- A `AP − 1 minuto`
-- A `AP − 30 segundos`
-- A `AP − 15 segundos`
-- En el momento del `AP`
-- A partir de ahí, cada **15 segundos** si el atleta continúa
-
-El atleta y el juez acuerdan antes del intento la señal y la respuesta esperada. Si el
-atleta no responde a la señal del juez, el juez repite el toque. Si persiste la no
-respuesta, el juez interrumpe el intento y extrae al atleta (BKO).
-
-### Qué hace la aplicación hoy
-
-El flujo del juez para STA es el mismo que para las disciplinas dinámicas: cronómetro
-activo, botón de finalizar, posibilidad de registrar BKO. No existe ninguna guía o
-registro de las señales táctiles obligatorias.
-
-### La diferencia
-
-El protocolo de señales táctiles es una responsabilidad del juez con consecuencias
-de seguridad. La aplicación podría asistir al juez mostrando los momentos en que debe
-contactar al atleta, calculados automáticamente desde el AP declarado. Hoy esa
-información no está disponible en la interfaz durante la performance.
+> **Decisión:** fuera de alcance. Las señales táctiles son responsabilidad operativa
+> del juez y no se registran en la aplicación.
 
 ---
 
@@ -281,13 +204,17 @@ en el Paso 3, lo que conceptualmente ocurre cuando el atleta se sumerge. Para la
 disciplinas dinámicas esto es equivalente. Para STA, sin embargo, el cronómetro que
 mide el resultado es el de la inmersión de vías respiratorias, no el inicio del movimiento.
 
-### La diferencia
+### La diferencia — decisión de incorporar
 
-En la práctica el flujo puede ser el mismo si el juez presiona el botón en el momento
-exacto de la inmersión de las vías respiratorias. Pero el reglamento es preciso: el
-resultado de STA se mide desde las vías respiratorias, y el botón actual dice "ATLETA
-INICIA" (que en dinámica significa el inicio del movimiento, no necesariamente de la
-apnea). La distinción es sutil pero relevante para la exactitud del registro.
+El flujo del Paso 3 en STA debe diferenciarse del flujo dinámico. En dinámica,
+"ATLETA INICIA" marca el momento en que el atleta se desplaza. En STA, el botón
+equivalente debe llamarse **"VÍAS RESPIRATORIAS EN AGUA"** y el cronómetro
+que arranca en ese momento es el que determina el RT oficial.
+
+El Paso 3 detecta la disciplina y muestra la etiqueta correcta. El resultado registrado
+es el tiempo entre ese toque y el momento en que el juez presiona "FINALIZAR"
+(cuando las vías respiratorias emergen). La ventana OT+30s aplica igual que en
+dinámica para determinar si el inicio es válido.
 
 ---
 
@@ -308,44 +235,19 @@ La aplicación registra DQ para el caso en que el atleta no inicia dentro de la 
 OT+30s. No hay un tipo específico de DQ para el inicio anticipado, ni una etiqueta
 diferenciada para SPE.
 
-### La diferencia
+### La diferencia — decisión de incorporar
 
-Es principalmente una diferencia de nomenclatura y registro. El reglamento reconoce
-la "Salida en falso" como un resultado específico de SPE. Para el audit log y para
-estadísticas, sería importante distinguir entre "no inició en ventana" (llegó tarde) y
-"inició antes del OT" (salida en falso), ya que son infracciones distintas con causas
-distintas.
+"Salida en falso" es un motivo de tarjeta roja dentro del CRUD de causas definido
+en la brecha #1. Se incorpora como motivo específico de descalificación, disponible
+para todas las disciplinas (aunque en SPE tiene nombre propio reglamentario).
+Junto con "No inició en ventana OT+30s", cubren los dos tipos de DQ por problema
+en el inicio.
 
 ---
 
 ## 10. Conducta antideportiva — sanciones que trascienden el evento (Anexo FAAS)
 
-### Qué dice el reglamento
-
-El Anexo FAAS establece que la comisión de apnea tiene potestad para sancionar la
-conducta antideportiva con medidas que van más allá de la descalificación del evento.
-Las sanciones pueden incluir:
-
-- Prohibición de competir en fechas futuras del mismo torneo.
-- Prohibición de participar en competencias internacionales.
-
-La sanción puede aplicarse al deportista, al entrenador, o a toda la escuela/club.
-La conducta antideportiva no necesita estar explícitamente detallada en el reglamento
-para ser sancionada.
-
-### Qué hace la aplicación hoy
-
-Las únicas consecuencias que la aplicación puede registrar son las que ocurren dentro
-de una performance: tarjeta blanca, amarilla, roja, DNS, o DQ. No existe ningún
-mecanismo para registrar sanciones que afecten la participación futura del atleta.
-
-### La diferencia
-
-Una sanción por conducta antideportiva afecta al atleta en múltiples torneos y en el
-tiempo. Hoy no hay manera de que el organizador registre este tipo de sanción en la
-plataforma, ni de que el sistema impida la inscripción de un atleta sancionado. Esta
-brecha es principalmente administrativa y de gestión de federación, no de gestión
-de performance individual.
+> **Decisión:** fuera de alcance por ahora. Es gestión de federación, no de torneo.
 
 ---
 
@@ -353,16 +255,16 @@ de performance individual.
 
 | # | Brecha | Artículo | Prioridad funcional |
 |---|--------|----------|-------------------|
-| 1 | Protocolo de superficie — 20s + signo OK post-performance | §1.2.2 | Alta |
-| 2 | Dos tipos de BKO con consecuencias distintas | §1.1.10 | Alta |
-| 3 | Penalizaciones técnicas independientes de la tarjeta | §1.1.13, §2.2.1.4, §2.2.2.2, §2.1.6.2 | Media |
-| 4 | Sistema completo de categorías con Masters | §1.1.7 | Media |
-| 5 | SPE tiene 4 variantes de distancia distintas | §1.1.8.7 | Media |
-| 6 | Orden de grilla por tipo de disciplina (invertido en SPE) | §1.2.4.3 | Media |
-| 7 | Señales táctiles del juez durante STA | §3.2.1.4 | Baja |
-| 8 | Inicio de cronómetro STA — inmersión de vías respiratorias | §3.1.3.1 | Baja |
-| 9 | "Salida en falso" como resultado específico de SPE | §4.2.1.3 | Baja |
-| 10 | Conducta antideportiva — sanciones multi-torneo | Anexo FAAS | Baja |
+| 1 | Motivo de tarjeta roja — CRUD de causas (BKO, protocolo, infracción) | §1.2.2, §1.1.10 | Alta |
+| 2 | Dos tipos de BKO — resuelto por brecha #1 (motivos de tarjeta roja) | §1.1.10 | — |
+| 3 | Tarjeta Blanca con penalizaciones — nuevo resultado con RP reducido | §1.1.13, §2.2.1.4, §2.2.2.2 | Alta |
+| 4 | Categorías Masters — fuera de alcance por ahora | §1.1.7 | — |
+| 5 | Subdisciplinas SPE — 4 variantes (2×50, 4×50, 8×50, 16×50) — incorporar | §1.1.8.7 | Media |
+| 6 | Orden de grilla reglamentario por tipo de disciplina — incorporar | §1.2.4.3 | Media |
+| 7 | Señales táctiles STA — fuera de alcance | §3.2.1.4 | — |
+| 8 | Inicio cronómetro STA — botón "Vías respiratorias en agua" — incorporar | §3.1.3.1 | Baja |
+| 9 | Salida en falso — motivo de tarjeta roja, resuelto por brecha #1 | §4.2.1.3 | — |
+| 10 | Conducta antideportiva — fuera de alcance | Anexo FAAS | — |
 
 ---
 

--- a/docs/plans/sp4/PLAN-SP4.md
+++ b/docs/plans/sp4/PLAN-SP4.md
@@ -27,9 +27,10 @@ notificaciones email en los momentos clave.
 
 | BC | Tipo | Novedad en SP4 |
 |----|------|----------------|
-| **Competencia** | Core / ES | Extensión — auditoría visible via API + hash SHA-256 al cierre de disciplina |
+| **Competencia** | Core / ES | Extensión — motivos tarjeta roja, tarjeta blanca con penalizaciones, orden de grilla, auditoría + hash SHA-256 |
+| **Torneo** | Supporting / CRUD | Extensión — subdisciplinas SPE (variante) |
+| **Resultados** | Supporting / CRUD | Extensión — RP penalizado, ranking por variante SPE, exportación CSV/JSON |
 | **Notificaciones** | Generic / ES | **Nuevo** — primera implementación real: aggregate + event store + email |
-| **Resultados** | Supporting / CRUD | Extensión — endpoint exportación CSV/JSON |
 | **Frontend** | React PWA | **Nuevo** — creación desde cero con Vite |
 
 ---
@@ -67,7 +68,33 @@ antes de escribir una línea de frontend.
 
 ---
 
-### INC-4.1 — Fundación Frontend
+### INC-4.1 — Correcciones de dominio por reglamento CMAS/FAAS
+
+**Prerequisito:** INC-4.0 aprobado.
+**DoD:** el dominio refleja el reglamento oficial en los puntos identificados. Cero regresiones
+en los 785 tests existentes. Las nuevas reglas tienen cobertura de tests unitarios ≥ 90%.
+
+> Este incremento es backend puro — no toca el frontend. Debe completarse antes de INC-4.3
+> (Interfaz del Juez) para que el frontend se construya sobre el modelo correcto.
+> Fuente: `docs/dominio/06-brechas-reglamento.md`
+
+| US | Descripción | BC afectado |
+|----|-------------|-------------|
+| US-4.1.1 | Motivos de tarjeta roja — CRUD de causas de descalificación (BKO superficie, BKO subacuático, no siguió protocolo, infracción técnica, no inició en ventana, salida en falso) | `competencia/domain/` |
+| US-4.1.2 | Tarjeta Blanca con penalizaciones — nuevo resultado: performance válida con infracciones técnicas; RP final = medido − N×3m; las penalizaciones se acumulan | `competencia/domain/`, `resultados/domain/` |
+| US-4.1.3 | Subdisciplinas SPE — cuatro variantes (2×50m, 4×50m, 8×50m, 16×50m); la disciplina SPE pasa a tener atributo `variante`; cada variante tiene su propia grilla y ranking | `torneo/domain/`, `resultados/domain/` |
+| US-4.1.4 | Orden de grilla reglamentario — generación de grilla con ordenamiento por AP ascendente (DNF/DYN/DBF/STA) o descendente (SPE); el organizador puede ajustar manualmente después | `competencia/domain/` |
+
+**Documentos a actualizar al cerrar INC-4.1:**
+- `docs/design/domain-model.md` — nuevos conceptos: motivos de tarjeta roja, tarjeta blanca con penalizaciones, variante SPE
+- `docs/design/event-storming-competencia.md` — nuevos eventos y comandos derivados de las correcciones
+- `CLAUDE.md §8` — lenguaje ubicuo: agregar términos Tarjeta Blanca con Penalizaciones, Motivo de DQ, Variante SPE
+- `docs/traceability/matrix.md` — registrar US-4.1.1 a US-4.1.4
+- ADR nuevo si alguna decisión de diseño lo amerita (ej: modelo de penalizaciones acumulables)
+
+---
+
+### INC-4.2 — Fundación Frontend
 
 **DoD:** la aplicación React PWA levanta, conecta con el backend existente, y muestra
 un health-check visual. La estructura de carpetas está establecida (BC-first o por feature
@@ -75,12 +102,12 @@ un health-check visual. La estructura de carpetas está establecida (BC-first o 
 
 | US | Descripción |
 |----|-------------|
-| US-4.1.1 | Scaffold Vite + React + PWA — estructura, routing base, health-check visual conectado a `GET /health` |
-| US-4.1.2 | Autenticación en frontend — login JWT, contexto de usuario, rutas protegidas por rol |
+| US-4.2.1 | Scaffold Vite + React + PWA — estructura, routing base, health-check visual conectado a `GET /health` |
+| US-4.2.2 | Autenticación en frontend — login JWT, contexto de usuario, rutas protegidas por rol |
 
 ---
 
-### INC-4.2 — Interfaz del Juez
+### INC-4.3 — Interfaz del Juez
 
 **DoD:** el juez puede ejecutar el flujo completo (6 pasos: Llamar → Confirmar → Iniciar →
 Finalizar → Registrar marca → Asignar tarjeta) desde la PWA en el celular, con los datos
@@ -89,14 +116,15 @@ contraste, máximo 6 toques por performance (AC-US-02, AC-US-03).
 
 | US | Descripción |
 |----|-------------|
-| US-4.2.1 | Pantalla de selección de competencia — juez ve sus disciplinas asignadas |
-| US-4.2.2 | Flujo de performance — los 6 pasos conectados al backend (AP, llamar, confirmar, resultado, tarjeta) |
-| US-4.2.3 | Casos alternativos — DNS y black-out desde la UI |
-| US-4.2.4 | Tarjeta amarilla como estado de revisión — flujo `Amarilla → Blanca\|Roja` + invariante cierre |
+| US-4.3.1 | Pantalla de selección de competencia — juez ve sus disciplinas asignadas |
+| US-4.3.2 | Flujo de performance — los 6 pasos conectados al backend (AP, llamar, confirmar, resultado, tarjeta) |
+| US-4.3.3 | Casos alternativos — DNS, motivos de tarjeta roja y tarjeta blanca con penalizaciones desde la UI |
+| US-4.3.4 | Tarjeta amarilla como estado de revisión — flujo `Amarilla → Blanca\|Roja` + invariante cierre |
+| US-4.3.5 | Adaptación STA — Paso 3 muestra botón "Vías respiratorias en agua" en lugar de "Atleta inicia"; cronómetro arranca en ese momento |
 
 ---
 
-### INC-4.3 — Offline-first
+### INC-4.4 — Offline-first
 
 **DoD:** el juez puede poner el celular en modo avión, registrar 5 performances, reconectar,
 y verificar que se sincronizaron al servidor. Un indicador visible muestra el estado de
@@ -104,13 +132,13 @@ conexión. Los datos persistidos en IndexedDB sobreviven un cierre del navegador
 
 | US | Descripción |
 |----|-------------|
-| US-4.3.1 | Service Worker + pre-carga — al abrir una disciplina se pre-cargan grilla, atletas y reglas en IndexedDB |
-| US-4.3.2 | Operación offline — el flujo de los 6 pasos funciona sin conexión (eventos locales en IndexedDB) |
-| US-4.3.3 | Sincronización — Background Sync API envía eventos locales al reconectar; indicador de conexión |
+| US-4.4.1 | Service Worker + pre-carga — al abrir una disciplina se pre-cargan grilla, atletas y reglas en IndexedDB |
+| US-4.4.2 | Operación offline — el flujo de los 6 pasos funciona sin conexión (eventos locales en IndexedDB) |
+| US-4.4.3 | Sincronización — Background Sync API envía eventos locales al reconectar; indicador de conexión |
 
 ---
 
-### INC-4.4 — BC Notificaciones
+### INC-4.5 — BC Notificaciones
 
 **DoD:** al confirmar la inscripción de un atleta se envía un email real a una dirección
 de prueba. El aggregate `Notificacion` tiene event store funcional. La idempotencia
@@ -118,14 +146,14 @@ exactly-once está verificada por test: un mismo evento fuente no dispara dos em
 
 | US | Descripción | BC afectado |
 |----|-------------|-------------|
-| US-4.4.1 | Aggregate `Notificacion` — ciclo de vida (Solicitada → Enviada / Fallida), event store, idempotencia | `notificaciones/domain/` |
-| US-4.4.2 | Adaptador email — integración con servicio gestionado (SendGrid / SES / Resend), puerto + adaptador | `notificaciones/infrastructure/` |
-| US-4.4.3 | Política P-10 — `InscripcionConfirmada` (Registro) → `SolicitarNotificacion` → email al atleta | `src/app.py`, `notificaciones/application/` |
-| US-4.4.4 | Política P-11 — `ResultadosPublicados` (Resultados) → email a atletas de esa disciplina | `src/app.py`, `notificaciones/application/` |
+| US-4.5.1 | Aggregate `Notificacion` — ciclo de vida (Solicitada → Enviada / Fallida), event store, idempotencia | `notificaciones/domain/` |
+| US-4.5.2 | Adaptador email — integración con servicio gestionado (SendGrid / SES / Resend), puerto + adaptador | `notificaciones/infrastructure/` |
+| US-4.5.3 | Política P-10 — `InscripcionConfirmada` (Registro) → `SolicitarNotificacion` → email al atleta | `src/app.py`, `notificaciones/application/` |
+| US-4.5.4 | Política P-11 — `ResultadosPublicados` (Resultados) → email a atletas de esa disciplina | `src/app.py`, `notificaciones/application/` |
 
 ---
 
-### INC-4.5 — Auditoría y Exportación
+### INC-4.6 — Auditoría y Exportación
 
 **DoD:** el organizador puede ver la traza completa de eventos de cualquier performance
 desde la UI. Al cerrar una disciplina se calcula y persiste el hash SHA-256 de todos
@@ -133,10 +161,10 @@ sus eventos. La exportación CSV/JSON de resultados funciona y descarga un archi
 
 | US | Descripción | BC afectado |
 |----|-------------|-------------|
-| US-4.5.1 | API de auditoría — `GET /competencias/{id}/performances/{pid}/audit-log` devuelve secuencia de eventos | `competencia/api/` |
-| US-4.5.2 | Hash SHA-256 al cierre — al ejecutar `CerrarCompetencia`, calcular y persistir hash de todos los eventos | `competencia/domain/`, `competencia/infrastructure/` |
-| US-4.5.3 | UI auditoría — pantalla del organizador: traza de eventos por performance, hash de disciplina cerrada | `frontend/` |
-| US-4.5.4 | Exportación — `GET /resultados/{torneo_id}/export?format=csv|json` descarga resultados completos | `resultados/api/` |
+| US-4.6.1 | API de auditoría — `GET /competencias/{id}/performances/{pid}/audit-log` devuelve secuencia de eventos | `competencia/api/` |
+| US-4.6.2 | Hash SHA-256 al cierre — al ejecutar `CerrarCompetencia`, calcular y persistir hash de todos los eventos | `competencia/domain/`, `competencia/infrastructure/` |
+| US-4.6.3 | UI auditoría — pantalla del organizador: traza de eventos por performance, hash de disciplina cerrada | `frontend/` |
+| US-4.6.4 | Exportación — `GET /resultados/{torneo_id}/export?format=csv|json` descarga resultados completos | `resultados/api/` |
 
 ---
 
@@ -144,14 +172,16 @@ sus eventos. La exportación CSV/JSON de resultados funciona y descarga un archi
 
 ```
 INC-4.0 (UX Design)
-  └── INC-4.1 (Fundación Frontend)
-        └── INC-4.2 (Interfaz del Juez)   ← prerequisito: tooling /implement-us
-              └── INC-4.3 (Offline-first)
-  INC-4.4 (Notificaciones)               ← independiente del frontend, paralelo a INC-4.2/4.3
-  INC-4.5 (Auditoría)                    ← depende de INC-4.1 (UI) e INC-4.2 (backend)
+  ├── INC-4.1 (Correcciones dominio)      ← backend puro, prerequisito de INC-4.3
+  └── INC-4.2 (Fundación Frontend)        ← prerequisito: tooling /implement-us
+        └── INC-4.3 (Interfaz del Juez)   ← requiere INC-4.1 + INC-4.2
+              └── INC-4.4 (Offline-first)
+  INC-4.5 (Notificaciones)               ← independiente del frontend, paralelo a INC-4.3/4.4
+  INC-4.6 (Auditoría)                    ← depende de INC-4.2 (UI) e INC-4.3 (backend)
 ```
 
-> INC-4.4 puede ejecutarse en paralelo con INC-4.2/4.3 — es backend puro.
+> INC-4.1 e INC-4.2 pueden ejecutarse en paralelo — son independientes entre sí.
+> INC-4.5 puede ejecutarse en paralelo con INC-4.3/4.4 — es backend puro.
 
 ---
 
@@ -227,7 +257,7 @@ Al ejecutar `CerrarCompetencia`, el command handler:
 ## DoD de Cierre (BL-004)
 
 - [ ] `pytest tests/` — 100% pass
-- [ ] Flujo E2E frontend: login juez → seleccionar disciplina → registrar 3 performances → ver ranking
+- [ ] Flujo E2E frontend: login juez → seleccionar disciplina → registrar 3 performances (con y sin penalizaciones) → ver ranking
 - [ ] Offline verificado: modo avión → 3 performances → reconectar → sincronización confirmada
 - [ ] Email enviado realmente a dirección de prueba al confirmar inscripción
 - [ ] `designreviewer src/` — cero CRITICAL


### PR DESCRIPTION
## Resumen

- Paquete UX completo para SP4: wireframes + prototipos HTML navegables para todos los roles (juez, organizador, atleta, registro/roles, setup de torneo)
- Análisis de brechas reglamento CMAS/FAAS v2022/01 → 10 brechas, decisiones tomadas, INC-4.1 planificado
- Decisiones de stack frontend formalizadas (Vite + React + TypeScript + Zustand + TanStack Query + shadcn/ui + Dexie.js)

## Artefactos incluidos

**Specs (input para `/implement-us`):**
- `flujos-por-rol.md` — flujos juez / organizador / atleta
- `wireframes-juez.md` — 6 pasos + BKO + DNS + offline (mobile-first, ≤6 toques)
- `wireframes-organizador.md` — panel en vivo: dashboard, grilla, amarillas, resultados, jueces, audit log
- `wireframes-atleta.md` — portal mobile: torneos, inscripción, AP, grilla, resultados
- `wireframes-registro-roles.md` — onboarding, perfil multirol, notificaciones, invitaciones de juez
- `wireframes-setup-torneo.md` — preparación del torneo: disciplinas, grilla, asignación de jueces
- `decisiones-frontend.md` — 8 decisiones técnicas con justificación y alternativas descartadas
- `decisiones-registro-usuario.md` — 7 decisiones de diseño (rol juez por invitación, multirol por torneo, etc.)

**Prototipos HTML navegables:**
- `prototipo-juez.html`, `prototipo-organizador.html`, `prototipo-atleta.html`
- `prototipo-registro-roles.html`, `prototipo-setup-torneo.html`

**Dominio:**
- `docs/dominio/06-brechas-reglamento.md` — 10 brechas CMAS/FAAS con decisiones (incorporar / fuera de alcance)
- `docs/plans/sp4/PLAN-SP4.md` — INC-4.1 nuevo (correcciones dominio), INCs renumerados 4.1→4.6

## DoD

- [x] Todos los artefactos comprometidos en `docs/design/ux/` presentes
- [x] Aprobados por Victor
- [x] No hay código de frontend — INC-4.0 produce solo especificaciones

## Test plan

- No aplica — incremento documental puro
- Los wireframes son el input de INC-4.2 (`/implement-us US-4.2.1`, `US-4.2.2`)
- INC-4.1 (backend CMAS/FAAS) puede iniciarse en paralelo desde `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)