### PR TITLE
fix(frontend+domain): mejoras UX INC-4.3 — flujo del juez

### DIFF
--- a/docs/contexto/HITO-19-INC-4-1-HALLAZGOS-DISENO-CIERRE.md
+++ b/docs/contexto/HITO-19-INC-4-1-HALLAZGOS-DISENO-CIERRE.md
@@ -1,0 +1,232 @@
+# HITO-19 — El cierre de incremento como checkpoint formal de captura de hallazgos de diseño
+
+| Campo | Valor |
+|-------|-------|
+| **Documento** | HITO-19 — Hallazgo metodológico al cierre de INC-4.1 |
+| **Fecha** | 2026-04-08 |
+| **Sprint** | SP4 — cierre de INC-4.1 |
+| **Relacionado** | `HITO-11` · `HITO-13` · `docs/plans/sp4/PLAN-SP4.md` · `docs/reports/US-4.1.2-report.md` · `docs/reports/US-4.1.3-report.md` · `docs/reports/US-4.1.4-report.md` |
+
+---
+
+## Contexto
+
+El cierre de `INC-4.1` dejó cuatro US implementadas:
+
+- `US-4.1.1` — motivos de tarjeta roja
+- `US-4.1.2` — tarjeta blanca con penalizaciones
+- `US-4.1.3` — subdisciplinas SPE
+- `US-4.1.4` — orden reglamentario de grilla
+
+Las funcionalidades quedaron completas, testeadas y con artefactos de pipeline.
+Sin embargo, al ejecutar `DesignReviewer` sobre el scope consolidado del incremento
+emergió nuevamente una pregunta estructural:
+
+> ¿cómo capturamos y planificamos la deuda de diseño que no bloquea la entrega
+> funcional de una US, pero sí afecta la mantenibilidad del siguiente tramo?
+
+Este HITO documenta el hallazgo y transforma la salida del quality gate en backlog
+planificable.
+
+---
+
+## Resultado consolidado del DesignReviewer
+
+Corrida ejecutada:
+
+```bash
+.venv/bin/designreviewer src/competencia src/shared src/torneo src/resultados --config pyproject.toml
+```
+
+Resultado:
+
+- `1 blocking`
+- `111 warning`
+
+### Blocking único
+
+- `Performance` en `src/competencia/domain/aggregates/performance.py`
+  - `GodObjectAnalyzer`
+  - métrica: `31/28`
+  - esfuerzo estimado: `4.5h`
+
+### Grupos de warnings dominantes
+
+1. **Aggregate / entidad sobrecargados**
+   - `Performance`
+   - `Competencia`
+   - `GrillaDeSalida`
+   - `RankingCompetencia`
+   - `Torneo`
+
+2. **Handlers de aplicación con demasiada orquestación**
+   - `RegistrarAPHandler`
+   - `RegistrarResultadoHandler`
+   - `RegistrarDNSHandler`
+   - `CorregirResultadoHandler`
+   - `GenerarGrillaHandler`
+   - `AsignarTarjetaHandler`
+   - `LlamarAtletaHandler`
+   - `CalcularRankingHandler`
+
+3. **Adaptadores / repositorios con responsabilidad expandida**
+   - `ResultadosCompetenciaAdapter`
+   - `SQLiteTorneoRepository`
+   - `PerformancesAPAdapter`
+   - `PerformancesEstadoAdapter`
+   - `AndarivelesActivosAdapter`
+
+4. **Objetos de soporte con demasiada lógica incidental**
+   - `TarjetaAsignada`
+   - `TarjetaAsignacion`
+   - `DisciplinaDescriptor`
+
+---
+
+## Qué se observó
+
+### 1. El pipeline de US funciona para entregar features, pero no absorbe por sí solo la deuda emergente
+
+`/implement-us` fue suficiente para llevar `INC-4.1` a un estado funcional correcto.
+Lo que no hace automáticamente es reabsorber el crecimiento estructural acumulado
+cuando varias US consecutivas expanden el mismo núcleo del dominio.
+
+El caso evidente fue `Performance`: cada US fue correcta en aislamiento, pero el
+efecto acumulado dejó al aggregate por encima del umbral del analyzer.
+
+### 2. El cierre de incremento es el punto correcto para mirar diseño
+
+Si el refactoring se hubiera intentado dentro de `US-4.1.2`, se mezclaban decisiones
+de diseño con una feature sensible del dominio. Si se hubiese postergado sin registro,
+quedaba como deuda difusa.
+
+La revisión al final del incremento produjo un mejor punto de corte:
+
+- las reglas del dominio ya están estables
+- el changeset funcional ya está cubierto por tests
+- los hallazgos pueden agruparse por afinidad estructural y no por urgencia táctica
+
+### 3. El quality gate no solo valida: también estructura backlog
+
+Esto extiende el patrón ya observado en `HITO-11`:
+
+- `HITO-11`: el quality gate actuó como catalizador de una decisión arquitectónica
+- `HITO-19`: el quality gate actúa como **mecanismo de agrupación y priorización**
+  de refactor post-incremento
+
+La salida relevante no es solo “hay warnings”, sino “qué conjunto coherente de ajustes
+conviene planificar ahora que el incremento cerró”.
+
+---
+
+## Decisión derivada
+
+Se establece una práctica explícita para incrementos con alto impacto de dominio:
+
+> **Todo cierre de incremento que acumule cambios sobre aggregates/core handlers debe
+> terminar con una corrida consolidada de DesignReviewer y, si aparecen hallazgos
+> estructurales significativos, generar un HITO de planificación de ajustes.**
+
+Este HITO no reemplaza al `SP-ADJ` formal descrito en `HITO-13`. Lo complementa.
+
+- `HITO-13` define **cuándo** existe una etapa formal de ajuste técnico
+- `HITO-19` define **cómo se captura y empaqueta** el backlog de diseño al cierre
+  de un incremento concreto
+
+---
+
+## Backlog de ajustes derivado
+
+### AJ-INC-4.1.1 — Descomponer `Performance`
+
+**Prioridad:** Crítica
+
+Objetivo:
+- reducir la concentración de responsabilidades del aggregate
+- extraer la resolución de tarjeta final / penalizaciones / compatibilidad legacy
+
+Focos:
+- separar cálculo y resolución de tarjeta de `Performance`
+- mover compatibilidad de payload legacy fuera del aggregate cuando sea posible
+- revisar firma larga de `asignar_tarjeta()`
+
+### AJ-INC-4.1.2 — Aliviar handlers de `competencia`
+
+**Prioridad:** Alta
+
+Objetivo:
+- reducir `FeatureEnvy` y `LongMethod` en handlers core
+
+Focos:
+- factorizar construcción de commands/policies/helpers
+- aislar validaciones de unidad, estado y stream en helpers reutilizables
+- simplificar `AsignarTarjetaHandler` y `GenerarGrillaHandler`
+
+### AJ-INC-4.1.3 — Simplificar `GrillaDeSalida` y agregado de ranking
+
+**Prioridad:** Media-Alta
+
+Objetivo:
+- bajar complejidad de métodos largos y lógica incidental de orden/ajuste
+
+Focos:
+- partir `GrillaDeSalida.ajustar()`
+- revisar `RankingCompetencia` y `ResultadosCompetenciaAdapter`
+
+### AJ-INC-4.1.4 — Limpiar `torneo` y objetos de soporte
+
+**Prioridad:** Media
+
+Objetivo:
+- reducir complejidad accidental en `Torneo`, `SQLiteTorneoRepository`,
+  `TarjetaAsignacion`, `TarjetaAsignada`, `DisciplinaDescriptor`
+
+---
+
+## Orden recomendado de ejecución
+
+1. `Performance`
+2. handlers de `competencia`
+3. `GrillaDeSalida` + `RankingCompetencia` + adapters de resultados
+4. `Torneo` + repositorio + objetos de soporte
+
+La razón del orden es simple: primero se ataca el único blocking y el núcleo con
+más riesgo de seguir creciendo; después se avanza hacia capas de soporte.
+
+---
+
+## Qué valida para el experimento
+
+Este HITO fortalece una hipótesis metodológica nueva:
+
+> **El incremento, no la US aislada, es la unidad correcta para capturar deuda
+> estructural emergente cuando varias features impactan el mismo núcleo de dominio.**
+
+Esto no contradice IEDD; lo complementa:
+
+- la US sigue siendo la unidad correcta de implementación funcional
+- el incremento aparece como la unidad correcta de lectura estructural
+
+En otras palabras:
+
+- **US:** entrega comportamiento
+- **Incremento:** revela acumulación de complejidad
+- **HITO de cierre:** traduce esa complejidad en backlog accionable
+
+---
+
+## Próximo paso recomendado
+
+Convertir este backlog en un artefacto operativo concreto:
+
+- o bien un `PLAN-SP-ADJ-*`
+- o bien un `INC` técnico corto de refactoring
+
+La decisión depende de si los ajustes se ejecutan:
+
+- inmediatamente al cierre de `INC-4.1`
+- o como etapa formal separada antes del siguiente bloque funcional de SP4
+
+---
+
+*Redactado: 2026-04-08 — cierre de INC-4.1*

--- a/docs/design/ux/mejoras-ux.md
+++ b/docs/design/ux/mejoras-ux.md
@@ -1,0 +1,139 @@
+# Mejoras UX — AtaraxiaDive
+
+Registro de ajustes de experiencia de usuario identificados durante el desarrollo y las sesiones de UAT.
+Cada entrada incluye el componente afectado, la descripción del problema y la solución propuesta.
+
+---
+
+## Pendientes
+
+### MUX-01 — Paso 5: keypad fuera de la región visible del teléfono
+
+**Componente:** `frontend/src/components/juez/RpSelector.tsx`
+**Detectado en:** UAT SP4 — smoke test INC-4.3
+
+El `RpSelector` apila display + 5 presets + 4 botones de ajuste + teclado 3×4. En móvil la suma supera la altura visible y el teclado queda fuera de pantalla.
+
+**Solución propuesta:** compactar padding y gaps internos del componente, especialmente en los botones del keypad (reducir `py-3` → `py-2`, `space-y-4` → `space-y-3`).
+
+---
+
+### MUX-02 — Paso 6: botones de tarjeta sin color identificatorio
+
+**Componente:** `frontend/src/components/juez/StepTarjeta.tsx`
+**Detectado en:** UAT SP4 — smoke test INC-4.3
+
+Los tres botones (Blanca, Roja, Amarilla) tienen color idéntico cuando no están seleccionados. Un juez sin experiencia no puede distinguir cuál es cada tarjeta.
+
+**Solución propuesta:** mostrar siempre el color distintivo de cada tarjeta con menor opacidad cuando no está seleccionada, y opacidad plena al seleccionarse:
+- Blanca no seleccionada: `border-white/30 bg-white/5` → seleccionada: `border-emerald-300 bg-emerald-400/15`
+- Roja no seleccionada: `border-red-300/30 bg-red-500/5` → seleccionada: `border-red-300 bg-red-400/15`
+- Amarilla no seleccionada: `border-amber-300/30 bg-amber-400/5` → seleccionada: `border-amber-300 bg-amber-400/15`
+
+---
+
+### MUX-03 — Grilla: el próximo atleta no aparece primero
+
+**Componente:** `frontend/src/pages/juez/GrillaPage.tsx`
+**Detectado en:** UAT SP4 — smoke test INC-4.3
+
+La grilla se renderiza en el orden que llega del backend (por `posicion` de competencia). El atleta marcado como `SIGUIENTE` puede estar en cualquier posición de la lista.
+
+**Solución propuesta:** ordenar client-side antes de renderizar según prioridad de estado:
+`SIGUIENTE` → `EN_CURSO` → `REVISION` → `PENDIENTE` → `FINALIZADA`
+
+---
+
+### MUX-04 — BKO: campo distanciaBlackout duplicado + bug canSubmitBko ⚠️ REVISADO
+
+**Componente:** `frontend/src/components/juez/StepBKO.tsx`, `frontend/src/hooks/usePerformanceFlow.ts`
+**Detectado en:** UAT SP4 — smoke test INC-4.3 / UAT SP4 — ronda 2
+
+**Diseño correcto:** el `RpSelector` de metros permanece en `StepBKO`. La distancia del BKO ES la distancia del selector — no son dos valores distintos. El campo de texto `distanciaBlackout` era el duplicado redundante.
+
+Primera iteración: se eliminó el campo de texto `distanciaBlackout`. Correcto en concepto, pero introdujo una regresión:
+
+**Regresión — Bug:** el botón "Confirmar BKO" nunca se habilita. `canSubmitBko` en `usePerformanceFlow.ts` aún requiere `distanciaBlackout.trim().length > 0`, que ya no se setea desde la UI (el campo fue eliminado).
+
+**Solución propuesta:**
+1. Mantener el `RpSelector` en `StepBKO` — el juez ingresa la distancia alcanzada antes del BKO.
+2. Corregir `canSubmitBko` en `usePerformanceFlow.ts`: para no-STA, solo requiere `!rpConfirmDisabled && motivoDq.length > 0` (sin chequear `distanciaBlackout`).
+3. En `bkoMutation`, derivar `distanciaBlackout` directamente de `metros` dentro de `mutationFn` — no desde estado React (que puede no haberse actualizado aún).
+
+---
+
+### MUX-05 — Pantalla completada: siempre verde aunque la tarjeta sea roja
+
+**Componente:** `frontend/src/pages/juez/PerformanceFlowPage.tsx`
+**Detectado en:** UAT SP4 — smoke test INC-4.3
+
+La sección "completada" usa siempre clases `emerald` (verde) sin importar el resultado final de la performance.
+
+**Solución propuesta:** aplicar colores condicionales según `flow.resultKind`:
+- Tarjeta roja / BKO → clases `red`
+- DNS → clases `slate`
+- Tarjeta amarilla → clases `amber`
+- Tarjeta blanca / blanca con penalizaciones → clases `emerald`
+
+---
+
+### MUX-06 — Paso 5: AtletaCard completa ocupa espacio del RpSelector
+
+**Componente:** `frontend/src/pages/juez/PerformanceFlowPage.tsx`, `frontend/src/components/juez/AtletaCard.tsx`
+**Detectado en:** UAT SP4 — ronda 2
+
+En el paso 5 (ingreso del RP), la `AtletaCard` completa (nombre + AP + andarivel + OT + estado) se muestra sobre el `RpSelector`. En pantalla móvil esto reduce el espacio disponible para el keypad.
+
+**Solución propuesta:** en el paso 5, reemplazar la `AtletaCard` completa por una versión compacta que muestre solo el nombre del atleta y el estado `EN CURSO`, sin los datos auxiliares (AP, andarivel, OT).
+
+---
+
+### MUX-07 — Tarjeta amarilla en revisión: UI demasiado compleja
+
+**Componente:** `frontend/src/components/juez/StepRevision.tsx`
+**Detectado en:** UAT SP4 — ronda 2
+
+La pantalla de resolución de tarjeta amarilla (paso 7) muestra la misma estructura compleja que el paso 6. El juez solo necesita decidir entre Blanca y Roja.
+
+**Solución propuesta:**
+- Mostrar solo el nombre del atleta con badge `EN REVISIÓN`
+- Selector de tarjeta en columna (Blanca / Roja), coloreados sin texto (misma lógica que MUX-02)
+- Dos botones únicamente: `VOLVER A LA GRILLA` y `CONFIRMAR RESOLUCIÓN`
+- Sin penalizaciones (no aplica en resolución)
+
+---
+
+### MUX-08 — STA: marcas no se muestran en formato mm:ss
+
+**Componente:** `frontend/src/components/juez/AtletaCard.tsx`, `frontend/src/pages/juez/GrillaPage.tsx`
+**Detectado en:** UAT SP4 — ronda 2
+
+Las marcas de STA (segundos) se muestran como número crudo (ej: `120 Segundos`) en la grilla y en la `AtletaCard`. El formato correcto es `mm:ss` (ej: `2:00 min`).
+
+**Solución propuesta:** crear una función utilitaria `formatMarca(valor, unidad)` que convierta automáticamente a `mm:ss` cuando `unidad === 'Segundos'`. Aplicarla en `AtletaCard` y en la grilla.
+
+---
+
+## Bugs detectados en UAT
+
+### BUG-01 — INV-DQ-01 se activa erróneamente en BKO para STA
+
+**Componente:** `src/competencia/domain/aggregates/competencia.py` (backend)
+**Detectado en:** UAT SP4 — ronda 2 — escenario T-02 (BKO STA)
+
+El invariante INV-DQ-01 exige `distancia_blackout > 0` para cualquier BKO, incluyendo STA. Para STA (apnea estática), no existe desplazamiento — el concepto de `distancia_blackout` no aplica.
+
+**Impacto:** el escenario T-02 no puede completarse. BKO en STA siempre falla con error de dominio.
+
+**Solución propuesta:** condicionar INV-DQ-01 a disciplinas dinámicas. Para STA, permitir `distancia_blackout = None`.
+
+---
+
+## Resueltos
+
+*(vacío — se irán moviendo aquí los ítems una vez implementados)*
+
+---
+
+*Creado: 2026-04-12 — UAT SP4 smoke test INC-4.3*
+*Actualizado: 2026-04-12 — UAT SP4 ronda 2: MUX-04 revisado, MUX-06..08 agregados, BUG-01*

--- a/frontend/src/components/juez/AtletaCard.tsx
+++ b/frontend/src/components/juez/AtletaCard.tsx
@@ -1,3 +1,5 @@
+import { formatMarca } from '../../hooks/usePerformanceFlow'
+
 interface AtletaCardProps {
   nombreAtleta: string
   apDeclarado: string
@@ -38,7 +40,7 @@ export function AtletaCard({
             Performance anunciada
           </p>
           <p className="mt-2 text-lg font-semibold text-slate-50">
-            {apDeclarado} {unidad}
+            {formatMarca(apDeclarado, unidad)}
           </p>
         </div>
         <div className="rounded-2xl bg-slate-950/70 p-3">

--- a/frontend/src/components/juez/RpSelector.tsx
+++ b/frontend/src/components/juez/RpSelector.tsx
@@ -49,12 +49,12 @@ export function RpSelector({
   }
 
   return (
-    <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-4">
+    <section className="space-y-3 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-3">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
           {isSecondsMode ? 'Tiempo' : 'Marca'}
         </p>
-        <p className="mt-2 text-3xl font-semibold text-white sm:text-4xl">
+        <p className="mt-1 text-3xl font-semibold text-white sm:text-4xl">
           {isSecondsMode ? (
             <>
               {metros}
@@ -72,7 +72,7 @@ export function RpSelector({
         </p>
       </div>
 
-      <div className="grid grid-cols-5 gap-1.5">
+      <div className="grid grid-cols-5 gap-1">
         {presets.map((preset) => (
           <button
             key={preset}
@@ -85,7 +85,7 @@ export function RpSelector({
               onMetrosChange(preset)
             }}
             className={[
-              'rounded-xl border px-2 py-2.5 text-xs font-semibold transition sm:text-sm',
+              'rounded-xl border px-2 py-2 text-xs font-semibold transition',
               (isSecondsMode ? totalSeconds === preset : metros === preset)
                 ? 'border-cyan-300 bg-cyan-400/20 text-cyan-100'
                 : 'border-slate-700 bg-slate-950/70 text-slate-200',
@@ -98,7 +98,7 @@ export function RpSelector({
         ))}
       </div>
 
-      <div className="grid grid-cols-4 gap-1.5 text-xs font-semibold sm:text-sm">
+      <div className="grid grid-cols-4 gap-1 text-xs font-semibold">
         {adjustments.map(([label, delta]) => (
           <button
             key={label}
@@ -110,7 +110,7 @@ export function RpSelector({
               }
               onMetrosChange(Math.max(0, metros + Number(delta)))
             }}
-            className="rounded-xl border border-slate-700 bg-slate-950/70 px-2 py-2.5 text-slate-100"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-2 py-2 text-slate-100"
           >
             {label}
           </button>
@@ -121,13 +121,13 @@ export function RpSelector({
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
           {isSecondsMode ? 'Segundos' : 'Centimetros'}
         </p>
-        <div className="mt-3 grid grid-cols-3 gap-1.5">
+        <div className="mt-2 grid grid-cols-3 gap-1">
           {keypad.slice(0, 9).map((digit) => (
             <button
               key={digit}
               type="button"
               onClick={() => pushDigit(digit)}
-              className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-base font-semibold text-white sm:py-4 sm:text-lg"
+              className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-base font-semibold text-white"
             >
               {digit}
             </button>
@@ -135,21 +135,21 @@ export function RpSelector({
           <button
             type="button"
             onClick={() => onCentimetrosChange('')}
-            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-xs font-semibold text-slate-200 sm:py-4 sm:text-sm"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-xs font-semibold text-slate-200"
           >
             CLR
           </button>
           <button
             type="button"
             onClick={() => pushDigit('0')}
-            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-base font-semibold text-white sm:py-4 sm:text-lg"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-base font-semibold text-white"
           >
             0
           </button>
           <button
             type="button"
             onClick={() => onCentimetrosChange(centimetros.slice(0, -1))}
-            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-3 text-xs font-semibold text-slate-200 sm:py-4 sm:text-sm"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-xs font-semibold text-slate-200"
           >
             DEL
           </button>

--- a/frontend/src/components/juez/StepBKO.tsx
+++ b/frontend/src/components/juez/StepBKO.tsx
@@ -7,13 +7,11 @@ interface StepBKOProps {
   metros: number
   centimetros: string
   unidad: string
-  distanciaBlackout: string
   motivoDq: string
   canSubmitBko: boolean
   isPending: boolean
   onMetrosChange: (value: number) => void
   onCentimetrosChange: (value: string) => void
-  onDistanciaChange: (value: string) => void
   onMotivoDqChange: (value: string) => void
   onConfirm: () => void
   onCancel: () => void
@@ -24,13 +22,11 @@ export function StepBKO({
   metros,
   centimetros,
   unidad,
-  distanciaBlackout,
   motivoDq,
   canSubmitBko,
   isPending,
   onMetrosChange,
   onCentimetrosChange,
-  onDistanciaChange,
   onMotivoDqChange,
   onConfirm,
   onCancel,
@@ -42,21 +38,13 @@ export function StepBKO({
         Registra la distancia alcanzada y el motivo de descalificación.
       </p>
       {!isSTA ? (
-        <>
-          <RpSelector
-            metros={metros}
-            centimetros={centimetros}
-            unidad={unidad}
-            onMetrosChange={onMetrosChange}
-            onCentimetrosChange={onCentimetrosChange}
-          />
-          <input
-            value={distanciaBlackout}
-            onChange={(event) => onDistanciaChange(event.target.value)}
-            placeholder="Distancia blackout"
-            className="w-full rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-white"
-          />
-        </>
+        <RpSelector
+          metros={metros}
+          centimetros={centimetros}
+          unidad={unidad}
+          onMetrosChange={onMetrosChange}
+          onCentimetrosChange={onCentimetrosChange}
+        />
       ) : null}
       <MotivoDqSelector value={motivoDq} options={BKO_REASONS} onChange={onMotivoDqChange} />
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/frontend/src/components/juez/StepRevision.tsx
+++ b/frontend/src/components/juez/StepRevision.tsx
@@ -38,11 +38,11 @@ export function StepRevision({
           const colorClasses =
             card === 'Blanca'
               ? isSelected
-                ? 'border-white bg-white/20 ring-2 ring-white/40'
-                : 'border-white/30 bg-white/5'
+                ? 'border-white bg-white ring-4 ring-white/50'
+                : 'border-white bg-white opacity-60'
               : isSelected
-                ? 'border-red-300 bg-red-500/25 ring-2 ring-red-300/40'
-                : 'border-red-300/40 bg-red-500/8'
+                ? 'border-red-500 bg-red-500 ring-4 ring-red-400/50'
+                : 'border-red-500 bg-red-500 opacity-60'
           return (
             <button
               key={card}

--- a/frontend/src/components/juez/StepRevision.tsx
+++ b/frontend/src/components/juez/StepRevision.tsx
@@ -52,7 +52,7 @@ export function StepRevision({
                 onSelectCard(card)
                 if (card === 'Blanca') onMotivoDqChange('')
               }}
-              className={`h-16 w-full rounded-2xl border transition ${colorClasses}`}
+              className={`h-40 w-full rounded-2xl border transition ${colorClasses}`}
             />
           )
         })}

--- a/frontend/src/components/juez/StepRevision.tsx
+++ b/frontend/src/components/juez/StepRevision.tsx
@@ -32,7 +32,7 @@ export function StepRevision({
       </span>
       <p className="text-xl font-semibold text-white">{nombreAtleta}</p>
 
-      <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-3">
         {(['Blanca', 'Roja'] as const).map((card) => {
           const isSelected = selectedCard === card
           const colorClasses =

--- a/frontend/src/components/juez/StepRevision.tsx
+++ b/frontend/src/components/juez/StepRevision.tsx
@@ -3,6 +3,7 @@ import type { TarjetaSeleccionada } from '../../hooks/usePerformanceFlow'
 import { MotivoDqSelector } from './MotivoDqSelector'
 
 interface StepRevisionProps {
+  nombreAtleta: string
   selectedCard: TarjetaSeleccionada
   motivoDq: string
   canSubmitRedCard: boolean
@@ -14,6 +15,7 @@ interface StepRevisionProps {
 }
 
 export function StepRevision({
+  nombreAtleta,
   selectedCard,
   motivoDq,
   canSubmitRedCard,
@@ -25,55 +27,48 @@ export function StepRevision({
 }: StepRevisionProps) {
   return (
     <section className="space-y-4 rounded-[2rem] border border-amber-300/30 bg-amber-400/10 p-5">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-200">
-        Revision pendiente
-      </p>
-      <h3 className="text-2xl font-semibold text-white">TARJETA AMARILLA</h3>
-      <p className="text-sm text-slate-200">
-        La performance quedo en revision. Podes resolverla ahora o volver a la grilla.
-      </p>
-      <div className="rounded-2xl border border-amber-300/20 bg-slate-950/40 p-4 text-sm text-slate-200">
-        Timer informativo: hasta 3 minutos de deliberacion.
+      <span className="inline-block rounded-full bg-amber-400/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-amber-200">
+        EN REVISIÓN
+      </span>
+      <p className="text-xl font-semibold text-white">{nombreAtleta}</p>
+
+      <div className="flex flex-col gap-3">
+        {(['Blanca', 'Roja'] as const).map((card) => {
+          const isSelected = selectedCard === card
+          const colorClasses =
+            card === 'Blanca'
+              ? isSelected
+                ? 'border-white bg-white/20 ring-2 ring-white/40'
+                : 'border-white/30 bg-white/5'
+              : isSelected
+                ? 'border-red-300 bg-red-500/25 ring-2 ring-red-300/40'
+                : 'border-red-300/40 bg-red-500/8'
+          return (
+            <button
+              key={card}
+              type="button"
+              aria-label={`Resolver como ${card}`}
+              onClick={() => {
+                onSelectCard(card)
+                if (card === 'Blanca') onMotivoDqChange('')
+              }}
+              className={`h-16 w-full rounded-2xl border transition ${colorClasses}`}
+            />
+          )
+        })}
       </div>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <button
-          type="button"
-          onClick={() => {
-            onSelectCard('Blanca')
-            onMotivoDqChange('')
-          }}
-          className={[
-            'rounded-2xl border px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em]',
-            selectedCard === 'Blanca'
-              ? 'border-cyan-300 bg-cyan-400/15 text-cyan-100'
-              : 'border-slate-700 bg-slate-950/70 text-slate-200',
-          ].join(' ')}
-        >
-          RESOLVER -&gt; BLANCA
-        </button>
-        <button
-          type="button"
-          onClick={() => onSelectCard('Roja')}
-          className={[
-            'rounded-2xl border px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em]',
-            selectedCard === 'Roja'
-              ? 'border-red-300 bg-red-400/15 text-red-100'
-              : 'border-slate-700 bg-slate-950/70 text-slate-200',
-          ].join(' ')}
-        >
-          RESOLVER -&gt; ROJA
-        </button>
-      </div>
+
       {selectedCard === 'Roja' ? (
         <MotivoDqSelector value={motivoDq} options={DQ_REASONS} onChange={onMotivoDqChange} />
       ) : null}
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+
+      <div className="grid grid-cols-2 gap-3">
         <button
           type="button"
           onClick={onVolver}
           className="w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-100"
         >
-          Volver a la grilla
+          VOLVER
         </button>
         <button
           type="button"
@@ -81,7 +76,7 @@ export function StepRevision({
           onClick={onConfirm}
           className="w-full rounded-2xl bg-amber-300 px-4 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950 disabled:opacity-50"
         >
-          Confirmar resolucion
+          CONFIRMAR
         </button>
       </div>
     </section>

--- a/frontend/src/components/juez/StepTarjeta.tsx
+++ b/frontend/src/components/juez/StepTarjeta.tsx
@@ -14,28 +14,22 @@ interface PenalizacionesConfig {
 interface StepTarjetaProps {
   selectedCard: TarjetaSeleccionada
   motivoDq: string
-  distanciaBlackout: string
-  needsBlackoutDistance: boolean
   canSubmitRedCard: boolean
   isPending: boolean
   penalizaciones: PenalizacionesConfig
   onSelectCard: (card: TarjetaSeleccionada) => void
   onMotivoDqChange: (value: string) => void
-  onDistanciaChange: (value: string) => void
   onConfirm: () => void
 }
 
 export function StepTarjeta({
   selectedCard,
   motivoDq,
-  distanciaBlackout,
-  needsBlackoutDistance,
   canSubmitRedCard,
   isPending,
   penalizaciones,
   onSelectCard,
   onMotivoDqChange,
-  onDistanciaChange,
   onConfirm,
 }: StepTarjetaProps) {
   function handleCardClick(card: 'Blanca' | 'Roja' | 'Amarilla') {
@@ -89,17 +83,7 @@ export function StepTarjeta({
       </div>
 
       {selectedCard === 'Roja' ? (
-        <>
-          <MotivoDqSelector value={motivoDq} options={DQ_REASONS} onChange={onMotivoDqChange} />
-          {needsBlackoutDistance ? (
-            <input
-              value={distanciaBlackout}
-              onChange={(event) => onDistanciaChange(event.target.value)}
-              placeholder="Distancia blackout"
-              className="w-full rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-white"
-            />
-          ) : null}
-        </>
+        <MotivoDqSelector value={motivoDq} options={DQ_REASONS} onChange={onMotivoDqChange} />
       ) : null}
 
       {selectedCard === 'Blanca' || selectedCard === 'BlancaConPenalizaciones' ? (

--- a/frontend/src/components/juez/StepTarjeta.tsx
+++ b/frontend/src/components/juez/StepTarjeta.tsx
@@ -60,25 +60,32 @@ export function StepTarjeta({
     <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
       <h3 className="text-xl font-semibold text-white">Paso 6 · Tarjeta</h3>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        {(['Blanca', 'Roja', 'Amarilla'] as const).map((card) => (
-          <button
-            key={card}
-            type="button"
-            aria-label={`Tarjeta ${card}`}
-            onClick={() => handleCardClick(card)}
-            className={[
-              'h-20 rounded-2xl border transition',
-              selectedCard === card ||
-              (card === 'Blanca' && selectedCard === 'BlancaConPenalizaciones')
-                ? card === 'Blanca'
-                  ? 'border-emerald-300 bg-emerald-400/15 text-emerald-100'
-                  : card === 'Roja'
-                    ? 'border-red-300 bg-red-400/15 text-red-100'
-                    : 'border-amber-300 bg-amber-400/15 text-amber-100'
-                : 'border-slate-700 bg-slate-950/70 text-slate-200',
-            ].join(' ')}
-          />
-        ))}
+        {(['Blanca', 'Roja', 'Amarilla'] as const).map((card) => {
+          const isSelected =
+            selectedCard === card ||
+            (card === 'Blanca' && selectedCard === 'BlancaConPenalizaciones')
+          const colorClasses =
+            card === 'Blanca'
+              ? isSelected
+                ? 'border-white bg-white/20 ring-2 ring-white/40'
+                : 'border-white/30 bg-white/5'
+              : card === 'Roja'
+                ? isSelected
+                  ? 'border-red-300 bg-red-500/25 ring-2 ring-red-300/40'
+                  : 'border-red-300/40 bg-red-500/8'
+                : isSelected
+                  ? 'border-amber-300 bg-amber-400/25 ring-2 ring-amber-300/40'
+                  : 'border-amber-300/40 bg-amber-400/8'
+          return (
+            <button
+              key={card}
+              type="button"
+              aria-label={`Tarjeta ${card}`}
+              onClick={() => handleCardClick(card)}
+              className={`h-20 rounded-2xl border transition ${colorClasses}`}
+            />
+          )
+        })}
       </div>
 
       {selectedCard === 'Roja' ? (

--- a/frontend/src/components/juez/StepTarjeta.tsx
+++ b/frontend/src/components/juez/StepTarjeta.tsx
@@ -76,7 +76,7 @@ export function StepTarjeta({
               type="button"
               aria-label={`Tarjeta ${card}`}
               onClick={() => handleCardClick(card)}
-              className={`h-20 rounded-2xl border transition ${colorClasses}`}
+              className={`h-40 rounded-2xl border transition ${colorClasses}`}
             />
           )
         })}

--- a/frontend/src/components/juez/StepTarjeta.tsx
+++ b/frontend/src/components/juez/StepTarjeta.tsx
@@ -61,15 +61,15 @@ export function StepTarjeta({
           const colorClasses =
             card === 'Blanca'
               ? isSelected
-                ? 'border-white bg-white/20 ring-2 ring-white/40'
-                : 'border-white/30 bg-white/5'
+                ? 'border-white bg-white ring-4 ring-white/50'
+                : 'border-white bg-white opacity-60'
               : card === 'Roja'
                 ? isSelected
-                  ? 'border-red-300 bg-red-500/25 ring-2 ring-red-300/40'
-                  : 'border-red-300/40 bg-red-500/8'
+                  ? 'border-red-500 bg-red-500 ring-4 ring-red-400/50'
+                  : 'border-red-500 bg-red-500 opacity-60'
                 : isSelected
-                  ? 'border-amber-300 bg-amber-400/25 ring-2 ring-amber-300/40'
-                  : 'border-amber-300/40 bg-amber-400/8'
+                  ? 'border-amber-400 bg-amber-400 ring-4 ring-amber-300/50'
+                  : 'border-amber-400 bg-amber-400 opacity-60'
           return (
             <button
               key={card}

--- a/frontend/src/hooks/usePerformanceFlow.ts
+++ b/frontend/src/hooks/usePerformanceFlow.ts
@@ -78,9 +78,8 @@ export function usePerformanceFlow() {
   const canSubmitRedCard = useMemo(() => {
     if (selectedCard !== 'Roja') return true
     if (!motivoDq) return false
-    if (needsBlackoutDistance && !distanciaBlackout.trim()) return false
     return true
-  }, [selectedCard, motivoDq, needsBlackoutDistance, distanciaBlackout])
+  }, [selectedCard, motivoDq])
 
   const canSubmitBko = isSTA
     ? motivoDq.length > 0
@@ -203,7 +202,9 @@ export function usePerformanceFlow() {
         motivoTexto: selectedCard === 'Amarilla' ? 'Revision pendiente del juez' : undefined,
         motivoDq: selectedCard === 'Roja' ? motivoDq : undefined,
         distanciaBlackout:
-          selectedCard === 'Roja' && needsBlackoutDistance ? distanciaBlackout : undefined,
+          selectedCard === 'Roja' && needsBlackoutDistance
+            ? buildRpValue(metros, centimetros)
+            : undefined,
         penalizaciones: selectedCard === 'BlancaConPenalizaciones' ? penalizaciones : [],
       })
     },

--- a/frontend/src/hooks/usePerformanceFlow.ts
+++ b/frontend/src/hooks/usePerformanceFlow.ts
@@ -84,9 +84,7 @@ export function usePerformanceFlow() {
 
   const canSubmitBko = isSTA
     ? motivoDq.length > 0
-    : !rpConfirmDisabled && motivoDq.length > 0 && !needsBlackoutDistance
-      ? true
-      : !rpConfirmDisabled && motivoDq.length > 0 && distanciaBlackout.trim().length > 0
+    : !rpConfirmDisabled && motivoDq.length > 0
 
   const completionTitle = useMemo(() => {
     if (resultKind === 'DNS') return 'DNS REGISTRADO'
@@ -263,7 +261,7 @@ export function usePerformanceFlow() {
         disciplina: disciplinaActiva!,
         tarjeta: 'Roja',
         motivoDq,
-        distanciaBlackout: isSTA ? undefined : distanciaBlackout,
+        distanciaBlackout: isSTA ? undefined : buildRpValue(metros, centimetros),
       })
     },
     onSuccess: async () => finalizeResult('ROJA', 'Ejecutada'),

--- a/frontend/src/pages/juez/GrillaPage.tsx
+++ b/frontend/src/pages/juez/GrillaPage.tsx
@@ -39,6 +39,14 @@ function resolveRowStatus(
   return 'PENDIENTE'
 }
 
+const STATUS_ORDER: Record<RowStatus, number> = {
+  SIGUIENTE: 0,
+  EN_CURSO: 1,
+  REVISION: 2,
+  PENDIENTE: 3,
+  FINALIZADA: 4,
+}
+
 function statusClasses(status: RowStatus) {
   if (status === 'EN_CURSO') {
     return 'border-cyan-300/60 bg-cyan-400/10'
@@ -80,6 +88,23 @@ export function GrillaPage() {
     return first?.performance_id ?? null
   }, [grillaQuery.data])
 
+  const grillaOrdenada = useMemo(() => {
+    const grilla = grillaQuery.data ?? []
+    return [...grilla].sort((a, b) => {
+      const statusA = resolveRowStatus(
+        a,
+        performanceActualQuery.data?.performance_id ?? null,
+        firstPendingPerformanceId,
+      )
+      const statusB = resolveRowStatus(
+        b,
+        performanceActualQuery.data?.performance_id ?? null,
+        firstPendingPerformanceId,
+      )
+      return STATUS_ORDER[statusA] - STATUS_ORDER[statusB]
+    })
+  }, [grillaQuery.data, performanceActualQuery.data, firstPendingPerformanceId])
+
   if (!competenciaId || !disciplinaActiva) {
     return (
       <JuezLayout title="Grilla" subtitle="Sin competencia seleccionada">
@@ -115,7 +140,7 @@ export function GrillaPage() {
         </section>
       ) : null}
 
-      {grillaQuery.data?.map((atleta) => {
+      {grillaOrdenada.map((atleta) => {
         const status = resolveRowStatus(
           atleta,
           performanceActualQuery.data?.performance_id ?? null,

--- a/frontend/src/pages/juez/GrillaPage.tsx
+++ b/frontend/src/pages/juez/GrillaPage.tsx
@@ -6,6 +6,7 @@ import {
   fetchPerformanceActual,
   type GrillaAtletaDto,
 } from '../../api/competencia'
+import { formatMarca } from '../../hooks/usePerformanceFlow'
 import { JuezLayout } from '../../components/juez/JuezLayout'
 import useCompetenciaStore from '../../stores/useCompetenciaStore'
 
@@ -176,7 +177,7 @@ export function GrillaPage() {
                 </p>
                 <h2 className="mt-2 text-lg font-semibold text-slate-50">{atleta.nombre_atleta}</h2>
                 <p className="mt-2 text-sm text-slate-400">
-                  AP {atleta.ap_declarado} {atleta.unidad}
+                  AP {formatMarca(atleta.ap_declarado, atleta.unidad)}
                 </p>
               </div>
               <span

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -32,7 +32,7 @@ export function PerformanceFlowPage() {
         <StepIndicator currentStep={flow.completed ? 6 : flow.step} />
       </section>
 
-      {flow.step !== 5 && flow.step !== 6 && flow.step !== 7 && !(flow.step === 4 && flow.isBkoMode) ? (
+      {flow.step !== 4 && flow.step !== 5 && flow.step !== 6 && flow.step !== 7 ? (
         <AtletaCard
           nombreAtleta={flow.atletaActivo.nombreAtleta}
           apDeclarado={flow.atletaActivo.apDeclarado}
@@ -144,6 +144,9 @@ export function PerformanceFlowPage() {
       ) : null}
 
       {/* Paso 4 — Performance en curso */}
+      {!flow.completed && flow.step === 4 && !flow.isBkoMode ? (
+        <p className="px-1 text-lg font-semibold text-white">{flow.atletaActivo.nombreAtleta}</p>
+      ) : null}
       {!flow.completed && flow.step === 4 && !flow.isBkoMode ? (
         <section className="space-y-4 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5">
           <h3 className="text-xl font-semibold text-white">Paso 4 · Performance</h3>

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -178,15 +178,16 @@ export function PerformanceFlowPage() {
           metros={flow.metros}
           centimetros={flow.centimetros}
           unidad={flow.atletaActivo.unidad}
-          distanciaBlackout={flow.distanciaBlackout}
           motivoDq={flow.motivoDq}
           canSubmitBko={flow.canSubmitBko}
           isPending={flow.bkoMutation.isPending}
           onMetrosChange={flow.setMetros}
           onCentimetrosChange={flow.setCentimetros}
-          onDistanciaChange={flow.setDistanciaBlackout}
           onMotivoDqChange={flow.setMotivoDq}
-          onConfirm={() => flow.bkoMutation.mutate()}
+          onConfirm={() => {
+            flow.setDistanciaBlackout(String(flow.metros))
+            flow.bkoMutation.mutate()
+          }}
           onCancel={() => {
             flow.setIsBkoMode(false)
             flow.setMotivoDq('')

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -32,7 +32,7 @@ export function PerformanceFlowPage() {
         <StepIndicator currentStep={flow.completed ? 6 : flow.step} />
       </section>
 
-      {flow.step !== 5 && flow.step !== 6 && !(flow.step === 4 && flow.isBkoMode) ? (
+      {flow.step !== 5 && flow.step !== 6 && flow.step !== 7 && !(flow.step === 4 && flow.isBkoMode) ? (
         <AtletaCard
           nombreAtleta={flow.atletaActivo.nombreAtleta}
           apDeclarado={flow.atletaActivo.apDeclarado}

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -258,8 +258,30 @@ export function PerformanceFlowPage() {
 
       {/* Completada */}
       {flow.completed ? (
-        <section className="space-y-4 rounded-[2rem] border border-emerald-300/30 bg-emerald-400/10 p-5">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-300">
+        <section
+          className={[
+            'space-y-4 rounded-[2rem] border p-5',
+            flow.resultKind === 'ROJA'
+              ? 'border-red-300/30 bg-red-500/10'
+              : flow.resultKind === 'DNS'
+                ? 'border-slate-600/40 bg-slate-800/40'
+                : flow.resultKind === 'AMARILLA'
+                  ? 'border-amber-300/30 bg-amber-400/10'
+                  : 'border-emerald-300/30 bg-emerald-400/10',
+          ].join(' ')}
+        >
+          <p
+            className={[
+              'text-xs font-semibold uppercase tracking-[0.24em]',
+              flow.resultKind === 'ROJA'
+                ? 'text-red-300'
+                : flow.resultKind === 'DNS'
+                  ? 'text-slate-400'
+                  : flow.resultKind === 'AMARILLA'
+                    ? 'text-amber-300'
+                    : 'text-emerald-300',
+            ].join(' ')}
+          >
             {flow.resultKind === 'DNS' ? 'DNS registrado' : 'Performance completada'}
           </p>
           <h3 className="text-2xl font-semibold text-white">{flow.completionTitle}</h3>

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -32,7 +32,7 @@ export function PerformanceFlowPage() {
         <StepIndicator currentStep={flow.completed ? 6 : flow.step} />
       </section>
 
-      {flow.step !== 5 && flow.step !== 6 ? (
+      {flow.step !== 5 && flow.step !== 6 && !(flow.step === 4 && flow.isBkoMode) ? (
         <AtletaCard
           nombreAtleta={flow.atletaActivo.nombreAtleta}
           apDeclarado={flow.atletaActivo.apDeclarado}
@@ -174,6 +174,9 @@ export function PerformanceFlowPage() {
       ) : null}
 
       {/* Paso 4 — BKO mode */}
+      {!flow.completed && flow.step === 4 && flow.isBkoMode ? (
+        <p className="px-1 text-lg font-semibold text-white">{flow.atletaActivo.nombreAtleta}</p>
+      ) : null}
       {!flow.completed && flow.step === 4 && flow.isBkoMode ? (
         <StepBKO
           isSTA={flow.isSTA}

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -32,14 +32,16 @@ export function PerformanceFlowPage() {
         <StepIndicator currentStep={flow.completed ? 6 : flow.step} />
       </section>
 
-      <AtletaCard
-        nombreAtleta={flow.atletaActivo.nombreAtleta}
-        apDeclarado={flow.atletaActivo.apDeclarado}
-        unidad={flow.atletaActivo.unidad}
-        andarivel={flow.atletaActivo.andarivel}
-        otProgramado={flow.atletaActivo.otProgramado}
-        estado={flow.completed ? 'COMPLETADA' : flow.atletaActivo.estado}
-      />
+      {flow.step !== 5 ? (
+        <AtletaCard
+          nombreAtleta={flow.atletaActivo.nombreAtleta}
+          apDeclarado={flow.atletaActivo.apDeclarado}
+          unidad={flow.atletaActivo.unidad}
+          andarivel={flow.atletaActivo.andarivel}
+          otProgramado={flow.atletaActivo.otProgramado}
+          estado={flow.completed ? 'COMPLETADA' : flow.atletaActivo.estado}
+        />
+      ) : null}
 
       {flow.inlineError ? (
         <section className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
@@ -195,7 +197,8 @@ export function PerformanceFlowPage() {
 
       {/* Paso 5 — Registrar RP */}
       {!flow.completed && flow.step === 5 ? (
-        <section className="space-y-4">
+        <section className="space-y-3">
+          <p className="px-1 text-lg font-semibold text-white">{flow.atletaActivo.nombreAtleta}</p>
           <RpSelector
             metros={flow.metros}
             centimetros={flow.centimetros}

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -184,10 +184,7 @@ export function PerformanceFlowPage() {
           onMetrosChange={flow.setMetros}
           onCentimetrosChange={flow.setCentimetros}
           onMotivoDqChange={flow.setMotivoDq}
-          onConfirm={() => {
-            flow.setDistanciaBlackout(String(flow.metros))
-            flow.bkoMutation.mutate()
-          }}
+          onConfirm={() => flow.bkoMutation.mutate()}
           onCancel={() => {
             flow.setIsBkoMode(false)
             flow.setMotivoDq('')

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -242,6 +242,7 @@ export function PerformanceFlowPage() {
       {/* Paso 7 — Resolver revisión */}
       {!flow.completed && flow.step === 7 ? (
         <StepRevision
+          nombreAtleta={flow.atletaActivo.nombreAtleta}
           selectedCard={flow.selectedCard}
           motivoDq={flow.motivoDq}
           canSubmitRedCard={flow.canSubmitRedCard}

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -32,7 +32,7 @@ export function PerformanceFlowPage() {
         <StepIndicator currentStep={flow.completed ? 6 : flow.step} />
       </section>
 
-      {flow.step !== 5 ? (
+      {flow.step !== 5 && flow.step !== 6 ? (
         <AtletaCard
           nombreAtleta={flow.atletaActivo.nombreAtleta}
           apDeclarado={flow.atletaActivo.apDeclarado}
@@ -219,11 +219,12 @@ export function PerformanceFlowPage() {
 
       {/* Paso 6 — Asignar tarjeta */}
       {!flow.completed && flow.step === 6 ? (
+        <p className="px-1 text-lg font-semibold text-white">{flow.atletaActivo.nombreAtleta}</p>
+      ) : null}
+      {!flow.completed && flow.step === 6 ? (
         <StepTarjeta
           selectedCard={flow.selectedCard}
           motivoDq={flow.motivoDq}
-          distanciaBlackout={flow.distanciaBlackout}
-          needsBlackoutDistance={flow.needsBlackoutDistance}
           canSubmitRedCard={flow.canSubmitRedCard}
           isPending={flow.tarjetaMutation.isPending}
           penalizaciones={{
@@ -234,7 +235,6 @@ export function PerformanceFlowPage() {
           }}
           onSelectCard={flow.setSelectedCard}
           onMotivoDqChange={flow.setMotivoDq}
-          onDistanciaChange={flow.setDistanciaBlackout}
           onConfirm={() => flow.tarjetaMutation.mutate()}
         />
       ) : null}

--- a/quality/reports/uat/SP4/capa1-http.json
+++ b/quality/reports/uat/SP4/capa1-http.json
@@ -1,0 +1,204 @@
+{
+  "UAT-1.1_health": 
+  {
+    "status": "ok"
+  }
+,
+  "UAT-1.2_login_juez": 
+  {"http_status": 200, "esperado": 200, "token_presente": true}
+,
+  "UAT-1.3_torneos": 
+  {"torneo_id": "94432cdd-98c2-49d7-9c5a-fefc972c36ad", "estado": "EJECUCION", "esperado": "EJECUCION"}
+,
+  "UAT-1.4_competencias_del_torneo": 
+  [
+    {
+      "competencia_id": "2952bc4f-476e-4c9d-9ca7-49182b484819",
+      "disciplina": "DNF",
+      "torneo_id": "94432cdd-98c2-49d7-9c5a-fefc972c36ad"
+    },
+    {
+      "competencia_id": "a312165b-2e9b-47b2-a419-9b6b1e91509c",
+      "disciplina": "STA",
+      "torneo_id": "94432cdd-98c2-49d7-9c5a-fefc972c36ad"
+    }
+  ]
+,
+  "UAT-1.5_estado_dnf": 
+  {
+    "estado": "EnEjecucion",
+    "intervalo_minutos": 7,
+    "grilla_confirmada": true,
+    "torneo_id": "94432cdd-98c2-49d7-9c5a-fefc972c36ad"
+  }
+,
+  "UAT-1.6_estado_sta": 
+  {
+    "estado": "EnEjecucion",
+    "intervalo_minutos": 7,
+    "grilla_confirmada": true,
+    "torneo_id": "94432cdd-98c2-49d7-9c5a-fefc972c36ad"
+  }
+,
+  "UAT-1.7_grilla_dnf": 
+  [
+    {
+      "performance_id": "46b60f23-0dfa-46a7-bb94-6072dc2bf3e5",
+      "atleta_id": "b13f9f6b-5004-4b7b-84eb-91599e4277eb",
+      "nombre_atleta": "Diego Vega",
+      "posicion": 1,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:06:00+00:00",
+      "ap_declarado": "40",
+      "unidad": "Metros",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "8e181a5a-cf5d-4267-9bef-cf60f5075c83",
+      "atleta_id": "44447034-92f2-4d23-a9a0-5aec2dfe8b72",
+      "nombre_atleta": "Laura Romero",
+      "posicion": 2,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:13:00+00:00",
+      "ap_declarado": "50",
+      "unidad": "Metros",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "ff5e0ad8-a759-43b8-8b90-a35ced3bb720",
+      "atleta_id": "201cc118-33cb-487b-be10-05491be507f1",
+      "nombre_atleta": "Carlos Iba\u00f1ez",
+      "posicion": 3,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:20:00+00:00",
+      "ap_declarado": "60",
+      "unidad": "Metros",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "cf1d4229-c1d8-4c3c-a85c-1a86303a58ff",
+      "atleta_id": "8e8c5bc1-f5a7-4970-bd2c-42dce9b44daa",
+      "nombre_atleta": "Ana Flores",
+      "posicion": 4,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:27:00+00:00",
+      "ap_declarado": "70",
+      "unidad": "Metros",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "4cc64ee0-c36a-4912-b1c0-10961627da4a",
+      "atleta_id": "882e54c2-93f2-4322-ae30-9038446d281d",
+      "nombre_atleta": "Roberto Chen",
+      "posicion": 5,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:34:00+00:00",
+      "ap_declarado": "80",
+      "unidad": "Metros",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "c3e536b1-a8a2-4205-aaf3-8c02c7a0acb0",
+      "atleta_id": "f6a2a5d5-3c52-4063-a9ad-b4873c88e404",
+      "nombre_atleta": "Patricia Ruiz",
+      "posicion": 6,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:41:00+00:00",
+      "ap_declarado": "90",
+      "unidad": "Metros",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "5f3bf954-f44b-4efd-8c26-8bfebc7a0e4b",
+      "atleta_id": "329acaf8-f19b-4df4-b97f-10c959401ede",
+      "nombre_atleta": "Martin Acosta",
+      "posicion": 7,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:48:00+00:00",
+      "ap_declarado": "100",
+      "unidad": "Metros",
+      "estado": "EnRevision"
+    },
+    {
+      "performance_id": "e317ed45-6769-4f98-be9d-aa4b4962cba4",
+      "atleta_id": "e722d63e-0d7d-438b-bc48-51ee9b17e83d",
+      "nombre_atleta": "Silvia Casas",
+      "posicion": 8,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T19:55:00+00:00",
+      "ap_declarado": "110",
+      "unidad": "Metros",
+      "estado": "EnRevision"
+    },
+    {
+      "performance_id": "2da36171-f6ce-4999-92bc-f2bcc8f5d7b2",
+      "atleta_id": "5f8acf33-cd39-4452-b589-883d095ac541",
+      "nombre_atleta": "Jorge Mendez",
+      "posicion": 9,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T20:02:00+00:00",
+      "ap_declarado": "120",
+      "unidad": "Metros",
+      "estado": "Llamada"
+    },
+    {
+      "performance_id": "ea51b94b-9733-4276-8cbe-6eac63c6b47e",
+      "atleta_id": "65779ee5-cc22-49ef-b06e-cb6c82d6bbe6",
+      "nombre_atleta": "Claudia Rios",
+      "posicion": 10,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T20:09:00+00:00",
+      "ap_declarado": "130",
+      "unidad": "Metros",
+      "estado": "ResultadoRegistrado"
+    }
+  ]
+,
+  "UAT-1.8_grilla_sta": 
+  [
+    {
+      "performance_id": "c5fd3432-1e32-4cdc-ae4a-a6762638d200",
+      "atleta_id": "8e73c365-f7db-4a5f-a3ad-cbcb7a85c76b",
+      "nombre_atleta": "Javier Herrera",
+      "posicion": 1,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T22:06:00+00:00",
+      "ap_declarado": "120",
+      "unidad": "Segundos",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "dd3baa83-0f92-4dd7-b2c8-f17f920dd094",
+      "atleta_id": "a30ff67d-0c02-4772-8124-a3203b992724",
+      "nombre_atleta": "Carolina Espinoza",
+      "posicion": 2,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T22:13:00+00:00",
+      "ap_declarado": "180",
+      "unidad": "Segundos",
+      "estado": "AnunciadaAP"
+    },
+    {
+      "performance_id": "e9400747-4064-4e0a-b8eb-bed65ff635f2",
+      "atleta_id": "d614deee-8641-4e94-9f22-5d2e6745d09e",
+      "nombre_atleta": "Fernando Bravo",
+      "posicion": 3,
+      "andarivel": 1,
+      "ot_programado": "2026-04-12T22:20:00+00:00",
+      "ap_declarado": "240",
+      "unidad": "Segundos",
+      "estado": "AnunciadaAP"
+    }
+  ]
+,
+  "UAT-1.9_performance_actual_dnf": 
+  {"performance_id":"2da36171-f6ce-4999-92bc-f2bcc8f5d7b2","nombre_atleta":"Atleta-5f8acf33","ap_declarado":"120","unidad":"Metros","unidad_esperada":"Metros","andarivel":2,"estado":"Llamada"}
+,
+  "UAT-1.10_progreso_dnf": 
+  {
+    "total": 10,
+    "ejecutadas": 0,
+    "dns_count": 0,
+    "completadas": 0
+  }
+}

--- a/quality/reports/uat/SP4/checklist.md
+++ b/quality/reports/uat/SP4/checklist.md
@@ -1,0 +1,195 @@
+# Checklist UAT SP4 — Flujo de Performance (Capa 2 Manual)
+
+**Generado:** 2026-04-12 15:07
+**Frontend:** http://localhost:5173
+**Login:** juez@uat-sp4.test / juezsp4uat2025
+
+---
+
+## Setup previo
+
+- [ ] Frontend corriendo: `cd frontend && npm run dev`
+- [ ] Backend corriendo en puerto 8000
+- [ ] Abrir http://localhost:5173 en Chrome/Safari (modo móvil en DevTools)
+- [ ] Hacer login con el usuario juez
+
+---
+
+## Competencia DNF
+
+**Cómo acceder:** Login → /juez/disciplinas → seleccionar DNF → grilla → tocar atleta
+
+### E-01 — DNS (Diego Vega, AP=40m)
+*Verifica el flujo de No Se Presenta*
+
+- [X] Atleta aparece en grilla con estado AnunciadaAP
+- [X] Paso 1: botón "LLAMAR ATLETA" visible y funcional
+- [X] Paso 2: aparece opción "DNS — NO SE PRESENTA"
+- [X] Al confirmar DNS: pantalla de completado muestra "DNS REGISTRADO"
+- [X] Botón "SIGUIENTE ATLETA" navega de vuelta a grilla
+
+---
+
+### E-02 — BKO mid-performance (Laura Romero, AP=50m)
+*Verifica el blackout durante la performance*
+
+- [X] Llegar al paso 4 (performance en curso)
+- [X] Botón "BKO — BLACK-OUT" visible
+- [X] Al presionar BKO: aparece formulario StepBKO con selector RP (metros.centímetros) y motivo DQ
+- [X] Ingresar metros=25, centímetros=50
+- [X ] Seleccionar motivo: BKO SUBACUÁTICO (requiere campo distancia blackout) 
+- [ ] Ingresar distancia blackout (ej: 20.00) no
+- [ ] Botón CONFIRMAR habilitado solo cuando todos los campos están completos (no se habilita)
+- [ ] Al confirmar: pantalla completada muestra "TARJETA ROJA"
+- [ ] Botón CANCELAR vuelve al paso 4 limpiando los campos
+
+---
+
+### E-03 — Blanca simple (Carlos Ibañez, AP=60m)
+*Flujo dorado completo: paso 1 → paso 6*
+
+- [X] Flujo completo paso 1 (llamar) → paso 2 (confirmar) → paso 3 (OT) → paso 4 (performance) → paso 5 (RP)
+- [X] Paso 5: ingresar metros=58, centímetros=00
+- [X] Paso 6: tres botones de tarjeta sin texto, con colores (blanco, rojo, amarillo)
+- [X] Seleccionar BLANCA: selector resaltado en verde
+- [X] No aparece selector de motivo DQ
+- [X] Botón CONFIRMAR TARJETA habilitado
+- [X] Pantalla completada muestra marca y "TARJETA BLANCA"
+
+---
+
+### E-04 — Blanca con penalizaciones (Ana Flores, AP=70m)
+*Verifica el selector de penalizaciones*
+
+- [X] Llegar al paso 6 con tarjeta BLANCA seleccionada
+- [X] Aparece sección de penalizaciones con 4 tipos
+- [X] Agregar 1 penalización "Sin contacto pared": contador sube a 1
+- [X] Agregar 1 penalización "Fuera de carril": contador sube a 1
+- [X] Resumen muestra "2 penalizaciones · −6m"
+- [X] Botón quitar (−) reduce el contador; no puede bajar de 0
+- [X] Al confirmar: pantalla completada muestra "TARJETA BLANCA CON PENALIZACIONES" y "2 penalizaciones"
+
+---
+
+### E-05 — Roja DQ estándar (Roberto Chen, AP=80m)
+*Verifica el selector de motivo DQ sin distancia*
+
+- [ ] Paso 6: seleccionar ROJA
+- [ ] Aparece selector de motivo DQ
+- [ ] Seleccionar "PROTOCOLO SUPERFICIE" (no requiere distancia)
+- [ ] Campo distancia blackout NO aparece
+- [ ] Botón CONFIRMAR habilitado con motivo seleccionado
+- [ ] Pantalla completada muestra "TARJETA ROJA"
+
+---
+
+### E-06 — Roja BKO post-performance (Patricia Ruiz, AP=90m)
+*Verifica distancia blackout obligatoria*
+
+- [ ] Paso 6: seleccionar ROJA
+- [ ] Seleccionar "BKO SUPERFICIE": aparece campo "Distancia blackout"
+- [ ] Botón CONFIRMAR deshabilitado hasta completar distancia
+- [ ] Ingresar distancia=15.00
+- [ ] Botón CONFIRMAR se habilita
+- [ ] Pantalla completada muestra "TARJETA ROJA"
+
+---
+
+### E-07 — Resolver revisión → Blanca (Martin Acosta, ya en EnRevision)
+*Resume: atleta ya tiene tarjeta amarilla asignada*
+
+- [ ] En grilla: atleta aparece con estado EnRevision
+- [ ] Al seleccionarlo: flow inicia directo en **paso 7** (no pasa por 1-6)
+- [ ] Pantalla muestra "TARJETA AMARILLA · Resolución pendiente"
+- [ ] Botón "RESOLVER → BLANCA" disponible
+- [ ] Al seleccionar Blanca: no aparece selector de motivo DQ
+- [ ] Botón CONFIRMAR RESOLUCIÓN habilitado
+- [ ] Pantalla completada muestra "TARJETA BLANCA"
+
+---
+
+### E-08 — Resolver revisión → Roja (Silvia Casas, ya en EnRevision)
+*Resume: atleta ya tiene tarjeta amarilla asignada*
+
+- [ ] Flow inicia en **paso 7**
+- [ ] Seleccionar "RESOLVER → ROJA": aparece selector de motivo DQ
+- [ ] Seleccionar motivo DQ (ej: INFRACCIÓN TÉCNICA)
+- [ ] Botón CONFIRMAR habilitado con motivo seleccionado
+- [ ] Pantalla completada muestra "TARJETA ROJA"
+
+---
+
+### R-01 — Resume en paso 2 (Jorge Mendez, ya Llamada)
+*Verifica que el flow retoma el estado correcto*
+
+- [ ] En grilla: atleta aparece con estado Llamada
+- [ ] Al seleccionarlo: flow inicia directo en **paso 2** (Confirmar presencia)
+- [ ] Paso 1 (Llamada) NO aparece (ya fue ejecutado)
+- [ ] Continuar flujo normal desde paso 2
+
+---
+
+### R-02 — Resume en paso 6 (Claudia Rios, ya ResultadoRegistrado)
+*Verifica que el flow retoma el estado correcto*
+
+- [ ] En grilla: atleta aparece con estado ResultadoRegistrado
+- [ ] Al seleccionarlo: flow inicia directo en **paso 6** (Tarjeta)
+- [ ] Pasos 1-5 NO aparecen
+- [ ] AtletaCard muestra el RP ya registrado (125m)
+- [ ] Continuar desde paso 6
+
+---
+
+## Competencia STA
+
+**Cómo acceder:** Login → /juez/disciplinas → seleccionar STA → grilla → tocar atleta
+
+### T-01 — DNS STA (Javier Herrera, AP=120s)
+*Verifica DNS en disciplina de tiempo*
+
+- [ ] Flow normal hasta paso 2
+- [ ] AtletaCard muestra "AP: 2:00 min" (no en metros)
+- [ ] Confirmar DNS → completado "DNS REGISTRADO"
+
+---
+
+### T-02 — BKO STA mid-performance (Carolina Espinoza, AP=180s)
+*Verifica BKO sin selector de metros (STA usa tiempo)*
+
+- [ ] Llegar al paso 4
+- [ ] Presionar "BKO — BLACK-OUT"
+- [ ] StepBKO **NO** muestra el selector RP (metros/centímetros) — es STA
+- [ ] Solo aparece: selector de motivo DQ
+- [ ] Seleccionar BKO SUBACUÁTICO
+- [ ] Botón CONFIRMAR habilitado solo con motivo (sin necesidad de metros ni distancia)
+- [ ] Confirmar → "TARJETA ROJA"
+
+---
+
+### T-03 — Blanca STA (Fernando Bravo, AP=240s)
+*Verifica el flujo de tiempo completo*
+
+- [ ] Paso 3: texto "Las vías respiratorias del atleta entran en contacto con el agua"
+- [ ] Botón VÍAS RESPIRATORIAS EN AGUA (en lugar de "ATLETA INICIA")
+- [ ] Paso 5: selector RP de tiempo (minutos + segundos, no metros)
+- [ ] Ingresar 4 minutos, 05 segundos
+- [ ] Paso 6: confirmar BLANCA
+- [ ] Pantalla completada muestra "4:05 min"
+
+---
+
+## Hallazgos de UI
+
+Documentar aquí cualquier problema encontrado durante el walk-through:
+
+.
+3. En la confirmación de la marca (paso 5) modificar el layout para que el ingreso del los números quede dentro de la region de la pantalla del teléfono
+4. En el paso 6 el selector tarjeta deber con los colores de cada tarjeta sin texto
+5. En la grilla de la competencia, el primero de la lista debe ser el proximo atleta.
+6. Cuando hay BKO, la distancia es la misma que se ingresa con los botones, no se necesario volver a pedirla
+7. Al confirmar: pantalla completada muestra "TARJETA ROJA", debe pintarse de rojo el badge
+8. Seleccionar BLANCA: selector resaltado en verde, la tarjeta debe ser de color blanca, cada una de las tres tarjetas deben estar pintadas para que el juez sepa los colores
+
+---
+
+*Generado automáticamente por run_uat.sh — Sun Apr 12 15:07:14 -03 2026*

--- a/quality/reports/uat/SP4/uat_ids.json
+++ b/quality/reports/uat/SP4/uat_ids.json
@@ -1,0 +1,21 @@
+{
+  "torneo_id": "2c682bb8-0200-4efa-ab55-3f95d27f7a97",
+  "competencia_dnf_id": "4846916a-65f9-4d33-af02-8c46e08c6248",
+  "competencia_sta_id": "d053f12d-4f44-48e6-b63e-cb411afc7b99",
+  "juez_id": "b38263ad-dc94-4824-9a33-f6ccba37319a",
+  "juez_email": "juez@uat-sp4.test",
+  "juez_password": "juezsp4uat2025",
+  "atleta_e01": "6dd0dabd-e766-4093-bbad-a2ae1eaacb1d",
+  "atleta_e02": "c06a5ae5-11be-405a-9f6d-9ef4349492a9",
+  "atleta_e03": "765035a8-fa24-40a4-b50a-d5a1311c910d",
+  "atleta_e04": "32c62771-533b-4f01-b81a-3d7c4298ec2f",
+  "atleta_e05": "1464f994-88a1-456e-83fe-ff690ac838e2",
+  "atleta_e06": "964d61c7-2ac9-4526-9482-88a6747081e6",
+  "atleta_e07": "c5cb905d-c2cf-45cd-8bae-61099d519002",
+  "atleta_e08": "11a96748-5fb1-40ac-9610-8342bfce11b7",
+  "atleta_r01": "97a4749e-86ef-45c2-bab1-b5bc97de6154",
+  "atleta_r02": "d2e7b119-7670-4796-b826-037ec3b3c8f9",
+  "atleta_t01": "8b8587b4-4010-48fd-bb2b-3196636bcef4",
+  "atleta_t02": "66711212-3ce8-41a1-a04c-776e819a645b",
+  "atleta_t03": "2318363c-a928-48ba-b0b3-7be60f9cb5e8"
+}

--- a/src/competencia/domain/aggregates/performance.py
+++ b/src/competencia/domain/aggregates/performance.py
@@ -430,12 +430,18 @@ class Performance(AggregateRoot):
                 "— solo se puede resolver revision desde EnRevision"
             )
 
+        distancia_blackout_revision = (
+            self._rp_medido
+            if motivo_dq is not None and motivo_dq.requiere_distancia_blackout()
+            else None
+        )
         tarjeta_asignacion = TarjetaAsignacion(
             tipo=tipo,
             motivo_dq=motivo_dq,
             motivo_texto=None,
-            distancia_blackout=None,
+            distancia_blackout=distancia_blackout_revision,
             penalizaciones=penalizaciones,
+            es_disciplina_tiempo=self._disciplina.es_tiempo(),
         )
         resolucion = ResolucionTarjeta.desde_asignacion(tarjeta_asignacion, self._rp_medido)
         event = crear_revision_resuelta(

--- a/src/competencia/domain/aggregates/performance.py
+++ b/src/competencia/domain/aggregates/performance.py
@@ -394,6 +394,7 @@ class Performance(AggregateRoot):
             motivo_texto=motivo_texto,
             distancia_blackout=distancia_blackout,
             penalizaciones=penalizaciones,
+            es_disciplina_tiempo=self._disciplina.es_tiempo(),
         )
         resolucion = ResolucionTarjeta.desde_asignacion(tarjeta_asignacion, self._rp_medido)
 

--- a/src/competencia/domain/value_objects/tarjeta_asignacion.py
+++ b/src/competencia/domain/value_objects/tarjeta_asignacion.py
@@ -27,6 +27,7 @@ class TarjetaAsignacion:
     motivo_texto: str | None
     distancia_blackout: Decimal | None
     penalizaciones: tuple[PenalizacionTecnica, ...] = ()
+    es_disciplina_tiempo: bool = False
 
     def __post_init__(self) -> None:
         self._validar_penalizaciones()
@@ -59,10 +60,12 @@ class TarjetaAsignacion:
 
     def _validar_distancia_blackout(self) -> None:
         if self.motivo_dq is not None and self.motivo_dq.requiere_distancia_blackout():
-            if self.distancia_blackout is None or self.distancia_blackout <= 0:
-                raise DistanciaBlackoutObligatoria(
-                    "Tarjeta roja por blackout requiere distancia_blackout > 0 (INV-DQ-01)"
-                )
+            # En disciplinas de tiempo (STA) no hay desplazamiento: distancia_blackout no aplica
+            if not self.es_disciplina_tiempo:
+                if self.distancia_blackout is None or self.distancia_blackout <= 0:
+                    raise DistanciaBlackoutObligatoria(
+                        "Tarjeta roja por blackout requiere distancia_blackout > 0 (INV-DQ-01)"
+                    )
             return
         if self.distancia_blackout is not None:
             raise DistanciaBlackoutNoAplica(

--- a/tests/uat/sp4/hallazgos-smoke-test.md
+++ b/tests/uat/sp4/hallazgos-smoke-test.md
@@ -1,0 +1,7 @@
+En el escenario 2, no se habilita el botón "Confirmar BKO", a pesar de indicar el motivo de DQ.
+En el paso 5, cuando se debe ingresar el resultado del performance, solo mostrar el nombre del atleta en LLAMADA
+Cuando finaliza con BKO, sigue estando el ingreso de metros que es redundante
+Cuando es en revision, tarjeta amarilla, solo mostrar el nombre del atleta EN REVISION, la tarjeta que aparezcan en columna coloreadas sin texto, con dos botenes, volver a la grilla y confirmar.
+En STA las marcas son con formato mm:ss, minutos:segundos
+En STA, cuando hay BKO hay un mensaje: Tarjeta roja por blackout requiere distancia_blackout > 0 (INV-DQ-01), que es incorrecto
+El escenario 2 de STA no se puede validar

--- a/tests/uat/sp4/run_uat.sh
+++ b/tests/uat/sp4/run_uat.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+# run_uat.sh — UAT SP4: checks HTTP automáticos del flujo de performance.
+#
+# Uso (desde la raíz del proyecto):
+#   bash tests/uat/sp4/run_uat.sh
+#
+# Precondición:
+#   - seed_sp4.py ya ejecutado (crea las DBs y los IDs)
+#   - Backend corriendo: uv run fastapi dev src/app.py
+#
+# Salidas:
+#   quality/reports/uat/SP4/uat_ids.json      — IDs del seed (ya existe)
+#   quality/reports/uat/SP4/capa1-http.json   — verificaciones HTTP automáticas
+#   quality/reports/uat/SP4/checklist.md      — checklist listo para capa 2 manual
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+UAT_DIR="$ROOT/quality/reports/uat/SP4"
+BASE_URL="${UAT_URL:-http://localhost:8000}"
+IDS_FILE="$UAT_DIR/uat_ids.json"
+
+echo
+echo "========================================================"
+echo "  UAT SP4 — Flujo de Performance (Capa 1: HTTP)"
+echo "========================================================"
+echo
+
+# ── Verificar seed ejecutado ──────────────────────────────────────────────────
+if [[ ! -f "$IDS_FILE" ]]; then
+    echo "ERROR: $IDS_FILE no encontrado."
+    echo "  Ejecutá primero: uv run python tests/uat/sp4/seed_sp4.py"
+    exit 1
+fi
+
+TORNEO_ID=$(python3 -c "import json; print(json.load(open('$IDS_FILE'))['torneo_id'])")
+CID_DNF=$(python3 -c "import json; print(json.load(open('$IDS_FILE'))['competencia_dnf_id'])")
+CID_STA=$(python3 -c "import json; print(json.load(open('$IDS_FILE'))['competencia_sta_id'])")
+JUEZ_EMAIL=$(python3 -c "import json; print(json.load(open('$IDS_FILE'))['juez_email'])")
+JUEZ_PASS=$(python3 -c "import json; print(json.load(open('$IDS_FILE'))['juez_password'])")
+
+echo "  torneo_id      : $TORNEO_ID"
+echo "  competencia_dnf: $CID_DNF"
+echo "  competencia_sta: $CID_STA"
+echo "  juez_email     : $JUEZ_EMAIL"
+echo
+
+# ── Verificar servidor ────────────────────────────────────────────────────────
+echo "[Verificación] Comprobando servidor en $BASE_URL ..."
+if ! curl -sf "$BASE_URL/health" > /dev/null; then
+    echo
+    echo "ERROR: El servidor no responde en $BASE_URL"
+    echo "  Levantá el servidor con: uv run fastapi dev src/app.py"
+    echo "  Luego volvé a correr este script."
+    exit 1
+fi
+echo "✓ Servidor disponible"
+echo
+
+# ── Obtener JWT ───────────────────────────────────────────────────────────────
+echo "[Auth] Obteniendo JWT para juez..."
+JWT_RESPONSE=$(curl -sf \
+    -X POST -H "Content-Type: application/json" \
+    -d "{\"email\": \"$JUEZ_EMAIL\", \"password\": \"$JUEZ_PASS\"}" \
+    "$BASE_URL/auth/login")
+JWT_TOKEN=$(echo "$JWT_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+AUTH="Authorization: Bearer $JWT_TOKEN"
+echo "✓ JWT obtenido"
+echo
+
+# ── Capa 1: verificaciones HTTP ───────────────────────────────────────────────
+echo "[Capa 1] Ejecutando checks HTTP..."
+echo
+
+HTTP_OUTPUT="$UAT_DIR/capa1-http.json"
+
+{
+  echo "{"
+
+  # ── UAT-1.1: /health ─────────────────────────────────────────────────────
+  echo '  "UAT-1.1_health": '
+  curl -sf "$BASE_URL/health" | python3 -m json.tool --indent 2 | sed 's/^/  /'
+  echo ","
+
+  # ── UAT-1.2: Login juez ───────────────────────────────────────────────────
+  STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X POST -H "Content-Type: application/json" \
+    -d "{\"email\": \"$JUEZ_EMAIL\", \"password\": \"$JUEZ_PASS\"}" \
+    "$BASE_URL/auth/login")
+  echo '  "UAT-1.2_login_juez": '
+  echo "  {\"http_status\": $STATUS, \"esperado\": 200, \"token_presente\": true}"
+  echo ","
+
+  # ── UAT-1.3: GET /torneos — torneo en EJECUCION visible ──────────────────
+  echo '  "UAT-1.3_torneos": '
+  TORNEOS=$(curl -sf "$BASE_URL/torneos")
+  TORNEO_ESTADO=$(echo "$TORNEOS" | python3 -c "
+import sys, json
+t = json.load(sys.stdin)
+match = next((x for x in t if x['torneo_id'] == '$TORNEO_ID'), None)
+print(match['estado'] if match else 'NOT_FOUND')
+")
+  echo "  {\"torneo_id\": \"$TORNEO_ID\", \"estado\": \"$TORNEO_ESTADO\", \"esperado\": \"EJECUCION\"}"
+  echo ","
+
+  # ── UAT-1.4: GET /competencia?torneo_id=... ───────────────────────────────
+  echo '  "UAT-1.4_competencias_del_torneo": '
+  curl -sf "$BASE_URL/competencia?torneo_id=$TORNEO_ID" \
+    | python3 -m json.tool --indent 2 | sed 's/^/  /'
+  echo ","
+
+  # ── UAT-1.5: Estado competencia DNF ──────────────────────────────────────
+  echo '  "UAT-1.5_estado_dnf": '
+  curl -sf "$BASE_URL/competencia/$CID_DNF/estado?disciplina=DNF" \
+    | python3 -m json.tool --indent 2 | sed 's/^/  /'
+  echo ","
+
+  # ── UAT-1.6: Estado competencia STA ──────────────────────────────────────
+  echo '  "UAT-1.6_estado_sta": '
+  curl -sf "$BASE_URL/competencia/$CID_STA/estado?disciplina=STA" \
+    | python3 -m json.tool --indent 2 | sed 's/^/  /'
+  echo ","
+
+  # ── UAT-1.7: Grilla DNF — 10 atletas en orden ────────────────────────────
+  echo '  "UAT-1.7_grilla_dnf": '
+  curl -sf "$BASE_URL/competencia/$CID_DNF/grilla?disciplina=DNF" \
+    | python3 -m json.tool --indent 2 | sed 's/^/  /'
+  echo ","
+
+  # ── UAT-1.8: Grilla STA — 3 atletas en orden ─────────────────────────────
+  echo '  "UAT-1.8_grilla_sta": '
+  curl -sf "$BASE_URL/competencia/$CID_STA/grilla?disciplina=STA" \
+    | python3 -m json.tool --indent 2 | sed 's/^/  /'
+  echo ","
+
+  # ── UAT-1.9: Performance actual DNF — R01 Jorge en Llamada ───────────────
+  echo '  "UAT-1.9_performance_actual_dnf": '
+  ACTUAL=$(curl -sf "$BASE_URL/competencia/$CID_DNF/performance/actual" || echo "null")
+  echo "  $ACTUAL"
+  echo ","
+
+  # ── UAT-1.10: Progreso DNF — 4 atletas avanzados ─────────────────────────
+  echo '  "UAT-1.10_progreso_dnf": '
+  curl -sf "$BASE_URL/competencia/$CID_DNF/progreso" \
+    | python3 -m json.tool --indent 2 | sed 's/^/  /'
+
+  echo "}"
+} > "$HTTP_OUTPUT"
+
+echo "✓ Capa 1 completada → $HTTP_OUTPUT"
+echo
+
+# ── Verificar estados esperados ───────────────────────────────────────────────
+echo "[Verificación] Chequeando estados esperados..."
+
+DNF_ESTADO=$(python3 -c "
+import json
+data = json.load(open('$HTTP_OUTPUT'))
+print(data.get('UAT-1.5_estado_dnf', {}).get('estado', 'N/A'))
+")
+STA_ESTADO=$(python3 -c "
+import json
+data = json.load(open('$HTTP_OUTPUT'))
+print(data.get('UAT-1.6_estado_sta', {}).get('estado', 'N/A'))
+")
+GRILLA_DNF_COUNT=$(python3 -c "
+import json
+grilla = json.load(open('$HTTP_OUTPUT')).get('UAT-1.7_grilla_dnf', [])
+print(len(grilla) if isinstance(grilla, list) else 'N/A')
+")
+GRILLA_STA_COUNT=$(python3 -c "
+import json
+grilla = json.load(open('$HTTP_OUTPUT')).get('UAT-1.8_grilla_sta', [])
+print(len(grilla) if isinstance(grilla, list) else 'N/A')
+")
+
+echo
+printf "  %-40s %s\n" "UAT-1.3 torneo.estado == EJECUCION" "$([ "$TORNEO_ESTADO" = "EJECUCION" ] && echo "✓ OK" || echo "✗ FALLO (got: $TORNEO_ESTADO)")"
+printf "  %-40s %s\n" "UAT-1.5 DNF.estado == EnEjecucion"  "$([ "$DNF_ESTADO" = "EnEjecucion" ] && echo "✓ OK" || echo "✗ FALLO (got: $DNF_ESTADO)")"
+printf "  %-40s %s\n" "UAT-1.6 STA.estado == EnEjecucion"  "$([ "$STA_ESTADO" = "EnEjecucion" ] && echo "✓ OK" || echo "✗ FALLO (got: $STA_ESTADO)")"
+printf "  %-40s %s\n" "UAT-1.7 grilla DNF tiene 10 atletas" "$([ "$GRILLA_DNF_COUNT" = "10" ] && echo "✓ OK" || echo "✗ FALLO (got: $GRILLA_DNF_COUNT)")"
+printf "  %-40s %s\n" "UAT-1.8 grilla STA tiene 3 atletas"  "$([ "$GRILLA_STA_COUNT" = "3" ] && echo "✓ OK" || echo "✗ FALLO (got: $GRILLA_STA_COUNT)")"
+echo
+
+# ── Generar checklist ─────────────────────────────────────────────────────────
+CHECKLIST="$UAT_DIR/checklist.md"
+
+cat > "$CHECKLIST" << CHECKLIST_EOF
+# Checklist UAT SP4 — Flujo de Performance (Capa 2 Manual)
+
+**Generado:** $(date "+%Y-%m-%d %H:%M")
+**Frontend:** http://localhost:5173
+**Login:** $JUEZ_EMAIL / $JUEZ_PASS
+
+---
+
+## Setup previo
+
+- [ ] Frontend corriendo: \`cd frontend && npm run dev\`
+- [ ] Backend corriendo en puerto 8000
+- [ ] Abrir http://localhost:5173 en Chrome/Safari (modo móvil en DevTools)
+- [ ] Hacer login con el usuario juez
+
+---
+
+## Competencia DNF
+
+**Cómo acceder:** Login → /juez/disciplinas → seleccionar DNF → grilla → tocar atleta
+
+### E-01 — DNS (Diego Vega, AP=40m)
+*Verifica el flujo de No Se Presenta*
+
+- [ ] Atleta aparece en grilla con estado AnunciadaAP
+- [ ] Paso 1: botón "LLAMAR ATLETA" visible y funcional
+- [ ] Paso 2: aparece opción "DNS — NO SE PRESENTA"
+- [ ] Al confirmar DNS: pantalla de completado muestra "DNS REGISTRADO"
+- [ ] Botón "SIGUIENTE ATLETA" navega de vuelta a grilla
+
+---
+
+### E-02 — BKO mid-performance (Laura Romero, AP=50m)
+*Verifica el blackout durante la performance*
+
+- [ ] Llegar al paso 4 (performance en curso)
+- [ ] Botón "BKO — BLACK-OUT" visible
+- [ ] Al presionar BKO: aparece formulario StepBKO con selector RP (metros.centímetros) y motivo DQ
+- [ ] Ingresar metros=25, centímetros=50
+- [ ] Seleccionar motivo: BKO SUBACUÁTICO (requiere campo distancia blackout)
+- [ ] Ingresar distancia blackout (ej: 20.00)
+- [ ] Botón CONFIRMAR habilitado solo cuando todos los campos están completos
+- [ ] Al confirmar: pantalla completada muestra "TARJETA ROJA"
+- [ ] Botón CANCELAR vuelve al paso 4 limpiando los campos
+
+---
+
+### E-03 — Blanca simple (Carlos Ibañez, AP=60m)
+*Flujo dorado completo: paso 1 → paso 6*
+
+- [ ] Flujo completo paso 1 (llamar) → paso 2 (confirmar) → paso 3 (OT) → paso 4 (performance) → paso 5 (RP)
+- [ ] Paso 5: ingresar metros=58, centímetros=00
+- [ ] Paso 6: tres botones de tarjeta sin texto, con colores (blanco, rojo, amarillo)
+- [ ] Seleccionar BLANCA: selector resaltado en verde
+- [ ] No aparece selector de motivo DQ
+- [ ] Botón CONFIRMAR TARJETA habilitado
+- [ ] Pantalla completada muestra marca y "TARJETA BLANCA"
+
+---
+
+### E-04 — Blanca con penalizaciones (Ana Flores, AP=70m)
+*Verifica el selector de penalizaciones*
+
+- [ ] Llegar al paso 6 con tarjeta BLANCA seleccionada
+- [ ] Aparece sección de penalizaciones con 4 tipos
+- [ ] Agregar 1 penalización "Sin contacto pared": contador sube a 1
+- [ ] Agregar 1 penalización "Fuera de carril": contador sube a 1
+- [ ] Resumen muestra "2 penalizaciones · −6m"
+- [ ] Botón quitar (−) reduce el contador; no puede bajar de 0
+- [ ] Al confirmar: pantalla completada muestra "TARJETA BLANCA CON PENALIZACIONES" y "2 penalizaciones"
+
+---
+
+### E-05 — Roja DQ estándar (Roberto Chen, AP=80m)
+*Verifica el selector de motivo DQ sin distancia*
+
+- [ ] Paso 6: seleccionar ROJA
+- [ ] Aparece selector de motivo DQ
+- [ ] Seleccionar "PROTOCOLO SUPERFICIE" (no requiere distancia)
+- [ ] Campo distancia blackout NO aparece
+- [ ] Botón CONFIRMAR habilitado con motivo seleccionado
+- [ ] Pantalla completada muestra "TARJETA ROJA"
+
+---
+
+### E-06 — Roja BKO post-performance (Patricia Ruiz, AP=90m)
+*Verifica distancia blackout obligatoria*
+
+- [ ] Paso 6: seleccionar ROJA
+- [ ] Seleccionar "BKO SUPERFICIE": aparece campo "Distancia blackout"
+- [ ] Botón CONFIRMAR deshabilitado hasta completar distancia
+- [ ] Ingresar distancia=15.00
+- [ ] Botón CONFIRMAR se habilita
+- [ ] Pantalla completada muestra "TARJETA ROJA"
+
+---
+
+### E-07 — Resolver revisión → Blanca (Martin Acosta, ya en EnRevision)
+*Resume: atleta ya tiene tarjeta amarilla asignada*
+
+- [ ] En grilla: atleta aparece con estado EnRevision
+- [ ] Al seleccionarlo: flow inicia directo en **paso 7** (no pasa por 1-6)
+- [ ] Pantalla muestra "TARJETA AMARILLA · Resolución pendiente"
+- [ ] Botón "RESOLVER → BLANCA" disponible
+- [ ] Al seleccionar Blanca: no aparece selector de motivo DQ
+- [ ] Botón CONFIRMAR RESOLUCIÓN habilitado
+- [ ] Pantalla completada muestra "TARJETA BLANCA"
+
+---
+
+### E-08 — Resolver revisión → Roja (Silvia Casas, ya en EnRevision)
+*Resume: atleta ya tiene tarjeta amarilla asignada*
+
+- [ ] Flow inicia en **paso 7**
+- [ ] Seleccionar "RESOLVER → ROJA": aparece selector de motivo DQ
+- [ ] Seleccionar motivo DQ (ej: INFRACCIÓN TÉCNICA)
+- [ ] Botón CONFIRMAR habilitado con motivo seleccionado
+- [ ] Pantalla completada muestra "TARJETA ROJA"
+
+---
+
+### R-01 — Resume en paso 2 (Jorge Mendez, ya Llamada)
+*Verifica que el flow retoma el estado correcto*
+
+- [ ] En grilla: atleta aparece con estado Llamada
+- [ ] Al seleccionarlo: flow inicia directo en **paso 2** (Confirmar presencia)
+- [ ] Paso 1 (Llamada) NO aparece (ya fue ejecutado)
+- [ ] Continuar flujo normal desde paso 2
+
+---
+
+### R-02 — Resume en paso 6 (Claudia Rios, ya ResultadoRegistrado)
+*Verifica que el flow retoma el estado correcto*
+
+- [ ] En grilla: atleta aparece con estado ResultadoRegistrado
+- [ ] Al seleccionarlo: flow inicia directo en **paso 6** (Tarjeta)
+- [ ] Pasos 1-5 NO aparecen
+- [ ] AtletaCard muestra el RP ya registrado (125m)
+- [ ] Continuar desde paso 6
+
+---
+
+## Competencia STA
+
+**Cómo acceder:** Login → /juez/disciplinas → seleccionar STA → grilla → tocar atleta
+
+### T-01 — DNS STA (Javier Herrera, AP=120s)
+*Verifica DNS en disciplina de tiempo*
+
+- [ ] Flow normal hasta paso 2
+- [ ] AtletaCard muestra "AP: 2:00 min" (no en metros)
+- [ ] Confirmar DNS → completado "DNS REGISTRADO"
+
+---
+
+### T-02 — BKO STA mid-performance (Carolina Espinoza, AP=180s)
+*Verifica BKO sin selector de metros (STA usa tiempo)*
+
+- [ ] Llegar al paso 4
+- [ ] Presionar "BKO — BLACK-OUT"
+- [ ] StepBKO **NO** muestra el selector RP (metros/centímetros) — es STA
+- [ ] Solo aparece: selector de motivo DQ
+- [ ] Seleccionar BKO SUBACUÁTICO
+- [ ] Botón CONFIRMAR habilitado solo con motivo (sin necesidad de metros ni distancia)
+- [ ] Confirmar → "TARJETA ROJA"
+
+---
+
+### T-03 — Blanca STA (Fernando Bravo, AP=240s)
+*Verifica el flujo de tiempo completo*
+
+- [ ] Paso 3: texto "Las vías respiratorias del atleta entran en contacto con el agua"
+- [ ] Botón VÍAS RESPIRATORIAS EN AGUA (en lugar de "ATLETA INICIA")
+- [ ] Paso 5: selector RP de tiempo (minutos + segundos, no metros)
+- [ ] Ingresar 4 minutos, 05 segundos
+- [ ] Paso 6: confirmar BLANCA
+- [ ] Pantalla completada muestra "4:05 min"
+
+---
+
+## Hallazgos de UI
+
+Documentar aquí cualquier problema encontrado durante el walk-through:
+
+$(cat "$ROOT/tests/uat/sp4/hallazgos-smoke-test.md" 2>/dev/null || echo "(ninguno previo)")
+
+---
+
+*Generado automáticamente por run_uat.sh — $(date)*
+CHECKLIST_EOF
+
+echo "✓ Checklist generado → $CHECKLIST"
+echo
+
+# ── Resumen ───────────────────────────────────────────────────────────────────
+echo "========================================================"
+echo "  Capa 1 completada"
+echo "========================================================"
+echo
+echo "  Artefactos:"
+echo "    $HTTP_OUTPUT"
+echo "    $CHECKLIST"
+echo
+echo "  Para la Capa 2 (manual):"
+echo "    1. Levantá el frontend : cd frontend && npm run dev"
+echo "    2. Abrí el checklist   : $CHECKLIST"
+echo "    3. Ejecutá cada escenario en http://localhost:5173"
+echo

--- a/tests/uat/sp4/seed_sp4.py
+++ b/tests/uat/sp4/seed_sp4.py
@@ -1,0 +1,570 @@
+"""Seed UAT SP4 — siembra el flujo de performance completo para la prueba de UI.
+
+Crea un torneo con dos competencias (DNF y STA) y 13 atletas, cubriendo los
+12 escenarios del flujo de performance del juez más los 3 casos de resume.
+
+  uv run python tests/uat/sp4/seed_sp4.py
+
+DBs utilizadas (se crean automáticamente):
+    data/torneo.db       — BC Torneo
+    data/registro.db     — BC Registro
+    data/competencia.db  — BC Competencia (event store)
+    data/identidad.db    — BC Identidad (usuario juez)
+
+Estado final tras el seed:
+    Competencia DNF — 10 atletas
+      E01 Diego Vega (40m)     → AnunciadaAP   [E-01: DNS en UI]
+      E02 Laura Romero (50m)   → AnunciadaAP   [E-02: BKO mid, paso 4]
+      E03 Carlos Ibañez (60m)  → AnunciadaAP   [E-03: Blanca simple]
+      E04 Ana Flores (70m)     → AnunciadaAP   [E-04: Blanca + penalizaciones]
+      E05 Roberto Chen (80m)   → AnunciadaAP   [E-05: Roja DQ estándar]
+      E06 Patricia Ruiz (90m)  → AnunciadaAP   [E-06: Roja BKO post]
+      E07 Martin Acosta (100m) → EnRevision    [E-07: resolver → Blanca, paso 7]
+      E08 Silvia Casas (110m)  → EnRevision    [E-08: resolver → Roja, paso 7]
+      R01 Jorge Mendez (120m)  → Llamada       [R-01: resume paso 2]
+      R02 Claudia Rios (130m)  → ResultadoRegistrado  [R-02: resume paso 6]
+
+    Competencia STA — 3 atletas
+      T01 Javier Herrera (120s)    → AnunciadaAP   [T-01: DNS STA]
+      T02 Carolina Espinoza (180s) → AnunciadaAP   [T-02: BKO STA mid]
+      T03 Fernando Bravo (240s)    → AnunciadaAP   [T-03: Blanca STA]
+
+    Usuario juez:  juez@uat-sp4.test / juezsp4uat2025
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from uuid import UUID, uuid4
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "src"))
+
+from competencia.application.commands.asignar_tarjeta import (
+    AsignarTarjetaCommand,
+    AsignarTarjetaHandler,
+)
+from competencia.application.commands.confirmar_grilla import (
+    ConfirmarGrillaCommand,
+    ConfirmarGrillaHandler,
+)
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTCommand,
+    ConfigurarIntervaloOTHandler,
+)
+from competencia.application.commands.generar_grilla import (
+    GenerarGrillaCommand,
+    GenerarGrillaHandler,
+)
+from competencia.application.commands.iniciar_competencia import (
+    IniciarCompetenciaCommand,
+    IniciarCompetenciaHandler,
+)
+from competencia.application.commands.llamar_atleta import (
+    LlamarAtletaCommand,
+    LlamarAtletaHandler,
+)
+from competencia.application.commands.registrar_ap import (
+    RegistrarAPCommand,
+    RegistrarAPHandler,
+)
+from competencia.application.commands.registrar_resultado import (
+    RegistrarResultadoCommand,
+    RegistrarResultadoHandler,
+)
+from competencia.application.queries.obtener_grilla import (
+    ObtenerGrillaHandler,
+    ObtenerGrillaQuery,
+)
+from competencia.domain.value_objects.tipo_tarjeta import TipoTarjeta
+from competencia.infrastructure.competencia_estado_stub import StubCompetenciaEstadoAdapter
+from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from competencia.infrastructure.repositories.competencia_estado_adapter import (
+    CompetenciaEstadoAdapter,
+)
+from competencia.infrastructure.repositories.disciplina_descriptor_adapter import (
+    DisciplinaDescriptorAdapter,
+)
+from competencia.infrastructure.repositories.performances_ap_adapter import PerformancesAPAdapter
+from competencia.infrastructure.repositories.performances_estado_adapter import (
+    PerformancesEstadoAdapter,
+)
+from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
+    SQLiteCompetenciasPorTorneo,
+)
+from identidad.application.commands.registrar_usuario import (
+    RegistrarUsuarioCommand,
+    RegistrarUsuarioHandler,
+)
+from identidad.domain.value_objects.rol import Rol
+from identidad.infrastructure.bcrypt_password_hasher import BcryptPasswordHasher
+from identidad.infrastructure.repositories.sqlite_usuario_repository import (
+    SQLiteUsuarioRepository,
+)
+from registro.application.commands.inscribir_atleta import (
+    InscribirAtletaCommand,
+    InscribirAtletaHandler,
+)
+from registro.application.commands.registrar_atleta import (
+    RegistrarAtletaCommand,
+    RegistrarAtletaHandler,
+)
+from registro.domain.value_objects.categoria import Categoria
+from registro.infrastructure.acl.sqlite_torneo_consulta import SQLiteTorneoConsulta
+from registro.infrastructure.repositories.sqlite_atleta_repository import SQLiteAtletaRepository
+from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
+    SQLiteInscripcionRepository,
+)
+from shared.domain.value_objects.disciplina import Disciplina
+from shared.domain.value_objects.unidad_medida import UnidadMedida
+from torneo.application.commands.asignar_disciplinas import (
+    AsignarDisciplinasCommand,
+    AsignarDisciplinasHandler,
+)
+from torneo.application.commands.crear_torneo import CrearTorneoCommand, CrearTorneoHandler
+from torneo.application.commands.asignar_juez import AsignarJuezCommand, AsignarJuezHandler
+from torneo.application.commands.transicionar_torneo import (
+    AbrirInscripcionHandler,
+    CerrarInscripcionHandler,
+    IniciarEjecucionHandler,
+    TransicionarTorneoCommand,
+)
+from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
+
+# ── Paths ──────────────────────────────────────────────────────────────────────
+
+_TORNEO_DB = str(ROOT / "data" / "torneo.db")
+_REGISTRO_DB = str(ROOT / "data" / "registro.db")
+_COMPETENCIA_DB = str(ROOT / "data" / "competencia.db")
+_IDENTIDAD_DB = str(ROOT / "data" / "identidad.db")
+_IDS_PATH = ROOT / "quality" / "reports" / "uat" / "SP4" / "uat_ids.json"
+
+# ── DDL ────────────────────────────────────────────────────────────────────────
+
+_CREATE_EVENTS_TABLE = """
+    CREATE TABLE IF NOT EXISTS events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL
+            DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+# ── Constantes ─────────────────────────────────────────────────────────────────
+
+_INTERVALO_MINUTOS = 7
+_OT_BASE = datetime.now(timezone.utc).replace(second=0, microsecond=0) + timedelta(hours=1)
+_JUEZ_ID = "juez-uat-sp4"
+_JUEZ_EMAIL = "juez@uat-sp4.test"
+_JUEZ_PASS = "juezsp4uat2025"
+
+# Atletas DNF: (label, nombre, apellido, cat, ap_metros)
+_ATLETAS_DNF = [
+    ("E01", "Diego",   "Vega",    Categoria.SENIOR_MASCULINO, 40),
+    ("E02", "Laura",   "Romero",  Categoria.SENIOR_FEMENINO,  50),
+    ("E03", "Carlos",  "Ibañez",  Categoria.MASTER_MASCULINO, 60),
+    ("E04", "Ana",     "Flores",  Categoria.MASTER_FEMENINO,  70),
+    ("E05", "Roberto", "Chen",    Categoria.SENIOR_MASCULINO, 80),
+    ("E06", "Patricia","Ruiz",    Categoria.SENIOR_FEMENINO,  90),
+    ("E07", "Martin",  "Acosta",  Categoria.MASTER_MASCULINO, 100),
+    ("E08", "Silvia",  "Casas",   Categoria.MASTER_FEMENINO,  110),
+    ("R01", "Jorge",   "Mendez",  Categoria.SENIOR_MASCULINO, 120),
+    ("R02", "Claudia", "Rios",    Categoria.SENIOR_FEMENINO,  130),
+]
+
+# Atletas STA: (label, nombre, apellido, cat, ap_segundos)
+_ATLETAS_STA = [
+    ("T01", "Javier",   "Herrera",  Categoria.MASTER_MASCULINO, 120),
+    ("T02", "Carolina", "Espinoza", Categoria.MASTER_FEMENINO,  180),
+    ("T03", "Fernando", "Bravo",    Categoria.SENIOR_MASCULINO, 240),
+]
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _ok(msg: str) -> None:
+    print(f"  ✓ {msg}")
+
+
+async def _registrar_atleta_e_inscribir(
+    label: str,
+    nombre: str,
+    apellido: str,
+    categoria: Categoria,
+    disciplina: Disciplina,
+    torneo_id: UUID,
+    atleta_repo: SQLiteAtletaRepository,
+    inscripcion_repo: SQLiteInscripcionRepository,
+    torneo_consulta: SQLiteTorneoConsulta,
+) -> UUID:
+    aid = uuid4()
+    email = f"uat.{label.lower()}@uat-sp4.test"
+    await RegistrarAtletaHandler(atleta_repo).handle(
+        RegistrarAtletaCommand(
+            atleta_id=aid,
+            nombre=nombre,
+            apellido=apellido,
+            email=email,
+            fecha_nacimiento=date(1990, 6, 15),
+            categoria=categoria,
+            club="UAT SP4",
+        )
+    )
+    await InscribirAtletaHandler(inscripcion_repo, torneo_consulta).handle(
+        InscribirAtletaCommand(
+            atleta_id=aid,
+            torneo_id=torneo_id,
+            disciplinas=frozenset({disciplina}),
+        )
+    )
+    _ok(f"{label} {nombre} {apellido} ({disciplina.value}, {categoria.value})")
+    return aid
+
+
+async def seed() -> None:
+    print()
+    print("=" * 65)
+    print("  UAT SP4 — Seed: Flujo de Performance (DNF + STA)")
+    print("=" * 65)
+    print()
+
+    # ── Inicializar event store ───────────────────────────────────────────────
+    import aiosqlite
+
+    Path(_COMPETENCIA_DB).parent.mkdir(parents=True, exist_ok=True)
+    async with aiosqlite.connect(_COMPETENCIA_DB) as db:
+        await db.execute(_CREATE_EVENTS_TABLE)
+        await db.commit()
+
+    # ── Repos ─────────────────────────────────────────────────────────────────
+    torneo_repo = SQLiteTorneoRepository(_TORNEO_DB)
+    atleta_repo = SQLiteAtletaRepository(_REGISTRO_DB)
+    inscripcion_repo = SQLiteInscripcionRepository(_REGISTRO_DB)
+    torneo_consulta = SQLiteTorneoConsulta(_TORNEO_DB)
+    store = SQLiteEventStore(_COMPETENCIA_DB)
+    stub = StubCompetenciaEstadoAdapter()
+    descriptor = DisciplinaDescriptorAdapter()
+
+    # ── BC Torneo ─────────────────────────────────────────────────────────────
+    print("[Torneo]")
+    torneo_id = await CrearTorneoHandler(torneo_repo).handle(
+        CrearTorneoCommand(
+            nombre="UAT SP4 — Flujo de Performance",
+            descripcion="Torneo de prueba para UAT SP4",
+            fecha_inicio=date(2025, 12, 1),
+            fecha_fin=date(2025, 12, 1),
+            sede_nombre="Pileta UAT",
+            sede_ciudad="Buenos Aires",
+            sede_pais="Argentina",
+            entidad_nombre="AIDA Argentina",
+            entidad_tipo="Federación",
+        )
+    )
+    _ok(f"Torneo creado: {torneo_id}")
+
+    await AsignarDisciplinasHandler(torneo_repo).handle(
+        AsignarDisciplinasCommand(
+            torneo_id=torneo_id,
+            disciplinas=frozenset({Disciplina.DNF, Disciplina.STA}),
+        )
+    )
+    _ok("Disciplinas asignadas: DNF, STA")
+
+    await AbrirInscripcionHandler(torneo_repo).handle(
+        TransicionarTorneoCommand(torneo_id=torneo_id)
+    )
+    _ok("Inscripción abierta")
+    print()
+
+    # ── BC Registro ───────────────────────────────────────────────────────────
+    print("[Registro]")
+    atleta_ids: dict[str, UUID] = {}
+    for label, nombre, apellido, cat, _ in _ATLETAS_DNF:
+        atleta_ids[label] = await _registrar_atleta_e_inscribir(
+            label, nombre, apellido, cat, Disciplina.DNF,
+            torneo_id, atleta_repo, inscripcion_repo, torneo_consulta,
+        )
+    for label, nombre, apellido, cat, _ in _ATLETAS_STA:
+        atleta_ids[label] = await _registrar_atleta_e_inscribir(
+            label, nombre, apellido, cat, Disciplina.STA,
+            torneo_id, atleta_repo, inscripcion_repo, torneo_consulta,
+        )
+    print()
+
+    # ── BC Competencia: DNF ───────────────────────────────────────────────────
+    print("[Competencia DNF]")
+    cid_dnf = uuid4()
+    await ConfigurarIntervaloOTHandler(store).handle(
+        ConfigurarIntervaloOTCommand(
+            competencia_id=cid_dnf,
+            disciplina=Disciplina.DNF,
+            intervalo_minutos=_INTERVALO_MINUTOS,
+            configurado_por="organizador-uat",
+            torneo_id=torneo_id,
+        )
+    )
+    _ok(f"DNF configurada: {cid_dnf} (intervalo={_INTERVALO_MINUTOS}min)")
+
+    ap_handler = RegistrarAPHandler(store, stub, descriptor)
+    for label, _, _, _, ap_m in _ATLETAS_DNF:
+        await ap_handler.handle(
+            RegistrarAPCommand(
+                competencia_id=cid_dnf,
+                participante_id=atleta_ids[label],
+                disciplina=Disciplina.DNF,
+                valor_ap=Decimal(str(ap_m)),
+                unidad=UnidadMedida.Metros,
+            )
+        )
+    _ok("APs DNF registrados (10/10): " + " ".join(
+        f"{l}={ap}m" for l, _, _, _, ap in _ATLETAS_DNF
+    ))
+
+    ap_adapter = PerformancesAPAdapter(store)
+    await GenerarGrillaHandler(store, ap_adapter, descriptor).handle(
+        GenerarGrillaCommand(
+            competencia_id=cid_dnf,
+            disciplina=Disciplina.DNF,
+            ot_inicio=_OT_BASE,
+            andariveles=1,
+        )
+    )
+    _ok("Grilla DNF generada (ascendente por AP)")
+
+    await ConfirmarGrillaHandler(store).handle(
+        ConfirmarGrillaCommand(competencia_id=cid_dnf, disciplina=Disciplina.DNF)
+    )
+    _ok("Grilla DNF confirmada")
+    print()
+
+    # ── BC Competencia: STA ───────────────────────────────────────────────────
+    print("[Competencia STA]")
+    cid_sta = uuid4()
+    await ConfigurarIntervaloOTHandler(store).handle(
+        ConfigurarIntervaloOTCommand(
+            competencia_id=cid_sta,
+            disciplina=Disciplina.STA,
+            intervalo_minutos=_INTERVALO_MINUTOS,
+            configurado_por="organizador-uat",
+            torneo_id=torneo_id,
+        )
+    )
+    _ok(f"STA configurada: {cid_sta} (intervalo={_INTERVALO_MINUTOS}min)")
+
+    sta_ot_base = _OT_BASE + timedelta(hours=3)
+    for label, _, _, _, ap_s in _ATLETAS_STA:
+        await ap_handler.handle(
+            RegistrarAPCommand(
+                competencia_id=cid_sta,
+                participante_id=atleta_ids[label],
+                disciplina=Disciplina.STA,
+                valor_ap=Decimal(str(ap_s)),
+                unidad=UnidadMedida.Segundos,
+            )
+        )
+    _ok("APs STA registrados (3/3): " + " ".join(
+        f"{l}={ap}s" for l, _, _, _, ap in _ATLETAS_STA
+    ))
+
+    await GenerarGrillaHandler(store, ap_adapter, descriptor).handle(
+        GenerarGrillaCommand(
+            competencia_id=cid_sta,
+            disciplina=Disciplina.STA,
+            ot_inicio=sta_ot_base,
+            andariveles=1,
+        )
+    )
+    _ok("Grilla STA generada (ascendente por AP)")
+
+    await ConfirmarGrillaHandler(store).handle(
+        ConfirmarGrillaCommand(competencia_id=cid_sta, disciplina=Disciplina.STA)
+    )
+    _ok("Grilla STA confirmada")
+    print()
+
+    # ── BC Identidad: crear usuario juez (antes de cerrar inscripción) ──────────
+    print("[Identidad: crear usuario juez]")
+    juez_repo = SQLiteUsuarioRepository(_IDENTIDAD_DB)
+    juez_id_uuid = await RegistrarUsuarioHandler(juez_repo, BcryptPasswordHasher()).handle(
+        RegistrarUsuarioCommand(email=_JUEZ_EMAIL, password=_JUEZ_PASS, rol=Rol.JUEZ)
+    )
+    _ok(f"Usuario juez creado: {_JUEZ_EMAIL} (id={juez_id_uuid})")
+
+    # Asignar juez a disciplinas ANTES de cerrar inscripción (restricción de dominio)
+    juez_handler = AsignarJuezHandler(torneo_repo)
+    for disc in [Disciplina.DNF, Disciplina.STA]:
+        await juez_handler.handle(
+            AsignarJuezCommand(torneo_id=torneo_id, disciplina=disc, juez_id=juez_id_uuid)
+        )
+        _ok(f"Juez asignado a {disc.value}")
+    print()
+
+    # ── Torneo: cerrar inscripción + iniciar ejecución ────────────────────────
+    print("[Torneo — transición a EJECUCION]")
+    await CerrarInscripcionHandler(torneo_repo).handle(
+        TransicionarTorneoCommand(torneo_id=torneo_id)
+    )
+    _ok("Inscripción cerrada")
+
+    await IniciarEjecucionHandler(torneo_repo).handle(
+        TransicionarTorneoCommand(torneo_id=torneo_id)
+    )
+    _ok("Torneo en EJECUCION — visible en frontend")
+    print()
+
+    # ── Iniciar competencias + registrar en proyección por torneo ────────────
+    print("[Iniciar competencias]")
+    comp_por_torneo = SQLiteCompetenciasPorTorneo(_COMPETENCIA_DB)
+
+    await IniciarCompetenciaHandler(store).handle(
+        IniciarCompetenciaCommand(
+            competencia_id=cid_dnf,
+            disciplina=Disciplina.DNF,
+            juez_id=_JUEZ_ID,
+        )
+    )
+    await comp_por_torneo.guardar(cid_dnf, Disciplina.DNF.value, torneo_id)
+    _ok("DNF iniciada → estado EnEjecucion + índice por torneo")
+
+    await IniciarCompetenciaHandler(store).handle(
+        IniciarCompetenciaCommand(
+            competencia_id=cid_sta,
+            disciplina=Disciplina.STA,
+            juez_id=_JUEZ_ID,
+        )
+    )
+    await comp_por_torneo.guardar(cid_sta, Disciplina.STA.value, torneo_id)
+    _ok("STA iniciada → estado EnEjecucion + índice por torneo")
+    print()
+
+    # ── Pre-avanzar atletas (E07, E08, R01, R02) ──────────────────────────────
+    print("[Pre-advance: leer grilla DNF]")
+    grilla_dnf = await ObtenerGrillaHandler(store).handle(
+        ObtenerGrillaQuery(competencia_id=cid_dnf, disciplina=Disciplina.DNF)
+    )
+    grilla_dnf_map = {UUID(e.atleta_id): e for e in grilla_dnf}
+    for e in sorted(grilla_dnf, key=lambda x: x.posicion):
+        print(f"    pos.{e.posicion:02d} | {e.atleta_id[:8]}... | OT={e.ot_programado[11:16]}")
+    print()
+
+    # Handlers sin chequeo de andarivel (seed secuencial)
+    estado_adapter = CompetenciaEstadoAdapter(store)
+    llamar = LlamarAtletaHandler(store, estado_adapter, andariveles_activos=None)
+    resultado_handler = RegistrarResultadoHandler(store, descriptor)
+    tarjeta_handler = AsignarTarjetaHandler(store, PerformancesEstadoAdapter(store), None)
+
+    async def _llamar(label: str, andarivel: int = 1) -> None:
+        aid = atleta_ids[label]
+        entrada = grilla_dnf_map[aid]
+        await llamar.handle(
+            LlamarAtletaCommand(
+                competencia_id=cid_dnf,
+                participante_id=aid,
+                disciplina=Disciplina.DNF,
+                ot_programado=datetime.fromisoformat(entrada.ot_programado),
+                posicion_grilla=entrada.posicion,
+                andarivel=andarivel,
+            )
+        )
+
+    async def _resultado_dnf(label: str, metros: int) -> None:
+        await resultado_handler.handle(
+            RegistrarResultadoCommand(
+                competencia_id=cid_dnf,
+                participante_id=atleta_ids[label],
+                disciplina=Disciplina.DNF,
+                valor_rp=Decimal(str(metros)),
+                unidad=UnidadMedida.Metros,
+                registrado_por=_JUEZ_ID,
+            )
+        )
+
+    async def _amarilla(label: str) -> None:
+        await tarjeta_handler.handle(
+            AsignarTarjetaCommand(
+                competencia_id=cid_dnf,
+                participante_id=atleta_ids[label],
+                disciplina=Disciplina.DNF,
+                tipo=TipoTarjeta.Amarilla,
+                motivo_texto="Revision pendiente del juez",
+                asignada_por=_JUEZ_ID,
+            )
+        )
+
+    print("[Pre-advance: E07 Martin Acosta → EnRevision (Amarilla)]")
+    await _llamar("E07")
+    await _resultado_dnf("E07", 95)
+    await _amarilla("E07")
+    _ok("E07 Martin Acosta → EnRevision (RP=95m, Amarilla asignada)")
+
+    print()
+    print("[Pre-advance: E08 Silvia Casas → EnRevision (Amarilla)]")
+    await _llamar("E08")
+    await _resultado_dnf("E08", 108)
+    await _amarilla("E08")
+    _ok("E08 Silvia Casas → EnRevision (RP=108m, Amarilla asignada)")
+
+    print()
+    print("[Pre-advance: R02 Claudia Rios → ResultadoRegistrado]")
+    await _llamar("R02")
+    await _resultado_dnf("R02", 125)
+    _ok("R02 Claudia Rios → ResultadoRegistrado (RP=125m, sin tarjeta)")
+
+    print()
+    print("[Pre-advance: R01 Jorge Mendez → Llamada]")
+    await _llamar("R01", andarivel=2)  # andarivel 2 → no bloquea andarivel 1 para el UAT
+    _ok("R01 Jorge Mendez → Llamada (sin resultado, andarivel=2)")
+    print()
+
+    # ── Guardar IDs ───────────────────────────────────────────────────────────
+    ids = {
+        "torneo_id": str(torneo_id),
+        "competencia_dnf_id": str(cid_dnf),
+        "competencia_sta_id": str(cid_sta),
+        "juez_id": str(juez_id_uuid),
+        "juez_email": _JUEZ_EMAIL,
+        "juez_password": _JUEZ_PASS,
+    }
+    for label, nombre, apellido, _, _ in _ATLETAS_DNF + _ATLETAS_STA:
+        ids[f"atleta_{label.lower()}"] = str(atleta_ids[label])
+
+    _IDS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _IDS_PATH.write_text(json.dumps(ids, indent=2))
+    _ok(f"IDs guardados: {_IDS_PATH.relative_to(ROOT)}")
+    print()
+
+    # ── Resumen ───────────────────────────────────────────────────────────────
+    print("=" * 65)
+    print("  Seed completado exitosamente")
+    print("=" * 65)
+    print()
+    print("  Competencia DNF")
+    print(f"    ID  : {cid_dnf}")
+    print(f"    URL : /juez/grilla (seleccionar DNF desde /juez/disciplinas)")
+    print()
+    print("  Competencia STA")
+    print(f"    ID  : {cid_sta}")
+    print(f"    URL : /juez/grilla (seleccionar STA desde /juez/disciplinas)")
+    print()
+    print("  Login juez")
+    print(f"    email    : {_JUEZ_EMAIL}")
+    print(f"    password : {_JUEZ_PASS}")
+    print()
+    print("  Próximos pasos:")
+    print("    1. Levantá el backend : uv run fastapi dev src/app.py")
+    print("    2. Levantá el frontend: cd frontend && npm run dev")
+    print("    3. Abrí el browser en : http://localhost:5173")
+    print("    4. Ejecutá run_uat.sh para checks HTTP + checklist")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed())


### PR DESCRIPTION
## Resumen

Resolución de 8 issues de UX (MUX-01..08) y 1 bug de dominio (BUG-01) identificados en el UAT de SP4, sobre el flujo de performance del juez.

### Frontend
- **MUX-01** — RpSelector compactado para que el keypad quede visible sin scroll
- **MUX-02** — Tarjetas (paso 6 y 7) con color sólido siempre; opacidad para indicar no-seleccionada
- **MUX-03** — Grilla ordenada por prioridad de estado: SIGUIENTE → EN_CURSO → REVISION → PENDIENTE → FINALIZADA
- **MUX-04** — Campo `distanciaBlackout` eliminado del UI; deriva automáticamente del RpSelector (metros)
- **MUX-05** — Pantalla de performance completada colorea según resultado (verde/rojo/amber/slate)
- **MUX-06** — Pasos 4/5/6/7 muestran solo el nombre del atleta; AtletaCard oculta para maximizar espacio
- **MUX-07** — Paso 7 (revisión): tarjetas en columnas, altura h-40, botones VOLVER + CONFIRMAR
- **MUX-08** — Marcas STA formateadas como mm:ss en grilla y AtletaCard

### Domain
- **BUG-01** — `TarjetaAsignacion` exime INV-DQ-01 para disciplinas de tiempo (STA BKO no requiere `distancia_blackout`); `resolver_revision()` deriva `distancia_blackout` desde `rp_medido` cuando el motivo lo requiere

## Archivos clave modificados

- `frontend/src/components/juez/StepTarjeta.tsx`
- `frontend/src/components/juez/StepRevision.tsx`
- `frontend/src/components/juez/StepBKO.tsx`
- `frontend/src/components/juez/AtletaCard.tsx`
- `frontend/src/pages/juez/GrillaPage.tsx`
- `frontend/src/pages/juez/PerformanceFlowPage.tsx`
- `frontend/src/hooks/usePerformanceFlow.ts`
- `src/competencia/domain/value_objects/tarjeta_asignacion.py`
- `src/competencia/domain/aggregates/performance.py`

## Artefactos UAT

- `tests/uat/sp4/` — seed, scripts y hallazgos del smoke test
- `quality/reports/uat/SP4/` — checklist y registros HTTP
- `docs/design/ux/mejoras-ux.md` — registro persistente de issues UX
- `docs/contexto/HITO-19-INC-4-1-HALLAZGOS-DISENO-CIERRE.md`

## Plan de prueba

- [ ] Reset de datos: `rm -f data/*.db && python scripts/seed_sp4.py`
- [ ] Capa 1 HTTP: `bash tests/uat/sp4/run_uat.sh` — todos los endpoints responden
- [ ] Capa 2 manual: recorrer flujo completo desde grilla → paso 7 en cada escenario del checklist
- [ ] Verificar formato mm:ss en grilla para disciplina STA
- [ ] Verificar BKO en STA (paso 4 y resolución de revisión) sin error INV-DQ-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)