### PR TITLE
US-4.3.2: Flujo de performance conectado al backend

### DIFF
--- a/.claude/tracking/US-4.3.2-tracking.json
+++ b/.claude/tracking/US-4.3.2-tracking.json
@@ -1,0 +1,72 @@
+{
+  "metadata": {
+    "us_id": "US-4.3.2",
+    "us_title": "Flujo de performance — los 6 pasos conectados al backend",
+    "us_points": 5,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-11T18:45:11.241921+00:00",
+    "completed_at": "2026-04-11T19:07:12.687813+00:00",
+    "total_elapsed_seconds": 1321,
+    "effective_seconds": 1321,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-11T18:46:28.391875+00:00",
+      "completed_at": "2026-04-11T18:47:17.578806+00:00",
+      "elapsed_seconds": 49,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-11T18:47:29.718270+00:00",
+      "completed_at": "2026-04-11T18:50:33.003777+00:00",
+      "elapsed_seconds": 183,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-11T18:50:34.248966+00:00",
+      "completed_at": "2026-04-11T18:53:20.992782+00:00",
+      "elapsed_seconds": 166,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-11T18:53:22.572742+00:00",
+      "completed_at": "2026-04-11T19:07:12.683758+00:00",
+      "elapsed_seconds": 830,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 4,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/plans/sp4/US-4.3.2-plan.md
+++ b/docs/plans/sp4/US-4.3.2-plan.md
@@ -1,0 +1,121 @@
+# Plan de Implementación: US-4.3.2 — Flujo de performance
+
+**Patrón:** Full-stack React + FastAPI
+**Producto:** frontend + competencia
+**Estimación Total:** 4h 30min
+**BDD:** validación manual UI sobre `tests/features/US-4.3.2-flujo-performance.feature`
+
+> **Ajuste al código real del repo:** la spec usa nombres de campos y contratos
+> algo distintos de los commands existentes. El plan toma como fuente de verdad
+> los handlers reales en `src/competencia/application/commands/`.
+
+---
+
+## Componentes a Implementar
+
+### 1. Backend API — endpoints del juez (55 min)
+
+- [ ] `src/competencia/api/router.py` (35 min)
+  - `POST /competencia/{competencia_id}/llamar`
+  - `POST /competencia/{competencia_id}/registrar-resultado`
+  - `POST /competencia/{competencia_id}/asignar-tarjeta`
+  - usar `JuezDep`
+  - extraer `sub` / `email` desde JWT para `juez_id` y `registrado_por`
+- [ ] schemas HTTP del router (20 min)
+  - body para llamar
+  - body para registrar resultado
+  - body para asignar tarjeta
+  - mapping correcto a `TipoTarjeta`, `UnidadMedida` y `MotivoDQ? = None`
+
+### 2. Frontend API clients (25 min)
+
+- [ ] `frontend/src/api/competencia.ts` (25 min)
+  - `fetchGrilla(competenciaId, disciplina)`
+  - `fetchPerformanceActual(competenciaId)`
+  - `callAtleta(...)`
+  - `registrarResultado(...)`
+  - `asignarTarjeta(...)`
+
+### 3. Store de competencia y navegación interna (20 min)
+
+- [ ] `frontend/src/stores/useCompetenciaStore.ts` (20 min)
+  - agregar `atletaActivo`
+  - agregar `setAtletaActivo` / `limpiarAtletaActivo`
+
+### 4. Grilla del juez real (45 min)
+
+- [ ] `frontend/src/pages/juez/GrillaPage.tsx` (45 min)
+  - reemplazar stub por vista S-02
+  - cargar grilla desde backend
+  - combinar con `performance actual` para destacar SIGUIENTE / EN CURSO
+  - tap en fila disponible abre wizard de pasos
+
+### 5. Componentes de flujo (75 min)
+
+- [ ] `frontend/src/components/juez/StepIndicator.tsx` (10 min)
+- [ ] `frontend/src/components/juez/AtletaCard.tsx` (10 min)
+- [ ] `frontend/src/components/juez/RpSelector.tsx` (20 min)
+- [ ] `frontend/src/pages/juez/PerformanceFlowPage.tsx` (35 min)
+  - pasos 1 a 6
+  - paso 2 y 3 con estado local
+  - cronómetro local simple en paso 4
+
+### 6. Routing e integración (15 min)
+
+- [ ] `frontend/src/App.tsx` (15 min)
+  - ruta protegida `/juez/performance`
+
+### 7. Validación técnica (25 min)
+
+- [ ] tests focalizados backend de router / handlers impactados (15 min)
+- [ ] `frontend`: `npm run build` (5 min)
+- [ ] `frontend`: `npm run lint` (5 min)
+
+### 8. Validación manual UI (30 min)
+
+- [ ] flujo feliz completo hasta tarjeta blanca
+- [ ] botón de confirmar marca deshabilitado sin RP
+- [ ] error backend 409 visible inline
+- [ ] regreso a grilla luego de completar performance
+
+---
+
+## Decisiones de implementación
+
+1. **No introducir ACL con Registro en esta US.**
+   La UI puede operar con nombres sintéticos ya proyectados por `competencia`
+   (`Atleta-xxxxxxxx`) para no abrir scope nuevo cross-BC.
+
+2. **Paso 2 y Paso 3 son local-first.**
+   Confirmar presencia, OT y cronómetro se resuelven en frontend.
+   Los POST reales ocurren en:
+   - Paso 1: llamar atleta
+   - Paso 5: registrar resultado
+   - Paso 6: asignar tarjeta
+
+3. **La grilla visible se arma con datos actuales disponibles.**
+   - `GET /competencia/{id}/grilla`
+   - `GET /competencia/{id}/performance/actual`
+   - si hace falta enriquecer estado visible, se evaluará extender query o
+     derivarlo en frontend con el mínimo cambio posible.
+
+4. **Scope de tarjeta en esta US:**
+   solo `Blanca` y `Roja`.
+   Penalizaciones y `Amarilla` quedan fuera hasta `US-4.3.3` y `US-4.3.4`.
+
+---
+
+## Riesgos concretos
+
+- El endpoint actual de grilla no trae estado semántico rico por fila.
+- Los bodies HTTP deben mapear con precisión a enums del dominio.
+- El wizard mobile puede crecer rápido si se intenta resolver diseño final y
+  edge cases en la misma pasada.
+
+---
+
+## Estado
+
+**Estado:** 0/13 tareas completadas
+
+*Plan generado: 2026-04-11 — US-4.3.2 INC-4.3 SP4*

--- a/docs/reports/US-4.3.2-context.md
+++ b/docs/reports/US-4.3.2-context.md
@@ -1,0 +1,75 @@
+# Contexto Validado — US-4.3.2
+
+| Campo | Valor |
+|-------|-------|
+| **US** | `US-4.3.2` — Flujo de performance — los 6 pasos conectados al backend |
+| **Producto** | `frontend` + `competencia` |
+| **Sprint** | SP4 |
+| **Incremento** | INC-4.3 |
+| **Puntos** | 5 (default operativo para tracking) |
+| **Fecha** | 2026-04-11 |
+
+---
+
+## Resultado de Fase 0
+
+La US está lista para avanzar a BDD y planificación, con varios ajustes que
+deben respetar el código real del repo.
+
+### Backend existente confirmado
+
+- Los handlers ya existen:
+  - `LlamarAtletaHandler`
+  - `RegistrarResultadoHandler`
+  - `AsignarTarjetaHandler`
+- El router `src/competencia/api/router.py` **todavía no** expone:
+  - `POST /competencia/{id}/llamar`
+  - `POST /competencia/{id}/registrar-resultado`
+  - `POST /competencia/{id}/asignar-tarjeta`
+- `JuezDep` ya existe y puede reutilizarse para autenticar esos endpoints.
+
+### Frontend existente confirmado
+
+- `US-4.3.1` ya dejó:
+  - `GrillaPage` stub
+  - `useCompetenciaStore`
+  - selección de `torneoId`, `competenciaId`, `disciplinaActiva`
+- `frontend` usa React + Zustand + TanStack Query + Vite proxy.
+
+### Hallazgos relevantes para el plan
+
+1. **La spec no coincide 1:1 con los commands reales del backend**
+   - `AsignarTarjetaCommand` usa `tipo: TipoTarjeta`, no `tarjeta`
+   - `registrado_por` / `asignada_por` puede salir del JWT server-side
+   - `UnidadMedida` y `TipoTarjeta` tienen valores concretos que deben reflejarse
+     en los schemas HTTP
+
+2. **La grilla del juez aún es stub**
+   `US-4.3.2` no es solo wizard de pasos; también tiene que reemplazar
+   `GrillaPage` por una pantalla funcional para seleccionar atleta y ver estado.
+
+3. **Esta US toca dos capas reales**
+   - backend API en `competencia/api/router.py`
+   - frontend juez en `frontend/src/pages/juez/`
+
+### Quality gates aplicables
+
+- backend / repo:
+  - tests focalizados de `competencia/api` y flujo impactado
+  - `pytest` puntual donde haya cobertura útil
+- frontend:
+  - `npm run build`
+  - `npm run lint`
+- validación funcional:
+  - manual UI con backend corriendo
+
+---
+
+## Conclusión
+
+`US-4.3.2` puede continuar con:
+
+1. feature BDD revisado contra contratos reales,
+2. plan de implementación full-stack,
+3. aprobación de Fase 2,
+4. implementación.

--- a/docs/reports/US-4.3.2-report.md
+++ b/docs/reports/US-4.3.2-report.md
@@ -1,0 +1,81 @@
+# Reporte de Implementación: US-4.3.2
+
+**US:** US-4.3.2 — Flujo de performance — los 6 pasos conectados al backend
+**Incremento:** INC-4.3
+**Sprint:** SP4 — La Plataforma
+**Fecha:** 2026-04-11
+**Branch:** `feature/US-4.3.2-flujo-performance`
+
+---
+
+## Resumen de Implementación
+
+### Artefactos creados
+
+| Artefacto | Path | Descripción |
+|-----------|------|-------------|
+| Componente | `frontend/src/components/juez/StepIndicator.tsx` | indicador visual de 6 pasos |
+| Componente | `frontend/src/components/juez/AtletaCard.tsx` | resumen de atleta, AP, OT y andarivel |
+| Componente | `frontend/src/components/juez/RpSelector.tsx` | selector de RP metros + centimetros |
+| Página | `frontend/src/pages/juez/PerformanceFlowPage.tsx` | wizard S-03 a S-09 |
+| Fixture | `scripts/setup_us_4_3_2_fixture.py` | reset de performance de prueba a `AnunciadaAP` |
+| Estrategia | `docs/reports/US-4.3.2-test-strategy.md` | salida Fases 4-6 |
+| Calidad | `quality/reports/codeguard/US-4.3.2-quality.json` | gates tecnicos |
+
+### Artefactos modificados
+
+| Artefacto | Path | Descripción |
+|-----------|------|-------------|
+| API competencia | `src/competencia/api/router.py` | nuevos POST del juez + grilla enriquecida |
+| Query | `src/competencia/application/queries/obtener_grilla.py` | estado, AP, unidad y nombre por fila |
+| Query | `src/competencia/application/queries/obtener_performance_actual.py` | corrige `andarivel` real |
+| API frontend | `frontend/src/api/competencia.ts` | fetches de grilla/performance y mutaciones POST |
+| Store | `frontend/src/stores/useCompetenciaStore.ts` | agrega `atletaActivo` |
+| Página | `frontend/src/pages/juez/GrillaPage.tsx` | reemplaza stub por grilla operativa |
+| Página | `frontend/src/pages/juez/DisciplinasPage.tsx` | normaliza estado `EJECUCION` |
+| Routing | `frontend/src/App.tsx` | agrega `/juez/performance` |
+| Matrix | `docs/traceability/matrix.md` | registra avance de US-4.3.2 |
+
+---
+
+## Decisiones y hallazgos relevantes
+
+1. **La API real necesitaba enriquecer la grilla:**
+   `GET /competencia/{id}/grilla` ahora entrega estado derivado del stream de
+   performance y datos suficientes para la UI del juez.
+
+2. **El backend ya tenia el dominio listo:**
+   la mayor parte del trabajo fue exponer handlers existentes en HTTP y alinear
+   el payload real (`tipo`/`tarjeta`, `unidad`, `motivo_dq`) con la spec.
+
+3. **Se agrega smoke test sin inventar un harness e2e inexistente:**
+   la validacion automatizada usa `TestClient` y una fixture local idempotente.
+
+---
+
+## Quality Gates
+
+| Gate | Resultado |
+|------|-----------|
+| `npm run build` | ✅ aprobado |
+| `npm run lint` | ✅ aprobado |
+| `python -m compileall src` | ✅ aprobado |
+| Smoke test `TestClient` | ✅ aprobado |
+| Validación manual BDD/UI | ✅ aprobada |
+
+---
+
+## Estado de cierre
+
+`US-4.3.2` quedó implementada y validada manualmente.
+
+Validación funcional realizada sobre la fixture local:
+
+- login como juez;
+- navegación `Mis disciplinas -> Grilla -> Performance`;
+- flujo completo `llamar -> confirmar -> OT -> performance -> registrar marca -> asignar tarjeta`;
+- cierre exitoso y retorno a grilla.
+
+---
+
+*Generado: 2026-04-11 — implementación manual secuencial de US-4.3.2*

--- a/docs/reports/US-4.3.2-test-strategy.md
+++ b/docs/reports/US-4.3.2-test-strategy.md
@@ -1,0 +1,31 @@
+# Fases 4-6 — US-4.3.2
+## Estrategia de tests y validacion para flujo juez + backend
+
+`US-4.3.2` extiende un frontend React/Vite y expone endpoints nuevos en FastAPI.
+El repositorio sigue sin harness automatizado de browser tests end-to-end, por lo
+que la validacion queda repartida entre chequeos tecnicos y smoke test funcional.
+
+- **Fase 4 (tests unitarios):** no se agregan suites nuevas; la cobertura tecnica
+  del frontend queda en `tsc`, `vite build` y `eslint`.
+- **Fase 5 (tests de integracion):** se ejecuta un smoke test con `TestClient`
+  contra `src.app`, autenticando como juez y recorriendo:
+  - `GET /competencia/{id}/grilla`
+  - `POST /competencia/{id}/llamar`
+  - `POST /competencia/{id}/registrar-resultado`
+  - `POST /competencia/{id}/asignar-tarjeta`
+- **Fase 6 (validacion BDD):** los escenarios del `.feature` se validan manualmente
+  con backend corriendo y fixture local reseteable.
+
+Cobertura aplicada:
+
+- `npm run build` en `frontend/`
+- `npm run lint` en `frontend/`
+- `python -m compileall src`
+- smoke test backend con `fastapi.testclient.TestClient`
+- fixture local `scripts/setup_us_4_3_2_fixture.py` para resetear la competencia
+
+Validacion manual confirmada:
+
+- recorrido completo del wizard desde `/juez/grilla`;
+- confirmacion de habilitado/deshabilitado en Paso 5;
+- cierre correcto con `TARJETA BLANCA` y retorno a grilla.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -304,6 +304,7 @@ Deben resolverse antes del SP que los involucra. No bloquean SP1 ni SP2.
 | US | Inc. | RFs / Decisiones cubiertos | Contenido principal | Estado |
 |----|------|----------------------------|---------------------|--------|
 | US-4.3.1 | 4.3 | D-02, D-03 · wireframes-juez S-01 | MisDisciplinas real en React · `api/torneo.ts` + `api/competencia.ts` · `useCompetenciaStore` · `DisciplinaCard` · `JuezLayout` · ruta `/juez/grilla` stub · `npm run build` y `npm run lint` OK · validación manual pendiente | 🟡 2026-04-11 |
+| US-4.3.2 | 4.3 | RF-EJ-05, RF-EJ-06 · wireframes-juez S-02 a S-09 | router `competencia` con `POST /llamar`, `POST /registrar-resultado`, `POST /asignar-tarjeta` · grilla enriquecida con estado/AP · `GrillaPage` operativa · wizard móvil `/juez/performance` · `StepIndicator`, `AtletaCard`, `RpSelector` · `npm run build`, `npm run lint`, `compileall` y smoke test `TestClient` OK · validación manual UI confirmada | ✅ 2026-04-11 |
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginPage } from './pages/LoginPage'
 import { RequireRole } from './components/RequireRole'
 import { DisciplinasPage } from './pages/juez/DisciplinasPage'
 import { GrillaPage } from './pages/juez/GrillaPage'
+import { PerformanceFlowPage } from './pages/juez/PerformanceFlowPage'
 import { DashboardPage } from './pages/organizador/DashboardPage'
 import { HealthCheck } from './components/HealthCheck'
 
@@ -39,6 +40,14 @@ function App() {
           element={
             <RequireRole role="juez">
               <GrillaPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/juez/performance"
+          element={
+            <RequireRole role="juez">
+              <PerformanceFlowPage />
             </RequireRole>
           }
         />

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -1,3 +1,14 @@
+import useAuthStore from '../stores/useAuthStore'
+
+export class ApiError extends Error {
+  status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
 export interface CompetenciaResumenDto {
   competencia_id: string
   disciplina: string
@@ -11,16 +22,68 @@ export interface EstadoCompetenciaDto {
   torneo_id: string | null
 }
 
+export interface GrillaAtletaDto {
+  performance_id: string
+  atleta_id: string
+  nombre_atleta: string
+  posicion: number
+  andarivel: number
+  ot_programado: string
+  ap_declarado: string
+  unidad: string
+  estado: string
+}
+
+export interface PerformanceActualDto {
+  performance_id: string
+  nombre_atleta: string
+  ap_declarado: string
+  unidad: string
+  unidad_esperada: string
+  andarivel: number
+  estado: string
+}
+
+function buildHeaders() {
+  const token = useAuthStore.getState().token
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  return headers
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  if (response.ok) {
+    if (response.status === 204) {
+      return undefined as T
+    }
+    return response.json() as Promise<T>
+  }
+
+  let detail = `Error de API: ${response.status}`
+
+  try {
+    const payload = (await response.json()) as { detail?: string }
+    if (payload.detail) {
+      detail = payload.detail
+    }
+  } catch {
+    // sin body JSON util
+  }
+
+  throw new ApiError(response.status, detail)
+}
+
 export async function fetchCompetenciasPorTorneo(
   torneoId: string,
 ): Promise<CompetenciaResumenDto[]> {
   const response = await fetch(`/competencia?torneo_id=${torneoId}`)
-
-  if (!response.ok) {
-    throw new Error(`Error al obtener competencias: ${response.status}`)
-  }
-
-  return response.json() as Promise<CompetenciaResumenDto[]>
+  return parseResponse<CompetenciaResumenDto[]>(response)
 }
 
 export async function fetchEstadoCompetencia(
@@ -30,10 +93,89 @@ export async function fetchEstadoCompetencia(
   const response = await fetch(
     `/competencia/${competenciaId}/estado?disciplina=${encodeURIComponent(disciplina)}`,
   )
+  return parseResponse<EstadoCompetenciaDto>(response)
+}
 
-  if (!response.ok) {
-    throw new Error(`Error al obtener estado de competencia: ${response.status}`)
-  }
+export async function fetchGrillaCompetencia(
+  competenciaId: string,
+  disciplina: string,
+): Promise<GrillaAtletaDto[]> {
+  const response = await fetch(
+    `/competencia/${competenciaId}/grilla?disciplina=${encodeURIComponent(disciplina)}`,
+  )
+  return parseResponse<GrillaAtletaDto[]>(response)
+}
 
-  return response.json() as Promise<EstadoCompetenciaDto>
+export async function fetchPerformanceActual(
+  competenciaId: string,
+): Promise<PerformanceActualDto | null> {
+  const response = await fetch(`/competencia/${competenciaId}/performance/actual`)
+  return parseResponse<PerformanceActualDto | null>(response)
+}
+
+export async function llamarAtleta(payload: {
+  competenciaId: string
+  participanteId: string
+  disciplina: string
+  otProgramado: string
+  posicionGrilla: number
+  andarivel: number
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/llamar`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      participante_id: payload.participanteId,
+      disciplina: payload.disciplina,
+      ot_programado: payload.otProgramado,
+      posicion_grilla: payload.posicionGrilla,
+      andarivel: payload.andarivel,
+    }),
+  })
+
+  await parseResponse<void>(response)
+}
+
+export async function registrarResultado(payload: {
+  competenciaId: string
+  participanteId: string
+  disciplina: string
+  valorRp: string
+  unidad: string
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/registrar-resultado`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      participante_id: payload.participanteId,
+      disciplina: payload.disciplina,
+      valor_rp: payload.valorRp,
+      unidad: payload.unidad,
+    }),
+  })
+
+  await parseResponse<void>(response)
+}
+
+export async function asignarTarjeta(payload: {
+  competenciaId: string
+  participanteId: string
+  disciplina: string
+  tarjeta: 'Blanca' | 'Roja'
+  motivoDq?: string
+  distanciaBlackout?: string
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/asignar-tarjeta`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      participante_id: payload.participanteId,
+      disciplina: payload.disciplina,
+      tarjeta: payload.tarjeta,
+      motivo_dq: payload.motivoDq ?? null,
+      distancia_blackout: payload.distanciaBlackout ?? null,
+    }),
+  })
+
+  await parseResponse<void>(response)
 }

--- a/frontend/src/components/juez/AtletaCard.tsx
+++ b/frontend/src/components/juez/AtletaCard.tsx
@@ -1,0 +1,47 @@
+interface AtletaCardProps {
+  nombreAtleta: string
+  apDeclarado: string
+  unidad: string
+  andarivel: number
+  otProgramado: string
+  estado: string
+}
+
+function formatOt(iso: string) {
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime())
+    ? iso
+    : date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+export function AtletaCard({
+  nombreAtleta,
+  apDeclarado,
+  unidad,
+  andarivel,
+  otProgramado,
+  estado,
+}: AtletaCardProps) {
+  return (
+    <section className="rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5 shadow-[0_24px_80px_-50px_rgba(34,211,238,0.7)]">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-300">{estado}</p>
+      <h2 className="mt-3 text-2xl font-semibold text-white">{nombreAtleta}</h2>
+      <div className="mt-4 grid grid-cols-3 gap-3 text-sm text-slate-300">
+        <div className="rounded-2xl bg-slate-950/70 p-3">
+          <p className="text-[11px] uppercase tracking-[0.18em] text-slate-500">AP</p>
+          <p className="mt-2 text-lg font-semibold text-slate-50">
+            {apDeclarado} {unidad}
+          </p>
+        </div>
+        <div className="rounded-2xl bg-slate-950/70 p-3">
+          <p className="text-[11px] uppercase tracking-[0.18em] text-slate-500">Andarivel</p>
+          <p className="mt-2 text-lg font-semibold text-slate-50">{andarivel}</p>
+        </div>
+        <div className="rounded-2xl bg-slate-950/70 p-3">
+          <p className="text-[11px] uppercase tracking-[0.18em] text-slate-500">OT</p>
+          <p className="mt-2 text-lg font-semibold text-slate-50">{formatOt(otProgramado)}</p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/juez/RpSelector.tsx
+++ b/frontend/src/components/juez/RpSelector.tsx
@@ -1,0 +1,109 @@
+interface RpSelectorProps {
+  metros: number
+  centimetros: string
+  onMetrosChange: (value: number) => void
+  onCentimetrosChange: (value: string) => void
+}
+
+const presets = [25, 50, 75, 100, 125]
+const keypad = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
+
+export function RpSelector({
+  metros,
+  centimetros,
+  onMetrosChange,
+  onCentimetrosChange,
+}: RpSelectorProps) {
+  function pushDigit(digit: string) {
+    const next = `${centimetros}${digit}`.slice(-2)
+    onCentimetrosChange(next)
+  }
+
+  return (
+    <section className="space-y-5 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Marca</p>
+        <p className="mt-2 text-4xl font-semibold text-white">
+          {metros}
+          <span className="text-slate-500">.</span>
+          {centimetros.padEnd(2, '0')} m
+        </p>
+      </div>
+
+      <div className="grid grid-cols-5 gap-2">
+        {presets.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => onMetrosChange(preset)}
+            className={[
+              'rounded-2xl border px-3 py-3 text-sm font-semibold transition',
+              metros === preset
+                ? 'border-cyan-300 bg-cyan-400/20 text-cyan-100'
+                : 'border-slate-700 bg-slate-950/70 text-slate-200',
+            ].join(' ')}
+          >
+            {preset}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-4 gap-2 text-sm font-semibold">
+        {[
+          ['-1', -1],
+          ['+1', 1],
+          ['+5', 5],
+          ['+10', 10],
+        ].map(([label, delta]) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => onMetrosChange(Math.max(0, metros + Number(delta)))}
+            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-slate-100"
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+          Centimetros
+        </p>
+        <div className="mt-3 grid grid-cols-3 gap-2">
+          {keypad.slice(0, 9).map((digit) => (
+            <button
+              key={digit}
+              type="button"
+              onClick={() => pushDigit(digit)}
+              className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-lg font-semibold text-white"
+            >
+              {digit}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => onCentimetrosChange('')}
+            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-sm font-semibold text-slate-200"
+          >
+            CLR
+          </button>
+          <button
+            type="button"
+            onClick={() => pushDigit('0')}
+            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-lg font-semibold text-white"
+          >
+            0
+          </button>
+          <button
+            type="button"
+            onClick={() => onCentimetrosChange(centimetros.slice(0, -1))}
+            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-sm font-semibold text-slate-200"
+          >
+            DEL
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/juez/StepIndicator.tsx
+++ b/frontend/src/components/juez/StepIndicator.tsx
@@ -1,0 +1,28 @@
+interface StepIndicatorProps {
+  currentStep: number
+  totalSteps?: number
+}
+
+export function StepIndicator({ currentStep, totalSteps = 6 }: StepIndicatorProps) {
+  return (
+    <div className="flex items-center justify-center gap-2">
+      {Array.from({ length: totalSteps }, (_, index) => {
+        const step = index + 1
+        const isActive = step === currentStep
+        const isComplete = step < currentStep
+
+        return (
+          <span
+            key={step}
+            className={[
+              'h-2.5 w-8 rounded-full transition',
+              isActive ? 'bg-cyan-400' : '',
+              isComplete ? 'bg-emerald-400/80' : '',
+              !isActive && !isComplete ? 'bg-slate-700' : '',
+            ].join(' ')}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/pages/juez/DisciplinasPage.tsx
+++ b/frontend/src/pages/juez/DisciplinasPage.tsx
@@ -18,6 +18,10 @@ function esTorneoActivo(estado: string) {
   return estado === 'EJECUCION' || estado === 'EnEjecucion'
 }
 
+function esCompetenciaActiva(estado: string) {
+  return estado === 'EJECUCION' || estado === 'EnEjecucion'
+}
+
 export function DisciplinasPage() {
   const navigate = useNavigate()
   const logout = useAuthStore((s) => s.logout)
@@ -58,7 +62,7 @@ export function DisciplinasPage() {
           return {
             disciplina,
             competenciaId: competencia.competencia_id,
-            estado: estado.estado === 'EnEjecucion' ? 'ACTIVA' : 'PENDIENTE',
+            estado: esCompetenciaActiva(estado.estado) ? 'ACTIVA' : 'PENDIENTE',
           } satisfies DisciplinaViewModel
         }),
       )

--- a/frontend/src/pages/juez/GrillaPage.tsx
+++ b/frontend/src/pages/juez/GrillaPage.tsx
@@ -1,15 +1,92 @@
-import { Link } from 'react-router-dom'
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link, useNavigate } from 'react-router-dom'
+import {
+  fetchGrillaCompetencia,
+  fetchPerformanceActual,
+  type GrillaAtletaDto,
+} from '../../api/competencia'
 import { JuezLayout } from '../../components/juez/JuezLayout'
 import useCompetenciaStore from '../../stores/useCompetenciaStore'
 
+type RowStatus = 'SIGUIENTE' | 'PENDIENTE' | 'EN_CURSO' | 'FINALIZADA'
+
+function resolveRowStatus(
+  atleta: GrillaAtletaDto,
+  currentPerformanceId: string | null,
+  firstPendingPerformanceId: string | null,
+): RowStatus {
+  if (atleta.performance_id === currentPerformanceId) {
+    return 'EN_CURSO'
+  }
+
+  if (atleta.estado === 'Ejecutada' || atleta.estado === 'DNS') {
+    return 'FINALIZADA'
+  }
+
+  if (atleta.estado === 'Llamada' || atleta.estado === 'ResultadoRegistrado') {
+    return 'EN_CURSO'
+  }
+
+  if (atleta.performance_id === firstPendingPerformanceId) {
+    return 'SIGUIENTE'
+  }
+
+  return 'PENDIENTE'
+}
+
+function statusClasses(status: RowStatus) {
+  if (status === 'EN_CURSO') {
+    return 'border-cyan-300/60 bg-cyan-400/10'
+  }
+  if (status === 'SIGUIENTE') {
+    return 'border-emerald-300/50 bg-emerald-400/10'
+  }
+  if (status === 'FINALIZADA') {
+    return 'border-slate-800 bg-slate-900/40 opacity-50'
+  }
+  return 'border-slate-800 bg-slate-900/75'
+}
+
 export function GrillaPage() {
+  const navigate = useNavigate()
   const disciplinaActiva = useCompetenciaStore((s) => s.disciplinaActiva)
   const competenciaId = useCompetenciaStore((s) => s.competenciaId)
+  const seleccionarAtleta = useCompetenciaStore((s) => s.seleccionarAtleta)
+
+  const grillaQuery = useQuery({
+    queryKey: ['grilla', competenciaId, disciplinaActiva],
+    queryFn: () => fetchGrillaCompetencia(competenciaId!, disciplinaActiva!),
+    enabled: Boolean(competenciaId && disciplinaActiva),
+  })
+
+  const performanceActualQuery = useQuery({
+    queryKey: ['performance-actual', competenciaId],
+    queryFn: () => fetchPerformanceActual(competenciaId!),
+    enabled: Boolean(competenciaId),
+    refetchInterval: 5000,
+  })
+
+  const firstPendingPerformanceId = useMemo(() => {
+    const grilla = grillaQuery.data ?? []
+    const first = grilla.find((atleta) => atleta.estado === 'AnunciadaAP')
+    return first?.performance_id ?? null
+  }, [grillaQuery.data])
+
+  if (!competenciaId || !disciplinaActiva) {
+    return (
+      <JuezLayout title="Grilla" subtitle="Sin competencia seleccionada">
+        <section className="rounded-3xl border border-slate-800 bg-slate-900/70 p-5 text-sm text-slate-300">
+          No hay competencia seleccionada.
+        </section>
+      </JuezLayout>
+    )
+  }
 
   return (
     <JuezLayout
       title="Grilla"
-      subtitle={disciplinaActiva ? `${disciplinaActiva} · ${competenciaId}` : 'Sin competencia seleccionada'}
+      subtitle={`${disciplinaActiva} · ${competenciaId}`}
       actions={
         <Link
           to="/juez/disciplinas"
@@ -19,10 +96,72 @@ export function GrillaPage() {
         </Link>
       }
     >
-      <section className="rounded-3xl border border-slate-800 bg-slate-900/70 p-5 text-sm text-slate-300">
-        Stub de grilla para US-4.3.1. La selección de disciplina y competencia activa ya quedó persistida en
-        el store.
-      </section>
+      {grillaQuery.isLoading ? (
+        <section className="rounded-3xl border border-slate-800 bg-slate-900/70 p-5 text-sm text-slate-300">
+          Cargando grilla...
+        </section>
+      ) : null}
+
+      {grillaQuery.isError ? (
+        <section className="rounded-3xl border border-red-500/30 bg-red-500/10 p-5 text-sm text-red-100">
+          No se pudo cargar la grilla.
+        </section>
+      ) : null}
+
+      {grillaQuery.data?.map((atleta) => {
+        const status = resolveRowStatus(
+          atleta,
+          performanceActualQuery.data?.performance_id ?? null,
+          firstPendingPerformanceId,
+        )
+        const disabled = status === 'FINALIZADA'
+
+        return (
+          <button
+            key={atleta.performance_id}
+            type="button"
+            disabled={disabled}
+            onClick={() => {
+              seleccionarAtleta({
+                performanceId: atleta.performance_id,
+                atletaId: atleta.atleta_id,
+                nombreAtleta: atleta.nombre_atleta,
+                posicion: atleta.posicion,
+                andarivel: atleta.andarivel,
+                otProgramado: atleta.ot_programado,
+                apDeclarado: atleta.ap_declarado,
+                unidad: atleta.unidad,
+                estado: atleta.estado,
+              })
+              void navigate('/juez/performance')
+            }}
+            className={`block w-full rounded-[2rem] border p-5 text-left transition ${statusClasses(status)}`}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  #{atleta.posicion} · andarivel {atleta.andarivel}
+                </p>
+                <h2 className="mt-2 text-lg font-semibold text-slate-50">{atleta.nombre_atleta}</h2>
+                <p className="mt-2 text-sm text-slate-400">
+                  AP {atleta.ap_declarado} {atleta.unidad}
+                </p>
+              </div>
+              <span
+                className={[
+                  'rounded-full px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em]',
+                  status === 'EN_CURSO' ? 'bg-cyan-400/15 text-cyan-200' : '',
+                  status === 'SIGUIENTE' ? 'bg-emerald-400/15 text-emerald-200' : '',
+                  status === 'PENDIENTE' ? 'bg-slate-800 text-slate-300' : '',
+                  status === 'FINALIZADA' ? 'bg-slate-950 text-slate-500' : '',
+                ].join(' ')}
+              >
+                {status}
+              </span>
+            </div>
+          </button>
+        )
+      })}
     </JuezLayout>
   )
 }

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -1,0 +1,350 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
+import {
+  ApiError,
+  asignarTarjeta,
+  llamarAtleta,
+  registrarResultado,
+} from '../../api/competencia'
+import { AtletaCard } from '../../components/juez/AtletaCard'
+import { JuezLayout } from '../../components/juez/JuezLayout'
+import { RpSelector } from '../../components/juez/RpSelector'
+import { StepIndicator } from '../../components/juez/StepIndicator'
+import useCompetenciaStore from '../../stores/useCompetenciaStore'
+
+const dqReasons = [
+  'BKO_SUPERFICIE',
+  'BKO_SUBACUATICO',
+  'PROTOCOLO_SUPERFICIE',
+  'INFRACCION_TECNICA_DQ',
+  'NO_INICIO_EN_VENTANA',
+  'SALIDA_EN_FALSO',
+] as const
+
+function buildRpValue(metros: number, centimetros: string) {
+  return `${metros}.${centimetros.padEnd(2, '0')}`
+}
+
+export function PerformanceFlowPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const competenciaId = useCompetenciaStore((s) => s.competenciaId)
+  const disciplinaActiva = useCompetenciaStore((s) => s.disciplinaActiva)
+  const atletaActivo = useCompetenciaStore((s) => s.atletaActivo)
+  const seleccionarAtleta = useCompetenciaStore((s) => s.seleccionarAtleta)
+  const limpiarAtleta = useCompetenciaStore((s) => s.limpiarAtleta)
+
+  const [step, setStep] = useState(1)
+  const [inlineError, setInlineError] = useState<string | null>(null)
+  const [metros, setMetros] = useState(0)
+  const [centimetros, setCentimetros] = useState('')
+  const [chronoStarted, setChronoStarted] = useState(false)
+  const [selectedCard, setSelectedCard] = useState<'Blanca' | 'Roja' | null>(null)
+  const [motivoDq, setMotivoDq] = useState<(typeof dqReasons)[number] | ''>('')
+  const [distanciaBlackout, setDistanciaBlackout] = useState('')
+  const [completed, setCompleted] = useState(false)
+
+  const rpConfirmDisabled = metros === 0 && centimetros.length === 0
+  const needsBlackoutDistance = motivoDq === 'BKO_SUPERFICIE' || motivoDq === 'BKO_SUBACUATICO'
+
+  const refreshCompetencia = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['grilla', competenciaId, disciplinaActiva] }),
+      queryClient.invalidateQueries({ queryKey: ['performance-actual', competenciaId] }),
+    ])
+  }
+
+  const llamarMutation = useMutation({
+    mutationFn: async () => {
+      await llamarAtleta({
+        competenciaId: competenciaId!,
+        participanteId: atletaActivo!.atletaId,
+        disciplina: disciplinaActiva!,
+        otProgramado: atletaActivo!.otProgramado,
+        posicionGrilla: atletaActivo!.posicion,
+        andarivel: atletaActivo!.andarivel,
+      })
+    },
+    onSuccess: async () => {
+      setInlineError(null)
+      await refreshCompetencia()
+      seleccionarAtleta({ ...atletaActivo!, estado: 'Llamada' })
+      setStep(2)
+    },
+    onError: (error) => {
+      setInlineError(
+        error instanceof ApiError && error.status === 409
+          ? 'No se puede ejecutar esta accion en el estado actual'
+          : 'No se pudo llamar al atleta',
+      )
+    },
+  })
+
+  const resultadoMutation = useMutation({
+    mutationFn: async () => {
+      await registrarResultado({
+        competenciaId: competenciaId!,
+        participanteId: atletaActivo!.atletaId,
+        disciplina: disciplinaActiva!,
+        valorRp: buildRpValue(metros, centimetros),
+        unidad: atletaActivo!.unidad || 'Metros',
+      })
+    },
+    onSuccess: async () => {
+      setInlineError(null)
+      await refreshCompetencia()
+      seleccionarAtleta({ ...atletaActivo!, estado: 'ResultadoRegistrado' })
+      setStep(6)
+    },
+    onError: (error) => {
+      setInlineError(error instanceof Error ? error.message : 'No se pudo registrar la marca')
+    },
+  })
+
+  const tarjetaMutation = useMutation({
+    mutationFn: async () => {
+      await asignarTarjeta({
+        competenciaId: competenciaId!,
+        participanteId: atletaActivo!.atletaId,
+        disciplina: disciplinaActiva!,
+        tarjeta: selectedCard!,
+        motivoDq: selectedCard === 'Roja' ? motivoDq : undefined,
+        distanciaBlackout:
+          selectedCard === 'Roja' && needsBlackoutDistance ? distanciaBlackout : undefined,
+      })
+    },
+    onSuccess: async () => {
+      setInlineError(null)
+      await refreshCompetencia()
+      seleccionarAtleta({ ...atletaActivo!, estado: 'Ejecutada' })
+      setCompleted(true)
+    },
+    onError: (error) => {
+      setInlineError(error instanceof Error ? error.message : 'No se pudo asignar la tarjeta')
+    },
+  })
+
+  const canSubmitRedCard = useMemo(() => {
+    if (selectedCard !== 'Roja') {
+      return true
+    }
+    if (!motivoDq) {
+      return false
+    }
+    if (needsBlackoutDistance && !distanciaBlackout.trim()) {
+      return false
+    }
+    return true
+  }, [selectedCard, motivoDq, needsBlackoutDistance, distanciaBlackout])
+
+  if (!competenciaId || !disciplinaActiva || !atletaActivo) {
+    return <Navigate to="/juez/grilla" replace />
+  }
+
+  return (
+    <JuezLayout
+      title="Performance"
+      subtitle={`${disciplinaActiva} · ${atletaActivo.nombreAtleta}`}
+      actions={
+        <Link
+          to="/juez/grilla"
+          className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-200"
+        >
+          Volver
+        </Link>
+      }
+    >
+      <section className="rounded-[2rem] border border-slate-800 bg-slate-950/60 p-4">
+        <StepIndicator currentStep={completed ? 6 : step} />
+      </section>
+
+      <AtletaCard
+        nombreAtleta={atletaActivo.nombreAtleta}
+        apDeclarado={atletaActivo.apDeclarado}
+        unidad={atletaActivo.unidad}
+        andarivel={atletaActivo.andarivel}
+        otProgramado={atletaActivo.otProgramado}
+        estado={completed ? 'COMPLETADA' : atletaActivo.estado}
+      />
+
+      {inlineError ? (
+        <section className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          {inlineError}
+        </section>
+      ) : null}
+
+      {!completed && step === 1 ? (
+        <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
+          <h3 className="text-xl font-semibold text-white">Paso 1 · Llamada</h3>
+          <p className="text-sm text-slate-300">Confirma la llamada del atleta para habilitar la performance.</p>
+          <button
+            type="button"
+            onClick={() => llamarMutation.mutate()}
+            disabled={llamarMutation.isPending}
+            className="w-full rounded-2xl bg-cyan-400 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950 disabled:opacity-60"
+          >
+            LLAMAR ATLETA
+          </button>
+        </section>
+      ) : null}
+
+      {!completed && step === 2 ? (
+        <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
+          <h3 className="text-xl font-semibold text-white">Paso 2 · Confirmar presencia</h3>
+          <p className="text-sm text-slate-300">Confirmado que el atleta está en cámara y listo para iniciar.</p>
+          <button
+            type="button"
+            onClick={() => setStep(3)}
+            className="w-full rounded-2xl bg-emerald-400 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+          >
+            CONTINUAR
+          </button>
+        </section>
+      ) : null}
+
+      {!completed && step === 3 ? (
+        <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
+          <h3 className="text-xl font-semibold text-white">Paso 3 · OT</h3>
+          <p className="text-sm text-slate-300">OT programado: {new Date(atletaActivo.otProgramado).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</p>
+          <button
+            type="button"
+            onClick={() => setStep(4)}
+            className="w-full rounded-2xl bg-amber-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+          >
+            INICIAR VENTANA OT
+          </button>
+        </section>
+      ) : null}
+
+      {!completed && step === 4 ? (
+        <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
+          <h3 className="text-xl font-semibold text-white">Paso 4 · Performance</h3>
+          <p className="text-sm text-slate-300">
+            {chronoStarted
+              ? 'La performance está en curso. Finaliza cuando el atleta complete su intento.'
+              : 'Inicia el cronómetro local cuando comience la performance.'}
+          </p>
+          {!chronoStarted ? (
+            <button
+              type="button"
+              onClick={() => setChronoStarted(true)}
+              className="w-full rounded-2xl bg-fuchsia-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+            >
+              INICIAR CRONO
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setStep(5)}
+              className="w-full rounded-2xl bg-orange-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+            >
+              FINALIZAR PERFORMANCE
+            </button>
+          )}
+        </section>
+      ) : null}
+
+      {!completed && step === 5 ? (
+        <section className="space-y-4">
+          <RpSelector
+            metros={metros}
+            centimetros={centimetros}
+            onMetrosChange={setMetros}
+            onCentimetrosChange={setCentimetros}
+          />
+          <button
+            type="button"
+            disabled={rpConfirmDisabled || resultadoMutation.isPending}
+            onClick={() => resultadoMutation.mutate()}
+            className="w-full rounded-2xl bg-white px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950 disabled:opacity-50"
+          >
+            CONFIRMAR MARCA
+          </button>
+        </section>
+      ) : null}
+
+      {!completed && step === 6 ? (
+        <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
+          <h3 className="text-xl font-semibold text-white">Paso 6 · Tarjeta</h3>
+          <div className="grid grid-cols-2 gap-3">
+            {(['Blanca', 'Roja'] as const).map((card) => (
+              <button
+                key={card}
+                type="button"
+                onClick={() => setSelectedCard(card)}
+                className={[
+                  'rounded-2xl border px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] transition',
+                  selectedCard === card
+                    ? 'border-cyan-300 bg-cyan-400/15 text-cyan-100'
+                    : 'border-slate-700 bg-slate-950/70 text-slate-200',
+                ].join(' ')}
+              >
+                Tarjeta {card}
+              </button>
+            ))}
+          </div>
+
+          {selectedCard === 'Roja' ? (
+            <div className="space-y-3 rounded-2xl bg-slate-950/70 p-4">
+              <label className="block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Motivo DQ
+              </label>
+              <select
+                value={motivoDq}
+                onChange={(event) => setMotivoDq(event.target.value as (typeof dqReasons)[number] | '')}
+                className="w-full rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-white"
+              >
+                <option value="">Seleccionar</option>
+                {dqReasons.map((reason) => (
+                  <option key={reason} value={reason}>
+                    {reason}
+                  </option>
+                ))}
+              </select>
+
+              {needsBlackoutDistance ? (
+                <input
+                  value={distanciaBlackout}
+                  onChange={(event) => setDistanciaBlackout(event.target.value)}
+                  placeholder="Distancia blackout"
+                  className="w-full rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-white"
+                />
+              ) : null}
+            </div>
+          ) : null}
+
+          <button
+            type="button"
+            disabled={!selectedCard || !canSubmitRedCard || tarjetaMutation.isPending}
+            onClick={() => tarjetaMutation.mutate()}
+            className="w-full rounded-2xl bg-cyan-400 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950 disabled:opacity-50"
+          >
+            CONFIRMAR TARJETA
+          </button>
+        </section>
+      ) : null}
+
+      {completed ? (
+        <section className="space-y-4 rounded-[2rem] border border-emerald-300/30 bg-emerald-400/10 p-5">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-300">
+            Performance completada
+          </p>
+          <h3 className="text-2xl font-semibold text-white">
+            TARJETA {selectedCard?.toUpperCase()} · {buildRpValue(metros, centimetros)} m
+          </h3>
+          <button
+            type="button"
+            onClick={() => {
+              limpiarAtleta()
+              void navigate('/juez/grilla')
+            }}
+            className="w-full rounded-2xl bg-white px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+          >
+            SIGUIENTE ATLETA
+          </button>
+        </section>
+      ) : null}
+    </JuezLayout>
+  )
+}

--- a/frontend/src/stores/useCompetenciaStore.ts
+++ b/frontend/src/stores/useCompetenciaStore.ts
@@ -1,14 +1,29 @@
 import { create } from 'zustand'
 
+export interface AtletaActivo {
+  performanceId: string
+  atletaId: string
+  nombreAtleta: string
+  posicion: number
+  andarivel: number
+  otProgramado: string
+  apDeclarado: string
+  unidad: string
+  estado: string
+}
+
 interface CompetenciaState {
   torneoId: string | null
   competenciaId: string | null
   disciplinaActiva: string | null
+  atletaActivo: AtletaActivo | null
   seleccionarCompetencia: (payload: {
     torneoId: string
     competenciaId: string
     disciplinaActiva: string
   }) => void
+  seleccionarAtleta: (atleta: AtletaActivo) => void
+  limpiarAtleta: () => void
   limpiarCompetencia: () => void
 }
 
@@ -16,9 +31,13 @@ const useCompetenciaStore = create<CompetenciaState>((set) => ({
   torneoId: null,
   competenciaId: null,
   disciplinaActiva: null,
+  atletaActivo: null,
   seleccionarCompetencia: ({ torneoId, competenciaId, disciplinaActiva }) =>
-    set({ torneoId, competenciaId, disciplinaActiva }),
-  limpiarCompetencia: () => set({ torneoId: null, competenciaId: null, disciplinaActiva: null }),
+    set({ torneoId, competenciaId, disciplinaActiva, atletaActivo: null }),
+  seleccionarAtleta: (atletaActivo) => set({ atletaActivo }),
+  limpiarAtleta: () => set({ atletaActivo: null }),
+  limpiarCompetencia: () =>
+    set({ torneoId: null, competenciaId: null, disciplinaActiva: null, atletaActivo: null }),
 }))
 
 export default useCompetenciaStore

--- a/quality/reports/codeguard/US-4.3.2-quality.json
+++ b/quality/reports/codeguard/US-4.3.2-quality.json
@@ -1,0 +1,37 @@
+{
+  "us_id": "US-4.3.2",
+  "fecha": "2026-04-11",
+  "producto": "frontend+backend",
+  "tipo_validacion": "full-stack-judge-flow",
+  "build": {
+    "estado": "APROBADO",
+    "comando": "npm run build",
+    "working_directory": "frontend"
+  },
+  "lint": {
+    "estado": "APROBADO",
+    "comando": "npm run lint",
+    "working_directory": "frontend"
+  },
+  "python_compile": {
+    "estado": "APROBADO",
+    "comando": "./.venv/bin/python -m compileall src",
+    "working_directory": "."
+  },
+  "smoke_backend": {
+    "estado": "APROBADO",
+    "comando": "IDENTIDAD_JWT_SECRET=dev ./.venv/bin/python - <<'PY' ... TestClient judge flow ... PY",
+    "working_directory": "."
+  },
+  "bdd_manual": {
+    "estado": "APROBADO",
+    "feature": "tests/features/US-4.3.2-flujo-performance.feature"
+  },
+  "estado_final": "APROBADO",
+  "observaciones": [
+    "Se agregaron los POST /llamar, /registrar-resultado y /asignar-tarjeta al router de competencia.",
+    "La grilla ahora expone nombre sintetico, AP, unidad y estado derivado del stream de performance.",
+    "Se agrego fixture local para resetear la performance de prueba a estado AnunciadaAP.",
+    "La validacion manual del flujo juez fue confirmada tras la implementacion."
+  ]
+}

--- a/scripts/setup_us_4_3_2_fixture.py
+++ b/scripts/setup_us_4_3_2_fixture.py
@@ -1,0 +1,179 @@
+"""Prepara una fixture minima para probar manualmente US-4.3.2.
+
+Deja la competencia de fixture con una performance en estado AnunciadaAP,
+lista para recorrer el flujo llamar -> registrar resultado -> asignar tarjeta.
+
+Uso:
+    ./.venv/bin/python scripts/setup_us_4_3_2_fixture.py
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPETENCIA_DB = ROOT / "data" / "competencia.db"
+IDENTIDAD_DB = ROOT / "data" / "identidad.db"
+
+COMPETENCIA_ID = "11111111-1111-1111-1111-111111111431"
+DISCIPLINA = "STA"
+PERFORMANCE_ID = "22222222-2222-2222-2222-222222224311"
+ATLETA_ID = "33333333-3333-3333-3333-333333334311"
+JUEZ_EMAIL = "juez@ataraxia.com"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def obtener_juez_id() -> str:
+    with sqlite3.connect(IDENTIDAD_DB) as conn:
+        row = conn.execute(
+            "SELECT usuario_id FROM usuarios WHERE email = ?",
+            (JUEZ_EMAIL,),
+        ).fetchone()
+    if row is None:
+        raise RuntimeError(f"No existe usuario juez para email {JUEZ_EMAIL}")
+    return row[0]
+
+
+def obtener_torneo_id() -> str:
+    with sqlite3.connect(COMPETENCIA_DB) as conn:
+        row = conn.execute(
+            "SELECT torneo_id FROM competencias_por_torneo WHERE competencia_id = ?",
+            (COMPETENCIA_ID,),
+        ).fetchone()
+    if row is None:
+        raise RuntimeError(f"No existe proyeccion para competencia {COMPETENCIA_ID}")
+    return row[0]
+
+
+def reset_competencia_stream(juez_id: str, torneo_id: str) -> None:
+    stream_id = f"competencia-{COMPETENCIA_ID}"
+    now = utc_now()
+
+    with sqlite3.connect(COMPETENCIA_DB) as conn:
+        conn.execute("DELETE FROM events WHERE stream_id = ?", (stream_id,))
+        conn.executemany(
+            """
+            INSERT INTO events (stream_id, event_type, payload, version)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                (
+                    stream_id,
+                    "IntervaloOTConfigurado",
+                    json.dumps(
+                        {
+                            "competencia_id": COMPETENCIA_ID,
+                            "disciplina": DISCIPLINA,
+                            "intervalo_minutos": 9,
+                            "configurado_por": "fixture-us-4.3.2",
+                            "torneo_id": torneo_id,
+                            "occurred_at": now,
+                        }
+                    ),
+                    1,
+                ),
+                (
+                    stream_id,
+                    "GrillaDeSalidaGenerada",
+                    json.dumps(
+                        {
+                            "competencia_id": COMPETENCIA_ID,
+                            "disciplina": DISCIPLINA,
+                            "ot_inicio": now,
+                            "performances": [
+                                {
+                                    "performance_id": PERFORMANCE_ID,
+                                    "atleta_id": ATLETA_ID,
+                                    "posicion": 1,
+                                    "andarivel": 1,
+                                    "ot_programado": now,
+                                }
+                            ],
+                            "generada_en": now,
+                            "occurred_at": now,
+                        }
+                    ),
+                    2,
+                ),
+                (
+                    stream_id,
+                    "GrillaConfirmada",
+                    json.dumps(
+                        {
+                            "competencia_id": COMPETENCIA_ID,
+                            "disciplina": DISCIPLINA,
+                            "confirmada_en": now,
+                            "occurred_at": now,
+                        }
+                    ),
+                    3,
+                ),
+                (
+                    stream_id,
+                    "CompetenciaIniciada",
+                    json.dumps(
+                        {
+                            "competencia_id": COMPETENCIA_ID,
+                            "disciplina": DISCIPLINA,
+                            "juez_id": juez_id,
+                            "iniciada_en": now,
+                            "occurred_at": now,
+                        }
+                    ),
+                    4,
+                ),
+            ],
+        )
+        conn.commit()
+
+
+def reset_performance_stream() -> None:
+    stream_id = f"performance-{COMPETENCIA_ID}-{ATLETA_ID}-{DISCIPLINA}"
+    now = utc_now()
+
+    with sqlite3.connect(COMPETENCIA_DB) as conn:
+        conn.execute("DELETE FROM events WHERE stream_id = ?", (stream_id,))
+        conn.execute(
+            """
+            INSERT INTO events (stream_id, event_type, payload, version)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                stream_id,
+                "APRegistrado",
+                json.dumps(
+                    {
+                        "performance_id": PERFORMANCE_ID,
+                        "competencia_id": COMPETENCIA_ID,
+                        "participante_id": ATLETA_ID,
+                        "disciplina": DISCIPLINA,
+                        "valor_ap": "300",
+                        "unidad": "Segundos",
+                        "occurred_at": now,
+                    }
+                ),
+                1,
+            ),
+        )
+        conn.commit()
+
+
+def main() -> None:
+    juez_id = obtener_juez_id()
+    torneo_id = obtener_torneo_id()
+    reset_competencia_stream(juez_id, torneo_id)
+    reset_performance_stream()
+    print("Fixture US-4.3.2 lista")
+    print(f"  competencia_id: {COMPETENCIA_ID}")
+    print(f"  atleta_id:      {ATLETA_ID}")
+    print(f"  disciplina:     {DISCIPLINA}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
 
@@ -10,6 +12,11 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from competencia.application.commands.asignar_tarjeta import (
+    AsignarTarjetaCommand,
+    AsignarTarjetaHandler,
+    PerformanceNoEncontrada as PerformanceNoEncontradaAsignarTarjeta,
+)
 from competencia.application.commands.ajustar_grilla import (
     AjustarGrillaCommand,
     AjustarGrillaHandler,
@@ -21,6 +28,19 @@ from competencia.application.commands.confirmar_grilla import (
 from competencia.application.commands.configurar_intervalo_ot import (
     ConfigurarIntervaloOTCommand,
     ConfigurarIntervaloOTHandler,
+)
+from competencia.application.commands.llamar_atleta import (
+    AndarivelesConflicto,
+    CompetenciaNoEnEjecucion,
+    LlamarAtletaCommand,
+    LlamarAtletaHandler,
+    PerformanceNoEncontrada as PerformanceNoEncontradaLlamar,
+)
+from competencia.application.commands.registrar_resultado import (
+    RegistrarResultadoCommand,
+    RegistrarResultadoHandler,
+    PerformanceNoEncontrada as PerformanceNoEncontradaRegistrarResultado,
+    UnidadIncompatible,
 )
 from competencia.application.queries.obtener_competencias_por_torneo import (
     ObtenerCompetenciasPorTorneoHandler,
@@ -63,9 +83,17 @@ from competencia.application.queries.obtener_progreso import (
 )
 from competencia.domain.value_objects.cambio_grilla import CambioGrilla
 from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.motivo_dq import MotivoDQ
+from competencia.domain.value_objects.penalizacion_tecnica import PenalizacionTecnica
+from competencia.domain.value_objects.tipo_penalizacion import TipoPenalizacion
+from competencia.domain.value_objects.tipo_tarjeta import TipoTarjeta
+from competencia.domain.value_objects.unidad_medida import UnidadMedida
 from competencia.domain.ports.competencias_por_torneo_port import CompetenciasPorTorneoPort
 from competencia.domain.ports.event_store_port import EventStorePort
 from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from competencia.infrastructure.repositories.competencia_estado_adapter import (
+    CompetenciaEstadoAdapter,
+)
 from competencia.infrastructure.repositories.andariveles_activos_adapter import (
     AndarivelesActivosAdapter,
 )
@@ -78,7 +106,8 @@ from competencia.infrastructure.repositories.performances_estado_adapter import 
 from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
     SQLiteCompetenciasPorTorneo,
 )
-from shared.api.dependencies import OrganizadorDep
+from competencia.domain.exceptions import DomainError
+from shared.api.dependencies import JuezDep, OrganizadorDep
 
 router = APIRouter(prefix="/competencia", tags=["competencia"])
 
@@ -124,6 +153,49 @@ class ConfigurarOTBody(BaseModel):
     torneo_id: UUID | None = None
 
 
+class LlamarAtletaBody(BaseModel):
+    """Body del endpoint POST /competencia/{id}/llamar."""
+
+    participante_id: UUID
+    disciplina: Disciplina
+    ot_programado: datetime
+    posicion_grilla: int
+    andarivel: int = 1
+
+
+class RegistrarResultadoBody(BaseModel):
+    """Body del endpoint POST /competencia/{id}/registrar-resultado."""
+
+    participante_id: UUID
+    disciplina: Disciplina
+    valor_rp: Decimal
+    unidad: UnidadMedida
+
+
+class PenalizacionTecnicaBody(BaseModel):
+    """Payload de una penalización técnica individual."""
+
+    tipo: TipoPenalizacion
+    deduccion: Decimal
+
+
+class AsignarTarjetaBody(BaseModel):
+    """Body del endpoint POST /competencia/{id}/asignar-tarjeta."""
+
+    participante_id: UUID
+    disciplina: Disciplina
+    tipo: TipoTarjeta | None = None
+    tarjeta: TipoTarjeta | None = None
+    motivo_dq: MotivoDQ | None = None
+    motivo_texto: str | None = None
+    distancia_blackout: Decimal | None = None
+    penalizaciones: list[PenalizacionTecnicaBody] = []
+
+    def resolve_tipo(self) -> TipoTarjeta:
+        """Compatibilidad con spec: acepta `tipo` o `tarjeta`."""
+        return self.tipo or self.tarjeta or TipoTarjeta.Blanca
+
+
 # ── Dependency providers ──────────────────────────────────────────────────────
 
 
@@ -165,6 +237,33 @@ def get_obtener_andariveles_activos_handler(
     return ObtenerAndarivelesActivosHandler(AndarivelesActivosAdapter(event_store))
 
 
+def get_llamar_atleta_handler(
+    event_store: EventStoreDep,
+) -> LlamarAtletaHandler:
+    """Dependency: handler para llamar al atleta."""
+    return LlamarAtletaHandler(
+        event_store,
+        CompetenciaEstadoAdapter(event_store),
+        AndarivelesActivosAdapter(event_store),
+    )
+
+
+def get_registrar_resultado_handler(
+    event_store: EventStoreDep,
+    disciplina_descriptor: DisciplinaDescriptorDep,
+) -> RegistrarResultadoHandler:
+    """Dependency: handler para registrar resultado."""
+    return RegistrarResultadoHandler(event_store, disciplina_descriptor)
+
+
+def get_asignar_tarjeta_handler(
+    event_store: EventStoreDep,
+    performances_estado: PerformancesEstadoAdapterDep,
+) -> AsignarTarjetaHandler:
+    """Dependency: handler para asignar tarjeta."""
+    return AsignarTarjetaHandler(event_store, performances_estado)
+
+
 EventStoreDep = Annotated[EventStorePort, Depends(get_event_store)]
 DisciplinaDescriptorDep = Annotated[DisciplinaDescriptorAdapter, Depends(get_disciplina_descriptor)]
 CompetenciasPorTorneoProjectionDep = Annotated[
@@ -175,6 +274,13 @@ ObtenerAndarivelesActivosHandlerDep = Annotated[
 ]
 PerformancesEstadoAdapterDep = Annotated[
     PerformancesEstadoAdapter, Depends(get_performances_estado_adapter)
+]
+LlamarAtletaHandlerDep = Annotated[LlamarAtletaHandler, Depends(get_llamar_atleta_handler)]
+RegistrarResultadoHandlerDep = Annotated[
+    RegistrarResultadoHandler, Depends(get_registrar_resultado_handler)
+]
+AsignarTarjetaHandlerDep = Annotated[
+    AsignarTarjetaHandler, Depends(get_asignar_tarjeta_handler)
 ]
 
 
@@ -474,6 +580,99 @@ async def post_ajustar_grilla(
     return JSONResponse(content=None, status_code=204)
 
 
+@router.post("/{competencia_id}/llamar", response_class=JSONResponse)
+async def post_llamar_atleta(
+    competencia_id: UUID,
+    body: LlamarAtletaBody,
+    handler: LlamarAtletaHandlerDep,
+    user: JuezDep,
+) -> JSONResponse:
+    """Llama al atleta seleccionado para iniciar el flujo de performance."""
+    try:
+        await handler.handle(
+            LlamarAtletaCommand(
+                competencia_id=competencia_id,
+                participante_id=body.participante_id,
+                disciplina=body.disciplina,
+                ot_programado=body.ot_programado,
+                posicion_grilla=body.posicion_grilla,
+                andarivel=body.andarivel,
+            )
+        )
+    except (
+        CompetenciaNoEnEjecucion,
+        AndarivelesConflicto,
+    ) as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc), "actor": user["email"]})
+    except PerformanceNoEncontradaLlamar as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except DomainError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    return JSONResponse(content=None, status_code=204)
+
+
+@router.post("/{competencia_id}/registrar-resultado", response_class=JSONResponse)
+async def post_registrar_resultado(
+    competencia_id: UUID,
+    body: RegistrarResultadoBody,
+    handler: RegistrarResultadoHandlerDep,
+    user: JuezDep,
+) -> JSONResponse:
+    """Registra el RP de la performance activa."""
+    try:
+        await handler.handle(
+            RegistrarResultadoCommand(
+                competencia_id=competencia_id,
+                participante_id=body.participante_id,
+                disciplina=body.disciplina,
+                valor_rp=body.valor_rp,
+                unidad=body.unidad,
+                registrado_por=user["email"],
+            )
+        )
+    except UnidadIncompatible as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except PerformanceNoEncontradaRegistrarResultado as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except DomainError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    return JSONResponse(content=None, status_code=204)
+
+
+@router.post("/{competencia_id}/asignar-tarjeta", response_class=JSONResponse)
+async def post_asignar_tarjeta(
+    competencia_id: UUID,
+    body: AsignarTarjetaBody,
+    handler: AsignarTarjetaHandlerDep,
+    user: JuezDep,
+) -> JSONResponse:
+    """Asigna la tarjeta final de la performance."""
+    try:
+        await handler.handle(
+            AsignarTarjetaCommand(
+                competencia_id=competencia_id,
+                participante_id=body.participante_id,
+                disciplina=body.disciplina,
+                tipo=body.resolve_tipo(),
+                asignada_por=user["email"],
+                motivo_dq=body.motivo_dq,
+                motivo_texto=body.motivo_texto,
+                distancia_blackout=body.distancia_blackout,
+                penalizaciones=tuple(
+                    PenalizacionTecnica(tipo=p.tipo, deduccion=p.deduccion)
+                    for p in body.penalizaciones
+                ),
+            )
+        )
+    except ValueError as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except PerformanceNoEncontradaAsignarTarjeta as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except DomainError as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    return JSONResponse(content=None, status_code=204)
+
+
 @router.post("/{competencia_id}/confirmar-grilla", response_class=JSONResponse)
 async def post_confirmar_grilla(
     competencia_id: UUID,
@@ -537,9 +736,13 @@ async def get_grilla(
             {
                 "performance_id": e.performance_id,
                 "atleta_id": e.atleta_id,
+                "nombre_atleta": e.nombre_atleta,
                 "posicion": e.posicion,
                 "andarivel": e.andarivel,
                 "ot_programado": e.ot_programado,
+                "ap_declarado": e.ap_declarado,
+                "unidad": e.unidad,
+                "estado": e.estado,
             }
             for e in entradas
         ],

--- a/src/competencia/application/queries/obtener_grilla.py
+++ b/src/competencia/application/queries/obtener_grilla.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from competencia.domain.aggregates.competencia import Competencia
+from competencia.domain.aggregates.performance import Performance
 from competencia.domain.ports.event_store_port import EventStorePort
 from competencia.domain.value_objects.disciplina import Disciplina
 
@@ -16,9 +17,13 @@ class EntradaGrillaDTO:
 
     performance_id: str
     atleta_id: str
+    nombre_atleta: str
     posicion: int
     andarivel: int
     ot_programado: str
+    ap_declarado: str
+    unidad: str
+    estado: str
 
 
 @dataclass(frozen=True)  # pylint: disable=too-few-public-methods
@@ -52,9 +57,46 @@ class ObtenerGrillaHandler:
             EntradaGrillaDTO(
                 performance_id=str(e.performance_id),
                 atleta_id=str(e.atleta_id),
+                nombre_atleta=performance.nombre_atleta,
                 posicion=e.posicion,
                 andarivel=e.andarivel,
                 ot_programado=e.ot_programado.isoformat(),
+                ap_declarado=performance.ap_declarado,
+                unidad=performance.unidad,
+                estado=performance.estado,
             )
             for e in competencia.grilla
+            for performance in [await self._load_performance(query.competencia_id, e.atleta_id, query.disciplina)]
         ]
+
+    async def _load_performance(
+        self,
+        competencia_id: UUID,
+        atleta_id: UUID,
+        disciplina: Disciplina,
+    ) -> "_PerformanceProjection":
+        stream_id = f"performance-{competencia_id}-{atleta_id}-{disciplina.value}"
+        events = await self._event_store.load(stream_id)
+        if not events:
+            return _PerformanceProjection(
+                nombre_atleta=f"Atleta-{str(atleta_id)[:8]}",
+                ap_declarado="",
+                unidad="",
+                estado="AnunciadaAP",
+            )
+        performance = Performance.reconstitute(events)
+        ap = performance.ap
+        return _PerformanceProjection(
+            nombre_atleta=f"Atleta-{str(atleta_id)[:8]}",
+            ap_declarado=str(ap.valor) if ap else "",
+            unidad=ap.unidad.value if ap else "",
+            estado=performance.estado.value if performance.estado else "",
+        )
+
+
+@dataclass(frozen=True)
+class _PerformanceProjection:
+    nombre_atleta: str
+    ap_declarado: str
+    unidad: str
+    estado: str

--- a/src/competencia/application/queries/obtener_performance_actual.py
+++ b/src/competencia/application/queries/obtener_performance_actual.py
@@ -88,5 +88,5 @@ class ObtenerPerformanceActualHandler:  # pylint: disable=too-few-public-methods
                 payload = event["payload"]
                 if isinstance(payload, str):
                     payload = json.loads(payload)
-                return int(payload.get("posicion_grilla", 0))
+                return int(payload.get("andarivel", 0))
         return 0

--- a/tests/features/US-4.3.2-flujo-performance.feature
+++ b/tests/features/US-4.3.2-flujo-performance.feature
@@ -1,0 +1,41 @@
+Feature: US-4.3.2 - Flujo de performance del juez conectado al backend
+
+  Background:
+    Given el juez "juez@ataraxia.com" esta autenticado
+    And la competencia C1 de disciplina DNF esta en estado EnEjecucion
+    And el atleta "Garcia, Ana" tiene AP 75m en AnunciadaAP
+
+  Scenario: flujo completo exitoso con tarjeta blanca
+    Given el juez esta en la grilla de la competencia C1
+    When toca la fila de "Garcia, Ana" en estado PENDIENTE
+    Then ve el Paso 1 con el boton "LLAMAR ATLETA"
+    When toca "LLAMAR ATLETA"
+    Then el backend recibe POST /competencia/C1/llamar para la performance seleccionada
+    And la UI avanza al Paso 2
+    When confirma presencia y avanza hasta el Paso 5
+    And ingresa 72m 00cm
+    And toca "CONFIRMAR MARCA"
+    Then el backend recibe POST /competencia/C1/registrar-resultado con valor_rp 72.00
+    When en el Paso 6 toca "TARJETA BLANCA"
+    Then el backend recibe POST /competencia/C1/asignar-tarjeta con tipo Blanca
+    And ve la pantalla final de performance completada
+    When toca "SIGUIENTE ATLETA"
+    Then regresa a la grilla S-02
+
+  Scenario: la grilla muestra estados visibles segun la performance
+    Given la grilla tiene performances en estados AnunciadaAP, Llamada y TarjetaAsignada
+    When el juez accede a /juez/grilla
+    Then la performance TarjetaAsignada aparece deshabilitada
+    And la performance Llamada aparece destacada como en curso
+    And la performance AnunciadaAP aparece disponible para iniciar
+
+  Scenario: boton confirmar marca deshabilitado sin RP ingresado
+    Given el juez esta en el Paso 5
+    When no ingresa metros ni centimetros
+    Then el boton "CONFIRMAR MARCA" esta deshabilitado
+
+  Scenario: error del backend se muestra inline y no rompe el flujo
+    Given el juez intenta llamar una performance que ya no esta en AnunciadaAP
+    When el backend responde 409
+    Then la pantalla muestra "No se puede ejecutar esta accion en el estado actual"
+    And el juez permanece en el paso actual


### PR DESCRIPTION
## Resumen
Implementa US-4.3.2 para el flujo del juez.

- expone POST /competencia/{id}/llamar, /registrar-resultado y /asignar-tarjeta
- reemplaza el stub de grilla por la pantalla operativa
- agrega wizard movil de 6 pasos en /juez/performance
- incorpora fixture local y artefactos del pipeline
- validacion tecnica y manual completadas

## Validacion
- npm run build
- npm run lint
- ./.venv/bin/python -m compileall src
- smoke test con TestClient
- validacion manual UI confirmada