### PR TITLE
US-4.5.1: Aggregate Notificacion - ciclo de vida e idempotencia

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -367,31 +367,47 @@ classDiagram
 
 ## 7. BC Notificaciones — Generic (Event Sourcing)
 
-> Modelo de referencia — implementación en SP4
+> `US-4.5.1` implementa el núcleo del aggregate y su event store propio.
+> Las políticas y el adaptador email real se completan en `US-4.5.2` a `US-4.5.4`.
 
 ### Aggregate
 
 | Aggregate | Tipo | Responsabilidad |
 |-----------|------|-----------------|
-| `Notificacion` | Aggregate root | Ciclo de vida de un intento de comunicación: Solicitada → Enviada / Fallida |
+| `Notificacion` | Aggregate root | Ciclo de vida de un intento de comunicación: `Solicitada -> Enviada | Fallida`; aplica idempotencia estructural por `evento_fuente_id` |
 
 ### Value Objects
 
 | Tipo | Descripción |
 |------|-------------|
-| `Destinatario` | userId + canal preferido (Email / Push) |
-| `PlantillaId` | Referencia a template de mensaje por tipo de evento |
-| `EventoFuenteId` | Id del evento de dominio que originó la notificación — clave de idempotencia |
+| `NotificacionId` | UUID inmutable del aggregate |
+| `EventoFuenteId` | Identificador del evento fuente que originó la notificación — clave de idempotencia |
+| `Destinatario` | Email válido + nombre opcional del receptor |
+| `ContenidoEmail` | Asunto no vacío + cuerpo de texto + HTML opcional |
+| `CanalEnvio` | Enum `Email | Push` (`SP4` implementa solo `Email`) |
 
 ### Eventos propios
 
 | Evento | Descripción |
 |--------|-------------|
-| `NotificacionSolicitada` | Intento registrado — incluye `eventoFuenteId` para idempotencia |
-| `NotificacionEnviada` | Canal externo confirmó entrega |
-| `NotificacionFallida` | Canal externo rechazó o timeout |
-| `NotificacionReintentada` | Reintento programado tras fallo |
-| `PreferenciasActualizadas` | Atleta cambió canal preferido |
+| `NotificacionSolicitada` | Primer evento del stream; captura destinatario, contenido, canal y `evento_fuente_id` |
+| `NotificacionEnviada` | Marca el stream como exitoso y terminal; puede persistir `proveedor_id` |
+| `NotificacionFallida` | Marca el stream como fallido y terminal; persiste `motivo` |
+
+### Event Store propio
+
+| Elemento | Decisión |
+|----------|----------|
+| Tabla | `notificaciones_events` |
+| Stream ID | `notificacion-{notificacion_id}` |
+| Índices | `stream_id` + `json_extract(payload, '$.evento_fuente_id')` |
+| Regla de idempotencia | si existe `NotificacionEnviada` para un `evento_fuente_id`, un nuevo `SolicitarEnvio` no emite eventos |
+
+### Puerto de repositorio
+
+| Puerto | Responsabilidad |
+|--------|-----------------|
+| `NotificacionRepository` | Persistir y rehidratar streams; consultar si ya existe `NotificacionEnviada` por `evento_fuente_id` |
 
 ---
 

--- a/docs/plans/sp4/US-4.5.1-plan.md
+++ b/docs/plans/sp4/US-4.5.1-plan.md
@@ -1,0 +1,130 @@
+# Plan de Implementación: US-4.5.1 - Aggregate Notificacion
+
+**Sprint:** SP4 - La Plataforma
+**Incremento:** INC-4.5
+**Bounded Context:** `notificaciones`
+**Patrón:** Hexagonal DDD BC-first + Event Sourcing
+**Estimación total:** 3h 20min
+
+## Objetivo
+
+Implementar el aggregate `Notificacion` con ciclo de vida `Solicitada -> Enviada | Fallida`,
+persistencia en event store propio del BC y chequeo de idempotencia estructural por
+`evento_fuente_id`.
+
+## Decisiones de diseño
+
+- Se implementará un event store propio en `notificaciones/infrastructure/event_store/`.
+  Motivo: la US exige tabla `notificaciones_events` e indexación por `evento_fuente_id`,
+  mientras que `shared.infrastructure.event_store.SQLiteEventStore` hoy asume tabla
+  genérica `events` y no expone helpers de idempotencia.
+- La validación de duplicados no vivirá en `application/`: se resolverá vía puerto
+  `NotificacionRepository` para preservar la regla de idempotencia como parte del
+  comportamiento estructural del aggregate.
+- `EmailPort` se definirá ahora por consistencia del modelo, pero quedará como contrato
+  sin implementación concreta hasta `US-4.5.2`.
+- Se usará `str` para `EventoFuenteId` en esta US, aunque la spec lo describe como UUID.
+  Motivo: `US-4.5.4` ya anticipa claves compuestas `"{evento}:{atleta_id}"`. El VO
+  preservará inmutabilidad y validación semántica sin encerrar la implementación en UUID
+  puro.
+
+## Componentes a implementar
+
+### 1. Dominio - Value Objects
+
+- [ ] `src/notificaciones/domain/value_objects/notificacion_id.py` (10 min)
+  - VO UUID para `NotificacionId`
+- [ ] `src/notificaciones/domain/value_objects/evento_fuente_id.py` (10 min)
+  - VO inmutable para clave de idempotencia
+- [ ] `src/notificaciones/domain/value_objects/destinatario.py` (15 min)
+  - valida email y nombre opcional
+- [ ] `src/notificaciones/domain/value_objects/contenido_email.py` (15 min)
+  - valida asunto no vacio y cuerpo disponible
+- [ ] `src/notificaciones/domain/value_objects/canal_envio.py` (5 min)
+  - enum `Email | Push`
+- [ ] actualizar `src/notificaciones/domain/value_objects/__init__.py` (5 min)
+
+### 2. Dominio - Eventos
+
+- [ ] `src/notificaciones/domain/events/notificacion_solicitada.py` (15 min)
+- [ ] `src/notificaciones/domain/events/notificacion_enviada.py` (15 min)
+- [ ] `src/notificaciones/domain/events/notificacion_fallida.py` (15 min)
+- [ ] actualizar `src/notificaciones/domain/events/__init__.py` (5 min)
+
+### 3. Dominio - Aggregate y puertos
+
+- [ ] `src/notificaciones/domain/ports/notificacion_repository.py` (15 min)
+  - `load(stream_id)`, `append(...)`, `exists_success_by_evento_fuente_id(...)`
+- [ ] `src/notificaciones/domain/ports/email_port.py` (10 min)
+  - contrato base para siguiente US
+- [ ] `src/notificaciones/domain/aggregates/notificacion.py` (35 min)
+  - crear solicitud
+  - registrar envio exitoso
+  - registrar fallo
+  - reconstitucion desde stream
+  - bloqueo terminal
+  - no emision de eventos si ya existe exito previo
+- [ ] actualizar `src/notificaciones/domain/ports/__init__.py` y `src/notificaciones/domain/aggregates/__init__.py` (5 min)
+
+### 4. Infraestructura - Event Store propio
+
+- [ ] `src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py` (35 min)
+  - crear tabla `notificaciones_events` si no existe
+  - append/load por stream
+  - consulta de exito previo por `evento_fuente_id`
+  - indice por `stream_id` y `json_extract(payload, '$.evento_fuente_id')`
+- [ ] `src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py` (20 min)
+  - adapter de infraestructura al puerto de dominio
+- [ ] actualizar exports en `src/notificaciones/infrastructure/event_store/__init__.py`
+  y `src/notificaciones/infrastructure/repositories/__init__.py` (5 min)
+
+### 5. Tests unitarios
+
+- [ ] `tests/unit/notificaciones/domain/test_value_objects.py` (20 min)
+  - email invalido
+  - asunto vacio
+  - VO ids
+- [ ] `tests/unit/notificaciones/domain/test_notificacion.py` (30 min)
+  - solicitud nueva
+  - terminalidad
+  - reintento tras fallo previo rehidratado
+  - rechazo de destinatario invalido
+  - idempotencia sin emitir eventos cuando repo informa envio exitoso previo
+
+### 6. Tests de integración
+
+- [ ] `tests/integration/notificaciones/test_sqlite_notificacion_repository.py` (30 min)
+  - persistencia de eventos
+  - rehidratacion desde stream
+  - deteccion de `NotificacionEnviada` por `evento_fuente_id`
+  - independencia de streams en mismo store
+
+### 7. BDD y validación
+
+- [ ] `tests/features/steps/notificacion_idempotencia_steps.py` (30 min)
+  - steps para los 6 escenarios de la feature
+- [ ] ejecutar pytest unitario + integración + BDD focalizado (10 min)
+- [ ] ejecutar CodeGuard sobre `src/notificaciones` (5 min)
+
+### 8. Documentación y reporte
+
+- [ ] actualizar `docs/design/domain-model.md` con aggregate, VOs y eventos de notificaciones (10 min)
+- [ ] crear `docs/reports/US-4.5.1-report.md` (10 min)
+
+## Riesgos a vigilar
+
+- La spec habla de chequeo en el aggregate "contra el store", pero el aggregate no debe
+  depender de infraestructura. Se resolverá inyectando la decisión desde un puerto o
+  factory de creación, manteniendo la garantía estructural sin romper hexagonalidad.
+- `EventoFuenteId` debe quedar preparado para `US-4.5.4`, donde la clave no será un UUID
+  puro sino compuesta.
+- No se implementará envío real todavía; cualquier referencia al canal externo debe quedar
+  sólo como contrato y no contaminar esta US.
+
+## Criterio de cierre de la US
+
+- Aggregate `Notificacion` funcional y rehidratable
+- Persistencia ES real en SQLite del BC Notificaciones
+- Idempotencia por `evento_fuente_id` verificada por tests
+- Feature BDD automatizada en verde
+- Reporte final de US generado en disco

--- a/docs/reports/US-4.5.1-report.md
+++ b/docs/reports/US-4.5.1-report.md
@@ -1,0 +1,150 @@
+# Reporte de Implementación — US-4.5.1
+## Aggregate `Notificacion` — ciclo de vida e idempotencia
+
+**Sprint:** SP4 — La Plataforma  
+**Incremento:** INC-4.5  
+**Branch:** `feature/US-4.5.1-notificacion-idempotencia`  
+**Fecha:** 2026-04-14
+
+---
+
+## Resumen
+
+Se implementó el núcleo del BC `notificaciones` con Event Sourcing propio:
+
+- aggregate `Notificacion`
+- value objects del dominio
+- eventos `NotificacionSolicitada`, `NotificacionEnviada` y `NotificacionFallida`
+- event store SQLite específico del BC sobre tabla `notificaciones_events`
+- repositorio con consulta de idempotencia por `evento_fuente_id`
+
+La idempotencia queda resuelta de forma estructural: si el repositorio detecta una
+`NotificacionEnviada` previa para un `evento_fuente_id`, la operación de solicitud no
+crea aggregate ni emite nuevos eventos.
+
+---
+
+## Cambios implementados
+
+### Código
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/notificaciones/domain/aggregates/notificacion.py` | Aggregate con rehidratación, transición `Solicitada -> Enviada/Fallida` y terminalidad |
+| `src/notificaciones/domain/events/*.py` | Tres eventos de dominio del ciclo de vida |
+| `src/notificaciones/domain/value_objects/*.py` | `NotificacionId`, `EventoFuenteId`, `Destinatario`, `ContenidoEmail`, `CanalEnvio` |
+| `src/notificaciones/domain/ports/notificacion_repository.py` | Puerto de persistencia e idempotencia |
+| `src/notificaciones/domain/ports/email_port.py` | Contrato para el canal email a usar en `US-4.5.2` |
+| `src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py` | Event store SQLite propio con tabla `notificaciones_events` e índice por `evento_fuente_id` |
+| `src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py` | Adaptador al puerto de repositorio |
+
+### Tests
+
+| Archivo | Cobertura |
+|---------|-----------|
+| `tests/unit/notificaciones/domain/test_value_objects.py` | Validaciones de VOs |
+| `tests/unit/notificaciones/domain/test_notificacion.py` | Solicitud, terminalidad, idempotencia y reintento |
+| `tests/integration/notificaciones/test_sqlite_notificacion_repository.py` | Persistencia real, rehidratación y búsqueda por `evento_fuente_id` |
+| `tests/features/US-4.5.1-notificacion-idempotencia.feature` | Escenarios BDD de la US |
+| `tests/features/steps/notificacion_idempotencia_steps.py` | Steps automatizados sobre SQLite real |
+
+### Documentación
+
+| Archivo | Cambio |
+|---------|--------|
+| `docs/plans/sp4/US-4.5.1-plan.md` | Plan aprobado de implementación |
+| `docs/design/domain-model.md` | BC Notificaciones actualizado al estado real de `US-4.5.1` |
+
+---
+
+## Decisiones de diseño
+
+### 1. Event store propio del BC
+
+No se reutilizó `shared.infrastructure.event_store.SQLiteEventStore` porque la US exige:
+
+- tabla específica `notificaciones_events`
+- indexación por `json_extract(payload, '$.evento_fuente_id')`
+- consulta explícita para idempotencia por evento fuente
+
+Esto deja al BC preparado para evolucionar sin forzar abstracciones prematuras en el
+store compartido.
+
+### 2. `EventoFuenteId` como VO basado en `str`
+
+Aunque la spec lo describe como UUID, se implementó como VO inmutable sobre `str`.
+Motivo: `US-4.5.4` requiere claves compuestas del tipo `"{evento}:{atleta_id}"`.
+La decisión evita rediseñar el VO en la siguiente US.
+
+### 3. `EmailPort` se define ahora pero no se usa aún
+
+`US-4.5.1` sólo implementa el ciclo de vida y la persistencia del aggregate.
+El envío real queda desacoplado y pendiente para `US-4.5.2`.
+
+---
+
+## Resultados de calidad
+
+### Pytest focalizado
+
+Comando ejecutado:
+
+```bash
+./.venv/bin/pytest tests/features/steps/notificacion_idempotencia_steps.py \
+  tests/unit/notificaciones/domain/test_value_objects.py \
+  tests/unit/notificaciones/domain/test_notificacion.py \
+  tests/integration/notificaciones/test_sqlite_notificacion_repository.py -q
+```
+
+Resultado:
+
+```text
+18 passed in 0.22s
+```
+
+### CodeGuard
+
+Comando ejecutado:
+
+```bash
+./.venv/bin/codeguard src/notificaciones
+```
+
+Resultado:
+
+```text
+0 errores
+0 advertencias
+```
+
+---
+
+## Estado respecto de la spec
+
+### Cumplido
+
+- aggregate `Notificacion` con ciclo `Solicitada -> Enviada/Fallida`
+- eventos persistidos en event store propio del BC
+- rehidratación desde stream
+- idempotencia por `evento_fuente_id`
+- reintento permitido tras fallo previo
+- validación de destinatario y contenido
+- estados terminales bloqueando comandos posteriores
+
+### Diferencia menor respecto de la redacción original
+
+- La validación de duplicado se decide con información provista por repositorio en el
+  momento de `solicitar_envio`, en lugar de hacer que el aggregate consulte infraestructura
+  directamente. La garantía sigue siendo estructural, pero sin romper la arquitectura
+  hexagonal.
+
+---
+
+## Riesgos y próximos pasos
+
+- `US-4.5.2` debe introducir el handler de aplicación para orquestar rehidratación,
+  llamada a `EmailPort` y persistencia de `NotificacionEnviada/Fallida`.
+- `US-4.5.3` y `US-4.5.4` siguen bloqueadas por la ausencia de sus eventos fuente reales
+  (`InscripcionConfirmada`, `ResultadosPublicados`) en los BC productores.
+- Si en el futuro más BCs requieren índices por payload en sus event stores, convendrá
+  evaluar una abstracción compartida de event store con hooks de schema específicos por BC.

--- a/src/notificaciones/domain/aggregates/__init__.py
+++ b/src/notificaciones/domain/aggregates/__init__.py
@@ -1,0 +1,5 @@
+"""Aggregates del BC Notificaciones."""
+
+from notificaciones.domain.aggregates.notificacion import Notificacion
+
+__all__ = ["Notificacion"]

--- a/src/notificaciones/domain/aggregates/notificacion.py
+++ b/src/notificaciones/domain/aggregates/notificacion.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from notificaciones.domain.events.notificacion_enviada import NotificacionEnviada
+from notificaciones.domain.events.notificacion_fallida import NotificacionFallida
+from notificaciones.domain.events.notificacion_solicitada import NotificacionSolicitada
+from notificaciones.domain.exceptions import EstadoNotificacionInvalido
+from notificaciones.domain.value_objects.canal_envio import CanalEnvio
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+from notificaciones.domain.value_objects.notificacion_id import NotificacionId
+from shared.domain.base.aggregate_root import AggregateRoot
+
+
+class Notificacion(AggregateRoot):
+    """Aggregate raíz del BC Notificaciones."""
+
+    def __init__(self, notificacion_id: NotificacionId) -> None:
+        super().__init__()
+        self._notificacion_id = notificacion_id
+        self._evento_fuente_id: EventoFuenteId | None = None
+        self._destinatario: Destinatario | None = None
+        self._contenido: ContenidoEmail | None = None
+        self._canal: CanalEnvio | None = None
+        self._estado = "Nueva"
+        self._proveedor_id: str | None = None
+        self._motivo_fallo: str | None = None
+
+    @property
+    def notificacion_id(self) -> NotificacionId:
+        return self._notificacion_id
+
+    @property
+    def evento_fuente_id(self) -> EventoFuenteId | None:
+        return self._evento_fuente_id
+
+    @property
+    def destinatario(self) -> Destinatario | None:
+        return self._destinatario
+
+    @property
+    def contenido(self) -> ContenidoEmail | None:
+        return self._contenido
+
+    @property
+    def canal(self) -> CanalEnvio | None:
+        return self._canal
+
+    @property
+    def estado(self) -> str:
+        return self._estado
+
+    @property
+    def proveedor_id(self) -> str | None:
+        return self._proveedor_id
+
+    @property
+    def motivo_fallo(self) -> str | None:
+        return self._motivo_fallo
+
+    @property
+    def stream_id(self) -> str:
+        return f"notificacion-{self._notificacion_id}"
+
+    @classmethod
+    async def solicitar_envio(
+        cls,
+        *,
+        evento_fuente_id: EventoFuenteId,
+        destinatario: Destinatario,
+        contenido: ContenidoEmail,
+        canal: CanalEnvio,
+        existe_envio_exitoso_previo: bool,
+    ) -> "Notificacion | None":
+        if existe_envio_exitoso_previo:
+            return None
+
+        aggregate = cls(NotificacionId())
+        event = NotificacionSolicitada(
+            event_type="NotificacionSolicitada",
+            aggregate_id=str(aggregate.notificacion_id),
+            occurred_at=NotificacionSolicitada.now(),
+            notificacion_id=str(aggregate.notificacion_id),
+            evento_fuente_id=str(evento_fuente_id),
+            destinatario_email=destinatario.email,
+            destinatario_nombre=destinatario.nombre,
+            asunto=contenido.asunto,
+            cuerpo_texto=contenido.cuerpo_texto,
+            cuerpo_html=contenido.cuerpo_html,
+            canal=canal.value,
+        )
+        aggregate._apply(event)
+        aggregate._record(event)
+        return aggregate
+
+    def registrar_envio_exitoso(self, proveedor_id: str | None = None) -> None:
+        self._assert_solicitada()
+        if self._evento_fuente_id is None:
+            raise EstadoNotificacionInvalido(
+                "Notificacion sin evento_fuente_id en estado Solicitada"
+            )
+        event = NotificacionEnviada(
+            event_type="NotificacionEnviada",
+            aggregate_id=str(self._notificacion_id),
+            occurred_at=NotificacionEnviada.now(),
+            notificacion_id=str(self._notificacion_id),
+            evento_fuente_id=str(self._evento_fuente_id),
+            proveedor_id=proveedor_id,
+            enviada_en=NotificacionEnviada.now().isoformat(),
+        )
+        self._apply(event)
+        self._record(event)
+
+    def registrar_fallo(self, motivo: str) -> None:
+        self._assert_solicitada()
+        if not motivo or not motivo.strip():
+            raise ValueError("motivo no puede ser vacío")
+        if self._evento_fuente_id is None:
+            raise EstadoNotificacionInvalido(
+                "Notificacion sin evento_fuente_id en estado Solicitada"
+            )
+        event = NotificacionFallida(
+            event_type="NotificacionFallida",
+            aggregate_id=str(self._notificacion_id),
+            occurred_at=NotificacionFallida.now(),
+            notificacion_id=str(self._notificacion_id),
+            evento_fuente_id=str(self._evento_fuente_id),
+            motivo=motivo,
+            fallida_en=NotificacionFallida.now().isoformat(),
+        )
+        self._apply(event)
+        self._record(event)
+
+    @classmethod
+    def reconstitute(cls, events: list[dict[str, Any]]) -> "Notificacion":
+        if not events:
+            raise ValueError("No se puede reconstituir Notificacion sin eventos")
+        first_payload = _parse_payload(events[0]["payload"])
+        aggregate = cls(NotificacionId(first_payload["notificacion_id"]))
+        for event in events:
+            aggregate._apply_stored(event)
+        return aggregate
+
+    def _assert_solicitada(self) -> None:
+        if self._estado != "Solicitada":
+            raise EstadoNotificacionInvalido(
+                f"Notificacion {self._notificacion_id} no acepta la operación "
+                f"en estado {self._estado}"
+            )
+
+    def _apply_stored(self, event: dict[str, Any]) -> None:
+        payload = _parse_payload(event["payload"])
+        handlers = {
+            "NotificacionSolicitada": NotificacionSolicitada.from_payload,
+            "NotificacionEnviada": NotificacionEnviada.from_payload,
+            "NotificacionFallida": NotificacionFallida.from_payload,
+        }
+        domain_event = handlers[event["event_type"]](payload)
+        self._apply(domain_event)
+
+    def _apply(
+        self,
+        event: NotificacionSolicitada | NotificacionEnviada | NotificacionFallida,
+    ) -> None:
+        if isinstance(event, NotificacionSolicitada):
+            self._evento_fuente_id = EventoFuenteId(event.evento_fuente_id)
+            self._destinatario = Destinatario(
+                email=event.destinatario_email,
+                nombre=event.destinatario_nombre,
+            )
+            self._contenido = ContenidoEmail(
+                asunto=event.asunto,
+                cuerpo_texto=event.cuerpo_texto,
+                cuerpo_html=event.cuerpo_html,
+            )
+            self._canal = CanalEnvio(event.canal)
+            self._estado = "Solicitada"
+            return
+        if isinstance(event, NotificacionEnviada):
+            self._proveedor_id = event.proveedor_id
+            self._estado = "Enviada"
+            return
+        self._motivo_fallo = event.motivo
+        self._estado = "Fallida"
+
+
+def _parse_payload(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, str):
+        return json.loads(payload)  # type: ignore[no-any-return]
+    return payload  # type: ignore[return-value]

--- a/src/notificaciones/domain/events/__init__.py
+++ b/src/notificaciones/domain/events/__init__.py
@@ -1,0 +1,11 @@
+"""Eventos de dominio del BC Notificaciones."""
+
+from notificaciones.domain.events.notificacion_enviada import NotificacionEnviada
+from notificaciones.domain.events.notificacion_fallida import NotificacionFallida
+from notificaciones.domain.events.notificacion_solicitada import NotificacionSolicitada
+
+__all__ = [
+    "NotificacionEnviada",
+    "NotificacionFallida",
+    "NotificacionSolicitada",
+]

--- a/src/notificaciones/domain/events/notificacion_enviada.py
+++ b/src/notificaciones/domain/events/notificacion_enviada.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from shared.domain.base.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class NotificacionEnviada(DomainEvent):
+    notificacion_id: str
+    evento_fuente_id: str
+    proveedor_id: str | None
+    enviada_en: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "notificacion_id": self.notificacion_id,
+            "evento_fuente_id": self.evento_fuente_id,
+            "proveedor_id": self.proveedor_id,
+            "enviada_en": self.enviada_en,
+            "occurred_at": self.occurred_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "NotificacionEnviada":
+        return cls(
+            event_type="NotificacionEnviada",
+            aggregate_id=payload["notificacion_id"],
+            occurred_at=datetime.fromisoformat(payload["occurred_at"]),
+            notificacion_id=payload["notificacion_id"],
+            evento_fuente_id=payload["evento_fuente_id"],
+            proveedor_id=payload.get("proveedor_id"),
+            enviada_en=payload["enviada_en"],
+        )

--- a/src/notificaciones/domain/events/notificacion_fallida.py
+++ b/src/notificaciones/domain/events/notificacion_fallida.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from shared.domain.base.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class NotificacionFallida(DomainEvent):
+    notificacion_id: str
+    evento_fuente_id: str
+    motivo: str
+    fallida_en: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "notificacion_id": self.notificacion_id,
+            "evento_fuente_id": self.evento_fuente_id,
+            "motivo": self.motivo,
+            "fallida_en": self.fallida_en,
+            "occurred_at": self.occurred_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "NotificacionFallida":
+        return cls(
+            event_type="NotificacionFallida",
+            aggregate_id=payload["notificacion_id"],
+            occurred_at=datetime.fromisoformat(payload["occurred_at"]),
+            notificacion_id=payload["notificacion_id"],
+            evento_fuente_id=payload["evento_fuente_id"],
+            motivo=payload["motivo"],
+            fallida_en=payload["fallida_en"],
+        )

--- a/src/notificaciones/domain/events/notificacion_solicitada.py
+++ b/src/notificaciones/domain/events/notificacion_solicitada.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from shared.domain.base.domain_event import DomainEvent
+
+
+@dataclass(frozen=True)
+class NotificacionSolicitada(DomainEvent):
+    notificacion_id: str
+    evento_fuente_id: str
+    destinatario_email: str
+    destinatario_nombre: str | None
+    asunto: str
+    cuerpo_texto: str
+    cuerpo_html: str | None
+    canal: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "notificacion_id": self.notificacion_id,
+            "evento_fuente_id": self.evento_fuente_id,
+            "destinatario_email": self.destinatario_email,
+            "destinatario_nombre": self.destinatario_nombre,
+            "asunto": self.asunto,
+            "cuerpo_texto": self.cuerpo_texto,
+            "cuerpo_html": self.cuerpo_html,
+            "canal": self.canal,
+            "occurred_at": self.occurred_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "NotificacionSolicitada":
+        return cls(
+            event_type="NotificacionSolicitada",
+            aggregate_id=payload["notificacion_id"],
+            occurred_at=datetime.fromisoformat(payload["occurred_at"]),
+            notificacion_id=payload["notificacion_id"],
+            evento_fuente_id=payload["evento_fuente_id"],
+            destinatario_email=payload["destinatario_email"],
+            destinatario_nombre=payload.get("destinatario_nombre"),
+            asunto=payload["asunto"],
+            cuerpo_texto=payload["cuerpo_texto"],
+            cuerpo_html=payload.get("cuerpo_html"),
+            canal=payload["canal"],
+        )

--- a/src/notificaciones/domain/exceptions.py
+++ b/src/notificaciones/domain/exceptions.py
@@ -1,0 +1,19 @@
+"""Excepciones de dominio del BC Notificaciones."""
+
+from __future__ import annotations
+
+
+class NotificacionesDomainError(Exception):
+    """Base de errores de dominio de Notificaciones."""
+
+
+class DestinatarioInvalido(NotificacionesDomainError):
+    """El destinatario no cumple el formato esperado."""
+
+
+class ContenidoEmailInvalido(NotificacionesDomainError):
+    """El contenido del email no cumple los invariantes."""
+
+
+class EstadoNotificacionInvalido(NotificacionesDomainError):
+    """La operación no es válida para el estado actual."""

--- a/src/notificaciones/domain/ports/__init__.py
+++ b/src/notificaciones/domain/ports/__init__.py
@@ -1,0 +1,6 @@
+"""Puertos del BC Notificaciones."""
+
+from notificaciones.domain.ports.email_port import EmailPort
+from notificaciones.domain.ports.notificacion_repository import NotificacionRepository
+
+__all__ = ["EmailPort", "NotificacionRepository"]

--- a/src/notificaciones/domain/ports/email_port.py
+++ b/src/notificaciones/domain/ports/email_port.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+
+
+class EmailPort(ABC):
+    @abstractmethod
+    async def enviar(
+        self,
+        destinatario: Destinatario,
+        contenido: ContenidoEmail,
+    ) -> str | None: ...

--- a/src/notificaciones/domain/ports/notificacion_repository.py
+++ b/src/notificaciones/domain/ports/notificacion_repository.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class NotificacionRepository(ABC):
+    @abstractmethod
+    async def append(
+        self,
+        stream_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> None: ...
+
+    @abstractmethod
+    async def load(self, stream_id: str) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def exists_success_by_evento_fuente_id(self, evento_fuente_id: str) -> bool: ...

--- a/src/notificaciones/domain/value_objects/__init__.py
+++ b/src/notificaciones/domain/value_objects/__init__.py
@@ -1,0 +1,15 @@
+"""Value Objects del BC Notificaciones."""
+
+from notificaciones.domain.value_objects.canal_envio import CanalEnvio
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+from notificaciones.domain.value_objects.notificacion_id import NotificacionId
+
+__all__ = [
+    "CanalEnvio",
+    "ContenidoEmail",
+    "Destinatario",
+    "EventoFuenteId",
+    "NotificacionId",
+]

--- a/src/notificaciones/domain/value_objects/canal_envio.py
+++ b/src/notificaciones/domain/value_objects/canal_envio.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class CanalEnvio(StrEnum):
+    EMAIL = "Email"
+    PUSH = "Push"

--- a/src/notificaciones/domain/value_objects/contenido_email.py
+++ b/src/notificaciones/domain/value_objects/contenido_email.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from notificaciones.domain.exceptions import ContenidoEmailInvalido
+
+
+@dataclass(frozen=True)
+class ContenidoEmail:
+    asunto: str
+    cuerpo_texto: str
+    cuerpo_html: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.asunto or not self.asunto.strip():
+            raise ContenidoEmailInvalido("ContenidoEmail.asunto no puede ser vacío")
+        if not self.cuerpo_texto or not self.cuerpo_texto.strip():
+            raise ContenidoEmailInvalido("ContenidoEmail.cuerpo_texto no puede ser vacío")

--- a/src/notificaciones/domain/value_objects/destinatario.py
+++ b/src/notificaciones/domain/value_objects/destinatario.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from notificaciones.domain.exceptions import DestinatarioInvalido
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+@dataclass(frozen=True)
+class Destinatario:
+    email: str
+    nombre: str | None = None
+
+    def __post_init__(self) -> None:
+        if not _EMAIL_RE.match(self.email):
+            raise DestinatarioInvalido("Destinatario.email debe tener formato válido")
+        if self.nombre is not None and not self.nombre.strip():
+            raise DestinatarioInvalido("Destinatario.nombre no puede ser vacío")

--- a/src/notificaciones/domain/value_objects/evento_fuente_id.py
+++ b/src/notificaciones/domain/value_objects/evento_fuente_id.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EventoFuenteId:
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.value or not self.value.strip():
+            raise ValueError("EventoFuenteId no puede ser vacío")
+
+    def __str__(self) -> str:
+        return self.value

--- a/src/notificaciones/domain/value_objects/notificacion_id.py
+++ b/src/notificaciones/domain/value_objects/notificacion_id.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+
+@dataclass(frozen=True)
+class NotificacionId:
+    value: UUID = field(default_factory=uuid4)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.value, str):
+            object.__setattr__(self, "value", UUID(self.value))
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/notificaciones/infrastructure/event_store/__init__.py
+++ b/src/notificaciones/infrastructure/event_store/__init__.py
@@ -1,0 +1,7 @@
+"""Event store del BC Notificaciones."""
+
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+
+__all__ = ["SQLiteNotificacionEventStore"]

--- a/src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py
+++ b/src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py
@@ -1,0 +1,116 @@
+"""Event Store SQLite específico del BC Notificaciones."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import aiosqlite
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS notificaciones_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    occurred_at TEXT NOT NULL
+)
+"""
+
+_CREATE_STREAM_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_notificaciones_stream
+ON notificaciones_events(stream_id)
+"""
+
+_CREATE_FUENTE_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_notificaciones_fuente
+ON notificaciones_events(json_extract(payload, '$.evento_fuente_id'))
+"""
+
+
+class SQLiteNotificacionEventStore:
+    def __init__(self, db_path: str | None = None) -> None:
+        self._db_path = db_path or os.getenv("NOTIFICACIONES_DB_PATH", "data/notificaciones.db")
+
+    async def append(
+        self,
+        stream_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> None:
+        async with aiosqlite.connect(self._db_path) as db:
+            await self._ensure_schema(db)
+            if expected_version is not None:
+                current_version = await self._current_version(db, stream_id)
+                if current_version != expected_version:
+                    raise ValueError(
+                        f"Versión esperada {expected_version}, versión actual {current_version}"
+                    )
+            version = await self._current_version(db, stream_id) + 1
+            occurred_at = payload.get("occurred_at", "")
+            await db.execute(
+                """
+                INSERT INTO notificaciones_events
+                    (stream_id, event_type, payload, version, occurred_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (stream_id, event_type, json.dumps(payload), version, occurred_at),
+            )
+            await db.commit()
+
+    async def load(self, stream_id: str) -> list[dict[str, Any]]:
+        async with aiosqlite.connect(self._db_path) as db:
+            await self._ensure_schema(db)
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                """
+                SELECT event_type, payload, version, occurred_at
+                FROM notificaciones_events
+                WHERE stream_id = ?
+                ORDER BY version ASC
+                """,
+                (stream_id,),
+            )
+            rows = await cursor.fetchall()
+        return [
+            {
+                "event_type": row["event_type"],
+                "payload": json.loads(row["payload"]),
+                "version": row["version"],
+                "occurred_at": row["occurred_at"],
+            }
+            for row in rows
+        ]
+
+    async def exists_success_by_evento_fuente_id(self, evento_fuente_id: str) -> bool:
+        async with aiosqlite.connect(self._db_path) as db:
+            await self._ensure_schema(db)
+            cursor = await db.execute(
+                """
+                SELECT 1
+                FROM notificaciones_events
+                WHERE event_type = 'NotificacionEnviada'
+                  AND json_extract(payload, '$.evento_fuente_id') = ?
+                LIMIT 1
+                """,
+                (evento_fuente_id,),
+            )
+            row = await cursor.fetchone()
+        return row is not None
+
+    async def _ensure_schema(self, db: aiosqlite.Connection) -> None:
+        await db.execute(_CREATE_TABLE)
+        await db.execute(_CREATE_STREAM_INDEX)
+        await db.execute(_CREATE_FUENTE_INDEX)
+        await db.commit()
+
+    async def _current_version(self, db: aiosqlite.Connection, stream_id: str) -> int:
+        cursor = await db.execute(
+            "SELECT COALESCE(MAX(version), 0) FROM notificaciones_events WHERE stream_id = ?",
+            (stream_id,),
+        )
+        row = await cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0

--- a/src/notificaciones/infrastructure/repositories/__init__.py
+++ b/src/notificaciones/infrastructure/repositories/__init__.py
@@ -1,0 +1,7 @@
+"""Repositorios del BC Notificaciones."""
+
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+
+__all__ = ["SQLiteNotificacionRepository"]

--- a/src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py
+++ b/src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from notificaciones.domain.ports.notificacion_repository import NotificacionRepository
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+
+
+class SQLiteNotificacionRepository(NotificacionRepository):
+    def __init__(self, event_store: SQLiteNotificacionEventStore | None = None) -> None:
+        self._event_store = event_store or SQLiteNotificacionEventStore()
+
+    async def append(
+        self,
+        stream_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> None:
+        await self._event_store.append(stream_id, event_type, payload, expected_version)
+
+    async def load(self, stream_id: str) -> list[dict[str, Any]]:
+        return await self._event_store.load(stream_id)
+
+    async def exists_success_by_evento_fuente_id(self, evento_fuente_id: str) -> bool:
+        return await self._event_store.exists_success_by_evento_fuente_id(evento_fuente_id)

--- a/tests/features/US-4.5.1-notificacion-idempotencia.feature
+++ b/tests/features/US-4.5.1-notificacion-idempotencia.feature
@@ -1,0 +1,35 @@
+Feature: Aggregate Notificacion con idempotencia
+
+  Scenario: solicitud de envio nueva
+    Given el event store de notificaciones no tiene eventos para evento_fuente_id "reg-001"
+    When se ejecuta SolicitarEnvio con evento_fuente_id "reg-001" y destinatario "juan@example.com"
+    Then el aggregate Notificacion emite NotificacionSolicitada
+    And el evento queda persistido en el event store de notificaciones
+
+  Scenario: solicitud duplicada con envio exitoso previo
+    Given el event store de notificaciones tiene NotificacionEnviada para evento_fuente_id "reg-001"
+    When se ejecuta SolicitarEnvio con evento_fuente_id "reg-001" nuevamente
+    Then el aggregate Notificacion no emite nuevos eventos
+    And no se realiza ningun envio al canal externo
+
+  Scenario: reintento permitido despues de un fallo definitivo
+    Given el event store de notificaciones tiene NotificacionFallida para evento_fuente_id "reg-002"
+    When se ejecuta SolicitarEnvio con evento_fuente_id "reg-002" y destinatario "ana@example.com"
+    Then el aggregate Notificacion emite NotificacionSolicitada como reintento
+
+  Scenario: destinatario con email invalido
+    When se ejecuta SolicitarEnvio con destinatario email "no-es-un-email"
+    Then el aggregate Notificacion rechaza la solicitud por validacion de dominio
+    And no emite ningun evento
+
+  Scenario: registro de envio exitoso
+    Given el aggregate Notificacion esta en estado Solicitada
+    When se ejecuta RegistrarEnvioExitoso
+    Then el aggregate Notificacion emite NotificacionEnviada
+    And la notificacion queda en estado terminal
+
+  Scenario: registro de fallo definitivo
+    Given el aggregate Notificacion esta en estado Solicitada
+    When se ejecuta RegistrarFallo con motivo "SMTP connection refused"
+    Then el aggregate Notificacion emite NotificacionFallida con ese motivo
+    And la notificacion queda en estado terminal

--- a/tests/features/steps/notificacion_idempotencia_steps.py
+++ b/tests/features/steps/notificacion_idempotencia_steps.py
@@ -1,0 +1,236 @@
+"""Step definitions BDD — US-4.5.1: Aggregate Notificacion con idempotencia."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from notificaciones.domain.aggregates.notificacion import Notificacion
+from notificaciones.domain.events.notificacion_enviada import NotificacionEnviada
+from notificaciones.domain.events.notificacion_fallida import NotificacionFallida
+from notificaciones.domain.events.notificacion_solicitada import NotificacionSolicitada
+from notificaciones.domain.value_objects.canal_envio import CanalEnvio
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+
+scenarios("../US-4.5.1-notificacion-idempotencia.feature")
+
+
+@pytest.fixture
+def ctx(tmp_path) -> dict:
+    store = SQLiteNotificacionEventStore(str(tmp_path / "notificaciones.db"))
+    repo = SQLiteNotificacionRepository(store)
+    return {
+        "store": store,
+        "repo": repo,
+        "aggregate": None,
+        "events": [],
+        "error": None,
+        "envio_externo": 0,
+    }
+
+
+async def _persist_pending(ctx: dict) -> None:
+    aggregate = ctx["aggregate"]
+    if aggregate is None:
+        return
+    for event in aggregate.pull_events():
+        ctx["events"].append(event)
+        await ctx["repo"].append(aggregate.stream_id, event.event_type, event.to_payload())
+
+
+@given(parsers.parse('el event store de notificaciones no tiene eventos para evento_fuente_id "{evento_fuente_id}"'))
+def given_store_vacio(ctx: dict, evento_fuente_id: str) -> None:
+    ctx["evento_fuente_id"] = evento_fuente_id
+
+
+@given(parsers.parse('el event store de notificaciones tiene NotificacionEnviada para evento_fuente_id "{evento_fuente_id}"'))
+def given_store_con_exito(ctx: dict, evento_fuente_id: str) -> None:
+    async def _run() -> None:
+        aggregate = await Notificacion.solicitar_envio(
+            evento_fuente_id=EventoFuenteId(evento_fuente_id),
+            destinatario=Destinatario(email="juan@example.com"),
+            contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+            canal=CanalEnvio.EMAIL,
+            existe_envio_exitoso_previo=False,
+        )
+        assert aggregate is not None
+        ctx["aggregate"] = aggregate
+        await _persist_pending(ctx)
+        aggregate.registrar_envio_exitoso("provider-1")
+        await _persist_pending(ctx)
+
+    asyncio.run(_run())
+    ctx["evento_fuente_id"] = evento_fuente_id
+
+
+@given(parsers.parse('el event store de notificaciones tiene NotificacionFallida para evento_fuente_id "{evento_fuente_id}"'))
+def given_store_con_fallo(ctx: dict, evento_fuente_id: str) -> None:
+    async def _run() -> None:
+        aggregate = await Notificacion.solicitar_envio(
+            evento_fuente_id=EventoFuenteId(evento_fuente_id),
+            destinatario=Destinatario(email="ana@example.com"),
+            contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+            canal=CanalEnvio.EMAIL,
+            existe_envio_exitoso_previo=False,
+        )
+        assert aggregate is not None
+        ctx["aggregate"] = aggregate
+        await _persist_pending(ctx)
+        aggregate.registrar_fallo("timeout")
+        await _persist_pending(ctx)
+
+    asyncio.run(_run())
+    ctx["evento_fuente_id"] = evento_fuente_id
+
+
+@given("el aggregate Notificacion esta en estado Solicitada")
+def given_notificacion_solicitada(ctx: dict) -> None:
+    async def _run() -> None:
+        aggregate = await Notificacion.solicitar_envio(
+            evento_fuente_id=EventoFuenteId("reg-solicited"),
+            destinatario=Destinatario(email="solicitada@example.com"),
+            contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+            canal=CanalEnvio.EMAIL,
+            existe_envio_exitoso_previo=False,
+        )
+        assert aggregate is not None
+        ctx["aggregate"] = aggregate
+
+    asyncio.run(_run())
+
+
+@when(parsers.parse('se ejecuta SolicitarEnvio con evento_fuente_id "{evento_fuente_id}" y destinatario "{email}"'))
+def when_solicitar_envio(ctx: dict, evento_fuente_id: str, email: str) -> None:
+    async def _run() -> None:
+        try:
+            aggregate = await Notificacion.solicitar_envio(
+                evento_fuente_id=EventoFuenteId(evento_fuente_id),
+                destinatario=Destinatario(email=email),
+                contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+                canal=CanalEnvio.EMAIL,
+                existe_envio_exitoso_previo=await ctx["repo"].exists_success_by_evento_fuente_id(
+                    evento_fuente_id
+                ),
+            )
+            ctx["aggregate"] = aggregate
+            if aggregate is not None:
+                await _persist_pending(ctx)
+        except Exception as exc:
+            ctx["error"] = exc
+
+    asyncio.run(_run())
+
+
+@when(parsers.parse('se ejecuta SolicitarEnvio con evento_fuente_id "{evento_fuente_id}" nuevamente'))
+def when_solicitar_envio_duplicado(ctx: dict, evento_fuente_id: str) -> None:
+    async def _run() -> None:
+        ctx["aggregate"] = await Notificacion.solicitar_envio(
+            evento_fuente_id=EventoFuenteId(evento_fuente_id),
+            destinatario=Destinatario(email="juan@example.com"),
+            contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+            canal=CanalEnvio.EMAIL,
+            existe_envio_exitoso_previo=await ctx["repo"].exists_success_by_evento_fuente_id(
+                evento_fuente_id
+            ),
+        )
+
+    asyncio.run(_run())
+
+
+@when(parsers.parse('se ejecuta SolicitarEnvio con evento_fuente_id "{evento_fuente_id}" y destinatario "ana@example.com"'))
+def when_reintento(ctx: dict, evento_fuente_id: str) -> None:
+    when_solicitar_envio(ctx, evento_fuente_id, "ana@example.com")
+
+
+@when(parsers.parse('se ejecuta SolicitarEnvio con destinatario email "{email}"'))
+def when_email_invalido(ctx: dict, email: str) -> None:
+    async def _run() -> None:
+        try:
+            await Notificacion.solicitar_envio(
+                evento_fuente_id=EventoFuenteId("reg-invalid"),
+                destinatario=Destinatario(email=email),
+                contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+                canal=CanalEnvio.EMAIL,
+                existe_envio_exitoso_previo=False,
+            )
+        except Exception as exc:
+            ctx["error"] = exc
+
+    asyncio.run(_run())
+
+
+@when("se ejecuta RegistrarEnvioExitoso")
+def when_registrar_envio_exitoso(ctx: dict) -> None:
+    ctx["aggregate"].registrar_envio_exitoso("provider-1")
+    ctx["events"] = ctx["aggregate"].pull_events()
+
+
+@when(parsers.parse('se ejecuta RegistrarFallo con motivo "{motivo}"'))
+def when_registrar_fallo(ctx: dict, motivo: str) -> None:
+    ctx["aggregate"].registrar_fallo(motivo)
+    ctx["events"] = ctx["aggregate"].pull_events()
+
+
+@then("el aggregate Notificacion emite NotificacionSolicitada")
+def then_emitio_solicitada(ctx: dict) -> None:
+    assert any(isinstance(event, NotificacionSolicitada) for event in ctx["events"])
+
+
+@then("el evento queda persistido en el event store de notificaciones")
+def then_evento_persistido(ctx: dict) -> None:
+    async def _run() -> None:
+        stored = await ctx["repo"].load(ctx["aggregate"].stream_id)
+        assert len(stored) == 1
+
+    asyncio.run(_run())
+
+
+@then("el aggregate Notificacion no emite nuevos eventos")
+def then_no_emite_eventos(ctx: dict) -> None:
+    assert ctx["aggregate"] is None
+
+
+@then("no se realiza ningun envio al canal externo")
+def then_sin_envio_externo(ctx: dict) -> None:
+    assert ctx["envio_externo"] == 0
+
+
+@then("el aggregate Notificacion emite NotificacionSolicitada como reintento")
+def then_reintento_emitido(ctx: dict) -> None:
+    assert ctx["aggregate"] is not None
+    assert any(isinstance(event, NotificacionSolicitada) for event in ctx["events"])
+
+
+@then("el aggregate Notificacion rechaza la solicitud por validacion de dominio")
+def then_rechazo_validacion(ctx: dict) -> None:
+    assert ctx["error"] is not None
+
+
+@then("no emite ningun evento")
+def then_no_emite_ningun_evento(ctx: dict) -> None:
+    assert ctx["events"] == []
+
+
+@then("el aggregate Notificacion emite NotificacionEnviada")
+def then_emitio_enviada(ctx: dict) -> None:
+    assert any(isinstance(event, NotificacionEnviada) for event in ctx["events"])
+
+
+@then("la notificacion queda en estado terminal")
+def then_terminal(ctx: dict) -> None:
+    assert ctx["aggregate"].estado in {"Enviada", "Fallida"}
+
+
+@then("el aggregate Notificacion emite NotificacionFallida con ese motivo")
+def then_emitio_fallida(ctx: dict) -> None:
+    assert any(isinstance(event, NotificacionFallida) for event in ctx["events"])

--- a/tests/integration/notificaciones/test_sqlite_notificacion_repository.py
+++ b/tests/integration/notificaciones/test_sqlite_notificacion_repository.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from notificaciones.domain.aggregates.notificacion import Notificacion
+from notificaciones.domain.value_objects.canal_envio import CanalEnvio
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_repository_persiste_y_rehidrata_stream(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+
+    aggregate = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-001"),
+        destinatario=Destinatario(email="juan@example.com", nombre="Juan"),
+        contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    assert aggregate is not None
+
+    for event in aggregate.pull_events():
+        await repo.append(aggregate.stream_id, event.event_type, event.to_payload())
+
+    stored = await repo.load(aggregate.stream_id)
+    reconstituted = Notificacion.reconstitute(stored)
+
+    assert reconstituted.estado == "Solicitada"
+    assert reconstituted.destinatario is not None
+    assert reconstituted.destinatario.email == "juan@example.com"
+
+
+@pytest.mark.asyncio
+async def test_repository_detecta_exito_previod_por_evento_fuente_id(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+
+    aggregate = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-001"),
+        destinatario=Destinatario(email="juan@example.com"),
+        contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    assert aggregate is not None
+    for event in aggregate.pull_events():
+        await repo.append(aggregate.stream_id, event.event_type, event.to_payload())
+    aggregate.registrar_envio_exitoso("provider-1")
+    for event in aggregate.pull_events():
+        await repo.append(aggregate.stream_id, event.event_type, event.to_payload(), expected_version=1)
+
+    assert await repo.exists_success_by_evento_fuente_id("reg-001") is True
+    assert await repo.exists_success_by_evento_fuente_id("reg-002") is False
+
+
+@pytest.mark.asyncio
+async def test_streams_independientes_comparten_mismo_store(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+
+    first = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-001"),
+        destinatario=Destinatario(email="uno@example.com"),
+        contenido=ContenidoEmail(asunto="A", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    second = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-002"),
+        destinatario=Destinatario(email="dos@example.com"),
+        contenido=ContenidoEmail(asunto="B", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    assert first is not None
+    assert second is not None
+
+    for event in first.pull_events():
+        await repo.append(first.stream_id, event.event_type, event.to_payload())
+    for event in second.pull_events():
+        await repo.append(second.stream_id, event.event_type, event.to_payload())
+
+    first_stream = await repo.load(first.stream_id)
+    second_stream = await repo.load(second.stream_id)
+
+    assert len(first_stream) == 1
+    assert len(second_stream) == 1
+    assert first_stream[0]["payload"]["evento_fuente_id"] == "reg-001"
+    assert second_stream[0]["payload"]["evento_fuente_id"] == "reg-002"

--- a/tests/unit/notificaciones/domain/test_notificacion.py
+++ b/tests/unit/notificaciones/domain/test_notificacion.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pytest
+
+from notificaciones.domain.aggregates.notificacion import Notificacion
+from notificaciones.domain.events.notificacion_enviada import NotificacionEnviada
+from notificaciones.domain.events.notificacion_solicitada import NotificacionSolicitada
+from notificaciones.domain.exceptions import EstadoNotificacionInvalido
+from notificaciones.domain.value_objects.canal_envio import CanalEnvio
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+
+
+@pytest.mark.asyncio
+async def test_solicitud_nueva_emite_notificacion_solicitada() -> None:
+    aggregate = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-001"),
+        destinatario=Destinatario(email="juan@example.com", nombre="Juan"),
+        contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+
+    assert aggregate is not None
+    events = aggregate.pull_events()
+    assert len(events) == 1
+    assert isinstance(events[0], NotificacionSolicitada)
+    assert aggregate.estado == "Solicitada"
+
+
+@pytest.mark.asyncio
+async def test_idempotencia_no_emite_eventos_si_ya_hubo_exito() -> None:
+    aggregate = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-001"),
+        destinatario=Destinatario(email="juan@example.com"),
+        contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=True,
+    )
+
+    assert aggregate is None
+
+
+@pytest.mark.asyncio
+async def test_registrar_envio_exitoso_deja_estado_terminal() -> None:
+    aggregate = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-001"),
+        destinatario=Destinatario(email="juan@example.com"),
+        contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    assert aggregate is not None
+    aggregate.pull_events()
+
+    aggregate.registrar_envio_exitoso("provider-1")
+    events = aggregate.pull_events()
+
+    assert len(events) == 1
+    assert isinstance(events[0], NotificacionEnviada)
+    assert aggregate.estado == "Enviada"
+
+    with pytest.raises(EstadoNotificacionInvalido):
+        aggregate.registrar_fallo("late failure")
+
+
+@pytest.mark.asyncio
+async def test_registrar_fallo_deja_estado_terminal() -> None:
+    aggregate = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-002"),
+        destinatario=Destinatario(email="ana@example.com"),
+        contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    assert aggregate is not None
+    aggregate.pull_events()
+
+    aggregate.registrar_fallo("SMTP connection refused")
+    assert aggregate.estado == "Fallida"
+    assert aggregate.motivo_fallo == "SMTP connection refused"
+
+    with pytest.raises(EstadoNotificacionInvalido):
+        aggregate.registrar_envio_exitoso()
+
+
+@pytest.mark.asyncio
+async def test_reconstituye_y_permite_reintento_tras_fallo_previo() -> None:
+    aggregate = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-002"),
+        destinatario=Destinatario(email="ana@example.com"),
+        contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    assert aggregate is not None
+    stored_events = [event.to_payload() for event in aggregate.pull_events()]
+    aggregate.registrar_fallo("timeout")
+    stored_events.extend(event.to_payload() for event in aggregate.pull_events())
+
+    reconstituted = Notificacion.reconstitute(
+        [
+            {"event_type": "NotificacionSolicitada", "payload": stored_events[0]},
+            {"event_type": "NotificacionFallida", "payload": stored_events[1]},
+        ]
+    )
+    assert reconstituted.estado == "Fallida"
+
+    retry = await Notificacion.solicitar_envio(
+        evento_fuente_id=EventoFuenteId("reg-002"),
+        destinatario=Destinatario(email="ana@example.com"),
+        contenido=ContenidoEmail(asunto="Reintento", cuerpo_texto="ok"),
+        canal=CanalEnvio.EMAIL,
+        existe_envio_exitoso_previo=False,
+    )
+    assert retry is not None
+    assert retry.estado == "Solicitada"

--- a/tests/unit/notificaciones/domain/test_value_objects.py
+++ b/tests/unit/notificaciones/domain/test_value_objects.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from notificaciones.domain.exceptions import ContenidoEmailInvalido, DestinatarioInvalido
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+from notificaciones.domain.value_objects.notificacion_id import NotificacionId
+
+
+def test_destinatario_rechaza_email_invalido() -> None:
+    with pytest.raises(DestinatarioInvalido):
+        Destinatario(email="no-es-un-email")
+
+
+def test_contenido_email_rechaza_asunto_vacio() -> None:
+    with pytest.raises(ContenidoEmailInvalido):
+        ContenidoEmail(asunto=" ", cuerpo_texto="hola")
+
+
+def test_notificacion_id_acepta_uuid_string() -> None:
+    raw = "12345678-1234-5678-1234-567812345678"
+    vo = NotificacionId(raw)
+    assert vo.value == UUID(raw)
+
+
+def test_evento_fuente_id_rechaza_vacio() -> None:
+    with pytest.raises(ValueError):
+        EventoFuenteId(" ")


### PR DESCRIPTION
## Resumen
Implementa el nucleo del BC Notificaciones para US-4.5.1:
- aggregate `Notificacion` con ciclo `Solicitada -> Enviada/Fallida`
- value objects y eventos de dominio del BC
- event store SQLite propio sobre `notificaciones_events`
- repositorio con idempotencia por `evento_fuente_id`
- cobertura unitaria, integracion y BDD

## Validacion
- `./.venv/bin/pytest tests/features/steps/notificacion_idempotencia_steps.py tests/unit/notificaciones/domain/test_value_objects.py tests/unit/notificaciones/domain/test_notificacion.py tests/integration/notificaciones/test_sqlite_notificacion_repository.py -q`
- `./.venv/bin/codeguard src/notificaciones`

## Notas
- `EmailPort` queda definido como contrato para `US-4.5.2`.
- `EventoFuenteId` se implementa como VO sobre `str` para soportar futuras claves compuestas en `US-4.5.4`.