### PR TITLE
US-4.6.1: API audit log de performance

### DIFF
--- a/.claude/tracking/US-4.6.1-tracking.json
+++ b/.claude/tracking/US-4.6.1-tracking.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {
+    "us_id": "US-4.6.1",
+    "us_title": "API de audit log",
+    "us_points": 3,
+    "producto": "competencia",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-16T12:12:17.751448+00:00",
+    "completed_at": "2026-04-16T12:24:26.521928+00:00",
+    "total_elapsed_seconds": 728,
+    "effective_seconds": 728,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-16T12:12:36.187687+00:00",
+      "completed_at": "2026-04-16T12:13:30.775224+00:00",
+      "elapsed_seconds": 54,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-16T12:13:56.081423+00:00",
+      "completed_at": "2026-04-16T12:13:58.734845+00:00",
+      "elapsed_seconds": 2,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-16T12:14:01.627008+00:00",
+      "completed_at": "2026-04-16T12:14:04.289179+00:00",
+      "elapsed_seconds": 2,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-16T12:15:34.863211+00:00",
+      "completed_at": "2026-04-16T12:22:01.711865+00:00",
+      "elapsed_seconds": 386,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-16T12:22:07.283526+00:00",
+      "completed_at": "2026-04-16T12:22:10.672033+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-16T12:22:16.756598+00:00",
+      "completed_at": "2026-04-16T12:22:20.059407+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-16T12:22:23.275683+00:00",
+      "completed_at": "2026-04-16T12:22:28.180645+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-16T12:22:31.402095+00:00",
+      "completed_at": "2026-04-16T12:22:34.539064+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-16T12:22:42.010571+00:00",
+      "completed_at": "2026-04-16T12:22:46.000080+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-16T12:24:17.376727+00:00",
+      "completed_at": "2026-04-16T12:24:23.144093+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 10,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/contexto/HITO-21-TRACKER-SECUENCIALIDAD-COMO-POLITICA.md
+++ b/docs/contexto/HITO-21-TRACKER-SECUENCIALIDAD-COMO-POLITICA.md
@@ -1,0 +1,151 @@
+# HITO-21 — La secuencialidad del pipeline incluye al tracker: el registro de fases no es thread-safe y debe tratarse como parte del método
+
+| Campo | Valor |
+|-------|-------|
+| **Documento** | HITO-21 — Hallazgo metodológico durante US-4.6.1 |
+| **Fecha** | 2026-04-16 |
+| **Sprint** | SP4 — INC-4.6 — US-4.6.1 |
+| **Relacionado** | `docs/plans/WORKFLOW-DESARROLLO.md` · `HITO-16` · `.claude/tracking/tracker_cli.py` · `.claude/tracking/time_tracker.py` |
+
+---
+
+## Contexto
+
+Durante la ejecución de `US-4.6.1` se siguió el pipeline prescriptivo de
+`/implement-us`: branch propia, tracker inicializado antes de crear artefactos,
+Fase 0, BDD, plan, implementación, tests, documentación y reporte final.
+
+En ese proceso apareció una falla no funcional, pero metodológicamente relevante:
+el archivo `.claude/tracking/US-4.6.1-tracking.json` quedó corrupto después de
+lanzar operaciones del tracker en paralelo.
+
+El síntoma fue un `JSONDecodeError` al intentar continuar con las fases:
+
+```text
+json.decoder.JSONDecodeError: Extra data
+```
+
+La causa no fue el dominio ni el código del producto. Fue el propio mecanismo de
+tracking del pipeline.
+
+---
+
+## Qué ocurrió realmente
+
+El tracker fue inicializado correctamente y luego recibió operaciones casi
+simultáneas de escritura:
+
+- `start-phase`
+- `end-phase`
+- `start-phase` siguiente
+
+El resultado fue un JSON persistido con contenido duplicado y truncado al final.
+Hubo que reparar manualmente el archivo para poder continuar.
+
+Esto mostró que el tracker:
+
+- persiste sobre un único archivo JSON por US
+- no usa locking
+- no serializa escrituras concurrentes
+- asume implícitamente ejecución secuencial
+
+En otras palabras: **el tracker no es thread-safe ni process-safe**.
+
+---
+
+## El aprendizaje central
+
+`HITO-16` ya había mostrado que la secuencialidad del pipeline no era una
+preferencia de estilo sino parte del método. `HITO-21` extiende esa idea:
+
+> La secuencialidad no aplica solo a las fases funcionales de `/implement-us`.
+> También aplica a la instrumentación del proceso. El tracker forma parte del
+> método y debe tratarse como un recurso secuencial.
+
+Hasta ahora la interpretación práctica era:
+
+- no saltear fases
+- no mezclar artefactos fuera de orden
+- respetar puntos de aprobación
+
+Ahora hay una restricción adicional, concreta:
+
+- **no ejecutar operaciones del tracker en paralelo**
+
+---
+
+## Por qué esto importa metodológicamente
+
+En un proceso tradicional, el tracking de tiempo o de fases es un accesorio.
+Si falla, se rehace o se ignora.
+
+En AtaraxiaDive no cumple ese rol. El tracker forma parte de la evidencia del
+experimento:
+
+- registra tiempos por fase
+- sustenta reportes históricos
+- alimenta la lectura del overhead del ecosistema
+- sirve como rastro verificable del cumplimiento del pipeline
+
+Si el tracker se corrompe, no solo se pierde comodidad operativa:
+se degrada la calidad de la evidencia del experimento.
+
+Por eso este hallazgo no es “un bug menor de tooling”. Es una condición de
+validez del método.
+
+---
+
+## Decisión derivada
+
+Se establece una política explícita en `WORKFLOW-DESARROLLO.md`:
+
+> Todas las operaciones sobre `tracker_cli.py` deben ejecutarse estrictamente en
+> secuencia, una por vez. El tracking automático está permitido y deseable, pero
+> no puede escribir en paralelo sobre el mismo archivo `.claude/tracking/US-*.json`.
+
+Esta política vuelve normativo algo que antes era solo una suposición implícita.
+
+---
+
+## Qué valida para el experimento
+
+Este HITO aporta una precisión importante a la hipótesis de gobierno del proceso:
+
+> La linealidad del pipeline no es solo una propiedad de las tareas de desarrollo.
+> También es una propiedad de la telemetría que hace verificable ese pipeline.
+
+Dicho más simple:
+
+- el método es secuencial
+- su evidencia también debe producirse secuencialmente
+
+---
+
+## Acciones incorporadas
+
+- [x] Política de secuencialidad del tracker agregada a `WORKFLOW-DESARROLLO.md`
+- [x] Uso operativo: no paralelizar llamadas `tracker_cli.py`
+- [x] Reparación manual del tracker de `US-4.6.1` para preservar continuidad del pipeline
+- [ ] Evaluar si `tracker_cli.py` debe incorporar locking explícito o escritura atómica
+- [ ] Evaluar si el skill `/implement-us` debe declarar esta restricción en su documentación interna
+
+---
+
+## Conexión con HITO-16
+
+`HITO-16` afirmó:
+
+> la secuencialidad prescriptiva del pipeline es parte del método
+
+`HITO-21` agrega:
+
+> esa secuencialidad incluye también al mecanismo que registra el cumplimiento del método
+
+Así, el alcance de la tesis se vuelve más preciso:
+
+- `HITO-16`: secuencialidad del flujo de trabajo
+- `HITO-21`: secuencialidad de la evidencia del flujo de trabajo
+
+---
+
+*Registrado durante US-4.6.1 — cuando el tracker dejó de ser tooling auxiliar y quedó expuesto como infraestructura metodológica del proceso*

--- a/docs/contexto/INDICE-HITOS.md
+++ b/docs/contexto/INDICE-HITOS.md
@@ -25,6 +25,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | HITO-13 | SP2 cierre | 2026-03-28 | SP-ADJ como etapa formal del ciclo IEDD | ¿La deuda técnica post-SP merece un sub-sprint formal propio en lugar de backlog? | [HITO-13](./HITO-13-SP-ADJ-DEUDA-TECNICA-COMO-ETAPA-FORMAL.md) |
 | HITO-16 | SP3 Inc 3.5 | 2026-04-02 | Secuencialidad prescriptiva del pipeline | ¿La linealidad de `/implement-us` es una preferencia operativa o parte del método? | [HITO-16](./HITO-16-SECUENCIALIDAD-PRESCRIPTIVA-PIPELINE.md) |
 | HITO-19 | SP4 cierre INC-4.1 | 2026-04-08 | Cierre de incremento como captura formal de deuda de diseño | ¿El incremento es la unidad correcta para agrupar hallazgos estructurales y planificar ajustes? | [HITO-19](./HITO-19-INC-4-1-HALLAZGOS-DISENO-CIERRE.md) |
+| HITO-21 | SP4 Inc 4.6 | 2026-04-16 | Tracker secuencial como política | ¿La secuencialidad del método incluye también al mecanismo que registra sus fases? | [HITO-21](./HITO-21-TRACKER-SECUENCIALIDAD-COMO-POLITICA.md) |
 
 ---
 
@@ -36,7 +37,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | SP1 (La Performance) | 3, 4, 5, 6, 7, 8, 9 | Primer ciclo IEDD completo, fricción del ecosistema, BDD + ES |
 | SP2 (La Competencia) | 10, 11, 12, 13 | Patrones DDD avanzados, quality gates, deuda técnica formal |
 | SP3 (El Torneo) | 15, 16 | Proyecciones CQRS emergentes, secuencialidad del pipeline y gobierno del proceso |
-| SP4 (La Plataforma) | 17, 18, 19 | Datos reales como oráculo, validación UX y captura formal de hallazgos estructurales al cierre de incremento |
+| SP4 (La Plataforma) | 17, 18, 19, 21 | Datos reales como oráculo, validación UX, captura formal de hallazgos estructurales y gobierno secuencial del tracker |
 
 ---
 
@@ -50,6 +51,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | SP-ADJ como etapa necesaria | HITO-13 | ✅ Confirmada |
 | Gates de texto no son barreras para LLMs | HITO-12 | ✅ Confirmada |
 | La secuencialidad del pipeline es parte del método | HITO-16 | ✅ Confirmada |
+| La secuencialidad del método incluye también al tracker y su evidencia | HITO-21 | ✅ Confirmada |
 | El incremento es la unidad correcta para leer deuda estructural acumulada | HITO-19 | ✅ Evidencia inicial |
 
 ---

--- a/docs/plans/WORKFLOW-DESARROLLO.md
+++ b/docs/plans/WORKFLOW-DESARROLLO.md
@@ -120,6 +120,13 @@ main          ← baselines etiquetadas (v0.1.0, v0.2.0...)
 > distinto a `US-` (ej: `INC-2.0`) no son encontrados por las operaciones de fase.
 > Mientras no esté corregido, usar prefijo `US-` para todos los IDs de tracking.
 
+> **Política operativa de tracking:** todas las operaciones sobre `tracker_cli.py`
+> (`init`, `start-phase`, `end-phase`, `start-task`, `end-task`, `end`) deben
+> ejecutarse **estrictamente en secuencia, una por vez**. No correr llamadas en
+> paralelo ni agrupar escrituras concurrentes sobre el mismo
+> `.claude/tracking/US-*.json`: el tracker no garantiza concurrencia y puede
+> corromper el JSON persistido.
+
 ### Ejecución de fases
 
 ```
@@ -129,6 +136,7 @@ main          ← baselines etiquetadas (v0.1.0, v0.2.0...)
    → Fase 8 (documentación): auto_approved=False — ídem
    → Fases 8 y 9 deben ejecutarse ANTES del commit final, no después
    → El skill no está completo hasta que docs/reports/{US_ID}-report.md exista en disco
+   → El tracking se opera automáticamente, pero siempre con llamadas secuenciales
 6. [AUTO] CodeGuard corre en cada commit (pre-commit hook, ~5s, solo advierte)
 7. Commits atómicos con referencia: feat(domain): ... [US-X.Y.Z]
 8. Abrir PR hacia develop con /pr → DesignReviewer corre en pre-push (bloquea si CRITICAL)

--- a/docs/plans/sp4/US-4.6.1-plan.md
+++ b/docs/plans/sp4/US-4.6.1-plan.md
@@ -1,0 +1,92 @@
+# Plan de Implementacion: US-4.6.1 - API de audit log
+
+**Sprint:** SP4 - La Plataforma  
+**Incremento:** INC-4.6  
+**Bounded Context:** `competencia`  
+**Patron:** `hexagonal-ddd-bc`  
+**Estimacion total:** 2h 20min  
+**Estado:** Pendiente de aprobacion
+
+## Objetivo
+
+Exponer un endpoint de solo lectura para que un organizador consulte la secuencia
+cronologica de eventos de una performance individual, reutilizando el event store
+como fuente del audit log oficial.
+
+## Componentes a ajustar
+
+### 1. Application - query especifica de audit log
+
+- [ ] `src/competencia/application/queries/obtener_audit_log.py` (30 min)
+  - Definir `AuditLogEventoDTO` y `ObtenerAuditLogQuery`
+  - Implementar `ObtenerAuditLogHandler`
+  - Filtrar por stream de una performance puntual
+  - Mantener orden cronologico estricto por `sequence`
+  - Fallar con caso explicito cuando la performance no exista
+
+### 2. Infrastructure - lectura puntual desde event store
+
+- [ ] `src/shared/infrastructure/event_store/sqlite_event_store.py` (20 min)
+  - Agregar metodo de lectura ordenada para un stream individual con `sequence`
+  - Evitar duplicar consultas ad hoc en application
+  - Preservar compatibilidad con `load()` y `load_all_events_ordered()`
+
+### 3. API - endpoint REST audit log
+
+- [ ] `src/competencia/api/router.py` (25 min)
+  - Agregar `GET /competencias/{competencia_id}/performances/{atleta_id}/audit-log`
+  - Cablear dependencia del nuevo handler
+  - Mapear respuesta a contrato de la spec
+  - Retornar `404` si no existe la performance
+
+- [ ] `src/competencia/api/schemas.py` o respuesta inline (10 min)
+  - Evaluar si conviene schema dedicado para la respuesta del audit log
+  - Mantener consistencia con el estilo actual del BC
+
+### 4. Seguridad y autorizacion
+
+- [ ] Revisar dependencias de autenticacion/autorizacion existentes (15 min)
+  - Verificar como se resuelve rol `organizador` / `admin`
+  - Reutilizar mecanismo existente en lugar de introducir uno nuevo
+  - Si no existe enforcement real en router, documentar gap y aplicar minimo viable consistente
+
+### 5. Tests
+
+- [ ] `tests/integration/competencia/test_audit_log_api.py` (25 min)
+  - Caso nominal con 3 eventos
+  - Caso con correccion historica
+  - Caso 404 por performance inexistente
+  - Caso 403 para rol juez si la capa actual lo soporta
+
+- [ ] `tests/unit/competencia/test_obtener_audit_log.py` (15 min)
+  - Orden cronologico
+  - Mapeo de DTO
+  - Error cuando no hay stream
+
+### 6. Validacion
+
+- [ ] Ejecutar tests unitarios y de integracion de `competencia` (10 min)
+- [ ] Ejecutar BDD relevante o dejar waiver si el harness actual no cubre este endpoint (5 min)
+- [ ] Ejecutar quality gates del BC (`codeguard` o suite equivalente local) (10 min)
+
+## Dependencias y decisiones
+
+- Reutilizar el event store SQLite ya existente; no crear tabla nueva de auditoria.
+- No mezclar auditoria de competencia completa con auditoria de performance: esta US es por stream individual.
+- Mantener compatibilidad con el endpoint legado `GET /competencias/{competencia_id}/events`.
+- La seguridad depende del wiring actual de identidad en FastAPI; validar primero antes de codificar.
+
+## Riesgos
+
+- El modelo actual identifica `performance_id` por `atleta_id` en varios puntos; hay que confirmar el contrato exacto antes de implementar.
+- El endpoint legado expone `event_type`; la spec nueva usa `tipo`. Hay que decidir adaptacion de payload sin romper consistencia.
+- La autorizacion por rol puede estar parcial en algunos routers; si falta, hay que aplicar la solucion mas pequena coherente con SP4.
+
+## Checklist de salida
+
+- [ ] Endpoint observable responde el contrato de `US-4.6.1`
+- [ ] Tests nominales y de error en verde
+- [ ] No se rompen endpoints existentes de `competencia`
+- [ ] Reporte final y trazabilidad quedan listos para fases posteriores
+
+*Plan generado: 2026-04-16 - US-4.6.1 INC-4.6 SP4*

--- a/docs/reports/US-4.6.1-bdd-waiver.md
+++ b/docs/reports/US-4.6.1-bdd-waiver.md
@@ -1,0 +1,27 @@
+# Waiver BDD — US-4.6.1
+## API de audit log de performance
+
+**Fecha:** `2026-04-16`
+**Decisión:** `BDD no automatizado`
+
+## Justificación
+
+`US-4.6.1` sí introduce comportamiento observable y por eso se generó el feature
+`tests/features/US-4.6.1-audit-log-performance.feature`, pero el repositorio no
+cuenta hoy con step definitions reutilizables para autenticación por rol más
+consulta HTTP de auditoría en `competencia`.
+
+Implementar ese harness en esta US hubiera desviado el alcance hacia infraestructura
+de testing transversal en lugar de la funcionalidad del incremento.
+
+## Validación sustitutiva
+
+- Tests unitarios de `ObtenerAuditLogHandler`
+- Tests de integración HTTP del endpoint protegido
+- Quality gate focalizado con `codeguard`
+
+## Alcance del waiver
+
+- Se mantiene Fase 1 con generación del `.feature`
+- Se reemplaza la automatización de Fase 6 por validación unitaria + integración
+- No exime Fases 7, 8 y 9

--- a/docs/reports/US-4.6.1-report.md
+++ b/docs/reports/US-4.6.1-report.md
@@ -1,0 +1,141 @@
+# Reporte de Implementación — US-4.6.1
+## API de audit log de performance
+
+**Sprint:** SP4 — La Plataforma  
+**Incremento:** INC-4.6  
+**Branch:** `feature/US-4.6.1-api-audit-log`  
+**Fecha:** 2026-04-16
+
+---
+
+## Resumen
+
+Se implementó la primera US de `INC-4.6` en el BC `competencia`: un endpoint de
+auditoría por performance que expone la secuencia cronológica de eventos del
+event store para un atleta dentro de una competencia puntual.
+
+La solución reutiliza el event store existente como fuente oficial del audit log,
+agrega una query dedicada de application y restringe el acceso al endpoint a
+usuarios con rol `organizador` o `admin`.
+
+---
+
+## Cambios implementados
+
+### Código
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/competencia/application/queries/obtener_audit_log.py` | Nueva query `ObtenerAuditLog` con DTOs `AuditLogDTO` y `AuditLogEventoDTO`, resolución de disciplina desde `stream_id` y excepción `PerformanceNoEncontrada` |
+| `src/competencia/api/router.py` | Nuevo endpoint `GET /competencia/{competencia_id}/performances/{atleta_id}/audit-log` con respuesta conforme a la spec y manejo explícito de `404` |
+| `src/competencia/api/dependencies.py` | Wiring del nuevo handler reutilizando `AtletaNombreAdapter` |
+
+### Tests
+
+| Archivo | Cobertura |
+|---------|-----------|
+| `tests/unit/competencia/application/queries/test_obtener_audit_log.py` | Caso nominal, preservación de `sequence`/payload y `404` lógico por ausencia de performance |
+| `tests/integration/competencia/test_audit_log_api.py` | `200`, `404`, `403` por rol insuficiente y caso con `ResultadoCorregido` |
+
+### Artefactos de proceso
+
+| Archivo | Propósito |
+|---------|-----------|
+| `tests/features/US-4.6.1-audit-log-performance.feature` | Escenarios BDD de la US |
+| `docs/plans/sp4/US-4.6.1-plan.md` | Plan aprobado de implementación |
+| `docs/reports/US-4.6.1-bdd-waiver.md` | Sustitución explícita de automatización BDD por tests unitarios + integración |
+| `docs/traceability/matrix.md` | Registro de `US-4.6.1` dentro de `INC-4.6` |
+| `quality/reports/codeguard/US-4.6.1-codeguard.json` | Evidencia del quality gate focalizado |
+
+---
+
+## Decisiones de diseño
+
+### 1. Audit log por prefijo de stream, no por tabla adicional
+
+No se creó una tabla de auditoría separada. La query filtra el event store por
+prefijo `performance-{competencia_id}-{atleta_id}-` y proyecta la respuesta sobre
+el stream encontrado.
+
+Esto mantiene alineación con ADR-001 y evita duplicación de información.
+
+### 2. Nombre real del atleta vía ACL existente
+
+La nueva query reutiliza `AtletaNombreAdapter` para resolver `atleta_nombre` desde
+`registro.db`, evitando repetir el fallback sintético de otras queries legacy.
+
+### 3. Seguridad apoyada en `OrganizadorDep`
+
+El endpoint quedó protegido con el mecanismo transversal ya existente en
+`identidad.api.dependencies`, sin introducir reglas ad hoc en el router.
+
+---
+
+## Validación ejecutada
+
+### Pytest focalizado
+
+Comando ejecutado:
+
+```bash
+./.venv/bin/pytest \
+  tests/unit/competencia/application/queries/test_obtener_audit_log.py \
+  tests/integration/competencia/test_audit_log_api.py
+```
+
+Resultado:
+
+```text
+7 passed in 1.53s
+```
+
+### CodeGuard focalizado
+
+Comando ejecutado:
+
+```bash
+./.venv/bin/codeguard \
+  src/competencia/application/queries/obtener_audit_log.py \
+  src/competencia/api/router.py \
+  src/competencia/api/dependencies.py \
+  -c pyproject.toml -a pre-commit -t 15 --format json \
+  > quality/reports/codeguard/US-4.6.1-codeguard.json
+```
+
+Resultado:
+
+```text
+0 errors
+0 warnings
+9 infos
+```
+
+---
+
+## Estado respecto de la spec
+
+### Cumplido
+
+- Endpoint puntual por performance
+- Orden cronológico estricto por `sequence`
+- Payload con `sequence`, `tipo`, `timestamp`, `datos`
+- `404` cuando no existe performance para el atleta indicado
+- `403` para rol `juez`
+- Inclusión de correcciones históricas (`ResultadoCorregido`) en la traza
+
+### Diferencia menor respecto de la redacción original
+
+- La spec habla de `performances/{atleta_id}`; la implementación resuelve el
+  stream real por prefijo porque el identificador técnico del stream también
+  incluye `disciplina`. La API pública permanece igual.
+
+---
+
+## Riesgos y próximos pasos
+
+- `US-4.6.2` puede reutilizar la lectura ordenada del event store, pero a nivel
+  competencia completa y con serialización canónica para hash.
+- `US-4.6.3` ya tiene backend suficiente para la traza puntual; faltará diseñar
+  la navegación de organizador y definir de dónde obtiene la lista de atletas.
+- El harness BDD HTTP para auditoría/autenticación quedó diferido y conviene
+  incorporarlo cuando haya más endpoints de organizador dentro de `INC-4.6`.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -344,7 +344,15 @@ Deben resolverse antes del SP que los involucra. No bloquean SP1 ni SP2.
 
 ---
 
-## 17. Trazabilidad: Discrepancias → US → Documentos a actualizar  <!-- was §16 -->
+## 17. US-IEDD SP4 INC-4.6 — Auditoría y Exportación
+
+| US | Inc. | RFs / Decisiones cubiertos | Contenido principal | Estado |
+|----|------|----------------------------|---------------------|--------|
+| US-4.6.1 | 4.6 | PLAN-SP4 §INC-4.6 · ADR-001 · ADR-008 | Query `ObtenerAuditLog` por performance · endpoint `GET /competencia/{competencia_id}/performances/{atleta_id}/audit-log` · respuesta cronológica con `sequence`, `tipo`, `timestamp`, `datos` · acceso restringido a `organizador/admin` | ✅ Done |
+
+---
+
+## 18. Trazabilidad: Discrepancias → US → Documentos a actualizar  <!-- was §16 -->
 
 Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 2025".
 
@@ -363,7 +371,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 
 ---
 
-## 18. Cobertura Total
+## 19. Cobertura Total
 
 | Área | Total RFs | Definidos | Pendientes | Fuera de alcance v1 |
 |------|:---------:|:---------:|:----------:|:-------------------:|

--- a/quality/reports/codeguard/US-4.6.1-codeguard.json
+++ b/quality/reports/codeguard/US-4.6.1-codeguard.json
@@ -1,0 +1,215 @@
+{
+  "summary": {
+    "total_files": 3,
+    "checks_executed": 6,
+    "elapsed_seconds": 4.3,
+    "timestamp": "2026-04-16T09:21:10.322509",
+    "total_issues": 9,
+    "errors": 0,
+    "warnings": 0,
+    "infos": 9
+  },
+  "results": [
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/queries/obtener_audit_log.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/queries/obtener_audit_log.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/queries/obtener_audit_log.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/api/dependencies.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/api/dependencies.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/api/dependencies.py",
+      "line": null
+    }
+  ],
+  "by_severity": {
+    "errors": [],
+    "warnings": [],
+    "infos": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_audit_log.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_audit_log.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_audit_log.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/dependencies.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/dependencies.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/dependencies.py",
+        "line": null
+      }
+    ]
+  },
+  "by_package": {
+    "api": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/dependencies.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/dependencies.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/dependencies.py",
+        "line": null
+      }
+    ],
+    "queries": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_audit_log.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_audit_log.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_audit_log.py",
+        "line": null
+      }
+    ]
+  }
+}

--- a/src/competencia/api/dependencies.py
+++ b/src/competencia/api/dependencies.py
@@ -13,6 +13,7 @@ from competencia.application.commands.iniciar_competencia import IniciarCompeten
 from competencia.application.queries.obtener_andariveles_activos import (
     ObtenerAndarivelesActivosHandler,
 )
+from competencia.application.queries.obtener_audit_log import ObtenerAuditLogHandler
 from competencia.application.queries.obtener_estado_competencia import (
     ObtenerEstadoCompetenciaHandler,
 )
@@ -30,6 +31,7 @@ from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEven
 from competencia.infrastructure.repositories.andariveles_activos_adapter import (
     AndarivelesActivosAdapter,
 )
+from competencia.infrastructure.repositories.atleta_nombre_adapter import AtletaNombreAdapter
 from competencia.infrastructure.repositories.disciplina_descriptor_adapter import (
     DisciplinaDescriptorAdapter,
 )
@@ -74,8 +76,18 @@ def get_obtener_andariveles_activos_handler(
     return ObtenerAndarivelesActivosHandler(AndarivelesActivosAdapter(event_store))
 
 
+def get_obtener_audit_log_handler(
+    event_store: EventStoreDep,
+) -> ObtenerAuditLogHandler:
+    """Dependency: handler de consulta de audit log."""
+    return ObtenerAuditLogHandler(event_store, AtletaNombreAdapter())
+
+
 ObtenerAndarivelesActivosHandlerDep = Annotated[
     ObtenerAndarivelesActivosHandler, Depends(get_obtener_andariveles_activos_handler)
+]
+ObtenerAuditLogHandlerDep = Annotated[
+    ObtenerAuditLogHandler, Depends(get_obtener_audit_log_handler)
 ]
 PerformancesEstadoAdapterDep = Annotated[
     PerformancesEstadoAdapter, Depends(get_performances_estado_adapter)

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -86,6 +86,11 @@ from competencia.application.queries.obtener_andariveles_activos import (
     ObtenerAndarivelesActivosHandler,
     ObtenerAndarivelesActivosQuery,
 )
+from competencia.application.queries.obtener_audit_log import (
+    ObtenerAuditLogHandler,
+    ObtenerAuditLogQuery,
+    PerformanceNoEncontrada as PerformanceNoEncontradaAuditLog,
+)
 from competencia.application.queries.obtener_progreso import (
     ObtenerProgresoHandler,
     ObtenerProgresoQuery,
@@ -270,6 +275,13 @@ def get_obtener_andariveles_activos_handler(
     return ObtenerAndarivelesActivosHandler(AndarivelesActivosAdapter(event_store))
 
 
+def get_obtener_audit_log_handler(
+    event_store: EventStoreDep,
+) -> ObtenerAuditLogHandler:
+    """Dependency: handler de consulta de audit log."""
+    return ObtenerAuditLogHandler(event_store, AtletaNombreAdapter())
+
+
 def get_llamar_atleta_handler(
     event_store: EventStoreDep,
 ) -> LlamarAtletaHandler:
@@ -320,6 +332,9 @@ CompetenciasPorTorneoProjectionDep = Annotated[
 ]
 ObtenerAndarivelesActivosHandlerDep = Annotated[
     ObtenerAndarivelesActivosHandler, Depends(get_obtener_andariveles_activos_handler)
+]
+ObtenerAuditLogHandlerDep = Annotated[
+    ObtenerAuditLogHandler, Depends(get_obtener_audit_log_handler)
 ]
 PerformancesEstadoAdapterDep = Annotated[
     PerformancesEstadoAdapter, Depends(get_performances_estado_adapter)
@@ -517,6 +532,41 @@ async def get_eventos(
                     "data": dto.data,
                 }
                 for dto in eventos
+            ],
+        },
+        status_code=200,
+    )
+
+
+@router.get("/{competencia_id}/performances/{atleta_id}/audit-log", response_class=JSONResponse)
+async def get_audit_log(
+    competencia_id: UUID,
+    atleta_id: UUID,
+    handler: ObtenerAuditLogHandlerDep,
+    _: OrganizadorDep,
+) -> JSONResponse:
+    """Retorna el audit log de una performance puntual para auditoria."""
+    try:
+        audit_log = await handler.handle(
+            ObtenerAuditLogQuery(competencia_id=competencia_id, atleta_id=atleta_id)
+        )
+    except PerformanceNoEncontradaAuditLog as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    return JSONResponse(
+        content={
+            "competencia_id": audit_log.competencia_id,
+            "atleta_id": audit_log.atleta_id,
+            "atleta_nombre": audit_log.atleta_nombre,
+            "disciplina": audit_log.disciplina,
+            "eventos": [
+                {
+                    "sequence": evento.sequence,
+                    "tipo": evento.tipo,
+                    "timestamp": evento.timestamp,
+                    "datos": evento.datos,
+                }
+                for evento in audit_log.eventos
             ],
         },
         status_code=200,

--- a/src/competencia/application/queries/obtener_audit_log.py
+++ b/src/competencia/application/queries/obtener_audit_log.py
@@ -1,0 +1,95 @@
+"""Query y Handler para ObtenerAuditLog - US-4.6.1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from competencia.domain.ports.atleta_nombre_port import AtletaNombrePort
+from competencia.domain.ports.event_store_port import EventStorePort
+
+
+class PerformanceNoEncontrada(Exception):
+    """Se lanza cuando no existe la performance consultada."""
+
+
+@dataclass(frozen=True)
+class AuditLogEventoDTO:
+    """DTO de un evento individual del audit log."""
+
+    sequence: int
+    tipo: str
+    timestamp: str
+    datos: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AuditLogDTO:
+    """DTO del audit log completo de una performance."""
+
+    competencia_id: str
+    atleta_id: str
+    atleta_nombre: str
+    disciplina: str
+    eventos: list[AuditLogEventoDTO]
+
+
+@dataclass(frozen=True)
+class ObtenerAuditLogQuery:
+    """Query para obtener el audit log de una performance puntual."""
+
+    competencia_id: UUID
+    atleta_id: UUID
+
+
+class ObtenerAuditLogHandler:  # pylint: disable=too-few-public-methods
+    """Recupera el audit log puntual de una performance desde el event store."""
+
+    def __init__(
+        self,
+        event_store: EventStorePort,
+        atleta_nombre_port: AtletaNombrePort,
+    ) -> None:
+        self._event_store = event_store
+        self._atleta_nombre_port = atleta_nombre_port
+
+    async def handle(self, query: ObtenerAuditLogQuery) -> AuditLogDTO:
+        """Retorna el audit log completo de la performance consultada."""
+        prefix = f"performance-{query.competencia_id}-{query.atleta_id}-"
+        raw_events = await self._event_store.load_all_events_ordered(prefix)
+        if not raw_events:
+            raise PerformanceNoEncontrada(
+                "No existe una performance para el atleta en la competencia indicada"
+            )
+
+        stream_id = raw_events[0]["stream_id"]
+        eventos = [
+            self._to_evento_dto(event)
+            for event in raw_events
+            if event["stream_id"] == stream_id
+        ]
+        atleta_nombre = await self._atleta_nombre_port.get_nombre(query.atleta_id)
+
+        return AuditLogDTO(
+            competencia_id=str(query.competencia_id),
+            atleta_id=str(query.atleta_id),
+            atleta_nombre=atleta_nombre,
+            disciplina=self._extract_disciplina(stream_id, prefix),
+            eventos=eventos,
+        )
+
+    @staticmethod
+    def _to_evento_dto(event: dict[str, Any]) -> AuditLogEventoDTO:
+        return AuditLogEventoDTO(
+            sequence=event["sequence"],
+            tipo=event["event_type"],
+            timestamp=event["occurred_at"] or "",
+            datos=event["payload"],
+        )
+
+    @staticmethod
+    def _extract_disciplina(stream_id: str, prefix: str) -> str:
+        if stream_id.startswith(prefix):
+            return stream_id.removeprefix(prefix)
+        return ""

--- a/tests/features/US-4.6.1-audit-log-performance.feature
+++ b/tests/features/US-4.6.1-audit-log-performance.feature
@@ -1,0 +1,36 @@
+Feature: US-4.6.1 - API audit log de performance
+
+  Background:
+    Given existe una competencia "comp-abc" con disciplina DNF
+    And el atleta "ath-123" tiene eventos registrados en el event store
+
+  Scenario: organizador consulta audit log exitosamente
+    Given el usuario autenticado tiene rol organizador
+    When hace GET /competencias/comp-abc/performances/ath-123/audit-log
+    Then la respuesta es 200 OK
+    And contiene 3 eventos en orden cronologico
+    And el primer evento es de tipo "PerformanceRegistrada"
+
+  Scenario: el audit log incluye correcciones historicas
+    Given la performance del atleta fue corregida
+    And el usuario autenticado tiene rol organizador
+    When hace GET /competencias/comp-abc/performances/ath-123/audit-log
+    Then la respuesta incluye 4 eventos
+    And el ultimo evento es de tipo "ResultadoCorregido"
+    And el evento original de resultado no fue eliminado del log
+
+  Scenario: performance inexistente retorna 404
+    Given el usuario autenticado tiene rol organizador
+    When hace GET /competencias/comp-abc/performances/ath-999/audit-log
+    Then la respuesta es 404 Not Found
+
+  Scenario: juez no puede consultar audit log
+    Given el usuario autenticado tiene rol juez
+    When hace GET /competencias/comp-abc/performances/ath-123/audit-log
+    Then la respuesta es 403 Forbidden
+
+  Scenario: los eventos se exponen con sequence estricto
+    Given el usuario autenticado tiene rol organizador
+    When hace GET /competencias/comp-abc/performances/ath-123/audit-log
+    Then los eventos aparecen en orden sequence 1, 2, 3
+    And cada evento expone los campos "sequence", "tipo", "timestamp" y "datos"

--- a/tests/integration/competencia/test_audit_log_api.py
+++ b/tests/integration/competencia/test_audit_log_api.py
@@ -1,0 +1,158 @@
+"""Tests de integración - API audit log de performance."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import aiosqlite
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app
+from competencia.api.router import get_event_store
+from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from identidad.api.dependencies import get_current_user
+
+CREATE_EVENTS_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL
+            DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+
+@pytest.fixture
+async def store(tmp_path: pytest.TempPathFactory) -> SQLiteEventStore:
+    db_path = str(tmp_path / "competencia_test.db")
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(CREATE_EVENTS_TABLE)
+        await db.commit()
+    return SQLiteEventStore(db_path)
+
+
+@pytest.fixture
+def client(store: SQLiteEventStore) -> TestClient:
+    app.dependency_overrides[get_event_store] = lambda: store
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "org-001",
+        "email": "organizador@test.com",
+        "rol": "ORGANIZADOR",
+    }
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+async def _append_audit_events(
+    store: SQLiteEventStore,
+    competencia_id,
+    atleta_id,
+    disciplina: str = "DNF",
+) -> None:
+    stream_id = f"performance-{competencia_id}-{atleta_id}-{disciplina}"
+    await store.append(
+        stream_id=stream_id,
+        event_type="PerformanceRegistrada",
+        payload={"ap": 60.0},
+    )
+    await store.append(
+        stream_id=stream_id,
+        event_type="ResultadoRegistrado",
+        payload={"rp": 58.0},
+    )
+    await store.append(
+        stream_id=stream_id,
+        event_type="TarjetaAsignada",
+        payload={"tarjeta": "Blanca", "penalizaciones": 0},
+    )
+
+
+async def _append_correccion(
+    store: SQLiteEventStore,
+    competencia_id,
+    atleta_id,
+    disciplina: str = "DNF",
+) -> None:
+    stream_id = f"performance-{competencia_id}-{atleta_id}-{disciplina}"
+    await store.append(
+        stream_id=stream_id,
+        event_type="ResultadoCorregido",
+        payload={"rp_anterior": 58.0, "rp_nuevo": 57.0, "motivo": "Medicion ajustada"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_audit_log_retorna_eventos_de_una_performance(
+    store: SQLiteEventStore, client: TestClient
+) -> None:
+    competencia_id = uuid4()
+    atleta_id = uuid4()
+    await _append_audit_events(store, competencia_id, atleta_id)
+
+    response = client.get(f"/competencia/{competencia_id}/performances/{atleta_id}/audit-log")
+
+    assert response.status_code == 200
+    assert response.json()["competencia_id"] == str(competencia_id)
+    assert response.json()["atleta_id"] == str(atleta_id)
+    assert response.json()["disciplina"] == "DNF"
+    assert [evento["tipo"] for evento in response.json()["eventos"]] == [
+        "PerformanceRegistrada",
+        "ResultadoRegistrado",
+        "TarjetaAsignada",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_audit_log_retorna_404_si_no_existe_performance(
+    store: SQLiteEventStore, client: TestClient
+) -> None:
+    competencia_id = uuid4()
+    atleta_id = uuid4()
+
+    response = client.get(f"/competencia/{competencia_id}/performances/{atleta_id}/audit-log")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == (
+        "No existe una performance para el atleta en la competencia indicada"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_audit_log_incluye_correccion_historica(
+    store: SQLiteEventStore, client: TestClient
+) -> None:
+    competencia_id = uuid4()
+    atleta_id = uuid4()
+    await _append_audit_events(store, competencia_id, atleta_id)
+    await _append_correccion(store, competencia_id, atleta_id)
+
+    response = client.get(f"/competencia/{competencia_id}/performances/{atleta_id}/audit-log")
+
+    assert response.status_code == 200
+    assert len(response.json()["eventos"]) == 4
+    assert response.json()["eventos"][-1]["tipo"] == "ResultadoCorregido"
+    assert response.json()["eventos"][-1]["datos"]["rp_nuevo"] == 57.0
+
+
+@pytest.mark.asyncio
+async def test_get_audit_log_retorna_403_para_rol_juez(
+    store: SQLiteEventStore, client: TestClient
+) -> None:
+    competencia_id = uuid4()
+    atleta_id = uuid4()
+    await _append_audit_events(store, competencia_id, atleta_id)
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "juez-001",
+        "email": "juez@test.com",
+        "rol": "JUEZ",
+    }
+
+    response = client.get(f"/competencia/{competencia_id}/performances/{atleta_id}/audit-log")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Rol insuficiente"

--- a/tests/unit/competencia/application/queries/test_obtener_audit_log.py
+++ b/tests/unit/competencia/application/queries/test_obtener_audit_log.py
@@ -1,0 +1,108 @@
+"""Tests unitarios - ObtenerAuditLogHandler."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from competencia.application.queries.obtener_audit_log import (
+    AuditLogDTO,
+    AuditLogEventoDTO,
+    ObtenerAuditLogHandler,
+    ObtenerAuditLogQuery,
+    PerformanceNoEncontrada,
+)
+from competencia.domain.ports.atleta_nombre_port import AtletaNombrePort
+from competencia.domain.ports.event_store_port import EventStorePort
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000000001")
+ATLETA_ID = UUID("aaaa0000-0000-0000-0000-000000000001")
+PREFIX = f"performance-{COMPETENCIA_ID}-{ATLETA_ID}-"
+STREAM_ID = f"{PREFIX}DNF"
+
+
+def _make_store(events: list[dict]) -> EventStorePort:
+    store = AsyncMock(spec=EventStorePort)
+    store.load_all_events_ordered = AsyncMock(return_value=events)
+    return store
+
+
+def _make_nombres(nombre: str = "Martin Garcia") -> AtletaNombrePort:
+    nombres = AsyncMock(spec=AtletaNombrePort)
+    nombres.get_nombre = AsyncMock(return_value=nombre)
+    return nombres
+
+
+@pytest.mark.asyncio
+async def test_retorna_audit_log_completo() -> None:
+    store = _make_store(
+        [
+            {
+                "sequence": 1,
+                "stream_id": STREAM_ID,
+                "event_type": "PerformanceRegistrada",
+                "payload": {"ap": 60.0},
+                "occurred_at": "2026-04-16T12:00:00Z",
+            },
+            {
+                "sequence": 2,
+                "stream_id": STREAM_ID,
+                "event_type": "ResultadoRegistrado",
+                "payload": {"rp": 58.0},
+                "occurred_at": "2026-04-16T12:03:00Z",
+            },
+        ]
+    )
+    nombres = _make_nombres()
+    handler = ObtenerAuditLogHandler(store, nombres)
+
+    result = await handler.handle(
+        ObtenerAuditLogQuery(competencia_id=COMPETENCIA_ID, atleta_id=ATLETA_ID)
+    )
+
+    assert isinstance(result, AuditLogDTO)
+    assert result.competencia_id == str(COMPETENCIA_ID)
+    assert result.atleta_id == str(ATLETA_ID)
+    assert result.atleta_nombre == "Martin Garcia"
+    assert result.disciplina == "DNF"
+    assert len(result.eventos) == 2
+    assert isinstance(result.eventos[0], AuditLogEventoDTO)
+    store.load_all_events_ordered.assert_called_once_with(PREFIX)
+    nombres.get_nombre.assert_called_once_with(ATLETA_ID)
+
+
+@pytest.mark.asyncio
+async def test_preserva_sequence_y_payload() -> None:
+    store = _make_store(
+        [
+            {
+                "sequence": 3,
+                "stream_id": STREAM_ID,
+                "event_type": "ResultadoCorregido",
+                "payload": {"rp_anterior": 55.0, "rp_nuevo": 58.0},
+                "occurred_at": "2026-04-16T12:05:00Z",
+            }
+        ]
+    )
+    handler = ObtenerAuditLogHandler(store, _make_nombres())
+
+    result = await handler.handle(
+        ObtenerAuditLogQuery(competencia_id=COMPETENCIA_ID, atleta_id=ATLETA_ID)
+    )
+
+    assert result.eventos[0].sequence == 3
+    assert result.eventos[0].tipo == "ResultadoCorregido"
+    assert result.eventos[0].timestamp == "2026-04-16T12:05:00Z"
+    assert result.eventos[0].datos == {"rp_anterior": 55.0, "rp_nuevo": 58.0}
+
+
+@pytest.mark.asyncio
+async def test_lanza_performance_no_encontrada_si_no_hay_eventos() -> None:
+    handler = ObtenerAuditLogHandler(_make_store([]), _make_nombres())
+
+    with pytest.raises(PerformanceNoEncontrada):
+        await handler.handle(
+            ObtenerAuditLogQuery(competencia_id=COMPETENCIA_ID, atleta_id=ATLETA_ID)
+        )


### PR DESCRIPTION
## Resumen
- agrega la query  en 
- expone 
- cubre casos 200/404/403 y corrección histórica
- actualiza trazabilidad, reporte final y HITO-21 del tracker secuencial

## Validación
- .venv/bin/pytest tests/unit/competencia/application/queries/test_obtener_audit_log.py tests/integration/competencia/test_audit_log_api.py
- .venv/bin/codeguard src/competencia/application/queries/obtener_audit_log.py src/competencia/api/router.py src/competencia/api/dependencies.py -c pyproject.toml -a pre-commit -t 15 --format json > quality/reports/codeguard/US-4.6.1-codeguard.json