### PR TITLE
US-4.3.5: adaptar STA en paso 3 y ajustar UI movil

### DIFF
--- a/.claude/tracking/US-4.3.5-tracking.json
+++ b/.claude/tracking/US-4.3.5-tracking.json
@@ -1,0 +1,83 @@
+{
+  "metadata": {
+    "us_id": "US-4.3.5",
+    "us_title": "Adaptacion STA en el Paso 3",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-12T13:16:39.147170+00:00",
+    "completed_at": null,
+    "total_elapsed_seconds": 267,
+    "effective_seconds": 267,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-12T13:16:54.545713+00:00",
+      "completed_at": "2026-04-12T13:16:58.846571+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-12T13:17:01.402283+00:00",
+      "completed_at": "2026-04-12T13:17:03.781151+00:00",
+      "elapsed_seconds": 2,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-12T13:17:06.520343+00:00",
+      "completed_at": "2026-04-12T13:17:08.818467+00:00",
+      "elapsed_seconds": 2,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-12T13:17:12.371892+00:00",
+      "completed_at": "2026-04-12T13:19:34.161923+00:00",
+      "elapsed_seconds": 141,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-12T13:21:07.035043+00:00",
+      "completed_at": null,
+      "elapsed_seconds": 0,
+      "status": "in_progress",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 5,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/plans/sp4/US-4.3.5-plan.md
+++ b/docs/plans/sp4/US-4.3.5-plan.md
@@ -1,0 +1,189 @@
+# Plan de Implementación — US-4.3.5
+
+**US:** US-4.3.5 — Adaptación STA en el Paso 3  
+**Incremento:** INC-4.3  
+**Sprint:** SP4 — La Plataforma  
+**Fecha:** 2026-04-12  
+**Branch:** `feature/US-4.3.5-sta-paso-3`
+
+---
+
+## Objetivo
+
+Adaptar el flujo del juez para STA de forma reglamentariamente correcta:
+
+- el inicio de la performance se registra cuando las vías respiratorias entran en agua;
+- la UI del Paso 3 cambia el CTA y su texto contextual para STA;
+- el Paso 5 usa un selector de tiempo en segundos, no de distancia.
+
+---
+
+## Alcance real
+
+### Frontend
+
+Modificar el flujo del juez para que:
+
+- Paso 3 maneje la ventana OT activa y el tap de inicio;
+- el CTA de inicio sea distinto en STA;
+- Paso 4 represente solo la performance ya iniciada;
+- `RpSelector` tenga una variante `Segundos`.
+
+### Backend
+
+Sin cambios.
+
+El backend ya soporta `registrar_resultado` con `unidad=Segundos`.
+
+---
+
+## Decisiones de implementación
+
+### 1. Corregir el desfasaje entre spec y UI actual
+
+La implementación vigente deja el inicio real en Paso 4.  
+Decisión:
+
+- mover la acción de inicio al Paso 3;
+- dejar Paso 4 solo para `FINALIZAR PERFORMANCE` y BKO.
+
+Esto es consistente con:
+
+- `docs/specs/sp4/US-4.3.2.md`
+- `docs/specs/sp4/US-4.3.5.md`
+- `docs/design/ux/wireframes-juez.md`
+
+### 2. Detectar STA por unidad existente
+
+Decisión:
+
+- reutilizar `atletaActivo.unidad === "Segundos"` como señal de STA;
+- no agregar banderas nuevas al store.
+
+### 3. Mantener un solo `RpSelector` con dos modos
+
+Decisión:
+
+- extender el componente con una prop de modo;
+- evitar duplicar selector de metros y selector de tiempo.
+
+Modos:
+
+- `Metros`
+- `Segundos`
+
+### 4. Serialización del valor RP para STA
+
+Decisión:
+
+- conservar el payload actual de `registrarResultado`;
+- para STA construir `valor_rp` como total de segundos;
+- seguir enviando `unidad` desde `atletaActivo.unidad`.
+
+---
+
+## Cambios propuestos
+
+### A. Flujo del juez
+
+Modificar:
+
+- [frontend/src/pages/juez/PerformanceFlowPage.tsx](/Users/victor/PycharmProjects/ataraxiadive/frontend/src/pages/juez/PerformanceFlowPage.tsx:1)
+
+Cambios:
+
+1. introducir estado local para ventana OT activa;
+2. mover el CTA de inicio al Paso 3;
+3. mostrar label y descripción alternativa cuando `isSTA`;
+4. al iniciar, avanzar directo a Paso 4 con cronómetro activo;
+5. simplificar Paso 4 para que solo permita finalizar o registrar BKO.
+
+### B. Selector de RP
+
+Modificar:
+
+- [frontend/src/components/juez/RpSelector.tsx](/Users/victor/PycharmProjects/ataraxiadive/frontend/src/components/juez/RpSelector.tsx:1)
+
+Cambios:
+
+1. agregar modo `Segundos`;
+2. renderizar display `MM:SS`;
+3. presets `120, 180, 240, 300, 360`;
+4. ajustes `-5, +5, +30, +60`;
+5. reutilizar el campo secundario como segundos cuando corresponda.
+
+### C. Helpers de formato/serialización
+
+Modificar:
+
+- [frontend/src/pages/juez/PerformanceFlowPage.tsx](/Users/victor/PycharmProjects/ataraxiadive/frontend/src/pages/juez/PerformanceFlowPage.tsx:1)
+
+Cambios:
+
+1. separar formateo de distancia y de tiempo;
+2. construir correctamente `valor_rp` para metros y para segundos;
+3. ajustar textos de cierre para STA.
+
+---
+
+## Riesgos
+
+### 1. Regresión en disciplinas de distancia
+
+Si el reordenamiento del Paso 3/4 se hace mal, DNF y otras disciplinas pueden cambiar su
+comportamiento esperado.
+
+Mitigación:
+
+- mantener exactamente la misma secuencia funcional para no-STA;
+- validar explícitamente DNF y STA.
+
+### 2. Formato incorrecto al enviar STA
+
+Si la UI muestra `MM:SS` pero serializa mal `valor_rp`, el backend puede registrar un RP
+distinto al esperado.
+
+Mitigación:
+
+- usar helpers explícitos para convertir entre display y total de segundos;
+- probar con un caso simple como `4:30`.
+
+### 3. Complejidad accidental en `PerformanceFlowPage`
+
+La pantalla ya concentra bastante lógica.
+
+Mitigación:
+
+- introducir helpers pequeños en vez de ramas duplicadas;
+- limitar el cambio al flujo OT y al formateo.
+
+---
+
+## Validación prevista
+
+- `frontend: npm run lint`
+- `frontend: npm run build`
+- validación manual STA:
+  - Paso 3 con CTA contextual
+  - inicio desde Paso 3
+  - Paso 5 en tiempo
+- validación manual DNF:
+  - Paso 3 estándar
+  - Paso 5 en metros
+
+---
+
+## Secuencia de implementación
+
+1. Inicializar tracking de `US-4.3.5`.
+2. Registrar Fase 0 con el contexto validado.
+3. Registrar Fase 1 con BDD.
+4. Registrar Fase 2 con plan.
+5. Implementar cambios en `PerformanceFlowPage`.
+6. Extender `RpSelector`.
+7. Ejecutar validaciones técnicas.
+8. Generar reporte final y preparar smoke manual.
+
+---
+
+*Plan generado: 2026-04-12 — US-4.3.5 INC-4.3 SP4*

--- a/docs/reports/US-4.3.5-context.md
+++ b/docs/reports/US-4.3.5-context.md
@@ -1,0 +1,104 @@
+# Contexto de Implementación — US-4.3.5
+
+| Campo | Valor |
+|---|---|
+| **US** | US-4.3.5 — Adaptación STA en el Paso 3 |
+| **Incremento** | INC-4.3 |
+| **Sprint** | SP4 — La Plataforma |
+| **Fecha** | 2026-04-12 |
+| **Branch** | `feature/US-4.3.5-sta-paso-3` |
+
+---
+
+## Hallazgos relevantes del código actual
+
+### 1. El inicio real de la performance hoy está corrido al Paso 4
+
+La spec de `US-4.3.2` y los wireframes del juez indican:
+
+- Paso 3: OT, ventana activa y acción de inicio;
+- Paso 4: performance en curso con cronómetro corriendo.
+
+La implementación actual en `PerformanceFlowPage.tsx` hace otra cosa:
+
+- Paso 3 solo abre la ventana OT;
+- Paso 4 recién muestra `INICIAR PERFORMANCE`;
+- Paso 4 también usa `chronoStarted` para alternar entre inicio y finalización.
+
+Conclusión:
+
+- `US-4.3.5` no conviene resolverse solo cambiando un label;
+- hay que realinear el flujo para que el tap de inicio suceda dentro del Paso 3.
+
+### 2. La detección de STA ya existe implícitamente por unidad
+
+La pantalla hoy calcula:
+
+- `isSTA = atletaActivo?.unidad === "Segundos"`
+
+Eso ya permite distinguir STA sin tocar backend ni store.
+
+Conclusión:
+
+- la adaptación puede resolverse solo en frontend;
+- no hace falta introducir una API nueva ni cambiar el dominio.
+
+### 3. `RpSelector` sigue modelado exclusivamente para metros y centímetros
+
+El selector actual:
+
+- recibe `metros` y `centimetros`;
+- usa presets `[25, 50, 75, 100, 125]`;
+- renderiza unidad fija `m`;
+- usa botones `-1`, `+1`, `+5`, `+10`.
+
+La spec de `US-4.3.5` requiere para STA:
+
+- display en `MM:SS`;
+- presets `2:00`, `3:00`, `4:00`, `5:00`, `6:00`;
+- ajustes `-5s`, `+5s`, `+30s`, `+1m`.
+
+Conclusión:
+
+- `RpSelector` necesita una variante explícita para tiempo;
+- no alcanza con cambiar textos desde la pantalla.
+
+### 4. El backend ya soporta resultados en segundos
+
+La API actual ya envía:
+
+- `valor_rp`
+- `unidad`
+
+La pantalla usa `atletaActivo.unidad` al registrar resultado, y la spec confirma que
+`unidad=Segundos` ya es compatible con backend.
+
+Conclusión:
+
+- la US sigue siendo frontend puro;
+- el foco real es serializar correctamente el valor para STA y ajustar la UX.
+
+### 5. No hay tests frontend automatizados en el repo
+
+`frontend/package.json` no incluye runner de tests y no se encontraron archivos `.test` o `.spec`.
+
+Conclusión:
+
+- la validación técnica viable para esta US es `npm run lint` y `npm run build`;
+- la validación funcional fuerte va a ser manual en navegador.
+
+---
+
+## Decisión para seguir
+
+La implementación de `US-4.3.5` va a incluir:
+
+1. realinear Paso 3 para que maneje OT + inicio;
+2. mostrar CTA contextual para STA: `VIAS RESPIRATORIAS EN AGUA`;
+3. dejar Paso 4 solo como performance en curso;
+4. agregar modo `Segundos` en `RpSelector` para STA;
+5. mantener sin cambios el backend.
+
+---
+
+*Generado: 2026-04-12 — Fase 0 US-4.3.5*

--- a/docs/reports/US-4.3.5-report.md
+++ b/docs/reports/US-4.3.5-report.md
@@ -1,0 +1,74 @@
+# Reporte de Implementación: US-4.3.5
+
+**US:** US-4.3.5 — Adaptación STA en el Paso 3  
+**Incremento:** INC-4.3  
+**Sprint:** SP4 — La Plataforma  
+**Fecha:** 2026-04-12  
+**Branch:** `feature/US-4.3.5-sta-paso-3`
+
+---
+
+## Resumen de Implementación
+
+### Artefactos creados
+
+| Artefacto | Path | Descripción |
+|-----------|------|-------------|
+| Contexto | `docs/reports/US-4.3.5-context.md` | hallazgos de Fase 0 |
+| Feature | `tests/features/US-4.3.5-sta-paso-3.feature` | escenarios BDD |
+| Plan | `docs/plans/sp4/US-4.3.5-plan.md` | plan de implementación |
+| Reporte | `docs/reports/US-4.3.5-report.md` | cierre técnico y validaciones |
+
+### Artefactos modificados
+
+| Artefacto | Path | Descripción |
+|-----------|------|-------------|
+| Flow juez | `frontend/src/pages/juez/PerformanceFlowPage.tsx` | Paso 3 con OT activa + CTA contextual STA y Paso 4 simplificado |
+| Selector RP | `frontend/src/components/juez/RpSelector.tsx` | variante `Segundos` para STA con presets y ajustes de tiempo |
+
+---
+
+## Decisiones y hallazgos relevantes
+
+1. **La US corrigió un desfasaje previo del flujo OT**  
+   La UI actual tenía el inicio real de la performance en el Paso 4. Se reordenó para que
+   el inicio ocurra dentro del Paso 3, alineado con `US-4.3.2`, `US-4.3.5` y los wireframes.
+
+2. **STA se resolvió sin tocar backend**  
+   La detección se apoya en `unidad === "Segundos"` y el backend siguió usando el mismo
+   endpoint `registrar_resultado`.
+
+3. **`RpSelector` pasó a tener dos modos reales**  
+   El mismo componente ahora cubre:
+   - distancia en metros/cm para disciplinas de distancia;
+   - tiempo en minutos/segundos para STA.
+
+4. **Se mantuvo compatibilidad para DNF y similares**  
+   Las disciplinas no-STA conservan CTA estándar en Paso 3 y selector en metros en Paso 5.
+
+---
+
+## Quality Gates
+
+| Gate | Resultado |
+|------|-----------|
+| `frontend: npm run lint` | ✅ aprobado |
+| `frontend: npm run build` | ✅ aprobado |
+| Validación manual STA + DNF | ⏳ pendiente |
+
+---
+
+## Estado de cierre
+
+`US-4.3.5` quedó implementada a nivel de frontend y validada técnicamente con `lint` y `build`.
+
+Pendiente para cierre funcional completo:
+
+- validar manualmente STA en Paso 3;
+- validar manualmente inicio desde Paso 3;
+- validar manualmente STA en Paso 5 con selector `MM:SS`;
+- validar manualmente DNF para confirmar que no hubo regresión.
+
+---
+
+*Generado: 2026-04-12 — implementación manual secuencial de US-4.3.5*

--- a/frontend/src/components/juez/AtletaCard.tsx
+++ b/frontend/src/components/juez/AtletaCard.tsx
@@ -32,7 +32,7 @@ export function AtletaCard({
         </p>
       ) : null}
       <h2 className="mt-3 text-2xl font-semibold text-white">{nombreAtleta}</h2>
-      <div className="mt-4 grid grid-cols-3 gap-3 text-sm text-slate-300">
+      <div className="mt-4 space-y-3 text-sm text-slate-300">
         <div className="rounded-2xl bg-slate-950/70 p-3">
           <p className="text-[11px] uppercase tracking-[0.18em] text-slate-500">
             Performance anunciada

--- a/frontend/src/components/juez/JuezLayout.tsx
+++ b/frontend/src/components/juez/JuezLayout.tsx
@@ -14,10 +14,9 @@ export function JuezLayout({ title, subtitle, actions, children }: JuezLayoutPro
         <header className="mb-6 rounded-3xl border border-slate-800 bg-slate-900/80 p-4 shadow-lg shadow-slate-950/40">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-400">
-                AtaraxiaDive
-              </p>
-              <h1 className="mt-2 text-2xl font-semibold text-slate-50">{title}</h1>
+              <h1 className="text-2xl font-semibold uppercase tracking-[0.18em] text-slate-50">
+                {title}
+              </h1>
               {subtitle ? <p className="mt-2 text-sm text-slate-400">{subtitle}</p> : null}
             </div>
             {actions}

--- a/frontend/src/components/juez/RpSelector.tsx
+++ b/frontend/src/components/juez/RpSelector.tsx
@@ -1,65 +1,116 @@
 interface RpSelectorProps {
   metros: number
   centimetros: string
+  unidad?: string
   onMetrosChange: (value: number) => void
   onCentimetrosChange: (value: string) => void
 }
 
-const presets = [25, 50, 75, 100, 125]
 const keypad = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
 
 export function RpSelector({
   metros,
   centimetros,
+  unidad = 'Metros',
   onMetrosChange,
   onCentimetrosChange,
 }: RpSelectorProps) {
+  const isSecondsMode = unidad === 'Segundos'
+  const displayMinor = centimetros.padStart(2, '0')
+  const totalSeconds = metros * 60 + Number(centimetros || '0')
+  const presets = isSecondsMode ? [120, 180, 240, 300, 360] : [25, 50, 75, 100, 125]
+  const adjustments = isSecondsMode
+    ? [
+        ['-5s', -5],
+        ['+5s', 5],
+        ['+30s', 30],
+        ['+1m', 60],
+      ]
+    : [
+        ['-1', -1],
+        ['+1', 1],
+        ['+5', 5],
+        ['+10', 10],
+      ]
+
+  function setTotalSeconds(next: number) {
+    const safeValue = Math.max(0, next)
+    onMetrosChange(Math.floor(safeValue / 60))
+    onCentimetrosChange(String(safeValue % 60))
+  }
+
   function pushDigit(digit: string) {
     const next = `${centimetros}${digit}`.slice(-2)
+    if (isSecondsMode) {
+      onCentimetrosChange(String(Math.min(59, Number(next))))
+      return
+    }
     onCentimetrosChange(next)
   }
 
   return (
-    <section className="space-y-5 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
+    <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-4">
       <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Marca</p>
-        <p className="mt-2 text-4xl font-semibold text-white">
-          {metros}
-          <span className="text-slate-500">.</span>
-          {centimetros.padEnd(2, '0')} m
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+          {isSecondsMode ? 'Tiempo' : 'Marca'}
+        </p>
+        <p className="mt-2 text-3xl font-semibold text-white sm:text-4xl">
+          {isSecondsMode ? (
+            <>
+              {metros}
+              <span className="text-slate-500">:</span>
+              {displayMinor}
+              <span className="ml-2 text-lg text-slate-500">min</span>
+            </>
+          ) : (
+            <>
+              {metros}
+              <span className="text-slate-500">.</span>
+              {centimetros.padEnd(2, '0')} m
+            </>
+          )}
         </p>
       </div>
 
-      <div className="grid grid-cols-5 gap-2">
+      <div className="grid grid-cols-5 gap-1.5">
         {presets.map((preset) => (
           <button
             key={preset}
             type="button"
-            onClick={() => onMetrosChange(preset)}
+            onClick={() => {
+              if (isSecondsMode) {
+                setTotalSeconds(preset)
+                return
+              }
+              onMetrosChange(preset)
+            }}
             className={[
-              'rounded-2xl border px-3 py-3 text-sm font-semibold transition',
-              metros === preset
+              'rounded-xl border px-2 py-2.5 text-xs font-semibold transition sm:text-sm',
+              (isSecondsMode ? totalSeconds === preset : metros === preset)
                 ? 'border-cyan-300 bg-cyan-400/20 text-cyan-100'
                 : 'border-slate-700 bg-slate-950/70 text-slate-200',
             ].join(' ')}
           >
-            {preset}
+            {isSecondsMode
+              ? `${Math.floor(preset / 60)}:${String(preset % 60).padStart(2, '0')}`
+              : preset}
           </button>
         ))}
       </div>
 
-      <div className="grid grid-cols-4 gap-2 text-sm font-semibold">
-        {[
-          ['-1', -1],
-          ['+1', 1],
-          ['+5', 5],
-          ['+10', 10],
-        ].map(([label, delta]) => (
+      <div className="grid grid-cols-4 gap-1.5 text-xs font-semibold sm:text-sm">
+        {adjustments.map(([label, delta]) => (
           <button
             key={label}
             type="button"
-            onClick={() => onMetrosChange(Math.max(0, metros + Number(delta)))}
-            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-slate-100"
+            onClick={() => {
+              if (isSecondsMode) {
+                setTotalSeconds(totalSeconds + Number(delta))
+                return
+              }
+              onMetrosChange(Math.max(0, metros + Number(delta)))
+            }}
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-2 py-2.5 text-slate-100"
           >
             {label}
           </button>
@@ -68,15 +119,15 @@ export function RpSelector({
 
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-          Centimetros
+          {isSecondsMode ? 'Segundos' : 'Centimetros'}
         </p>
-        <div className="mt-3 grid grid-cols-3 gap-2">
+        <div className="mt-3 grid grid-cols-3 gap-1.5">
           {keypad.slice(0, 9).map((digit) => (
             <button
               key={digit}
               type="button"
               onClick={() => pushDigit(digit)}
-              className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-lg font-semibold text-white"
+              className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-base font-semibold text-white sm:py-4 sm:text-lg"
             >
               {digit}
             </button>
@@ -84,21 +135,21 @@ export function RpSelector({
           <button
             type="button"
             onClick={() => onCentimetrosChange('')}
-            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-sm font-semibold text-slate-200"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-xs font-semibold text-slate-200 sm:py-4 sm:text-sm"
           >
             CLR
           </button>
           <button
             type="button"
             onClick={() => pushDigit('0')}
-            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-lg font-semibold text-white"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-base font-semibold text-white sm:py-4 sm:text-lg"
           >
             0
           </button>
           <button
             type="button"
             onClick={() => onCentimetrosChange(centimetros.slice(0, -1))}
-            className="rounded-2xl border border-slate-700 bg-slate-950/70 px-3 py-4 text-sm font-semibold text-slate-200"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-xs font-semibold text-slate-200 sm:py-4 sm:text-sm"
           >
             DEL
           </button>

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -48,8 +48,21 @@ function buildRpValue(metros: number, centimetros: string) {
   return `${metros}.${centimetros.padEnd(2, '0')}`
 }
 
+function buildResultadoValue(metros: number, centimetros: string, unidad: string) {
+  if (unidad === 'Segundos') {
+    return String(metros * 60 + Number(centimetros || '0'))
+  }
+  return buildRpValue(metros, centimetros)
+}
+
 function formatMarca(value: string, unidad: string) {
-  return `${value} ${unidad === 'Segundos' ? 's' : 'm'}`
+  if (unidad === 'Segundos') {
+    const totalSeconds = Number(value || '0')
+    const minutos = Math.floor(totalSeconds / 60)
+    const segundos = totalSeconds % 60
+    return `${minutos}:${String(segundos).padStart(2, '0')} min`
+  }
+  return `${value} m`
 }
 
 function admitePenalizaciones(disciplina: string) {
@@ -82,6 +95,7 @@ export function PerformanceFlowPage() {
   const [inlineError, setInlineError] = useState<string | null>(null)
   const [metros, setMetros] = useState(0)
   const [centimetros, setCentimetros] = useState('')
+  const [otWindowActive, setOtWindowActive] = useState(false)
   const [chronoStarted, setChronoStarted] = useState(false)
   const [selectedCard, setSelectedCard] = useState<TarjetaSeleccionada>(null)
   const [motivoDq, setMotivoDq] = useState('')
@@ -164,7 +178,7 @@ export function PerformanceFlowPage() {
         competenciaId: competenciaId!,
         participanteId: atletaActivo!.atletaId,
         disciplina: disciplinaActiva!,
-        valorRp: buildRpValue(metros, centimetros),
+        valorRp: buildResultadoValue(metros, centimetros, atletaActivo!.unidad || 'Metros'),
         unidad: atletaActivo!.unidad || 'Metros',
       })
     },
@@ -302,7 +316,10 @@ export function PerformanceFlowPage() {
     if (resultKind === 'AMARILLA') {
       return 'La performance queda en revision hasta definir tarjeta final'
     }
-    const marca = formatMarca(buildRpValue(metros, centimetros), atletaActivo?.unidad ?? 'Metros')
+    const marca = formatMarca(
+      buildResultadoValue(metros, centimetros, atletaActivo?.unidad ?? 'Metros'),
+      atletaActivo?.unidad ?? 'Metros',
+    )
     if (resultKind === 'BLANCA_CON_PENALIZACIONES') {
       return `${marca} · ${penaltyCount} penalizaciones`
     }
@@ -315,8 +332,7 @@ export function PerformanceFlowPage() {
 
   return (
     <JuezLayout
-      title="Performance"
-      subtitle={`${disciplinaActiva} · ${atletaActivo.nombreAtleta}`}
+      title={disciplinaActiva}
       actions={
         <Link
           to="/juez/grilla"
@@ -371,7 +387,10 @@ export function PerformanceFlowPage() {
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <button
               type="button"
-              onClick={() => setStep(3)}
+              onClick={() => {
+                setOtWindowActive(false)
+                setStep(3)
+              }}
               className="w-full rounded-2xl bg-emerald-400 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
             >
               CONTINUAR
@@ -398,13 +417,38 @@ export function PerformanceFlowPage() {
               minute: '2-digit',
             })}
           </p>
-          <button
-            type="button"
-            onClick={() => setStep(4)}
-            className="w-full rounded-2xl bg-amber-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
-          >
-            INICIAR VENTANA OT
-          </button>
+          {!otWindowActive ? (
+            <button
+              type="button"
+              onClick={() => setOtWindowActive(true)}
+              className="w-full rounded-2xl bg-amber-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+            >
+              INICIAR VENTANA OT
+            </button>
+          ) : (
+            <>
+              <div className="rounded-3xl border border-cyan-400/20 bg-cyan-400/10 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">
+                  Ventana OT activa
+                </p>
+                <p className="mt-2 text-sm text-slate-100">
+                  {isSTA
+                    ? 'Las vias respiratorias del atleta entran en contacto con el agua.'
+                    : 'El atleta comienza su performance dentro de la ventana oficial.'}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setChronoStarted(true)
+                  setStep(4)
+                }}
+                className="w-full rounded-2xl bg-emerald-400 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+              >
+                {isSTA ? 'VIAS RESPIRATORIAS EN AGUA' : 'ATLETA INICIA'}
+              </button>
+            </>
+          )}
         </section>
       ) : null}
 
@@ -413,26 +457,16 @@ export function PerformanceFlowPage() {
           <h3 className="text-xl font-semibold text-white">Paso 4 · Performance</h3>
           <p className="text-sm text-slate-300">
             {chronoStarted
-              ? 'La performance está en curso. Finaliza cuando el atleta complete su intento.'
-              : 'Inicia el cronómetro local cuando comience la performance.'}
+              ? 'La performance esta en curso. Finaliza cuando el atleta complete su intento.'
+              : 'La performance ya fue iniciada desde la ventana OT.'}
           </p>
-          {!chronoStarted ? (
-            <button
-              type="button"
-              onClick={() => setChronoStarted(true)}
-              className="w-full rounded-2xl bg-fuchsia-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
-            >
-              INICIAR PERFORMANCE
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setStep(5)}
-              className="w-full rounded-2xl bg-orange-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
-            >
-              FINALIZAR PERFORMANCE
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => setStep(5)}
+            className="w-full rounded-2xl bg-orange-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+          >
+            FINALIZAR PERFORMANCE
+          </button>
           <button
             type="button"
             onClick={() => {
@@ -458,6 +492,7 @@ export function PerformanceFlowPage() {
               <RpSelector
                 metros={metros}
                 centimetros={centimetros}
+                unidad={atletaActivo.unidad}
                 onMetrosChange={setMetros}
                 onCentimetrosChange={setCentimetros}
               />
@@ -499,6 +534,7 @@ export function PerformanceFlowPage() {
           <RpSelector
             metros={metros}
             centimetros={centimetros}
+            unidad={atletaActivo.unidad}
             onMetrosChange={setMetros}
             onCentimetrosChange={setCentimetros}
           />
@@ -517,14 +553,11 @@ export function PerformanceFlowPage() {
         <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
           <h3 className="text-xl font-semibold text-white">Paso 6 · Tarjeta</h3>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-            {([
-              ['Blanca', 'Tarjeta Blanca'],
-              ['Roja', 'Tarjeta Roja'],
-              ['Amarilla', 'Tarjeta Amarilla'],
-            ] as const).map(([card, label]) => (
+            {(['Blanca', 'Roja', 'Amarilla'] as const).map((card) => (
               <button
                 key={card}
                 type="button"
+                aria-label={`Tarjeta ${card}`}
                 onClick={() => {
                   setSelectedCard(card)
                   if (card === 'Blanca') {
@@ -538,7 +571,7 @@ export function PerformanceFlowPage() {
                   }
                 }}
                 className={[
-                  'rounded-2xl border px-4 py-4 text-center text-sm font-semibold uppercase tracking-[0.18em] transition',
+                  'h-20 rounded-2xl border transition',
                   (selectedCard === card ||
                     (card === 'Blanca' && selectedCard === 'BlancaConPenalizaciones'))
                     ? card === 'Blanca'
@@ -548,15 +581,7 @@ export function PerformanceFlowPage() {
                         : 'border-amber-300 bg-amber-400/15 text-amber-100'
                     : 'border-slate-700 bg-slate-950/70 text-slate-200',
                 ].join(' ')}
-              >
-                <span className="block text-[11px] tracking-[0.24em] text-slate-400">Tarjeta</span>
-                <span className="mt-2 block">
-                  {card === 'Blanca' ? 'VERDE' : card === 'Roja' ? 'ROJA' : 'AMARILLA'}
-                </span>
-                <span className="mt-2 block text-[11px] normal-case tracking-normal text-current/80">
-                  {label}
-                </span>
-              </button>
+              />
             ))}
           </div>
 

--- a/tests/features/US-4.3.5-sta-paso-3.feature
+++ b/tests/features/US-4.3.5-sta-paso-3.feature
@@ -1,0 +1,36 @@
+Feature: US-4.3.5 - Adaptacion STA en el Paso 3
+
+  Background:
+    Given el juez "juez@ataraxia.com" esta autenticado
+    And la competencia C1 es de disciplina STA
+    And el atleta "Rodriguez, Pedro" tiene AP 4m30s en AnunciadaAP
+
+  Scenario: Paso 3 en STA muestra boton adaptado
+    Given el juez llamo a Rodriguez y esta en el Paso 3
+    And la ventana OT esta activa
+    Then el boton muestra "VIAS RESPIRATORIAS EN AGUA"
+    And no se muestra "ATLETA INICIA"
+    And hay un texto descriptivo "Las vias respiratorias del atleta entran en contacto con el agua"
+
+  Scenario: Tap en boton STA arranca el cronometro normalmente
+    Given el juez esta en el Paso 3 de STA con ventana activa
+    When toca "VIAS RESPIRATORIAS EN AGUA"
+    Then la UI avanza al Paso 4
+    And el estado visible es "Performance en curso"
+    And el cronometro local ya esta iniciado
+
+  Scenario: Paso 3 en DNF mantiene boton estandar
+    Given el juez esta en el Paso 3 de una disciplina DNF con ventana activa
+    Then el boton muestra "ATLETA INICIA"
+    And no hay mencion de "vias respiratorias"
+
+  Scenario: Paso 5 de STA usa selector de tiempo
+    Given el juez llego al Paso 5 de STA
+    Then el selector muestra minutos y segundos
+    And los presets son "2:00", "3:00", "4:00", "5:00", "6:00"
+    And los ajustes son "-5s", "+5s", "+30s", "+1m"
+
+  Scenario: Paso 5 de DNF mantiene selector en metros
+    Given el juez llego al Paso 5 de DNF
+    Then el selector muestra metros y centimetros
+    And los presets son "25", "50", "75", "100", "125"


### PR DESCRIPTION
## Resumen
- adapta el Paso 3 para STA con CTA 'VIAS RESPIRATORIAS EN AGUA'
- realinea el flujo OT para iniciar la performance desde el Paso 3
- agrega modo Segundos en RpSelector para STA
- aplica ajustes de UI detectados en la validacion manual

## Validacion
- npm run lint
- npm run build
- fixture manual refrescada para STA y DNF

## Pendiente
- validacion manual final en navegador para cierre funcional de US-4.3.5