### PR TITLE
US-4.5.4: Política P-11 resultados publicados

### DIFF
--- a/.claude/tracking/US-4.5.4-tracking.json
+++ b/.claude/tracking/US-4.5.4-tracking.json
@@ -1,0 +1,152 @@
+{
+  "metadata": {
+    "us_id": "US-4.5.4",
+    "us_title": "Politica P-11 emails de resultados publicados",
+    "us_points": 3,
+    "producto": "notificaciones",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-15T12:00:24.845873+00:00",
+    "completed_at": "2026-04-15T12:15:01.272976+00:00",
+    "total_elapsed_seconds": 876,
+    "effective_seconds": 876,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-15T12:00:30.688048+00:00",
+      "completed_at": "2026-04-15T12:00:50.121439+00:00",
+      "elapsed_seconds": 19,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-15T12:00:56.779112+00:00",
+      "completed_at": "2026-04-15T12:01:15.903971+00:00",
+      "elapsed_seconds": 19,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-15T12:01:52.505283+00:00",
+      "completed_at": "2026-04-15T12:03:14.853597+00:00",
+      "elapsed_seconds": 82,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-15T12:03:58.996752+00:00",
+      "completed_at": "2026-04-15T12:05:45.970487+00:00",
+      "elapsed_seconds": 106,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Implementar politica P-11 y template",
+          "task_type": "application",
+          "estimated_minutes": 95.0,
+          "started_at": "2026-04-15T12:04:14.951655+00:00",
+          "completed_at": "2026-04-15T12:05:40.052688+00:00",
+          "elapsed_seconds": 85,
+          "actual_minutes": 1.42,
+          "variance_minutes": -93.58,
+          "file_created": "src/notificaciones/application/policies/politica_p11.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-15T12:05:55.182450+00:00",
+      "completed_at": "2026-04-15T12:07:10.702336+00:00",
+      "elapsed_seconds": 75,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-15T12:07:16.690030+00:00",
+      "completed_at": "2026-04-15T12:08:13.711499+00:00",
+      "elapsed_seconds": 57,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-15T12:08:19.884320+00:00",
+      "completed_at": "2026-04-15T12:09:46.749188+00:00",
+      "elapsed_seconds": 86,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-15T12:09:54.294832+00:00",
+      "completed_at": "2026-04-15T12:11:16.863313+00:00",
+      "elapsed_seconds": 82,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-15T12:11:34.588480+00:00",
+      "completed_at": "2026-04-15T12:12:24.372505+00:00",
+      "elapsed_seconds": 49,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-15T12:13:49.311636+00:00",
+      "completed_at": "2026-04-15T12:14:42.147101+00:00",
+      "elapsed_seconds": 52,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 1,
+    "completed_tasks": 1,
+    "total_phases": 10,
+    "estimated_total_minutes": 95.0,
+    "actual_total_minutes": 1.42,
+    "variance_minutes": -93.58,
+    "variance_percent": -98.51
+  }
+}

--- a/docs/architecture/15-bc-notificaciones.md
+++ b/docs/architecture/15-bc-notificaciones.md
@@ -46,10 +46,8 @@ El BC `notificaciones` ya cuenta con:
 - adaptador concreto `ResendEmailAdapter` en infraestructura para envío real por HTTP.
 - comandos de aplicación `SolicitarEnvioHandler` y `EnviarNotificacionHandler`;
 - política P-10 (`InscripcionConfirmada` -> email de confirmación al atleta);
-- template `InscripcionConfirmadaTemplate`.
-
-La política P-11 (`ResultadosPublicados` -> emails a atletas de la disciplina)
-queda pendiente para `US-4.5.4`.
+- política P-11 (`ResultadosPublicados` -> emails a atletas de la disciplina);
+- templates `InscripcionConfirmadaTemplate` y `ResultadosPublicadosTemplate`.
 
 ## Rol del bounded context
 
@@ -211,6 +209,12 @@ recibe un DTO de aplicación `InscripcionConfirmada`, renderiza el contenido con
 directamente `NotificacionFallida` con motivo `destinatario_sin_email` sin
 interrumpir el flujo principal de inscripción.
 
+En `US-4.5.4`, la política P-11 aplica el mismo patrón para resultados
+publicados: recibe un DTO `ResultadosPublicados`, genera una notificación por
+cada atleta notificable y usa `"{evento.id}:{atleta_id}"` como clave compuesta
+de idempotencia. Los atletas con `estado = "Retirado"` se omiten; los atletas
+con `estado = "DNS"` reciben email. Un fallo en un atleta no bloquea el resto.
+
 ### Domain Layer
 
 Contiene el modelo propio del BC.
@@ -285,7 +289,7 @@ Entre los disparadores ya definidos aparecen, por ejemplo:
 
 - `InscripcionConfirmada` desde `Registro` para P-10;
 - recordatorios vinculados a anuncios;
-- `ResultadosPublicados`;
+- `ResultadosPublicados` desde `Resultados` para P-11;
 - `TorneoCerrado`.
 
 ## Integraciones de salida

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -370,7 +370,7 @@ classDiagram
 > `US-4.5.1` implementa el núcleo del aggregate y su event store propio.
 > `US-4.5.2` implementa el adaptador email con Resend.
 > `US-4.5.3` implementa P-10: `InscripcionConfirmada` -> email de confirmación.
-> P-11 (`ResultadosPublicados`) queda para `US-4.5.4`.
+> `US-4.5.4` implementa P-11: `ResultadosPublicados` -> email individual a atletas.
 
 ### Aggregate
 
@@ -418,13 +418,16 @@ classDiagram
 | `SolicitarEnvioHandler` | Crea `NotificacionSolicitada` si no existe un envío exitoso previo para el `evento_fuente_id` |
 | `EnviarNotificacionHandler` | Rehidrata la notificación, llama `EmailPort` y registra `NotificacionEnviada` o `NotificacionFallida` |
 | `PoliticaP10Handler` | Recibe `InscripcionConfirmada`, renderiza contenido y orquesta solicitud + envío de email al atleta |
+| `PoliticaP11Handler` | Recibe `ResultadosPublicados`, crea una notificación por atleta y aplica idempotencia con clave compuesta `{evento.id}:{atleta_id}` |
 
 ### Templates e integración
 
 | Componente | Responsabilidad |
 |------------|-----------------|
 | `InscripcionConfirmadaTemplate` | Genera asunto y cuerpo de email con atleta, torneo, fecha, sede y disciplinas |
+| `ResultadosPublicadosTemplate` | Genera email individual con posición, RP, tarjeta, podio y link al ranking |
 | `build_p10_handler` | Factory en `src/app.py` para componer P-10 con repositorio SQLite y `ResendEmailAdapter` |
+| `build_p11_handler` | Factory en `src/app.py` para componer P-11 con repositorio SQLite y `ResendEmailAdapter` |
 
 ### Puerto y adaptador de email
 

--- a/docs/plans/sp4/US-4.5.4-plan.md
+++ b/docs/plans/sp4/US-4.5.4-plan.md
@@ -1,0 +1,144 @@
+# Plan de Implementación: US-4.5.4 - Política P-11 resultados publicados
+
+**Sprint:** SP4 - La Plataforma  
+**Incremento:** INC-4.5  
+**Bounded Context:** `notificaciones`  
+**Patrón:** Hexagonal DDD BC-first + política de aplicación in-process  
+**Estimación total:** 3h 25min  
+**Estado:** Fase 3 implementada; tests pendientes  
+**Fecha:** 2026-04-15
+
+## Objetivo
+
+Implementar la política P-11 para que un evento `ResultadosPublicados` dispare un email
+individual a cada atleta de la disciplina publicada, con posición, RP, tarjeta y podio.
+
+La política debe ser idempotente por par `(evento_publicacion, atleta_id)` mediante una
+clave compuesta `"{evento.id}:{atleta_id}"`, evitando que el primer envío bloquee a los
+demás atletas del mismo evento.
+
+## Decisiones de Diseño
+
+- `ResultadosPublicados` será un DTO de aplicación de `notificaciones`, no un import desde
+  `resultados`.
+- Se reutilizan `SolicitarEnvioHandler` y `EnviarNotificacionHandler` de `US-4.5.3`.
+- `PoliticaP11Handler` procesa atletas en forma independiente: un fallo no corta el resto.
+- Para atletas sin email, se registra `NotificacionFallida` con motivo
+  `destinatario_sin_email`, usando el soporte agregado en `US-4.5.3`.
+- No se introduce queue, rate limiting ni event bus genérico en SP4.
+- Atletas con `estado = "Retirado"` se omiten; atletas con `estado = "DNS"` se notifican.
+
+## Componentes a Implementar
+
+### 1. Application - política P-11
+
+- [x] `src/notificaciones/application/policies/politica_p11.py` (45 min)
+  - DTO `ResultadoPublicadoAtleta`
+  - DTO `PodioPublicado`
+  - DTO `ResultadosPublicados`
+  - `ResultadosPublicadosTemplatePort`
+  - `PoliticaP11Handler`
+  - clave compuesta `"{evento.id}:{resultado.atleta_id}"`
+  - omitir `estado == "Retirado"`
+  - registrar fallo por email ausente sin interrumpir la iteración
+  - continuar ante fallos técnicos por atleta
+
+- [x] `src/notificaciones/application/policies/__init__.py` (5 min)
+  - exportar P-11 junto con P-10
+
+### 2. Infrastructure - template de resultados
+
+- [x] `src/notificaciones/infrastructure/templates/resultados_publicados_template.py` (30 min)
+  - asunto `Resultados publicados - {disciplina} - {torneo_nombre}`
+  - cuerpo con atleta, disciplina, torneo, posición, RP, tarjeta y podio
+  - incluir URL de ranking si `torneo_id` está disponible
+  - representar DNS sin transformarlo
+
+- [x] `src/notificaciones/infrastructure/templates/__init__.py` (5 min)
+  - export público del template
+
+### 3. Wiring de aplicación
+
+- [x] `src/app.py` (15 min)
+  - factory `build_p11_handler()`
+  - usar repositorio SQLite, `ResendEmailAdapter` y template real
+  - mantener P-11 preparado para integración in-process futura desde `resultados`
+
+## Tests
+
+### 4. Unitarios
+
+- [x] `tests/unit/notificaciones/application/test_politica_p11.py` (40 min)
+  - envía un email por atleta
+  - idempotencia por atleta
+  - atleta sin email no interrumpe los demás
+  - fallo de proveedor en un atleta continúa con los demás
+  - atleta retirado no se notifica
+  - atleta DNS sí se notifica
+
+- [x] `tests/unit/notificaciones/infrastructure/test_resultados_publicados_template.py` (20 min)
+  - asunto correcto
+  - cuerpo contiene posición, RP, tarjeta y podio
+  - cuerpo conserva DNS
+
+### 5. Integración
+
+- [x] `tests/integration/notificaciones/test_politica_p11_integration.py` (35 min)
+  - SQLite real del BC Notificaciones
+  - fake `EmailPort`
+  - tres atletas exitosos -> tres `NotificacionEnviada`
+  - reproceso del mismo evento no duplica
+  - fallo por email ausente persiste `NotificacionFallida`
+
+### 6. BDD
+
+- [x] `tests/features/steps/politica_p11_steps.py` (40 min)
+  - automatizar `tests/features/US-4.5.4-politica-p11.feature`
+  - usar SQLite temporal y fake email adapter
+
+- [x] Ejecutar validación BDD focalizada (5 min)
+  - `uv run pytest tests/features/steps/politica_p11_steps.py -q`
+
+## Validación y Quality Gates
+
+- [x] Ejecutar suite focalizada de notificaciones (10 min)
+  - unitarios, integración y BDD de `notificaciones`
+  - BDD previos de `US-4.5.1`, `US-4.5.2`, `US-4.5.3`
+
+- [x] Ejecutar CodeGuard sobre `src/notificaciones` (5 min)
+  - guardar reporte en `quality/reports/codeguard/US-4.5.4-quality.json`
+
+## Documentación y Reporte
+
+- [x] Actualizar `docs/architecture/15-bc-notificaciones.md` (10 min)
+  - documentar P-11 y clave compuesta por atleta
+
+- [x] Actualizar `docs/design/domain-model.md` (10 min)
+  - reflejar `PoliticaP11Handler` y `ResultadosPublicadosTemplate`
+
+- [x] Actualizar `docs/traceability/matrix.md` (10 min)
+  - marcar RF-NT-04 como implementado
+
+- [x] Crear `docs/reports/US-4.5.4-report.md` (10 min)
+  - resumen de implementación
+  - validaciones ejecutadas
+  - decisiones y riesgos
+
+## Riesgos
+
+- `ResultadosPublicados` no existe aún como evento real en `resultados`; la política se
+  implementa contra DTO propio del BC Notificaciones.
+- Si un evento tiene muchos atletas, el procesamiento sigue siendo secuencial en SP4.
+  Rate limiting/background workers quedan para SP5.
+- El contenido del email usa strings ya formateados (`rp`, `tarjeta`) para evitar que
+  Notificaciones conozca reglas internas de `resultados`.
+
+## Criterio de Cierre
+
+- Feature BDD automatizada y en verde.
+- Se envía un email por atleta notificable.
+- Reprocesar el mismo `ResultadosPublicados` no duplica emails.
+- Email ausente y fallos técnicos quedan registrados sin bloquear a otros atletas.
+- Atletas DNS reciben email; atletas retirados se omiten.
+- Tests unitarios, integración y quality gate focalizado pasan.
+- Documentación y reporte final existen en disco antes del cierre del tracker.

--- a/docs/reports/US-4.5.4-report.md
+++ b/docs/reports/US-4.5.4-report.md
@@ -1,0 +1,188 @@
+# Reporte de Implementación — US-4.5.4
+## Política P-11 — emails de resultados publicados
+
+**Sprint:** SP4 — La Plataforma  
+**Incremento:** INC-4.5  
+**Branch:** `feature/US-4.5.4-politica-p11`  
+**Fecha:** 2026-04-15  
+**Estado:** Completado
+
+---
+
+## Resumen
+
+Se implementó la política P-11 del BC `notificaciones`: ante un evento de aplicación
+`ResultadosPublicados`, el sistema genera una notificación por atleta notificable y
+envía un email individual con posición, RP, tarjeta y podio de la disciplina.
+
+La implementación reutiliza los command handlers de `US-4.5.3`:
+`SolicitarEnvioHandler` y `EnviarNotificacionHandler`.
+
+La idempotencia se garantiza por atleta mediante clave compuesta:
+`"{resultados_publicados.id}:{atleta_id}"`.
+
+---
+
+## Componentes Implementados
+
+### Código
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/notificaciones/application/policies/politica_p11.py` | DTOs `ResultadosPublicados`, `ResultadoPublicadoAtleta`, `PodioPublicado` y `PoliticaP11Handler` |
+| `src/notificaciones/infrastructure/templates/resultados_publicados_template.py` | Template de email con resultado individual, podio y link al ranking |
+| `src/notificaciones/application/policies/__init__.py` | Exports públicos de P-11 |
+| `src/notificaciones/infrastructure/templates/__init__.py` | Export de `ResultadosPublicadosTemplate` |
+| `src/notificaciones/infrastructure/__init__.py` | Reexport de template de resultados |
+| `src/app.py` | Factory `build_p11_handler()` con repositorio SQLite, Resend y template real |
+
+### Tests
+
+| Archivo | Cobertura |
+|---------|-----------|
+| `tests/features/US-4.5.4-politica-p11.feature` | Escenarios BDD aprobados para P-11 |
+| `tests/features/steps/politica_p11_steps.py` | Automatización BDD con SQLite temporal y fake email |
+| `tests/unit/notificaciones/application/test_politica_p11.py` | Idempotencia por atleta, email ausente, fallo aislado, retirados y DNS |
+| `tests/unit/notificaciones/infrastructure/test_resultados_publicados_template.py` | Contenido del email y preservación de DNS |
+| `tests/integration/notificaciones/test_politica_p11_integration.py` | Persistencia real en SQLite e idempotencia end-to-end |
+
+### Documentación
+
+| Archivo | Cambio |
+|---------|--------|
+| `docs/plans/sp4/US-4.5.4-plan.md` | Plan y checklist actualizado |
+| `docs/architecture/15-bc-notificaciones.md` | Estado real del BC con P-11 |
+| `docs/design/domain-model.md` | Application layer de Notificaciones actualizada con P-11 |
+| `docs/traceability/matrix.md` | RF-NT-04 marcado como implementado |
+
+---
+
+## Decisiones de Diseño
+
+### 1. DTO propio en Notificaciones
+
+`ResultadosPublicados` es un DTO de aplicación del BC `notificaciones`, no un import
+desde `resultados`. Esto mantiene la frontera BC-first y permite conectar el evento real
+mediante composition root o ACL cuando el productor exista.
+
+### 2. Idempotencia por atleta
+
+La clave `"{evento.id}:{atleta_id}"` evita que el primer email enviado para un evento de
+publicación bloquee los emails de los demás atletas.
+
+### 3. Fallos independientes
+
+P-11 procesa cada atleta de forma independiente:
+
+- email ausente -> `NotificacionFallida(destinatario_sin_email)`;
+- error técnico del proveedor -> `NotificacionFallida`;
+- resto de atletas sigue su flujo normal.
+
+### 4. Reglas de elegibilidad
+
+- Atletas con `estado == "Retirado"` se omiten.
+- Atletas con `estado == "DNS"` reciben email, porque DNS es un resultado publicado.
+
+---
+
+## Validación Ejecutada
+
+### Tests focalizados completos
+
+```bash
+uv run pytest tests/unit/notificaciones \
+  tests/integration/notificaciones \
+  tests/features/steps/notificacion_idempotencia_steps.py \
+  tests/features/steps/adaptador_email_steps.py \
+  tests/features/steps/politica_p10_steps.py \
+  tests/features/steps/politica_p11_steps.py -q
+```
+
+Resultado:
+
+```text
+62 passed in 1.77s
+```
+
+### Unitarios P-11
+
+```bash
+uv run pytest tests/unit/notificaciones/application/test_politica_p11.py \
+  tests/unit/notificaciones/infrastructure/test_resultados_publicados_template.py -q
+```
+
+Resultado:
+
+```text
+8 passed in 0.32s
+```
+
+### Integración P-11
+
+```bash
+uv run pytest tests/integration/notificaciones/test_politica_p11_integration.py -q
+```
+
+Resultado:
+
+```text
+3 passed in 0.43s
+```
+
+### BDD P-11
+
+```bash
+uv run pytest tests/features/steps/politica_p11_steps.py -q
+```
+
+Resultado:
+
+```text
+6 passed in 0.55s
+```
+
+### CodeGuard
+
+```bash
+uv run codeguard src/notificaciones --format json \
+  > quality/reports/codeguard/US-4.5.4-quality.json
+```
+
+Resultado:
+
+```text
+0 errors
+0 warnings
+111 infos
+```
+
+---
+
+## Estado Respecto de la Spec
+
+### Cumplido
+
+- Un email enviado por atleta notificable.
+- Email personalizado con posición, RP, tarjeta y podio.
+- Idempotencia por par `(evento_publicacion, atleta_id)`.
+- Atleta sin email no interrumpe a los demás y queda como `NotificacionFallida`.
+- Fallo de proveedor en un atleta no bloquea el resto.
+- Atleta con DNS recibe email.
+- Atleta retirado se omite.
+
+### Alcance deliberado
+
+- No se implementó un event bus genérico.
+- No se conectó contra un evento real de `resultados`, porque `ResultadosPublicados`
+  aún no existe como productor en código.
+- No se implementó rate limiting ni background worker; queda diferido a SP5 si el volumen
+  real lo justifica.
+
+---
+
+## Riesgos y Próximos Pasos
+
+- Cuando `resultados` publique un evento real, hará falta mapearlo al DTO
+  `ResultadosPublicados` sin romper fronteras entre BCs.
+- RF-NT-01 sigue parcialmente implementado: email cubierto para P-10/P-11, push pendiente.
+- Si se dispara P-11 con decenas de atletas, el envío sigue siendo secuencial en SP4.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -134,10 +134,10 @@ el incremento donde se implementa y la US-IEDD candidata que lo especifica.
 
 | RF | Descripción | BC | SP | Inc. | US-IEDD candidata | Estado |
 |----|-------------|----|----|------|-------------------|--------|
-| RF-NT-01 | Notificaciones por email y push | Notificaciones | SP4 | 4.5 | US-4.5.x | 🟡 implementación parcial (`US-4.5.1`/`US-4.5.2` email base; `US-4.5.3` P-10 inscripción; push pendiente) |
+| RF-NT-01 | Notificaciones por email y push | Notificaciones | SP4 | 4.5 | US-4.5.x | 🟡 email implementado para P-10/P-11 (`US-4.5.1`..`US-4.5.4`); push pendiente |
 | RF-NT-02 | Recordatorio al atleta cuando se acerca el plazo de AP | Notificaciones | SP4 | 4.5 | US-4.5.x | ✅ definido · pendiente de implementación |
 | RF-NT-03 | Notificaciones a juez u organizador durante ejecución | Notificaciones | — | — | — | ⏳ pendiente |
-| RF-NT-04 | Notificar a atletas cuando se publican resultados finales | Notificaciones | SP4 | 4.5 | US-4.5.x | ✅ definido · pendiente de implementación (`US-4.5.4`) |
+| RF-NT-04 | Notificar a atletas cuando se publican resultados finales | Notificaciones | SP4 | 4.5 | US-4.5.x | ✅ implementado (`US-4.5.4`) |
 
 ---
 

--- a/quality/reports/codeguard/US-4.5.4-quality.json
+++ b/quality/reports/codeguard/US-4.5.4-quality.json
@@ -1,0 +1,2385 @@
+{
+  "summary": {
+    "total_files": 37,
+    "checks_executed": 6,
+    "elapsed_seconds": 49.53,
+    "timestamp": "2026-04-15T09:11:00.803470",
+    "total_issues": 111,
+    "errors": 0,
+    "warnings": 0,
+    "infos": 111
+  },
+  "results": [
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/aggregates/notificacion.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/aggregates/notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/aggregates/notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/destinatario.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/destinatario.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/destinatario.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/ports/email_port.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/ports/email_port.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/ports/email_port.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/templates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/templates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/templates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/infrastructure/email/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/infrastructure/email/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/infrastructure/email/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/policies/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/policies/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/policies/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/policies/politica_p11.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/policies/politica_p11.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/application/policies/politica_p11.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/policies/politica_p10.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/policies/politica_p10.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/application/policies/politica_p10.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/notificaciones/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/notificaciones/application/commands/solicitar_envio.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/notificaciones/application/commands/solicitar_envio.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/notificaciones/application/commands/solicitar_envio.py",
+      "line": null
+    }
+  ],
+  "by_severity": {
+    "errors": [],
+    "warnings": [],
+    "infos": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/politica_p11.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/politica_p11.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/policies/politica_p11.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      }
+    ]
+  },
+  "by_package": {
+    "aggregates": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/aggregates/notificacion.py",
+        "line": null
+      }
+    ],
+    "api": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/api/__init__.py",
+        "line": null
+      }
+    ],
+    "application": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/__init__.py",
+        "line": null
+      }
+    ],
+    "commands": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/enviar_notificacion.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/commands/solicitar_envio.py",
+        "line": null
+      }
+    ],
+    "domain": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/exceptions.py",
+        "line": null
+      }
+    ],
+    "email": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/email/resend_email_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/email/__init__.py",
+        "line": null
+      }
+    ],
+    "event_store": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/event_store/sqlite_notificacion_event_store.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/event_store/__init__.py",
+        "line": null
+      }
+    ],
+    "events": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_solicitada.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_fallida.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/events/notificacion_enviada.py",
+        "line": null
+      }
+    ],
+    "infrastructure": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/__init__.py",
+        "line": null
+      }
+    ],
+    "notificaciones": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/__init__.py",
+        "line": null
+      }
+    ],
+    "policies": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/policies/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/politica_p11.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/politica_p11.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/policies/politica_p11.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/application/policies/politica_p10.py",
+        "line": null
+      }
+    ],
+    "ports": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/email_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/ports/notificacion_repository.py",
+        "line": null
+      }
+    ],
+    "queries": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/application/queries/__init__.py",
+        "line": null
+      }
+    ],
+    "repositories": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/repositories/sqlite_notificacion_repository.py",
+        "line": null
+      }
+    ],
+    "templates": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/templates/inscripcion_confirmada_template.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/infrastructure/templates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/infrastructure/templates/resultados_publicados_template.py",
+        "line": null
+      }
+    ],
+    "value_objects": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/evento_fuente_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/notificacion_id.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/notificaciones/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/destinatario.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/contenido_email.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/notificaciones/domain/value_objects/canal_envio.py",
+        "line": null
+      }
+    ]
+  }
+}

--- a/src/app.py
+++ b/src/app.py
@@ -27,6 +27,7 @@ from notificaciones.application.commands.enviar_notificacion import (
 )
 from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
 from notificaciones.application.policies.politica_p10 import PoliticaP10Handler
+from notificaciones.application.policies.politica_p11 import PoliticaP11Handler
 from notificaciones.infrastructure.email.resend_email_adapter import ResendEmailAdapter
 from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
     SQLiteNotificacionEventStore,
@@ -36,6 +37,9 @@ from notificaciones.infrastructure.repositories.sqlite_notificacion_repository i
 )
 from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
     InscripcionConfirmadaTemplate,
+)
+from notificaciones.infrastructure.templates.resultados_publicados_template import (
+    ResultadosPublicadosTemplate,
 )
 from registro.api.router import router as registro_router
 from torneo.api.exception_handlers import register_torneo_exception_handlers
@@ -89,6 +93,21 @@ def build_p10_handler() -> PoliticaP10Handler:
             ResendEmailAdapter(),
         ),
         template=InscripcionConfirmadaTemplate(),
+    )
+
+
+def build_p11_handler() -> PoliticaP11Handler:
+    """Construye la política P-11 con adaptadores reales de Notificaciones."""
+    store = SQLiteNotificacionEventStore()
+    repository = SQLiteNotificacionRepository(store)
+    return PoliticaP11Handler(
+        repository=repository,
+        solicitar_envio_handler=SolicitarEnvioHandler(repository),
+        enviar_notificacion_handler=EnviarNotificacionHandler(
+            repository,
+            ResendEmailAdapter(),
+        ),
+        template=ResultadosPublicadosTemplate(),
     )
 
 

--- a/src/notificaciones/application/policies/__init__.py
+++ b/src/notificaciones/application/policies/__init__.py
@@ -2,5 +2,18 @@ from notificaciones.application.policies.politica_p10 import (
     InscripcionConfirmada,
     PoliticaP10Handler,
 )
+from notificaciones.application.policies.politica_p11 import (
+    PodioPublicado,
+    PoliticaP11Handler,
+    ResultadoPublicadoAtleta,
+    ResultadosPublicados,
+)
 
-__all__ = ["InscripcionConfirmada", "PoliticaP10Handler"]
+__all__ = [
+    "InscripcionConfirmada",
+    "PodioPublicado",
+    "PoliticaP10Handler",
+    "PoliticaP11Handler",
+    "ResultadoPublicadoAtleta",
+    "ResultadosPublicados",
+]

--- a/src/notificaciones/application/policies/politica_p11.py
+++ b/src/notificaciones/application/policies/politica_p11.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from notificaciones.application.commands.enviar_notificacion import (
+    EnviarNotificacionCommand,
+    EnviarNotificacionHandler,
+)
+from notificaciones.application.commands.solicitar_envio import (
+    SolicitarEnvioCommand,
+    SolicitarEnvioHandler,
+    persistir_eventos_pendientes,
+)
+from notificaciones.domain.aggregates.notificacion import Notificacion
+from notificaciones.domain.ports.notificacion_repository import NotificacionRepository
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+from notificaciones.domain.value_objects.destinatario import Destinatario
+from notificaciones.domain.value_objects.evento_fuente_id import EventoFuenteId
+
+
+@dataclass(frozen=True)
+class ResultadoPublicadoAtleta:
+    atleta_id: str
+    atleta_email: str | None
+    atleta_nombre: str
+    posicion: int | None
+    rp: str
+    tarjeta: str | None
+    estado: str = "Clasificado"
+
+
+@dataclass(frozen=True)
+class PodioPublicado:
+    posicion: int
+    atleta_nombre: str
+    rp: str
+
+
+@dataclass(frozen=True)
+class ResultadosPublicados:
+    id: str
+    torneo_id: str | None
+    torneo_nombre: str
+    disciplina: str
+    resultados: tuple[ResultadoPublicadoAtleta, ...]
+    podio: tuple[PodioPublicado, ...]
+
+
+class ResultadosPublicadosTemplatePort(Protocol):
+    def render(
+        self,
+        *,
+        evento: ResultadosPublicados,
+        resultado: ResultadoPublicadoAtleta,
+    ) -> ContenidoEmail: ...
+
+
+class PoliticaP11Handler:
+    def __init__(
+        self,
+        *,
+        repository: NotificacionRepository,
+        solicitar_envio_handler: SolicitarEnvioHandler,
+        enviar_notificacion_handler: EnviarNotificacionHandler,
+        template: ResultadosPublicadosTemplatePort,
+    ) -> None:
+        self._repository = repository
+        self._solicitar_envio_handler = solicitar_envio_handler
+        self._enviar_notificacion_handler = enviar_notificacion_handler
+        self._template = template
+
+    async def handle(self, evento: ResultadosPublicados) -> None:
+        for resultado in evento.resultados:
+            if resultado.estado == "Retirado":
+                continue
+            await self._procesar_resultado(evento, resultado)
+
+    async def _procesar_resultado(
+        self,
+        evento: ResultadosPublicados,
+        resultado: ResultadoPublicadoAtleta,
+    ) -> None:
+        evento_fuente_id = self._evento_fuente_id(evento, resultado)
+        if not resultado.atleta_email or not resultado.atleta_email.strip():
+            await self._registrar_fallo_sin_email(evento_fuente_id)
+            return
+
+        contenido = self._template.render(evento=evento, resultado=resultado)
+        notificacion_id = await self._solicitar_envio_handler.handle(
+            SolicitarEnvioCommand(
+                evento_fuente_id=evento_fuente_id,
+                destinatario=Destinatario(
+                    email=resultado.atleta_email,
+                    nombre=resultado.atleta_nombre,
+                ),
+                contenido=contenido,
+            )
+        )
+        if notificacion_id is None:
+            return
+        await self._enviar_notificacion_handler.handle(
+            EnviarNotificacionCommand(notificacion_id=notificacion_id)
+        )
+
+    async def _registrar_fallo_sin_email(self, evento_fuente_id: str) -> None:
+        if await self._repository.exists_success_by_evento_fuente_id(evento_fuente_id):
+            return
+        aggregate = Notificacion.registrar_fallo_de_solicitud(
+            evento_fuente_id=EventoFuenteId(evento_fuente_id),
+            motivo="destinatario_sin_email",
+        )
+        await persistir_eventos_pendientes(self._repository, aggregate)
+
+    def _evento_fuente_id(
+        self,
+        evento: ResultadosPublicados,
+        resultado: ResultadoPublicadoAtleta,
+    ) -> str:
+        return f"{evento.id}:{resultado.atleta_id}"

--- a/src/notificaciones/infrastructure/__init__.py
+++ b/src/notificaciones/infrastructure/__init__.py
@@ -1,6 +1,13 @@
 """Infraestructura del BC Notificaciones."""
 
 from notificaciones.infrastructure.email import ResendEmailAdapter
-from notificaciones.infrastructure.templates import InscripcionConfirmadaTemplate
+from notificaciones.infrastructure.templates import (
+    InscripcionConfirmadaTemplate,
+    ResultadosPublicadosTemplate,
+)
 
-__all__ = ["InscripcionConfirmadaTemplate", "ResendEmailAdapter"]
+__all__ = [
+    "InscripcionConfirmadaTemplate",
+    "ResendEmailAdapter",
+    "ResultadosPublicadosTemplate",
+]

--- a/src/notificaciones/infrastructure/templates/__init__.py
+++ b/src/notificaciones/infrastructure/templates/__init__.py
@@ -1,5 +1,8 @@
 from notificaciones.infrastructure.templates.inscripcion_confirmada_template import (
     InscripcionConfirmadaTemplate,
 )
+from notificaciones.infrastructure.templates.resultados_publicados_template import (
+    ResultadosPublicadosTemplate,
+)
 
-__all__ = ["InscripcionConfirmadaTemplate"]
+__all__ = ["InscripcionConfirmadaTemplate", "ResultadosPublicadosTemplate"]

--- a/src/notificaciones/infrastructure/templates/resultados_publicados_template.py
+++ b/src/notificaciones/infrastructure/templates/resultados_publicados_template.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from notificaciones.domain.value_objects.contenido_email import ContenidoEmail
+
+
+class ResultadoPublicadoLike(Protocol):
+    atleta_nombre: str
+    posicion: int | None
+    rp: str
+    tarjeta: str | None
+
+
+class PodioPublicadoLike(Protocol):
+    posicion: int
+    atleta_nombre: str
+    rp: str
+
+
+class ResultadosPublicadosLike(Protocol):
+    torneo_id: str | None
+    torneo_nombre: str
+    disciplina: str
+    podio: tuple[PodioPublicadoLike, ...]
+
+
+class ResultadosPublicadosTemplate:
+    def render(
+        self,
+        *,
+        evento: ResultadosPublicadosLike,
+        resultado: ResultadoPublicadoLike,
+    ) -> ContenidoEmail:
+        asunto = f"Resultados publicados - {evento.disciplina} - {evento.torneo_nombre}"
+        posicion = f"#{resultado.posicion}" if resultado.posicion is not None else "-"
+        tarjeta = resultado.tarjeta or "-"
+        podio = self._render_podio(evento.podio)
+        ranking_url = self._ranking_url(evento.torneo_id)
+
+        cuerpo = "\n".join(
+            [
+                f"Hola {resultado.atleta_nombre},",
+                "",
+                f"Ya estan disponibles los resultados de la disciplina {evento.disciplina}",
+                f"en el torneo {evento.torneo_nombre}.",
+                "",
+                "Tu resultado:",
+                f"  Posicion: {posicion}",
+                f"  RP: {resultado.rp}",
+                f"  Tarjeta: {tarjeta}",
+                "",
+                f"Podio {evento.disciplina}:",
+                podio,
+                "",
+                f"Ranking completo: {ranking_url}",
+                "",
+                "Felicitaciones por tu participacion!",
+                "El equipo de AtaraxiaDive",
+            ]
+        )
+        return ContenidoEmail(asunto=asunto, cuerpo_texto=cuerpo)
+
+    def _render_podio(self, podio: tuple[PodioPublicadoLike, ...]) -> str:
+        return "\n".join(
+            f"  #{item.posicion} {item.atleta_nombre} - {item.rp}"
+            for item in podio[:3]
+        )
+
+    def _ranking_url(self, torneo_id: str | None) -> str:
+        if not torneo_id:
+            return "https://ataraxiadive.app/resultados"
+        return f"https://ataraxiadive.app/resultados/{torneo_id}"

--- a/tests/features/US-4.5.4-politica-p11.feature
+++ b/tests/features/US-4.5.4-politica-p11.feature
@@ -1,0 +1,41 @@
+Feature: US-4.5.4 - Politica P-11 emails de resultados publicados
+
+  Background:
+    Given el evento ResultadosPublicados contiene 3 atletas con emails validos
+
+  Scenario: emails enviados a todos los atletas al publicar resultados
+    When se procesa la politica P-11
+    Then se crean 3 aggregates Notificacion, uno por atleta
+    And cada aggregate queda en estado "Enviada"
+    And cada atleta recibe un email con su posicion individual y el podio
+
+  Scenario: email personalizado con datos correctos
+    When se procesa la politica P-11
+    Then el email de "Martin Garcia" contiene "Posicion: #1"
+    And el email de "Martin Garcia" contiene "96m"
+    And el email de "Martin Garcia" contiene el podio con los 3 primeros clasificados
+
+  Scenario: idempotencia ante ResultadosPublicados procesado dos veces
+    Given los resultados "evt-res-001" ya fueron publicados y emails enviados
+    When la politica P-11 recibe nuevamente el evento "evt-res-001"
+    Then no se envian emails duplicados a ningun atleta
+    And el store conserva exactamente una NotificacionEnviada por par evento-atleta
+
+  Scenario: atleta sin email no interrumpe el envio a los demas
+    Given uno de los 3 atletas no tiene email registrado
+    When se procesa la politica P-11
+    Then los 2 atletas con email reciben su notificacion
+    And el atleta sin email tiene una Notificacion en estado "Fallida" con motivo "destinatario_sin_email"
+    And la publicacion de resultados no se revierte
+
+  Scenario: fallo de proveedor en un atleta continua con los demas
+    Given el proveedor de email falla solo para el primer atleta
+    When se procesa la politica P-11
+    Then el primer atleta tiene Notificacion en estado "Fallida"
+    And los atletas restantes reciben su email exitosamente
+
+  Scenario: atleta con DNS recibe email
+    Given un atleta tiene estado "DNS" en los resultados
+    When se procesa la politica P-11
+    Then ese atleta recibe el email con "DNS" como su resultado
+    And el email incluye el podio de la disciplina

--- a/tests/features/steps/politica_p11_steps.py
+++ b/tests/features/steps/politica_p11_steps.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import aiosqlite
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from notificaciones.application.commands.enviar_notificacion import EnviarNotificacionHandler
+from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
+from notificaciones.application.policies.politica_p11 import (
+    PodioPublicado,
+    PoliticaP11Handler,
+    ResultadoPublicadoAtleta,
+    ResultadosPublicados,
+)
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+from notificaciones.infrastructure.templates.resultados_publicados_template import (
+    ResultadosPublicadosTemplate,
+)
+
+scenarios("../US-4.5.4-politica-p11.feature")
+
+
+class FakeEmailPort:
+    def __init__(self) -> None:
+        self.fail_first = False
+        self.calls = 0
+        self.messages: list[dict[str, str]] = []
+
+    async def enviar(self, destinatario, contenido) -> str | None:
+        self.calls += 1
+        if self.fail_first and self.calls == 1:
+            raise RuntimeError("proveedor_no_disponible")
+        self.messages.append(
+            {
+                "to": destinatario.email,
+                "subject": contenido.asunto,
+                "body": contenido.cuerpo_texto,
+            }
+        )
+        return f"provider-{self.calls}"
+
+
+@pytest.fixture
+def ctx(tmp_path) -> dict[str, Any]:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+    handler = PoliticaP11Handler(
+        repository=repo,
+        solicitar_envio_handler=SolicitarEnvioHandler(repo),
+        enviar_notificacion_handler=EnviarNotificacionHandler(repo, email),
+        template=ResultadosPublicadosTemplate(),
+    )
+    return {
+        "db_path": db_path,
+        "repo": repo,
+        "email": email,
+        "handler": handler,
+        "evento": _evento(),
+        "error": None,
+    }
+
+
+def _base_resultados() -> tuple[ResultadoPublicadoAtleta, ...]:
+    return (
+        ResultadoPublicadoAtleta("ath-1", "martin@example.com", "Martin Garcia", 1, "96m", "Blanca"),
+        ResultadoPublicadoAtleta("ath-2", "ana@example.com", "Ana Lopez", 2, "88m", "Blanca"),
+        ResultadoPublicadoAtleta("ath-3", "diego@example.com", "Diego Vega", 3, "DNS", None, "DNS"),
+    )
+
+
+def _evento(
+    *,
+    evento_id: str = "evt-res-001",
+    resultados: tuple[ResultadoPublicadoAtleta, ...] | None = None,
+) -> ResultadosPublicados:
+    return ResultadosPublicados(
+        id=evento_id,
+        torneo_id="torneo-001",
+        torneo_nombre="Open BA 2026",
+        disciplina="DNF",
+        resultados=resultados or _base_resultados(),
+        podio=(
+            PodioPublicado(posicion=1, atleta_nombre="Martin Garcia", rp="96m"),
+            PodioPublicado(posicion=2, atleta_nombre="Ana Lopez", rp="88m"),
+            PodioPublicado(posicion=3, atleta_nombre="Diego Vega", rp="DNS"),
+        ),
+    )
+
+
+async def _events(db_path) -> list[dict[str, Any]]:
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT event_type, payload FROM notificaciones_events ORDER BY id ASC"
+        )
+        rows = await cursor.fetchall()
+    return [
+        {"event_type": row["event_type"], "payload": json.loads(row["payload"])}
+        for row in rows
+    ]
+
+
+@given("el evento ResultadosPublicados contiene 3 atletas con emails validos")
+def given_evento_tres_atletas(ctx: dict[str, Any]) -> None:
+    ctx["evento"] = _evento()
+
+
+@given(parsers.parse('los resultados "{evento_id}" ya fueron publicados y emails enviados'))
+def given_resultados_ya_publicados(ctx: dict[str, Any], evento_id: str) -> None:
+    async def _run() -> None:
+        ctx["evento"] = _evento(evento_id=evento_id)
+        await ctx["handler"].handle(ctx["evento"])
+
+    asyncio.run(_run())
+
+
+@given("uno de los 3 atletas no tiene email registrado")
+def given_un_atleta_sin_email(ctx: dict[str, Any]) -> None:
+    resultados = (
+        ResultadoPublicadoAtleta("ath-1", None, "Martin Garcia", 1, "96m", "Blanca"),
+        *_base_resultados()[1:],
+    )
+    ctx["evento"] = _evento(resultados=resultados)
+
+
+@given("el proveedor de email falla solo para el primer atleta")
+def given_falla_primer_atleta(ctx: dict[str, Any]) -> None:
+    ctx["email"].fail_first = True
+
+
+@given(parsers.parse('un atleta tiene estado "{estado}" en los resultados'))
+def given_atleta_estado(ctx: dict[str, Any], estado: str) -> None:
+    resultados = (
+        _base_resultados()[0],
+        _base_resultados()[1],
+        ResultadoPublicadoAtleta("ath-3", "diego@example.com", "Diego Vega", 3, estado, None, estado),
+    )
+    ctx["evento"] = _evento(resultados=resultados)
+
+
+@when("se procesa la politica P-11")
+def when_procesar_p11(ctx: dict[str, Any]) -> None:
+    async def _run() -> None:
+        try:
+            await ctx["handler"].handle(ctx["evento"])
+        except Exception as exc:  # noqa: BLE001
+            ctx["error"] = exc
+
+    asyncio.run(_run())
+
+
+@when(parsers.parse('la politica P-11 recibe nuevamente el evento "{evento_id}"'))
+def when_reprocesar_p11(ctx: dict[str, Any], evento_id: str) -> None:
+    ctx["evento"] = _evento(evento_id=evento_id)
+    when_procesar_p11(ctx)
+
+
+@then("se crean 3 aggregates Notificacion, uno por atleta")
+def then_tres_notificaciones(ctx: dict[str, Any]) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    assert [event["event_type"] for event in events].count("NotificacionSolicitada") == 3
+
+
+@then(parsers.parse('cada aggregate queda en estado "{estado}"'))
+def then_cada_estado(ctx: dict[str, Any], estado: str) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    if estado == "Enviada":
+        assert [event["event_type"] for event in events].count("NotificacionEnviada") == 3
+    else:
+        raise AssertionError(f"Estado no soportado: {estado}")
+
+
+@then("cada atleta recibe un email con su posicion individual y el podio")
+def then_cada_email_personalizado(ctx: dict[str, Any]) -> None:
+    assert len(ctx["email"].messages) == 3
+    assert all("Posicion:" in message["body"] for message in ctx["email"].messages)
+    assert all("Podio DNF" in message["body"] for message in ctx["email"].messages)
+
+
+@then(parsers.parse('el email de "{nombre}" contiene "{texto}"'))
+def then_email_de_contiene(ctx: dict[str, Any], nombre: str, texto: str) -> None:
+    message = next(message for message in ctx["email"].messages if nombre in message["body"])
+    assert texto in message["body"]
+
+
+@then(parsers.parse('el email de "{nombre}" contiene el podio con los 3 primeros clasificados'))
+def then_email_de_contiene_podio(ctx: dict[str, Any], nombre: str) -> None:
+    message = next(message for message in ctx["email"].messages if nombre in message["body"])
+    assert "#1 Martin Garcia - 96m" in message["body"]
+    assert "#2 Ana Lopez - 88m" in message["body"]
+    assert "#3 Diego Vega - DNS" in message["body"]
+
+
+@then("no se envian emails duplicados a ningun atleta")
+def then_no_duplicados(ctx: dict[str, Any]) -> None:
+    assert len(ctx["email"].messages) == 3
+
+
+@then("el store conserva exactamente una NotificacionEnviada por par evento-atleta")
+def then_una_enviada_por_par(ctx: dict[str, Any]) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    enviadas = [event for event in events if event["event_type"] == "NotificacionEnviada"]
+    assert len(enviadas) == 3
+    assert {event["payload"]["evento_fuente_id"] for event in enviadas} == {
+        "evt-res-001:ath-1",
+        "evt-res-001:ath-2",
+        "evt-res-001:ath-3",
+    }
+
+
+@then("los 2 atletas con email reciben su notificacion")
+def then_dos_con_email(ctx: dict[str, Any]) -> None:
+    assert len(ctx["email"].messages) == 2
+
+
+@then(
+    parsers.parse(
+        'el atleta sin email tiene una Notificacion en estado "{estado}" con motivo "{motivo}"'
+    )
+)
+def then_sin_email_fallida(ctx: dict[str, Any], estado: str, motivo: str) -> None:
+    assert estado == "Fallida"
+    events = asyncio.run(_events(ctx["db_path"]))
+    fallidas = [event for event in events if event["event_type"] == "NotificacionFallida"]
+    assert len(fallidas) == 1
+    assert fallidas[0]["payload"]["motivo"] == motivo
+
+
+@then("la publicacion de resultados no se revierte")
+def then_publicacion_no_revierte(ctx: dict[str, Any]) -> None:
+    assert ctx["error"] is None
+
+
+@then(parsers.parse('el primer atleta tiene Notificacion en estado "{estado}"'))
+def then_primer_atleta_estado(ctx: dict[str, Any], estado: str) -> None:
+    events = asyncio.run(_events(ctx["db_path"]))
+    assert estado == "Fallida"
+    assert events[1]["event_type"] == "NotificacionFallida"
+
+
+@then("los atletas restantes reciben su email exitosamente")
+def then_restantes_exitosos(ctx: dict[str, Any]) -> None:
+    assert len(ctx["email"].messages) == 2
+
+
+@then(parsers.parse('ese atleta recibe el email con "{texto}" como su resultado'))
+def then_dns_recibe_email(ctx: dict[str, Any], texto: str) -> None:
+    message = next(message for message in ctx["email"].messages if "Diego Vega" in message["body"])
+    assert texto in message["body"]
+
+
+@then("el email incluye el podio de la disciplina")
+def then_email_incluye_podio(ctx: dict[str, Any]) -> None:
+    assert any("Podio DNF" in message["body"] for message in ctx["email"].messages)

--- a/tests/integration/notificaciones/test_politica_p11_integration.py
+++ b/tests/integration/notificaciones/test_politica_p11_integration.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import aiosqlite
+import pytest
+
+from notificaciones.application.commands.enviar_notificacion import EnviarNotificacionHandler
+from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
+from notificaciones.application.policies.politica_p11 import (
+    PodioPublicado,
+    PoliticaP11Handler,
+    ResultadoPublicadoAtleta,
+    ResultadosPublicados,
+)
+from notificaciones.infrastructure.event_store.sqlite_notificacion_event_store import (
+    SQLiteNotificacionEventStore,
+)
+from notificaciones.infrastructure.repositories.sqlite_notificacion_repository import (
+    SQLiteNotificacionRepository,
+)
+from notificaciones.infrastructure.templates.resultados_publicados_template import (
+    ResultadosPublicadosTemplate,
+)
+
+
+class FakeEmailPort:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, str]] = []
+
+    async def enviar(self, destinatario, contenido) -> str | None:
+        self.messages.append({"to": destinatario.email, "body": contenido.cuerpo_texto})
+        return f"provider-{len(self.messages)}"
+
+
+def _evento(*, resultados: tuple[ResultadoPublicadoAtleta, ...] | None = None):
+    return ResultadosPublicados(
+        id="evt-res-001",
+        torneo_id="torneo-001",
+        torneo_nombre="Open BA 2026",
+        disciplina="DNF",
+        resultados=resultados
+        or (
+            ResultadoPublicadoAtleta("ath-1", "martin@example.com", "Martin Garcia", 1, "96m", "Blanca"),
+            ResultadoPublicadoAtleta("ath-2", "ana@example.com", "Ana Lopez", 2, "88m", "Blanca"),
+            ResultadoPublicadoAtleta("ath-3", "diego@example.com", "Diego Vega", 3, "DNS", None, "DNS"),
+        ),
+        podio=(
+            PodioPublicado(posicion=1, atleta_nombre="Martin Garcia", rp="96m"),
+            PodioPublicado(posicion=2, atleta_nombre="Ana Lopez", rp="88m"),
+            PodioPublicado(posicion=3, atleta_nombre="Diego Vega", rp="DNS"),
+        ),
+    )
+
+
+def _handler(repo: SQLiteNotificacionRepository, email: FakeEmailPort) -> PoliticaP11Handler:
+    return PoliticaP11Handler(
+        repository=repo,
+        solicitar_envio_handler=SolicitarEnvioHandler(repo),
+        enviar_notificacion_handler=EnviarNotificacionHandler(repo, email),
+        template=ResultadosPublicadosTemplate(),
+    )
+
+
+async def _events(db_path) -> list[dict[str, Any]]:
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT event_type, payload FROM notificaciones_events ORDER BY id ASC"
+        )
+        rows = await cursor.fetchall()
+    return [
+        {"event_type": row["event_type"], "payload": json.loads(row["payload"])}
+        for row in rows
+    ]
+
+
+@pytest.mark.asyncio
+async def test_p11_persiste_tres_envios_en_sqlite(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+
+    await _handler(repo, email).handle(_evento())
+
+    events = await _events(db_path)
+    assert len(email.messages) == 3
+    assert [event["event_type"] for event in events].count("NotificacionEnviada") == 3
+    assert await repo.exists_success_by_evento_fuente_id("evt-res-001:ath-1") is True
+    assert await repo.exists_success_by_evento_fuente_id("evt-res-001:ath-2") is True
+    assert await repo.exists_success_by_evento_fuente_id("evt-res-001:ath-3") is True
+
+
+@pytest.mark.asyncio
+async def test_p11_no_duplica_al_reprocesar_evento(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+    handler = _handler(repo, email)
+
+    await handler.handle(_evento())
+    await handler.handle(_evento())
+
+    events = await _events(db_path)
+    assert len(email.messages) == 3
+    assert [event["event_type"] for event in events].count("NotificacionEnviada") == 3
+
+
+@pytest.mark.asyncio
+async def test_p11_persiste_fallo_por_email_ausente(tmp_path) -> None:
+    db_path = tmp_path / "notificaciones.db"
+    repo = SQLiteNotificacionRepository(SQLiteNotificacionEventStore(str(db_path)))
+    email = FakeEmailPort()
+    resultados = (
+        ResultadoPublicadoAtleta("ath-1", None, "Martin Garcia", 1, "96m", "Blanca"),
+        ResultadoPublicadoAtleta("ath-2", "ana@example.com", "Ana Lopez", 2, "88m", "Blanca"),
+    )
+
+    await _handler(repo, email).handle(_evento(resultados=resultados))
+
+    events = await _events(db_path)
+    assert len(email.messages) == 1
+    assert [event["event_type"] for event in events] == [
+        "NotificacionFallida",
+        "NotificacionSolicitada",
+        "NotificacionEnviada",
+    ]
+    assert events[0]["payload"]["evento_fuente_id"] == "evt-res-001:ath-1"
+    assert events[0]["payload"]["motivo"] == "destinatario_sin_email"

--- a/tests/unit/notificaciones/application/test_politica_p11.py
+++ b/tests/unit/notificaciones/application/test_politica_p11.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notificaciones.application.commands.enviar_notificacion import EnviarNotificacionHandler
+from notificaciones.application.commands.solicitar_envio import SolicitarEnvioHandler
+from notificaciones.application.policies.politica_p11 import (
+    PodioPublicado,
+    PoliticaP11Handler,
+    ResultadoPublicadoAtleta,
+    ResultadosPublicados,
+)
+from notificaciones.infrastructure.templates.resultados_publicados_template import (
+    ResultadosPublicadosTemplate,
+)
+
+
+class FakeNotificacionRepository:
+    def __init__(self) -> None:
+        self.events_by_stream: dict[str, list[dict[str, Any]]] = {}
+
+    async def append(
+        self,
+        stream_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> None:
+        self.events_by_stream.setdefault(stream_id, []).append(
+            {
+                "event_type": event_type,
+                "payload": payload,
+                "version": len(self.events_by_stream.get(stream_id, [])) + 1,
+                "occurred_at": payload["occurred_at"],
+            }
+        )
+
+    async def load(self, stream_id: str) -> list[dict[str, Any]]:
+        return self.events_by_stream.get(stream_id, [])
+
+    async def exists_success_by_evento_fuente_id(self, evento_fuente_id: str) -> bool:
+        return any(
+            event["event_type"] == "NotificacionEnviada"
+            and event["payload"]["evento_fuente_id"] == evento_fuente_id
+            for events in self.events_by_stream.values()
+            for event in events
+        )
+
+    def event_types(self) -> list[str]:
+        return [
+            event["event_type"]
+            for events in self.events_by_stream.values()
+            for event in events
+        ]
+
+
+class FakeEmailPort:
+    def __init__(self, fail_for: set[str] | None = None) -> None:
+        self.fail_for = fail_for or set()
+        self.messages: list[dict[str, str]] = []
+
+    async def enviar(self, destinatario, contenido) -> str | None:
+        if destinatario.email in self.fail_for:
+            raise RuntimeError("proveedor_no_disponible")
+        self.messages.append(
+            {
+                "to": destinatario.email,
+                "subject": contenido.asunto,
+                "body": contenido.cuerpo_texto,
+            }
+        )
+        return f"provider-{len(self.messages)}"
+
+
+def _evento(*, resultados: tuple[ResultadoPublicadoAtleta, ...] | None = None):
+    return ResultadosPublicados(
+        id="evt-res-001",
+        torneo_id="torneo-001",
+        torneo_nombre="Open BA 2026",
+        disciplina="DNF",
+        resultados=resultados
+        or (
+            ResultadoPublicadoAtleta(
+                atleta_id="ath-1",
+                atleta_email="martin@example.com",
+                atleta_nombre="Martin Garcia",
+                posicion=1,
+                rp="96m",
+                tarjeta="Blanca",
+            ),
+            ResultadoPublicadoAtleta(
+                atleta_id="ath-2",
+                atleta_email="ana@example.com",
+                atleta_nombre="Ana Lopez",
+                posicion=2,
+                rp="88m",
+                tarjeta="BlancaConPenalizaciones",
+            ),
+            ResultadoPublicadoAtleta(
+                atleta_id="ath-3",
+                atleta_email="diego@example.com",
+                atleta_nombre="Diego Vega",
+                posicion=3,
+                rp="DNS",
+                tarjeta=None,
+                estado="DNS",
+            ),
+        ),
+        podio=(
+            PodioPublicado(posicion=1, atleta_nombre="Martin Garcia", rp="96m"),
+            PodioPublicado(posicion=2, atleta_nombre="Ana Lopez", rp="88m"),
+            PodioPublicado(posicion=3, atleta_nombre="Diego Vega", rp="DNS"),
+        ),
+    )
+
+
+def _handler(repo: FakeNotificacionRepository, email: FakeEmailPort) -> PoliticaP11Handler:
+    return PoliticaP11Handler(
+        repository=repo,
+        solicitar_envio_handler=SolicitarEnvioHandler(repo),
+        enviar_notificacion_handler=EnviarNotificacionHandler(repo, email),
+        template=ResultadosPublicadosTemplate(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_p11_envia_un_email_por_atleta() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+
+    await _handler(repo, email).handle(_evento())
+
+    assert len(email.messages) == 3
+    assert repo.event_types() == [
+        "NotificacionSolicitada",
+        "NotificacionEnviada",
+        "NotificacionSolicitada",
+        "NotificacionEnviada",
+        "NotificacionSolicitada",
+        "NotificacionEnviada",
+    ]
+    assert all("Podio DNF" in message["body"] for message in email.messages)
+
+
+@pytest.mark.asyncio
+async def test_p11_es_idempotente_por_atleta() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+    handler = _handler(repo, email)
+
+    await handler.handle(_evento())
+    await handler.handle(_evento())
+
+    assert len(email.messages) == 3
+    assert repo.event_types().count("NotificacionEnviada") == 3
+
+
+@pytest.mark.asyncio
+async def test_p11_atleta_sin_email_no_interrumpe_los_demas() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+    resultados = (
+        ResultadoPublicadoAtleta("ath-1", None, "Martin Garcia", 1, "96m", "Blanca"),
+        ResultadoPublicadoAtleta("ath-2", "ana@example.com", "Ana Lopez", 2, "88m", "Blanca"),
+    )
+
+    await _handler(repo, email).handle(_evento(resultados=resultados))
+
+    assert len(email.messages) == 1
+    assert repo.event_types() == [
+        "NotificacionFallida",
+        "NotificacionSolicitada",
+        "NotificacionEnviada",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_p11_fallo_de_proveedor_en_un_atleta_continua_con_los_demas() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort(fail_for={"martin@example.com"})
+
+    await _handler(repo, email).handle(_evento())
+
+    assert len(email.messages) == 2
+    assert repo.event_types().count("NotificacionFallida") == 1
+    assert repo.event_types().count("NotificacionEnviada") == 2
+
+
+@pytest.mark.asyncio
+async def test_p11_omite_atleta_retirado() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+    resultados = (
+        ResultadoPublicadoAtleta(
+            "ath-1", "martin@example.com", "Martin Garcia", 1, "96m", "Blanca"
+        ),
+        ResultadoPublicadoAtleta(
+            "ath-2", "ana@example.com", "Ana Lopez", None, "-", None, estado="Retirado"
+        ),
+    )
+
+    await _handler(repo, email).handle(_evento(resultados=resultados))
+
+    assert len(email.messages) == 1
+    assert "ana@example.com" not in {message["to"] for message in email.messages}
+
+
+@pytest.mark.asyncio
+async def test_p11_notifica_atleta_dns() -> None:
+    repo = FakeNotificacionRepository()
+    email = FakeEmailPort()
+
+    await _handler(repo, email).handle(_evento())
+
+    dns_email = next(message for message in email.messages if message["to"] == "diego@example.com")
+    assert "DNS" in dns_email["body"]
+    assert "Podio DNF" in dns_email["body"]

--- a/tests/unit/notificaciones/infrastructure/test_resultados_publicados_template.py
+++ b/tests/unit/notificaciones/infrastructure/test_resultados_publicados_template.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from notificaciones.application.policies.politica_p11 import (
+    PodioPublicado,
+    ResultadoPublicadoAtleta,
+    ResultadosPublicados,
+)
+from notificaciones.infrastructure.templates.resultados_publicados_template import (
+    ResultadosPublicadosTemplate,
+)
+
+
+def test_template_renderiza_resultado_y_podio() -> None:
+    evento = ResultadosPublicados(
+        id="evt-res-001",
+        torneo_id="torneo-001",
+        torneo_nombre="Open BA 2026",
+        disciplina="DNF",
+        resultados=(),
+        podio=(
+            PodioPublicado(posicion=1, atleta_nombre="Martin Garcia", rp="96m"),
+            PodioPublicado(posicion=2, atleta_nombre="Ana Lopez", rp="88m"),
+            PodioPublicado(posicion=3, atleta_nombre="Diego Vega", rp="DNS"),
+        ),
+    )
+    resultado = ResultadoPublicadoAtleta(
+        atleta_id="ath-1",
+        atleta_email="martin@example.com",
+        atleta_nombre="Martin Garcia",
+        posicion=1,
+        rp="96m",
+        tarjeta="Blanca",
+    )
+
+    contenido = ResultadosPublicadosTemplate().render(evento=evento, resultado=resultado)
+
+    assert contenido.asunto == "Resultados publicados - DNF - Open BA 2026"
+    assert "Posicion: #1" in contenido.cuerpo_texto
+    assert "RP: 96m" in contenido.cuerpo_texto
+    assert "Tarjeta: Blanca" in contenido.cuerpo_texto
+    assert "#1 Martin Garcia - 96m" in contenido.cuerpo_texto
+    assert "#2 Ana Lopez - 88m" in contenido.cuerpo_texto
+    assert "#3 Diego Vega - DNS" in contenido.cuerpo_texto
+    assert "https://ataraxiadive.app/resultados/torneo-001" in contenido.cuerpo_texto
+
+
+def test_template_conserva_dns() -> None:
+    evento = ResultadosPublicados(
+        id="evt-res-001",
+        torneo_id=None,
+        torneo_nombre="Open BA 2026",
+        disciplina="DNF",
+        resultados=(),
+        podio=(PodioPublicado(posicion=1, atleta_nombre="Diego Vega", rp="DNS"),),
+    )
+    resultado = ResultadoPublicadoAtleta(
+        atleta_id="ath-3",
+        atleta_email="diego@example.com",
+        atleta_nombre="Diego Vega",
+        posicion=1,
+        rp="DNS",
+        tarjeta=None,
+        estado="DNS",
+    )
+
+    contenido = ResultadosPublicadosTemplate().render(evento=evento, resultado=resultado)
+
+    assert "RP: DNS" in contenido.cuerpo_texto
+    assert "#1 Diego Vega - DNS" in contenido.cuerpo_texto
+    assert "https://ataraxiadive.app/resultados" in contenido.cuerpo_texto


### PR DESCRIPTION
## Resumen
- Implementa PoliticaP11Handler para ResultadosPublicados -> emails individuales a atletas.
- Agrega DTOs ResultadosPublicados, ResultadoPublicadoAtleta y PodioPublicado dentro de Notificaciones.
- Agrega ResultadosPublicadosTemplate y factory build_p11_handler().
- Implementa idempotencia por atleta con clave compuesta evento:atleta.
- Cubre DNS, Retirado, email ausente y fallos aislados del proveedor.

## Validacion
- uv run pytest tests/unit/notificaciones tests/integration/notificaciones tests/features/steps/notificacion_idempotencia_steps.py tests/features/steps/adaptador_email_steps.py tests/features/steps/politica_p10_steps.py tests/features/steps/politica_p11_steps.py -q
- uv run codeguard src/notificaciones --format json > quality/reports/codeguard/US-4.5.4-quality.json
- git diff --check

## Notas
- P-11 queda implementada contra DTO propio del BC Notificaciones.
- ResultadosPublicados todavia no existe como evento real de resultados; el mapeo queda para composition root/ACL cuando el productor este disponible.
- Push sigue fuera de scope.