### PR TITLE
US-4.5.3: Política P-10 email de confirmación

### DIFF
--- a/.claude/tracking/US-4.5.3-tracking.json
+++ b/.claude/tracking/US-4.5.3-tracking.json
@@ -1,0 +1,152 @@
+{
+  "metadata": {
+    "us_id": "US-4.5.3",
+    "us_title": "Politica P-10 email de confirmacion de inscripcion",
+    "us_points": 3,
+    "producto": "notificaciones",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-15T11:34:07.436186+00:00",
+    "completed_at": "2026-04-15T11:53:49.413361+00:00",
+    "total_elapsed_seconds": 1181,
+    "effective_seconds": 1181,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-15T11:34:18.935468+00:00",
+      "completed_at": "2026-04-15T11:34:45.434625+00:00",
+      "elapsed_seconds": 26,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-15T11:34:55.845058+00:00",
+      "completed_at": "2026-04-15T11:35:31.806817+00:00",
+      "elapsed_seconds": 35,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-15T11:37:42.976937+00:00",
+      "completed_at": "2026-04-15T11:38:45.973245+00:00",
+      "elapsed_seconds": 62,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-15T11:41:25.683456+00:00",
+      "completed_at": "2026-04-15T11:44:12.499099+00:00",
+      "elapsed_seconds": 166,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Implementar comandos y politica P-10",
+          "task_type": "application",
+          "estimated_minutes": 120.0,
+          "started_at": "2026-04-15T11:42:04.553767+00:00",
+          "completed_at": "2026-04-15T11:44:08.083121+00:00",
+          "elapsed_seconds": 123,
+          "actual_minutes": 2.05,
+          "variance_minutes": -117.95,
+          "file_created": "src/notificaciones/application/policies/politica_p10.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-15T11:44:43.316645+00:00",
+      "completed_at": "2026-04-15T11:47:31.346951+00:00",
+      "elapsed_seconds": 168,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-15T11:47:46.515577+00:00",
+      "completed_at": "2026-04-15T11:48:25.797961+00:00",
+      "elapsed_seconds": 39,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-15T11:48:32.389432+00:00",
+      "completed_at": "2026-04-15T11:49:39.763809+00:00",
+      "elapsed_seconds": 67,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-15T11:49:47.001761+00:00",
+      "completed_at": "2026-04-15T11:51:26.326968+00:00",
+      "elapsed_seconds": 99,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-15T11:51:37.363347+00:00",
+      "completed_at": "2026-04-15T11:52:22.398189+00:00",
+      "elapsed_seconds": 45,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-15T11:52:47.056322+00:00",
+      "completed_at": "2026-04-15T11:53:45.671716+00:00",
+      "elapsed_seconds": 58,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 1,
+    "completed_tasks": 1,
+    "total_phases": 10,
+    "estimated_total_minutes": 120.0,
+    "actual_total_minutes": 2.05,
+    "variance_minutes": -117.95,
+    "variance_percent": -98.29
+  }
+}

--- a/.claude/tracking/US-ADJ-1.2-tracking.json
+++ b/.claude/tracking/US-ADJ-1.2-tracking.json
@@ -7,10 +7,10 @@
     "tracking_version": "1.0"
   },
   "timeline": {
-    "started_at": "2026-03-28T10:50:00.000000+00:00",
-    "completed_at": null,
-    "total_elapsed_seconds": 0,
-    "effective_seconds": 0,
+    "started_at": "2026-03-28T10:50:00+00:00",
+    "completed_at": "2026-04-15T11:32:06.000243+00:00",
+    "total_elapsed_seconds": 1557726,
+    "effective_seconds": 1557726,
     "paused_seconds": 0
   },
   "phases": [],
@@ -22,6 +22,6 @@
     "estimated_total_minutes": 0,
     "actual_total_minutes": 0,
     "variance_minutes": 0,
-    "variance_percent": 0
+    "variance_percent": 0.0
   }
 }

--- a/docs/architecture/15-bc-notificaciones.md
+++ b/docs/architecture/15-bc-notificaciones.md
@@ -44,10 +44,12 @@ El BC `notificaciones` ya cuenta con:
 - tabla `notificaciones_events` e idempotencia por `evento_fuente_id`;
 - puerto `EmailPort`;
 - adaptador concreto `ResendEmailAdapter` en infraestructura para envío real por HTTP.
+- comandos de aplicación `SolicitarEnvioHandler` y `EnviarNotificacionHandler`;
+- política P-10 (`InscripcionConfirmada` -> email de confirmación al atleta);
+- template `InscripcionConfirmadaTemplate`.
 
-La capa `application/` permanece casi vacía: los casos de uso que conectan
-eventos de otros BCs con el envío real se implementan en `US-4.5.3` y
-`US-4.5.4`.
+La política P-11 (`ResultadosPublicados` -> emails a atletas de la disciplina)
+queda pendiente para `US-4.5.4`.
 
 ## Rol del bounded context
 
@@ -202,6 +204,13 @@ Sus responsabilidades son:
   `NotificacionFallida`;
 - coordinar políticas de reintento cuando corresponda.
 
+En `US-4.5.3`, la política P-10 se implementa como listener in-process:
+recibe un DTO de aplicación `InscripcionConfirmada`, renderiza el contenido con
+`InscripcionConfirmadaTemplate`, ejecuta `SolicitarEnvioHandler` y luego
+`EnviarNotificacionHandler`. Si el evento no trae email del atleta, registra
+directamente `NotificacionFallida` con motivo `destinatario_sin_email` sin
+interrumpir el flujo principal de inscripción.
+
 ### Domain Layer
 
 Contiene el modelo propio del BC.
@@ -267,13 +276,14 @@ Los value objects centrales son:
 La colaboración sigue estas reglas:
 
 - ningún BC funcional espera una respuesta síncrona de `Notificaciones`;
-- el BC consume eventos de dominio de manera asíncrona;
+- en SP4, el BC consume eventos mediante callbacks in-process registrados en el
+  composition root;
 - la semántica del evento recibido se traduce al lenguaje ubicuo propio del BC;
 - el evento fuente se conserva como clave de idempotencia.
 
 Entre los disparadores ya definidos aparecen, por ejemplo:
 
-- confirmaciones o cambios relevantes de inscripción;
+- `InscripcionConfirmada` desde `Registro` para P-10;
 - recordatorios vinculados a anuncios;
 - `ResultadosPublicados`;
 - `TorneoCerrado`.

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -368,7 +368,9 @@ classDiagram
 ## 7. BC Notificaciones — Generic (Event Sourcing)
 
 > `US-4.5.1` implementa el núcleo del aggregate y su event store propio.
-> Las políticas y el adaptador email real se completan en `US-4.5.2` a `US-4.5.4`.
+> `US-4.5.2` implementa el adaptador email con Resend.
+> `US-4.5.3` implementa P-10: `InscripcionConfirmada` -> email de confirmación.
+> P-11 (`ResultadosPublicados`) queda para `US-4.5.4`.
 
 ### Aggregate
 
@@ -408,6 +410,21 @@ classDiagram
 | Puerto | Responsabilidad |
 |--------|-----------------|
 | `NotificacionRepository` | Persistir y rehidratar streams; consultar si ya existe `NotificacionEnviada` por `evento_fuente_id` |
+
+### Application
+
+| Componente | Responsabilidad |
+|------------|-----------------|
+| `SolicitarEnvioHandler` | Crea `NotificacionSolicitada` si no existe un envío exitoso previo para el `evento_fuente_id` |
+| `EnviarNotificacionHandler` | Rehidrata la notificación, llama `EmailPort` y registra `NotificacionEnviada` o `NotificacionFallida` |
+| `PoliticaP10Handler` | Recibe `InscripcionConfirmada`, renderiza contenido y orquesta solicitud + envío de email al atleta |
+
+### Templates e integración
+
+| Componente | Responsabilidad |
+|------------|-----------------|
+| `InscripcionConfirmadaTemplate` | Genera asunto y cuerpo de email con atleta, torneo, fecha, sede y disciplinas |
+| `build_p10_handler` | Factory en `src/app.py` para componer P-10 con repositorio SQLite y `ResendEmailAdapter` |
 
 ### Puerto y adaptador de email
 

--- a/docs/plans/sp4/US-4.5.3-plan.md
+++ b/docs/plans/sp4/US-4.5.3-plan.md
@@ -1,0 +1,182 @@
+# Plan de Implementación: US-4.5.3 - Política P-10 email de confirmación
+
+**Sprint:** SP4 - La Plataforma  
+**Incremento:** INC-4.5  
+**Bounded Context:** `notificaciones`  
+**Patrón:** Hexagonal DDD BC-first + política de aplicación in-process  
+**Estimación total:** 3h 10min  
+**Estado:** Fase 3 implementada; tests pendientes  
+**Fecha:** 2026-04-15
+
+## Objetivo
+
+Implementar la política P-10 para que un evento de inscripción confirmada dispare una
+notificación por email al atleta, reutilizando el aggregate `Notificacion`, el event store
+propio del BC y el `EmailPort` implementado en `US-4.5.1`/`US-4.5.2`.
+
+La política debe ser idempotente: procesar dos veces el mismo `evento_fuente_id` no debe
+enviar dos emails ni duplicar `NotificacionEnviada`.
+
+## Decisiones de Diseño
+
+- La política vivirá en `src/notificaciones/application/policies/`.
+- `notificaciones` no importará tipos de `registro`; recibirá un DTO/evento de aplicación
+  propio llamado `InscripcionConfirmada`.
+- La conexión con `registro` quedará en `src/app.py` mediante wiring/callback in-process,
+  siguiendo el estilo existente de P-08/P-09.
+- No se introduce un event bus genérico en esta US. SP4 necesita una integración
+  in-process verificable; una mensajería externa queda diferida a SP5.
+- Para `atleta_email` ausente o vacío, la política creará una notificación fallida con
+  motivo `destinatario_sin_email` sin llamar al proveedor.
+- Los comandos de aplicación serán pequeños y testeables:
+  `SolicitarEnvioHandler` crea/persiste `NotificacionSolicitada`;
+  `EnviarNotificacionHandler` llama `EmailPort` y persiste `NotificacionEnviada` o
+  `NotificacionFallida`.
+
+## Componentes a Implementar
+
+### 1. Application - comandos de notificaciones
+
+- [x] `src/notificaciones/application/commands/solicitar_envio.py` (25 min)
+  - `SolicitarEnvioCommand`
+  - `SolicitarEnvioHandler`
+  - consulta `exists_success_by_evento_fuente_id`
+  - persiste eventos pendientes del aggregate
+  - retorna `notificacion_id | None` para cubrir idempotencia
+
+- [x] `src/notificaciones/application/commands/enviar_notificacion.py` (30 min)
+  - `EnviarNotificacionCommand`
+  - `EnviarNotificacionHandler`
+  - rehidrata desde `NotificacionRepository.load`
+  - llama `EmailPort.enviar`
+  - registra éxito con `provider_id`
+  - registra fallo técnico sin propagar excepción
+  - persiste eventos pendientes
+
+- [x] `src/notificaciones/application/commands/__init__.py` (5 min)
+  - exportar comandos y handlers públicos del BC
+
+### 2. Application - política P-10
+
+- [x] `src/notificaciones/application/policies/politica_p10.py` (35 min)
+  - DTO `InscripcionConfirmada`
+  - `PoliticaP10Handler`
+  - render de template
+  - orquestación `SolicitarEnvio` -> `EnviarNotificacion`
+  - manejo `destinatario_sin_email`
+
+- [x] `src/notificaciones/application/policies/__init__.py` (5 min)
+  - export público de la política
+
+### 3. Infrastructure - template de email
+
+- [x] `src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py` (20 min)
+  - `InscripcionConfirmadaTemplate.render(evento)`
+  - asunto `Inscripcion confirmada - {torneo_nombre}`
+  - cuerpo texto con atleta, torneo, fecha, sede y disciplinas
+  - HTML opcional si conviene mantener consistencia con `ContenidoEmail`
+
+- [x] `src/notificaciones/infrastructure/templates/__init__.py` (5 min)
+  - export público del template
+
+### 4. Wiring de aplicación
+
+- [x] `src/app.py` (25 min)
+  - factory/helper de composición para P-10
+  - usar `SQLiteNotificacionRepository`, `SQLiteNotificacionEventStore` y `ResendEmailAdapter`
+  - dejar punto de integración preparado para callback desde `registro`
+
+- [x] `src/registro/application/commands/inscribir_atleta.py` (20 min)
+  - incorporar callback opcional post-save, sin importar `notificaciones`
+  - no revertir inscripción si el callback falla
+  - mantener compatibilidad con tests existentes
+
+## Tests
+
+### 5. Unitarios
+
+- [x] `tests/unit/notificaciones/application/test_solicitar_envio_handler.py` (20 min)
+  - crea notificación cuando no hay envío exitoso previo
+  - no crea ni persiste cuando existe éxito previo
+
+- [x] `tests/unit/notificaciones/application/test_enviar_notificacion_handler.py` (25 min)
+  - registra `NotificacionEnviada` con proveedor exitoso
+  - registra `NotificacionFallida` ante error del `EmailPort`
+
+- [x] `tests/unit/notificaciones/application/test_politica_p10.py` (30 min)
+  - éxito nominal
+  - idempotencia
+  - atleta sin email
+  - fallo del proveedor sin excepción hacia el flujo principal
+
+- [x] `tests/unit/notificaciones/infrastructure/test_inscripcion_confirmada_template.py` (15 min)
+  - asunto correcto
+  - cuerpo contiene atleta, torneo, fecha, sede y disciplinas
+
+- [x] Ajustar tests de `registro` si el constructor del handler cambia (10 min)
+  - validar compatibilidad del callback opcional
+
+### 6. Integración
+
+- [x] `tests/integration/notificaciones/test_politica_p10_integration.py` (30 min)
+  - repositorio SQLite real
+  - fake `EmailPort`
+  - persistencia de `NotificacionSolicitada` + `NotificacionEnviada/Fallida`
+  - idempotencia real por `evento_fuente_id`
+
+### 7. BDD
+
+- [x] `tests/features/steps/politica_p10_steps.py` (30 min)
+  - automatizar `tests/features/US-4.5.3-politica-p10.feature`
+  - usar SQLite temporal y fake email adapter
+
+- [x] Ejecutar validación BDD focalizada (5 min)
+  - `uv run pytest tests/features/steps/politica_p10_steps.py -q`
+
+## Validación y Quality Gates
+
+- [x] Ejecutar suite focalizada de notificaciones (10 min)
+  - unitarios de application/domain/infrastructure afectados
+  - integración de `notificaciones`
+  - BDD de `US-4.5.3`
+
+- [x] Ejecutar regresión mínima de `registro` (5 min)
+  - `uv run pytest tests/unit/registro/test_inscribir_atleta_handler.py -q`
+
+- [x] Ejecutar CodeGuard sobre `src/notificaciones` (5 min)
+  - guardar reporte en `quality/reports/codeguard/US-4.5.3-quality.json`
+
+## Documentación y Reporte
+
+- [x] Actualizar `docs/architecture/15-bc-notificaciones.md` (10 min)
+  - documentar P-10 y su wiring in-process
+
+- [x] Actualizar `docs/design/domain-model.md` (10 min)
+  - reflejar command handlers y política P-10
+
+- [x] Actualizar `docs/traceability/matrix.md` si cambia estado RF-NT-01/RF-NT-02 (10 min)
+
+- [x] Crear `docs/reports/US-4.5.3-report.md` (10 min)
+  - resumen de implementación
+  - validaciones ejecutadas
+  - decisiones y riesgos
+
+## Riesgos
+
+- `registro` no tiene todavía un evento de dominio persistido `InscripcionConfirmada`.
+  La integración debe quedar como callback in-process para no sobredimensionar esta US.
+- `InscripcionConfirmada` necesita datos que `InscribirAtletaCommand` no recibe hoy
+  (`atleta_email`, `atleta_nombre`, `torneo_nombre`, `torneo_fecha`, `torneo_sede`).
+  La política se implementará contra su DTO; el wiring real puede requerir un ACL o
+  enriquecimiento en una US posterior si el endpoint actual no entrega esos datos.
+- El motivo `destinatario_sin_email` requiere crear y persistir una notificación fallida
+  sin construir `Destinatario` inválido.
+
+## Criterio de Cierre
+
+- Feature BDD automatizada y en verde.
+- La política P-10 envía un email cuando el evento contiene datos válidos.
+- Reprocesar el mismo `evento_fuente_id` no envía un segundo email.
+- Email ausente y fallo técnico quedan registrados como `NotificacionFallida`.
+- Tests unitarios, integración y quality gate focalizado pasan.
+- Documentación y reporte final existen en disco antes del cierre del tracker.

--- a/docs/reports/US-4.5.3-report.md
+++ b/docs/reports/US-4.5.3-report.md
@@ -1,0 +1,172 @@
+# Reporte de Implementación — US-4.5.3
+## Política P-10 — email de confirmación de inscripción
+
+**Sprint:** SP4 — La Plataforma  
+**Incremento:** INC-4.5  
+**Branch:** `feature/US-4.5.3-politica-p10`  
+**Fecha:** 2026-04-15  
+**Estado:** Completado
+
+---
+
+## Resumen
+
+Se implementó la política P-10 del BC `notificaciones`: ante un evento de aplicación
+`InscripcionConfirmada`, el sistema solicita y envía una notificación por email al
+atleta, registrando el ciclo de vida completo en el event store de Notificaciones.
+
+La implementación reutiliza el aggregate `Notificacion`, el repositorio/event store de
+`US-4.5.1` y el `EmailPort`/`ResendEmailAdapter` de `US-4.5.2`.
+
+---
+
+## Componentes Implementados
+
+### Código
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/notificaciones/application/commands/solicitar_envio.py` | Command + handler para crear `NotificacionSolicitada` con idempotencia por `evento_fuente_id` |
+| `src/notificaciones/application/commands/enviar_notificacion.py` | Command + handler para llamar `EmailPort` y registrar `NotificacionEnviada` o `NotificacionFallida` |
+| `src/notificaciones/application/policies/politica_p10.py` | DTO `InscripcionConfirmada` y `PoliticaP10Handler` |
+| `src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py` | Template de asunto/cuerpo para confirmación de inscripción |
+| `src/notificaciones/domain/aggregates/notificacion.py` | Soporte para registrar fallos de solicitud tempranos, como `destinatario_sin_email` |
+| `src/app.py` | Factory `build_p10_handler()` con repositorio SQLite, Resend y template real |
+| `src/registro/application/commands/inscribir_atleta.py` | Callback opcional post-save para integración in-process sin acoplar BCs |
+
+### Tests y BDD
+
+| Archivo | Cobertura |
+|---------|-----------|
+| `tests/features/US-4.5.3-politica-p10.feature` | Escenarios BDD aprobados para P-10 |
+| `tests/features/steps/politica_p10_steps.py` | Automatización BDD con SQLite temporal y fake email |
+| `tests/unit/notificaciones/application/test_solicitar_envio_handler.py` | Solicitud e idempotencia por éxito previo |
+| `tests/unit/notificaciones/application/test_enviar_notificacion_handler.py` | Envío exitoso y fallo técnico del proveedor |
+| `tests/unit/notificaciones/application/test_politica_p10.py` | Orquestación P-10, idempotencia, email ausente y fallo del proveedor |
+| `tests/unit/notificaciones/infrastructure/test_inscripcion_confirmada_template.py` | Datos requeridos en asunto y cuerpo |
+| `tests/integration/notificaciones/test_politica_p10_integration.py` | Persistencia real en SQLite e idempotencia end-to-end |
+
+### Documentación
+
+| Archivo | Cambio |
+|---------|--------|
+| `docs/plans/sp4/US-4.5.3-plan.md` | Plan y checklist actualizado |
+| `docs/architecture/15-bc-notificaciones.md` | Estado real del BC con P-10 y wiring in-process |
+| `docs/design/domain-model.md` | Application layer de Notificaciones actualizada |
+| `docs/traceability/matrix.md` | RF-NT-01 actualizado con P-10 implementada |
+
+---
+
+## Decisiones de Diseño
+
+### 1. DTO propio en `notificaciones`
+
+`PoliticaP10Handler` recibe `InscripcionConfirmada` como DTO de aplicación del BC
+Notificaciones. Esto evita imports desde `registro` y respeta la regla BC-first:
+la traducción desde el productor queda en el composition root o en un ACL futuro.
+
+### 2. Integración in-process para SP4
+
+No se introdujo un event bus genérico. Se agregó `build_p10_handler()` en `src/app.py`
+como punto de composición con infraestructura real. El handler de inscripción acepta
+un callback opcional post-save, sin revertir la inscripción si Notificaciones falla.
+
+### 3. Fallo temprano sin email
+
+Como `Destinatario` valida formato de email, el caso `atleta_email` ausente no puede
+pasar por el flujo normal de `SolicitarEnvio`. Se agregó
+`Notificacion.registrar_fallo_de_solicitud()` para persistir `NotificacionFallida`
+con motivo `destinatario_sin_email`.
+
+---
+
+## Validación Ejecutada
+
+### Tests focalizados completos
+
+```bash
+uv run pytest tests/unit/notificaciones \
+  tests/integration/notificaciones \
+  tests/features/steps/notificacion_idempotencia_steps.py \
+  tests/features/steps/adaptador_email_steps.py \
+  tests/features/steps/politica_p10_steps.py \
+  tests/unit/registro/test_inscribir_atleta_handler.py -q
+```
+
+Resultado:
+
+```text
+51 passed, 3 warnings in 2.05s
+```
+
+Las advertencias provienen de `datetime.utcnow()` en tests existentes de `registro`;
+no fueron introducidas por esta US.
+
+### BDD focalizado
+
+```bash
+uv run pytest tests/features/steps/politica_p10_steps.py -q
+```
+
+Resultado:
+
+```text
+5 passed in 0.36s
+```
+
+### Integración focalizada
+
+```bash
+uv run pytest tests/integration/notificaciones/test_politica_p10_integration.py -q
+```
+
+Resultado:
+
+```text
+4 passed in 0.34s
+```
+
+### CodeGuard
+
+```bash
+uv run codeguard src/notificaciones --format json \
+  > quality/reports/codeguard/US-4.5.3-quality.json
+```
+
+Resultado:
+
+```text
+0 errors
+0 warnings
+105 infos
+```
+
+---
+
+## Estado Respecto de la Spec
+
+### Cumplido
+
+- Email enviado exitosamente al confirmar inscripción.
+- Idempotencia: reprocesar el mismo `evento_fuente_id` no envía un segundo email.
+- Atleta sin email genera `NotificacionFallida` con motivo `destinatario_sin_email`.
+- Fallo técnico del proveedor queda registrado como `NotificacionFallida`.
+- La inscripción no se revierte por fallos de Notificaciones.
+- El email contiene atleta, torneo, fecha, sede y disciplinas.
+
+### Alcance deliberado
+
+- No se creó un bus de eventos genérico.
+- No se implementó enriquecimiento automático desde `registro` para obtener email,
+  nombre del atleta y datos del torneo. La política queda implementada contra el DTO
+  completo esperado por la spec.
+
+---
+
+## Riesgos y Próximos Pasos
+
+- `US-4.5.4` debe reutilizar el patrón de `SolicitarEnvioHandler` +
+  `EnviarNotificacionHandler` para `ResultadosPublicados`.
+- Para conectar P-10 a endpoints reales de inscripción, falta definir cómo se enriquece
+  `InscripcionConfirmada` con datos de atleta y torneo sin acoplar BCs.
+- Push sigue fuera de scope de SP4; RF-NT-01 queda parcialmente implementado por email.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -134,7 +134,7 @@ el incremento donde se implementa y la US-IEDD candidata que lo especifica.
 
 | RF | Descripción | BC | SP | Inc. | US-IEDD candidata | Estado |
 |----|-------------|----|----|------|-------------------|--------|
-| RF-NT-01 | Notificaciones por email y push | Notificaciones | SP4 | 4.5 | US-4.5.x | 🟡 definido · implementación parcial (`US-4.5.1`/`US-4.5.2`: email sí, push pendiente) |
+| RF-NT-01 | Notificaciones por email y push | Notificaciones | SP4 | 4.5 | US-4.5.x | 🟡 implementación parcial (`US-4.5.1`/`US-4.5.2` email base; `US-4.5.3` P-10 inscripción; push pendiente) |
 | RF-NT-02 | Recordatorio al atleta cuando se acerca el plazo de AP | Notificaciones | SP4 | 4.5 | US-4.5.x | ✅ definido · pendiente de implementación |
 | RF-NT-03 | Notificaciones a juez u organizador durante ejecución | Notificaciones | — | — | — | ⏳ pendiente |
 | RF-NT-04 | Notificar a atletas cuando se publican resultados finales | Notificaciones | SP4 | 4.5 | US-4.5.x | ✅ definido · pendiente de implementación (`US-4.5.4`) |

--- a/quality/reports/codeguard/US-4.5.3-quality.json
+++ b/quality/reports/codeguard/US-4.5.3-quality.json
@@ -1,0 +1,2259 @@
+{
+  "summary": {
+    "total_files": 35,
+    "checks_executed": 6,
+    "elapsed_seconds": 22.77,
+    "timestamp": "2026-04-15T08:51:06.882514",
+    "total_issues": 105,
+    "errors": 0,
+    "warnings": 0,
+    "infos": 105
+  },
+  "results": [
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/aggregates/notificacion.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/aggregates/notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/aggregates/notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/destinatario.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/destinatario.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/destinatario.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/ports/email_port.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/ports/email_port.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/ports/email_port.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/templates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/templates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/templates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/email/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/email/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/email/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/policies/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/policies/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/policies/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/policies/politica_p10.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/policies/politica_p10.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/application/policies/politica_p10.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/commands/solicitar_envio.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/commands/solicitar_envio.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/application/commands/solicitar_envio.py",
+      "line": null
+    }
+  ],
+  "by_severity": {
+    "errors": [],
+    "warnings": [],
+    "infos": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      }
+    ]
+  },
+  "by_package": {
+    "aggregates": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      }
+    ],
+    "api": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      }
+    ],
+    "application": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      }
+    ],
+    "commands": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      }
+    ],
+    "domain": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      }
+    ],
+    "email": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      }
+    ],
+    "event_store": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      }
+    ],
+    "events": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      }
+    ],
+    "infrastructure": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      }
+    ],
+    "notificaciones": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      }
+    ],
+    "policies": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      }
+    ],
+    "ports": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      }
+    ],
+    "queries": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      }
+    ],
+    "repositories": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      }
+    ],
+    "templates": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      }
+    ],
+    "value_objects": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      }
+    ]
+  }
+}

--- a/src/app.py
+++ b/src/app.py
@@ -22,6 +22,21 @@ from identidad.api.dependencies import configure_identity_dependencies
 from identidad.api.router import router as identidad_router
 from identidad.infrastructure.bcrypt_password_hasher import BcryptPasswordHasher
 from identidad.infrastructure.jwt_service import JWTService
+from notificaciones.application.commands.enviar_notificacion import (
+    EnviarNotificacionHandler,
+)
+from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
+from notificaciones.application.policies.politica_p10 import PoliticaP10Handler
+from notificaciones.infrastructure.email.resend_email_adapter import ResendEmailAdapter
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
+    InscripcionConfirmadaTemplate,
+)
 from registro.api.router import router as registro_router
 from torneo.api.exception_handlers import register_torneo_exception_handlers
 from torneo.api.router import router as torneo_router
@@ -60,6 +75,21 @@ app.include_router(resultados_router)
 app.include_router(torneo_router)
 register_exception_handlers(app)
 register_torneo_exception_handlers(app)
+
+
+def build_p10_handler() -> PoliticaP10Handler:
+    """Construye la política P-10 con adaptadores reales de Notificaciones."""
+    store = SQLiteNotificacionEventStore()
+    repository = SQLiteNotificacionRepository(store)
+    return PoliticaP10Handler(
+        repository=repository,
+        solicitar_envio_handler=SolicitarEnvioHandler(repository),
+        enviar_notificacion_handler=EnviarNotificacionHandler(
+            repository,
+            ResendEmailAdapter(),
+        ),
+        template=InscripcionConfirmadaTemplate(),
+    )
 
 
 # ── Política P-08: CompetenciaFinalizada → CalcularRanking ────────────────────

--- a/src/notificaciones/application/commands/__init__.py
+++ b/src/notificaciones/application/commands/__init__.py
@@ -1,0 +1,15 @@
+from notificaciones.application.commands.enviar_notificacion import (
+    EnviarNotificacionCommand,
+    EnviarNotificacionHandler,
+)
+from notificaciones.application.commands.solicitar_envio import (
+    SolicitarEnvioCommand,
+    SolicitarEnvioHandler,
+)
+
+__all__ = [
+    "EnviarNotificacionCommand",
+    "EnviarNotificacionHandler",
+    "SolicitarEnvioCommand",
+    "SolicitarEnvioHandler",
+]

--- a/src/notificaciones/application/commands/enviar_notificacion.py
+++ b/src/notificaciones/application/commands/enviar_notificacion.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from notificaciones.application.commands.solicitar_envio import (
+    persistir_eventos_pendientes,
+)
+from notificaciones.domain.aggregates.notificacion import Notificacion
+from notificaciones.domain.ports.email_port import EmailPort
+from notificaciones.domain.ports.notificacion_repository import NotificacionRepository
+from notificaciones.domain.value_objects.notificacion_id import NotificacionId
+
+
+@dataclass(frozen=True)
+class EnviarNotificacionCommand:
+    notificacion_id: NotificacionId
+
+
+class EnviarNotificacionHandler:
+    def __init__(
+        self,
+        repository: NotificacionRepository,
+        email_port: EmailPort,
+    ) -> None:
+        self._repository = repository
+        self._email_port = email_port
+
+    async def handle(self, command: EnviarNotificacionCommand) -> None:
+        stream_id = f"notificacion-{command.notificacion_id}"
+        events = await self._repository.load(stream_id)
+        aggregate = Notificacion.reconstitute(events)
+
+        if aggregate.destinatario is None or aggregate.contenido is None:
+            aggregate.registrar_fallo("notificacion_sin_contenido")
+            await persistir_eventos_pendientes(self._repository, aggregate)
+            return
+
+        try:
+            proveedor_id = await self._email_port.enviar(
+                aggregate.destinatario,
+                aggregate.contenido,
+            )
+            aggregate.registrar_envio_exitoso(proveedor_id)
+        except Exception as exc:  # noqa: BLE001
+            aggregate.registrar_fallo(str(exc) or exc.__class__.__name__)
+
+        await persistir_eventos_pendientes(self._repository, aggregate)

--- a/src/notificaciones/application/commands/solicitar_envio.py
+++ b/src/notificaciones/application/commands/solicitar_envio.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from notificaciones.domain.aggregates.notificacion import Notificacion
+from notificaciones.domain.ports.notificacion_repository import NotificacionRepository
+from notificaciones.domain.value_objects.canal_envio import CanalEnvio
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+from notificaciones.domain.value_objects.notificacion_id import NotificacionId
+
+
+@dataclass(frozen=True)
+class SolicitarEnvioCommand:
+    evento_fuente_id: str
+    destinatario: Destinatario
+    contenido: ContenidoEmail
+    canal: CanalEnvio = CanalEnvio.EMAIL
+
+
+class SolicitarEnvioHandler:
+    def __init__(self, repository: NotificacionRepository) -> None:
+        self._repository = repository
+
+    async def handle(self, command: SolicitarEnvioCommand) -> NotificacionId | None:
+        evento_fuente_id = EventoFuenteId(command.evento_fuente_id)
+        aggregate = await Notificacion.solicitar_envio(
+            evento_fuente_id=evento_fuente_id,
+            destinatario=command.destinatario,
+            contenido=command.contenido,
+            canal=command.canal,
+            existe_envio_exitoso_previo=await self._repository.exists_success_by_evento_fuente_id(
+                str(evento_fuente_id)
+            ),
+        )
+        if aggregate is None:
+            return None
+        await persistir_eventos_pendientes(self._repository, aggregate)
+        return aggregate.notificacion_id
+
+
+async def persistir_eventos_pendientes(
+    repository: NotificacionRepository,
+    aggregate: Notificacion,
+) -> None:
+    for event in aggregate.pull_events():
+        await repository.append(aggregate.stream_id, event.event_type, event.to_payload())

--- a/src/notificaciones/application/policies/__init__.py
+++ b/src/notificaciones/application/policies/__init__.py
@@ -1,0 +1,6 @@
+from notificaciones.application.policies.politica_p10 import (
+    InscripcionConfirmada,
+    PoliticaP10Handler,
+)
+
+__all__ = ["InscripcionConfirmada", "PoliticaP10Handler"]

--- a/src/notificaciones/application/policies/politica_p10.py
+++ b/src/notificaciones/application/policies/politica_p10.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Protocol
+
+from notificaciones.application.commands.enviar_notificacion import (
+    EnviarNotificacionCommand,
+    EnviarNotificacionHandler,
+)
+from notificaciones.application.commands.solicitar_envio import (
+    SolicitarEnvioCommand,
+    SolicitarEnvioHandler,
+    persistir_eventos_pendientes,
+)
+from notificaciones.domain.aggregates.notificacion import Notificacion
+from notificaciones.domain.ports.notificacion_repository import NotificacionRepository
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+
+
+@dataclass(frozen=True)
+class InscripcionConfirmada:
+    id: str
+    atleta_id: str
+    atleta_email: str | None
+    atleta_nombre: str
+    torneo_nombre: str
+    torneo_fecha: date | str
+    torneo_sede: str
+    disciplinas: tuple[str, ...]
+
+
+class InscripcionConfirmadaTemplatePort(Protocol):
+    def render(self, evento: InscripcionConfirmada) -> ContenidoEmail: ...
+
+
+class PoliticaP10Handler:
+    def __init__(
+        self,
+        *,
+        repository: NotificacionRepository,
+        solicitar_envio_handler: SolicitarEnvioHandler,
+        enviar_notificacion_handler: EnviarNotificacionHandler,
+        template: InscripcionConfirmadaTemplatePort,
+    ) -> None:
+        self._repository = repository
+        self._solicitar_envio_handler = solicitar_envio_handler
+        self._enviar_notificacion_handler = enviar_notificacion_handler
+        self._template = template
+
+    async def handle(self, evento: InscripcionConfirmada) -> None:
+        if not evento.atleta_email or not evento.atleta_email.strip():
+            await self._registrar_fallo_sin_email(evento)
+            return
+
+        contenido = self._template.render(evento)
+        notificacion_id = await self._solicitar_envio_handler.handle(
+            SolicitarEnvioCommand(
+                evento_fuente_id=evento.id,
+                destinatario=Destinatario(
+                    email=evento.atleta_email,
+                    nombre=evento.atleta_nombre,
+                ),
+                contenido=contenido,
+            )
+        )
+        if notificacion_id is None:
+            return
+
+        await self._enviar_notificacion_handler.handle(
+            EnviarNotificacionCommand(notificacion_id=notificacion_id)
+        )
+
+    async def _registrar_fallo_sin_email(self, evento: InscripcionConfirmada) -> None:
+        if await self._repository.exists_success_by_evento_fuente_id(evento.id):
+            return
+        aggregate = Notificacion.registrar_fallo_de_solicitud(
+            evento_fuente_id=EventoFuenteId(evento.id),
+            motivo="destinatario_sin_email",
+        )
+        await persistir_eventos_pendientes(self._repository, aggregate)

--- a/src/notificaciones/domain/aggregates/notificacion.py
+++ b/src/notificaciones/domain/aggregates/notificacion.py
@@ -96,6 +96,30 @@ class Notificacion(AggregateRoot):
         aggregate._record(event)
         return aggregate
 
+    @classmethod
+    def registrar_fallo_de_solicitud(
+        cls,
+        *,
+        evento_fuente_id: EventoFuenteId,
+        motivo: str,
+    ) -> "Notificacion":
+        if not motivo or not motivo.strip():
+            raise ValueError("motivo no puede ser vacío")
+
+        aggregate = cls(NotificacionId())
+        event = NotificacionFallida(
+            event_type="NotificacionFallida",
+            aggregate_id=str(aggregate.notificacion_id),
+            occurred_at=NotificacionFallida.now(),
+            notificacion_id=str(aggregate.notificacion_id),
+            evento_fuente_id=str(evento_fuente_id),
+            motivo=motivo,
+            fallida_en=NotificacionFallida.now().isoformat(),
+        )
+        aggregate._apply(event)
+        aggregate._record(event)
+        return aggregate
+
     def registrar_envio_exitoso(self, proveedor_id: str | None = None) -> None:
         self._assert_solicitada()
         if self._evento_fuente_id is None:
@@ -180,9 +204,11 @@ class Notificacion(AggregateRoot):
             self._estado = "Solicitada"
             return
         if isinstance(event, NotificacionEnviada):
+            self._evento_fuente_id = EventoFuenteId(event.evento_fuente_id)
             self._proveedor_id = event.proveedor_id
             self._estado = "Enviada"
             return
+        self._evento_fuente_id = EventoFuenteId(event.evento_fuente_id)
         self._motivo_fallo = event.motivo
         self._estado = "Fallida"
 

--- a/src/notificaciones/infrastructure/__init__.py
+++ b/src/notificaciones/infrastructure/__init__.py
@@ -1,5 +1,6 @@
 """Infraestructura del BC Notificaciones."""
 
 from notificaciones.infrastructure.email import ResendEmailAdapter
+from notificaciones.infrastructure.templates import InscripcionConfirmadaTemplate
 
-__all__ = ["ResendEmailAdapter"]
+__all__ = ["InscripcionConfirmadaTemplate", "ResendEmailAdapter"]

--- a/src/notificaciones/infrastructure/templates/__init__.py
+++ b/src/notificaciones/infrastructure/templates/__init__.py
@@ -1,0 +1,5 @@
+from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
+    InscripcionConfirmadaTemplate,
+)
+
+__all__ = ["InscripcionConfirmadaTemplate"]

--- a/src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py
+++ b/src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+
+
+class InscripcionConfirmadaLike(Protocol):
+    atleta_nombre: str
+    torneo_nombre: str
+    torneo_fecha: object
+    torneo_sede: str
+    disciplinas: tuple[str, ...]
+
+
+class InscripcionConfirmadaTemplate:
+    def render(self, evento: InscripcionConfirmadaLike) -> ContenidoEmail:
+        disciplinas = ", ".join(evento.disciplinas)
+        asunto = f"Inscripcion confirmada - {evento.torneo_nombre}"
+        cuerpo = "\n".join(
+            [
+                f"Hola {evento.atleta_nombre},",
+                "",
+                f"Tu inscripcion al torneo {evento.torneo_nombre} ha sido confirmada.",
+                "",
+                f"Fecha: {evento.torneo_fecha}",
+                f"Sede: {evento.torneo_sede}",
+                f"Disciplinas inscriptas: {disciplinas}",
+                "",
+                "Buena suerte!",
+                "El equipo de AtaraxiaDive",
+            ]
+        )
+        return ContenidoEmail(asunto=asunto, cuerpo_texto=cuerpo)

--- a/src/registro/application/commands/inscribir_atleta.py
+++ b/src/registro/application/commands/inscribir_atleta.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Awaitable, Callable
 from uuid import UUID
 
 from registro.domain.aggregates.inscripcion import Inscripcion
@@ -26,9 +27,11 @@ class InscribirAtletaHandler:
         self,
         inscripcion_repo: InscripcionRepositoryPort,
         torneo_consulta: TorneoConsultaPort,
+        on_inscripcion_confirmada: Callable[[Inscripcion], Awaitable[None]] | None = None,
     ) -> None:
         self._inscripcion_repo = inscripcion_repo
         self._torneo_consulta = torneo_consulta
+        self._on_inscripcion_confirmada = on_inscripcion_confirmada
 
     async def handle(self, cmd: InscribirAtletaCommand) -> UUID:
         if not cmd.disciplinas:
@@ -60,4 +63,9 @@ class InscribirAtletaHandler:
             disciplinas=cmd.disciplinas,
         )
         await self._inscripcion_repo.save(inscripcion)
+        if self._on_inscripcion_confirmada is not None:
+            try:
+                await self._on_inscripcion_confirmada(inscripcion)
+            except Exception:
+                pass
         return inscripcion.inscripcion_id

--- a/tests/features/US-4.5.3-politica-p10.feature
+++ b/tests/features/US-4.5.3-politica-p10.feature
@@ -1,0 +1,43 @@
+Feature: US-4.5.3 - Politica P-10 email de confirmacion de inscripcion
+
+  Scenario: email enviado exitosamente al confirmar inscripcion
+    Given el sistema recibe el evento InscripcionConfirmada para "Martin Garcia"
+    And el evento tiene email "garcia@apnea.com" y torneo "Open BA 2026"
+    And el evento contiene las disciplinas "DNF" y "STA"
+    When se procesa la politica P-10
+    Then se crea un aggregate Notificacion en estado "Enviada"
+    And el email llega a "garcia@apnea.com" con asunto "Inscripcion confirmada - Open BA 2026"
+    And el cuerpo del email contiene el torneo "Open BA 2026"
+    And el cuerpo del email contiene las disciplinas "DNF" y "STA"
+
+  Scenario: idempotencia ante el mismo evento procesado dos veces
+    Given el evento InscripcionConfirmada "evt-reg-001" ya fue procesado exitosamente
+    When la politica P-10 recibe nuevamente el evento "evt-reg-001"
+    Then no se envia un segundo email
+    And el store conserva exactamente una NotificacionEnviada para "evt-reg-001"
+
+  Scenario: atleta sin email registrado
+    Given el sistema recibe un evento InscripcionConfirmada sin email de atleta
+    When se procesa la politica P-10
+    Then se crea un aggregate Notificacion en estado "Fallida"
+    And el motivo del fallo es "destinatario_sin_email"
+    And la politica P-10 no lanza excepcion
+
+  Scenario: fallo tecnico del proveedor de email
+    Given el proveedor de email falla al enviar la confirmacion
+    And el sistema recibe el evento InscripcionConfirmada para "Martin Garcia"
+    When se procesa la politica P-10
+    Then se crea un aggregate Notificacion en estado "Fallida"
+    And el fallo queda registrado en el event store de notificaciones
+    And la inscripcion del atleta no se revierte
+
+  Scenario: contenido del email de confirmacion
+    Given el sistema recibe el evento InscripcionConfirmada para "Martin Garcia"
+    And el evento tiene torneo "Open BA 2026", fecha "2026-05-15" y sede "Club Nautico"
+    And el evento contiene las disciplinas "DNF" y "STA"
+    When se procesa la politica P-10
+    Then el asunto del email incluye "Open BA 2026"
+    And el cuerpo del email contiene "Martin Garcia"
+    And el cuerpo del email contiene "2026-05-15"
+    And el cuerpo del email contiene "Club Nautico"
+    And el cuerpo del email contiene las disciplinas "DNF" y "STA"

--- a/tests/features/steps/politica_p10_steps.py
+++ b/tests/features/steps/politica_p10_steps.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import aiosqlite
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from notificaciones.application.commands.enviar_notificacion import EnviarNotificacionHandler
+from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
+from notificaciones.application.policies.politica_p10 import (
+    InscripcionConfirmada,
+    PoliticaP10Handler,
+)
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
+    InscripcionConfirmadaTemplate,
+)
+
+scenarios("../US-4.5.3-politica-p10.feature")
+
+
+class FakeEmailPort:
+    def __init__(self) -> None:
+        self.fail = False
+        self.sent = 0
+        self.messages: list[dict[str, Any]] = []
+
+    async def enviar(self, destinatario, contenido) -> str | None:
+        if self.fail:
+            raise RuntimeError("proveedor_no_disponible")
+        self.sent += 1
+        self.messages.append(
+            {
+                "to": destinatario.email,
+                "subject": contenido.asunto,
+                "body": contenido.cuerpo_texto,
+            }
+        )
+        return f"provider-{self.sent}"
+
+
+@pytest.fixture
+def ctx(tmp_path) -> dict[str, Any]:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+    handler = PoliticaP10Handler(
+        repository=repo,
+        solicitar_envio_handler=SolicitarEnvioHandler(repo),
+        enviar_notificacion_handler=EnviarNotificacionHandler(repo, email),
+        template=InscripcionConfirmadaTemplate(),
+    )
+    return {
+        "db_path": db_path,
+        "repo": repo,
+        "email": email,
+        "handler": handler,
+        "evento": _evento(),
+        "error": None,
+    }
+
+
+def _evento(
+    *,
+    evento_id: str = "evt-reg-001",
+    atleta_nombre: str = "Martin Garcia",
+    atleta_email: str | None = "garcia@apnea.com",
+    torneo_nombre: str = "Open BA 2026",
+    torneo_fecha: str = "2026-05-15",
+    torneo_sede: str = "Club Nautico",
+    disciplinas: tuple[str, ...] = ("DNF", "STA"),
+) -> InscripcionConfirmada:
+    return InscripcionConfirmada(
+        id=evento_id,
+        atleta_id="ath-123",
+        atleta_email=atleta_email,
+        atleta_nombre=atleta_nombre,
+        torneo_nombre=torneo_nombre,
+        torneo_fecha=torneo_fecha,
+        torneo_sede=torneo_sede,
+        disciplinas=disciplinas,
+    )
+
+
+async def _events(db_path) -> list[dict[str, Any]]:
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            """
+            SELECT event_type, payload
+            FROM notificaciones_events
+            ORDER BY id ASC
+            """
+        )
+        rows = await cursor.fetchall()
+    return [{"event_type": row["event_type"], "payload": row["payload"]} for row in rows]
+
+
+@given(parsers.parse('el sistema recibe el evento InscripcionConfirmada para "{nombre}"'))
+def given_evento_para_atleta(ctx: dict[str, Any], nombre: str) -> None:
+    ctx["evento"] = _evento(atleta_nombre=nombre)
+
+
+@given(parsers.parse('el evento tiene email "{email}" y torneo "{torneo}"'))
+def given_email_y_torneo(ctx: dict[str, Any], email: str, torneo: str) -> None:
+    evento = ctx["evento"]
+    ctx["evento"] = _evento(
+        atleta_nombre=evento.atleta_nombre,
+        atleta_email=email,
+        torneo_nombre=torneo,
+        disciplinas=evento.disciplinas,
+    )
+
+
+@given(parsers.parse('el evento contiene las disciplinas "{disciplina_a}" y "{disciplina_b}"'))
+def given_disciplinas(ctx: dict[str, Any], disciplina_a: str, disciplina_b: str) -> None:
+    evento = ctx["evento"]
+    ctx["evento"] = _evento(
+        atleta_nombre=evento.atleta_nombre,
+        atleta_email=evento.atleta_email,
+        torneo_nombre=evento.torneo_nombre,
+        torneo_fecha=evento.torneo_fecha,
+        torneo_sede=evento.torneo_sede,
+        disciplinas=(disciplina_a, disciplina_b),
+    )
+
+
+@given(parsers.parse('el evento InscripcionConfirmada "{evento_id}" ya fue procesado exitosamente'))
+def given_evento_ya_procesado(ctx: dict[str, Any], evento_id: str) -> None:
+    async def _run() -> None:
+        ctx["evento"] = _evento(evento_id=evento_id)
+        await ctx["handler"].handle(ctx["evento"])
+
+    asyncio.run(_run())
+
+
+@given("el sistema recibe un evento InscripcionConfirmada sin email de atleta")
+def given_evento_sin_email(ctx: dict[str, Any]) -> None:
+    ctx["evento"] = _evento(atleta_email=None)
+
+
+@given("el proveedor de email falla al enviar la confirmacion")
+def given_proveedor_falla(ctx: dict[str, Any]) -> None:
+    ctx["email"].fail = True
+
+
+@given(
+    parsers.parse(
+        'el evento tiene torneo "{torneo}", fecha "{fecha}" y sede "{sede}"'
+    )
+)
+def given_torneo_fecha_sede(ctx: dict[str, Any], torneo: str, fecha: str, sede: str) -> None:
+    evento = ctx["evento"]
+    ctx["evento"] = _evento(
+        atleta_nombre=evento.atleta_nombre,
+        atleta_email=evento.atleta_email,
+        torneo_nombre=torneo,
+        torneo_fecha=fecha,
+        torneo_sede=sede,
+        disciplinas=evento.disciplinas,
+    )
+
+
+@when("se procesa la politica P-10")
+def when_procesar_p10(ctx: dict[str, Any]) -> None:
+    async def _run() -> None:
+        try:
+            await ctx["handler"].handle(ctx["evento"])
+        except Exception as exc:  # noqa: BLE001
+            ctx["error"] = exc
+
+    asyncio.run(_run())
+
+
+@when(parsers.parse('la politica P-10 recibe nuevamente el evento "{evento_id}"'))
+def when_reprocesar_evento(ctx: dict[str, Any], evento_id: str) -> None:
+    ctx["evento"] = _evento(evento_id=evento_id)
+    when_procesar_p10(ctx)
+
+
+@then(parsers.parse('se crea un aggregate Notificacion en estado "{estado}"'))
+def then_estado_notificacion(ctx: dict[str, Any], estado: str) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    assert events
+    if estado == "Enviada":
+        assert events[-1]["event_type"] == "NotificacionEnviada"
+    elif estado == "Fallida":
+        assert events[-1]["event_type"] == "NotificacionFallida"
+    else:
+        raise AssertionError(f"Estado no soportado en test: {estado}")
+
+
+@then(parsers.parse('el email llega a "{email}" con asunto "{asunto}"'))
+def then_email_llega(ctx: dict[str, Any], email: str, asunto: str) -> None:
+    assert ctx["email"].messages[-1]["to"] == email
+    assert ctx["email"].messages[-1]["subject"] == asunto
+
+
+@then(parsers.parse('el cuerpo del email contiene el torneo "{torneo}"'))
+def then_cuerpo_contiene_torneo(ctx: dict[str, Any], torneo: str) -> None:
+    assert torneo in ctx["email"].messages[-1]["body"]
+
+
+@then(parsers.parse('el cuerpo del email contiene las disciplinas "{a}" y "{b}"'))
+def then_cuerpo_contiene_disciplinas(ctx: dict[str, Any], a: str, b: str) -> None:
+    body = ctx["email"].messages[-1]["body"]
+    assert a in body
+    assert b in body
+
+
+@then("no se envia un segundo email")
+def then_no_segundo_email(ctx: dict[str, Any]) -> None:
+    assert ctx["email"].sent == 1
+
+
+@then(parsers.parse('el store conserva exactamente una NotificacionEnviada para "{evento_id}"'))
+def then_una_enviada(ctx: dict[str, Any], evento_id: str) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    enviadas = [event for event in events if event["event_type"] == "NotificacionEnviada"]
+    assert len(enviadas) == 1
+    assert evento_id in enviadas[0]["payload"]
+
+
+@then(parsers.parse('el motivo del fallo es "{motivo}"'))
+def then_motivo_fallo(ctx: dict[str, Any], motivo: str) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    assert motivo in events[-1]["payload"]
+
+
+@then("la politica P-10 no lanza excepcion")
+def then_no_exception(ctx: dict[str, Any]) -> None:
+    assert ctx["error"] is None
+
+
+@then("el fallo queda registrado en el event store de notificaciones")
+def then_fallo_registrado(ctx: dict[str, Any]) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    assert events[-1]["event_type"] == "NotificacionFallida"
+
+
+@then("la inscripcion del atleta no se revierte")
+def then_inscripcion_no_revertida(ctx: dict[str, Any]) -> None:
+    assert ctx["error"] is None
+
+
+@then(parsers.parse('el asunto del email incluye "{texto}"'))
+def then_asunto_incluye(ctx: dict[str, Any], texto: str) -> None:
+    assert texto in ctx["email"].messages[-1]["subject"]
+
+
+@then(parsers.parse('el cuerpo del email contiene "{texto}"'))
+def then_cuerpo_contiene(ctx: dict[str, Any], texto: str) -> None:
+    assert texto in ctx["email"].messages[-1]["body"]

--- a/tests/integration/notificaciones/test_politica_p10_integration.py
+++ b/tests/integration/notificaciones/test_politica_p10_integration.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from notificaciones.application.commands.enviar_notificacion import EnviarNotificacionHandler
+from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
+from notificaciones.application.policies.politica_p10 import (
+    InscripcionConfirmada,
+    PoliticaP10Handler,
+)
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
+    InscripcionConfirmadaTemplate,
+)
+
+
+class FakeEmailPort:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.sent = 0
+
+    async def enviar(self, destinatario, contenido) -> str | None:
+        self.sent += 1
+        if self.fail:
+            raise RuntimeError("proveedor_no_disponible")
+        return "provider-123"
+
+
+def _evento(email: str | None = "garcia@apnea.com") -> InscripcionConfirmada:
+    return InscripcionConfirmada(
+        id="evt-reg-001",
+        atleta_id="ath-123",
+        atleta_email=email,
+        atleta_nombre="Martin Garcia",
+        torneo_nombre="Open BA 2026",
+        torneo_fecha="2026-05-15",
+        torneo_sede="Club Nautico",
+        disciplinas=("DNF", "STA"),
+    )
+
+
+def _handler(repo: SQLiteNotificacionRepository, email: FakeEmailPort) -> PoliticaP10Handler:
+    return PoliticaP10Handler(
+        repository=repo,
+        solicitar_envio_handler=SolicitarEnvioHandler(repo),
+        enviar_notificacion_handler=EnviarNotificacionHandler(repo, email),
+        template=InscripcionConfirmadaTemplate(),
+    )
+
+
+async def _event_types(db_path) -> list[str]:
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            "SELECT event_type FROM notificaciones_events ORDER BY id ASC"
+        )
+        rows = await cursor.fetchall()
+    return [row[0] for row in rows]
+
+
+@pytest.mark.asyncio
+async def test_p10_persiste_solicitud_y_envio_en_sqlite(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+
+    await _handler(repo, email).handle(_evento())
+
+    assert email.sent == 1
+    assert await _event_types(db_path) == [
+        "NotificacionSolicitada",
+        "NotificacionEnviada",
+    ]
+    assert await repo.exists_success_by_evento_fuente_id("evt-reg-001") is True
+
+
+@pytest.mark.asyncio
+async def test_p10_no_duplica_envio_al_reprocesar_evento(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+    handler = _handler(repo, email)
+
+    await handler.handle(_evento())
+    await handler.handle(_evento())
+
+    assert email.sent == 1
+    assert await _event_types(db_path) == [
+        "NotificacionSolicitada",
+        "NotificacionEnviada",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_p10_persiste_fallo_por_email_ausente(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+
+    await _handler(repo, email).handle(_evento(email=None))
+
+    assert email.sent == 0
+    assert await _event_types(db_path) == ["NotificacionFallida"]
+
+
+@pytest.mark.asyncio
+async def test_p10_persiste_fallo_tecnico_del_proveedor(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort(fail=True)
+
+    await _handler(repo, email).handle(_evento())
+
+    assert email.sent == 1
+    assert await _event_types(db_path) == [
+        "NotificacionSolicitada",
+        "NotificacionFallida",
+    ]

--- a/tests/unit/notificaciones/application/test_enviar_notificacion_handler.py
+++ b/tests/unit/notificaciones/application/test_enviar_notificacion_handler.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notificaciones.application.commands.enviar_notificacion import (
+    EnviarNotificacionCommand,
+    EnviarNotificacionHandler,
+)
+from notificaciones.application.commands.solicitar_envio import (
+    SolicitarEnvioCommand,
+    SolicitarEnvioHandler,
+)
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+
+
+class FakeNotificacionRepository:
+    def __init__(self) -> None:
+        self.events_by_stream: dict[str, list[dict[str, Any]]] = {}
+
+    async def append(
+        self,
+        stream_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> None:
+        self.events_by_stream.setdefault(stream_id, []).append(
+            {
+                "event_type": event_type,
+                "payload": payload,
+                "version": len(self.events_by_stream.get(stream_id, [])) + 1,
+                "occurred_at": payload["occurred_at"],
+            }
+        )
+
+    async def load(self, stream_id: str) -> list[dict[str, Any]]:
+        return self.events_by_stream.get(stream_id, [])
+
+    async def exists_success_by_evento_fuente_id(self, evento_fuente_id: str) -> bool:
+        return any(
+            event["event_type"] == "NotificacionEnviada"
+            and event["payload"]["evento_fuente_id"] == evento_fuente_id
+            for events in self.events_by_stream.values()
+            for event in events
+        )
+
+
+class FakeEmailPort:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.sent = 0
+
+    async def enviar(self, destinatario, contenido) -> str | None:
+        self.sent += 1
+        if self.fail:
+            raise RuntimeError("proveedor_no_disponible")
+        return "provider-123"
+
+
+async def _crear_solicitada(repo: FakeNotificacionRepository):
+    handler = SolicitarEnvioHandler(repo)
+    return await handler.handle(
+        SolicitarEnvioCommand(
+            evento_fuente_id="evt-reg-001",
+            destinatario=Destinatario(email="garcia@apnea.com"),
+            contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_enviar_notificacion_registra_envio_exitoso() -> None:
+    repo = FakeNotificacionRepository()
+    notificacion_id = await _crear_solicitada(repo)
+    assert notificacion_id is not None
+
+    email = FakeEmailPort()
+    await EnviarNotificacionHandler(repo, email).handle(
+        EnviarNotificacionCommand(notificacion_id=notificacion_id)
+    )
+
+    events = next(iter(repo.events_by_stream.values()))
+    assert email.sent == 1
+    assert events[-1]["event_type"] == "NotificacionEnviada"
+    assert events[-1]["payload"]["proveedor_id"] == "provider-123"
+
+
+@pytest.mark.asyncio
+async def test_enviar_notificacion_registra_fallo_tecnico() -> None:
+    repo = FakeNotificacionRepository()
+    notificacion_id = await _crear_solicitada(repo)
+    assert notificacion_id is not None
+
+    email = FakeEmailPort(fail=True)
+    await EnviarNotificacionHandler(repo, email).handle(
+        EnviarNotificacionCommand(notificacion_id=notificacion_id)
+    )
+
+    events = next(iter(repo.events_by_stream.values()))
+    assert email.sent == 1
+    assert events[-1]["event_type"] == "NotificacionFallida"
+    assert "proveedor_no_disponible" in events[-1]["payload"]["motivo"]

--- a/tests/unit/notificaciones/application/test_politica_p10.py
+++ b/tests/unit/notificaciones/application/test_politica_p10.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notificaciones.application.commands.enviar_notificacion import EnviarNotificacionHandler
+from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
+from notificaciones.application.policies.politica_p10 import (
+    InscripcionConfirmada,
+    PoliticaP10Handler,
+)
+from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
+    InscripcionConfirmadaTemplate,
+)
+
+
+class FakeNotificacionRepository:
+    def __init__(self) -> None:
+        self.events_by_stream: dict[str, list[dict[str, Any]]] = {}
+
+    async def append(
+        self,
+        stream_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> None:
+        self.events_by_stream.setdefault(stream_id, []).append(
+            {
+                "event_type": event_type,
+                "payload": payload,
+                "version": len(self.events_by_stream.get(stream_id, [])) + 1,
+                "occurred_at": payload["occurred_at"],
+            }
+        )
+
+    async def load(self, stream_id: str) -> list[dict[str, Any]]:
+        return self.events_by_stream.get(stream_id, [])
+
+    async def exists_success_by_evento_fuente_id(self, evento_fuente_id: str) -> bool:
+        return any(
+            event["event_type"] == "NotificacionEnviada"
+            and event["payload"]["evento_fuente_id"] == evento_fuente_id
+            for events in self.events_by_stream.values()
+            for event in events
+        )
+
+    def event_types(self) -> list[str]:
+        return [
+            event["event_type"]
+            for events in self.events_by_stream.values()
+            for event in events
+        ]
+
+
+class FakeEmailPort:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.sent = 0
+        self.last_subject: str | None = None
+        self.last_body: str | None = None
+
+    async def enviar(self, destinatario, contenido) -> str | None:
+        self.sent += 1
+        self.last_subject = contenido.asunto
+        self.last_body = contenido.cuerpo_texto
+        if self.fail:
+            raise RuntimeError("proveedor_no_disponible")
+        return "provider-123"
+
+
+def _evento(email: str | None = "garcia@apnea.com") -> InscripcionConfirmada:
+    return InscripcionConfirmada(
+        id="evt-reg-001",
+        atleta_id="ath-123",
+        atleta_email=email,
+        atleta_nombre="Martin Garcia",
+        torneo_nombre="Open BA 2026",
+        torneo_fecha="2026-05-15",
+        torneo_sede="Club Nautico",
+        disciplinas=("DNF", "STA"),
+    )
+
+
+def _handler(repo: FakeNotificacionRepository, email: FakeEmailPort) -> PoliticaP10Handler:
+    return PoliticaP10Handler(
+        repository=repo,
+        solicitar_envio_handler=SolicitarEnvioHandler(repo),
+        enviar_notificacion_handler=EnviarNotificacionHandler(repo, email),
+        template=InscripcionConfirmadaTemplate(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_p10_envia_email_de_confirmacion() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+
+    await _handler(repo, email).handle(_evento())
+
+    assert email.sent == 1
+    assert repo.event_types() == ["NotificacionSolicitada", "NotificacionEnviada"]
+    assert email.last_subject == "Inscripcion confirmada - Open BA 2026"
+    assert email.last_body is not None
+    assert "Open BA 2026" in email.last_body
+    assert "DNF, STA" in email.last_body
+
+
+@pytest.mark.asyncio
+async def test_p10_es_idempotente_si_evento_ya_fue_enviado() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+    handler = _handler(repo, email)
+
+    await handler.handle(_evento())
+    await handler.handle(_evento())
+
+    assert email.sent == 1
+    assert repo.event_types() == ["NotificacionSolicitada", "NotificacionEnviada"]
+
+
+@pytest.mark.asyncio
+async def test_p10_registra_fallo_si_atleta_no_tiene_email() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+
+    await _handler(repo, email).handle(_evento(email=None))
+
+    assert email.sent == 0
+    assert repo.event_types() == ["NotificacionFallida"]
+    event = next(iter(repo.events_by_stream.values()))[0]
+    assert event["payload"]["motivo"] == "destinatario_sin_email"
+
+
+@pytest.mark.asyncio
+async def test_p10_no_propaga_fallo_del_proveedor() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort(fail=True)
+
+    await _handler(repo, email).handle(_evento())
+
+    assert email.sent == 1
+    assert repo.event_types() == ["NotificacionSolicitada", "NotificacionFallida"]

--- a/tests/unit/notificaciones/application/test_solicitar_envio_handler.py
+++ b/tests/unit/notificaciones/application/test_solicitar_envio_handler.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notificaciones.application.commands.solicitar_envio import (
+    SolicitarEnvioCommand,
+    SolicitarEnvioHandler,
+)
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+
+
+class FakeNotificacionRepository:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, Any]]] = []
+        self.success_evento_fuente_ids: set[str] = set()
+
+    async def append(
+        self,
+        stream_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> None:
+        self.events.append((stream_id, event_type, payload))
+
+    async def load(self, stream_id: str) -> list[dict[str, Any]]:
+        return []
+
+    async def exists_success_by_evento_fuente_id(self, evento_fuente_id: str) -> bool:
+        return evento_fuente_id in self.success_evento_fuente_ids
+
+
+@pytest.mark.asyncio
+async def test_solicitar_envio_crea_notificacion_si_no_hay_exito_previo() -> None:
+    repo = FakeNotificacionRepository()
+    handler = SolicitarEnvioHandler(repo)
+
+    notificacion_id = await handler.handle(
+        SolicitarEnvioCommand(
+            evento_fuente_id="evt-reg-001",
+            destinatario=Destinatario(email="garcia@apnea.com"),
+            contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        )
+    )
+
+    assert notificacion_id is not None
+    assert len(repo.events) == 1
+    assert repo.events[0][1] == "NotificacionSolicitada"
+    assert repo.events[0][2]["evento_fuente_id"] == "evt-reg-001"
+
+
+@pytest.mark.asyncio
+async def test_solicitar_envio_no_persiste_si_existe_envio_exitoso_previo() -> None:
+    repo = FakeNotificacionRepository()
+    repo.success_evento_fuente_ids.add("evt-reg-001")
+    handler = SolicitarEnvioHandler(repo)
+
+    notificacion_id = await handler.handle(
+        SolicitarEnvioCommand(
+            evento_fuente_id="evt-reg-001",
+            destinatario=Destinatario(email="garcia@apnea.com"),
+            contenido=ContenidoEmail(asunto="Inscripcion", cuerpo_texto="ok"),
+        )
+    )
+
+    assert notificacion_id is None
+    assert repo.events == []

--- a/tests/unit/notificaciones/infrastructure/test_inscripcion_confirmada_template.py
+++ b/tests/unit/notificaciones/infrastructure/test_inscripcion_confirmada_template.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from notificaciones.application.policies.politica_p10 import InscripcionConfirmada
+from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
+    InscripcionConfirmadaTemplate,
+)
+
+
+def test_template_renderiza_datos_de_inscripcion_confirmada() -> None:
+    evento = InscripcionConfirmada(
+        id="evt-reg-001",
+        atleta_id="ath-123",
+        atleta_email="garcia@apnea.com",
+        atleta_nombre="Martin Garcia",
+        torneo_nombre="Open BA 2026",
+        torneo_fecha="2026-05-15",
+        torneo_sede="Club Nautico",
+        disciplinas=("DNF", "STA"),
+    )
+
+    contenido = InscripcionConfirmadaTemplate().render(evento)
+
+    assert contenido.asunto == "Inscripcion confirmada - Open BA 2026"
+    assert "Martin Garcia" in contenido.cuerpo_texto
+    assert "Open BA 2026" in contenido.cuerpo_texto
+    assert "2026-05-15" in contenido.cuerpo_texto
+    assert "Club Nautico" in contenido.cuerpo_texto
+    assert "DNF, STA" in contenido.cuerpo_texto

--- a/uv.lock
+++ b/uv.lock
@@ -99,6 +99,7 @@ dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "sqlalchemy" },
@@ -108,7 +109,6 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "black" },
-    { name = "httpx" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -128,7 +128,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.1.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.110.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },


### PR DESCRIPTION
## Resumen
- Implementa PoliticaP10Handler para InscripcionConfirmada -> email de confirmacion al atleta.
- Agrega SolicitarEnvioHandler y EnviarNotificacionHandler reutilizando el aggregate Notificacion y EmailPort.
- Agrega template de confirmacion, BDD, tests unitarios/integracion, documentacion y reporte final.
- Agrega callback opcional post-save en Registro sin acoplar BCs.

## Validacion
- uv run pytest tests/unit/notificaciones tests/integration/notificaciones tests/features/steps/notificacion_idempotencia_steps.py tests/features/steps/adaptador_email_steps.py tests/features/steps/politica_p10_steps.py tests/unit/registro/test_inscribir_atleta_handler.py -q
- uv run codeguard src/notificaciones --format json > quality/reports/codeguard/US-4.5.3-quality.json
- git diff --check

## Notas
- P-10 queda implementada contra DTO de aplicacion InscripcionConfirmada.
- El enriquecimiento real desde endpoints de Registro queda como integracion posterior/ACL si se necesita.
- Push sigue fuera de scope.