### PR TITLE
US-4.6.3: UI de auditoria del organizador

### DIFF
--- a/.claude/tracking/US-4.6.3-tracking.json
+++ b/.claude/tracking/US-4.6.3-tracking.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {
+    "us_id": "US-4.6.3",
+    "us_title": "UI de auditoría",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-16T13:09:51.021294+00:00",
+    "completed_at": "2026-04-16T13:21:31.183743+00:00",
+    "total_elapsed_seconds": 700,
+    "effective_seconds": 700,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-16T13:09:56.690719+00:00",
+      "completed_at": "2026-04-16T13:09:59.544205+00:00",
+      "elapsed_seconds": 2,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-16T13:10:02.586228+00:00",
+      "completed_at": "2026-04-16T13:10:43.596834+00:00",
+      "elapsed_seconds": 41,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-16T13:10:46.654421+00:00",
+      "completed_at": "2026-04-16T13:10:49.954042+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-16T13:19:03.338177+00:00",
+      "completed_at": "2026-04-16T13:19:14.092984+00:00",
+      "elapsed_seconds": 10,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-16T13:19:17.450178+00:00",
+      "completed_at": "2026-04-16T13:19:20.515128+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-16T13:19:24.398407+00:00",
+      "completed_at": "2026-04-16T13:19:29.999975+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-16T13:19:33.381993+00:00",
+      "completed_at": "2026-04-16T13:19:49.447853+00:00",
+      "elapsed_seconds": 16,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-16T13:19:53.857867+00:00",
+      "completed_at": "2026-04-16T13:20:26.614755+00:00",
+      "elapsed_seconds": 32,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-16T13:20:31.644343+00:00",
+      "completed_at": "2026-04-16T13:21:13.894851+00:00",
+      "elapsed_seconds": 42,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-16T13:21:18.675662+00:00",
+      "completed_at": "2026-04-16T13:21:22.819052+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 10,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/contexto/HITO-23-AUDITORIA-UI-COMPOSICION-QUERIES.md
+++ b/docs/contexto/HITO-23-AUDITORIA-UI-COMPOSICION-QUERIES.md
@@ -1,0 +1,184 @@
+# HITO-23 — La auditoría navegable no emerge de un backend aislado: aparece cuando la evidencia del Event Sourcing se vuelve composable en read models y accesible desde la UI
+
+| Campo | Valor |
+|-------|-------|
+| **Documento** | HITO-23 — Hallazgo metodológico durante US-4.6.3 |
+| **Fecha** | 2026-04-16 |
+| **Sprint** | SP4 — INC-4.6 — US-4.6.3 |
+| **Relacionado** | `frontend/src/pages/organizador/` · `frontend/src/hooks/useAuditoriaCompetencia.ts` · `src/competencia/application/queries/obtener_estado_competencia.py` · `HITO-22` · `docs/reports/US-4.6.3-report.md` |
+
+---
+
+## Contexto
+
+Durante `US-4.6.3` se implementó la UI de auditoría para organizador. A primera
+vista parecía una historia puramente frontend: pantallas nuevas, rutas nuevas y
+consumo de `US-4.6.1` y `US-4.6.2`.
+
+La implementación mostró algo distinto. La evidencia ya existía en backend, pero
+no estaba todavía en una forma directamente consumible por la interfaz. El caso
+concreto fue `hash_sha256`: estaba persistido en `CompetenciaFinalizada`, pero
+no estaba expuesto por ninguna query pensada para encabezados de pantalla.
+
+---
+
+## Qué reveló la implementación
+
+La UI de auditoría terminó dependiendo de una composición de fuentes:
+
+- `GET /competencia/{id}/estado`
+- `GET /competencia/{id}/grilla`
+- `GET /resultados/{id}/ranking`
+- `GET /competencia/{id}/performances/{atleta_id}/audit-log`
+
+Eso dejó dos hallazgos claros:
+
+- la US no era frontend puro
+- la solución no necesitaba una mega-query nueva si las queries existentes podían
+  enriquecerse y componerse bien
+
+---
+
+## El aprendizaje central
+
+`US-4.6.1` validó la trazabilidad puntual. `US-4.6.2` validó la integridad del
+cierre. `US-4.6.3` agrega la tercera capa:
+
+> La auditoría no se vuelve realmente útil cuando existe en la base o en el API.
+> Se vuelve útil cuando la evidencia del dominio puede recorrerse sin conocer el
+> event store, componiendo read models estables y navegables en la UI.
+
+Esto desplaza la lectura de “frontend como presentación” hacia algo más preciso:
+
+- el frontend no inventa la auditoría
+- la hace operable
+
+---
+
+## La falsa frontera entre frontend y backend
+
+La spec parecía ubicar la US enteramente en `frontend/`, pero el hash de cierre
+no podía mostrarse sin una extensión backend mínima. Eso expuso una regla útil:
+
+> Cuando una pantalla necesita un dato semántico de estado, la separación
+> frontend/backend deja de ser una frontera de alcance válida. El alcance real
+> está en la cadena completa que vuelve observable ese dato.
+
+En este caso, la decisión correcta no fue crear un endpoint nuevo, sino ampliar
+`GET /estado` con `hash_sha256`.
+
+Eso deja una heurística estable:
+
+- si el dato pertenece al encabezado semántico de la pantalla, enriquecer la
+  query de estado suele ser mejor que abrir una API paralela
+
+---
+
+## La auditoría como composición, no como proyección monolítica
+
+Otra lección importante es que la pantalla no necesitó una query agregada
+monolítica. La solución se armó con composición:
+
+- `estado` para contexto y hash
+- `grilla` para lista base de atletas
+- `ranking` para enriquecimiento del resultado final
+- `audit-log` para la traza puntual
+
+Esto confirma una idea útil para CQRS liviano:
+
+> Varias queries pequeñas, estables y bien nombradas pueden sostener una
+> experiencia compleja sin necesidad inmediata de una proyección única.
+
+La condición es que cada query tenga una frontera semántica clara y que el
+frontend tolere que algunas sean enriquecimiento opcional, no dependencia dura.
+
+---
+
+## El ranking como dato opcional
+
+La implementación mostró también que `ranking` no debía ser obligatorio para
+abrir la auditoría. Si la pantalla colapsaba por ausencia de ranking, una capa
+de enriquecimiento terminaba bloqueando el acceso a la evidencia principal.
+
+Eso produjo otra regla práctica:
+
+> En una UI operativa de auditoría, distinguir entre datos nucleares y datos de
+> enriquecimiento no es detalle de UX; es una decisión de resiliencia funcional.
+
+En esta US:
+
+- núcleo: estado, hash, grilla, audit log
+- enriquecimiento: ranking
+
+---
+
+## El límite metodológico actual: falta infraestructura de tests frontend
+
+La validación de `US-4.6.3` quedó apoyada en:
+
+- pytest backend
+- `npm run build`
+- `npm run lint`
+
+Eso fue suficiente para cerrar la US, pero dejó visible un límite del ecosistema:
+
+> SP4 ya tiene suficiente superficie React como para que la ausencia de harness
+> formal de testing frontend deje de ser una omisión menor y pase a ser deuda
+> metodológica visible.
+
+Mientras el frontend era mínimo, `build` y `lint` bastaban. Con rutas por rol,
+hooks, navegación y estados de carga/error, ya no cubren toda la semántica.
+
+---
+
+## Implicancia para INC-4.6 y para el experimento
+
+Las tres primeras US de `INC-4.6` forman una secuencia coherente:
+
+- `US-4.6.1`: la traza es legible
+- `US-4.6.2`: la traza es verificable
+- `US-4.6.3`: la traza es accesible operativamente
+
+La tesis que emerge es fuerte:
+
+> El valor de auditoría no aparece al implementar solo el backend. Aparece
+> cuando la evidencia técnica del Event Sourcing se traduce en una interfaz que
+> un organizador puede recorrer sin acceso a base de datos ni conocimiento del
+> modelo interno de eventos.
+
+Eso valida una idea importante para sistemas DDD con Event Sourcing:
+
+- el event store resuelve persistencia y trazabilidad
+- los read models resuelven operabilidad
+- la UI resuelve apropiación real del valor por parte del usuario
+
+---
+
+## Acciones incorporadas
+
+- [x] `GET /estado` extendido con `hash_sha256`
+- [x] Navegación de organizador desde dashboard hasta traza puntual
+- [x] Composición de queries en frontend en lugar de endpoint monolítico nuevo
+- [x] Ranking tratado como enriquecimiento opcional
+- [ ] Evaluar incorporación formal de `vitest` o `playwright` para SP4/SP5
+- [ ] Evaluar si `US-4.6.4` debe reutilizar esta navegación como punto de entrada a exportación
+
+---
+
+## Conexión con HITO-22
+
+`HITO-22` mostró que el event store puede sostener integridad criptográfica.
+`HITO-23` agrega la siguiente capa:
+
+> no alcanza con que la evidencia exista y sea correcta; también debe estar
+> dispuesta en read models y navegación para que un usuario no técnico pueda
+> usarla
+
+Así, la secuencia queda:
+
+- `HITO-22`: la evidencia del dominio es verificable
+- `HITO-23`: la evidencia verificable debe ser composable y navegable para tener valor operativo
+
+---
+
+*Registrado durante US-4.6.3 — cuando la auditoría dejó de ser solo una capacidad del backend y pasó a ser una experiencia operable para organizador*

--- a/docs/contexto/INDICE-HITOS.md
+++ b/docs/contexto/INDICE-HITOS.md
@@ -27,6 +27,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | HITO-19 | SP4 cierre INC-4.1 | 2026-04-08 | Cierre de incremento como captura formal de deuda de diseño | ¿El incremento es la unidad correcta para agrupar hallazgos estructurales y planificar ajustes? | [HITO-19](./HITO-19-INC-4-1-HALLAZGOS-DISENO-CIERRE.md) |
 | HITO-21 | SP4 Inc 4.6 | 2026-04-16 | Tracker secuencial como política | ¿La secuencialidad del método incluye también al mecanismo que registra sus fases? | [HITO-21](./HITO-21-TRACKER-SECUENCIALIDAD-COMO-POLITICA.md) |
 | HITO-22 | SP4 Inc 4.6 | 2026-04-16 | Event Sourcing como base de integridad criptográfica | ¿La misma traza de eventos puede sostener auditoría legible e integridad verificable sin persistencia adicional? | [HITO-22](./HITO-22-EVENT-SOURCING-INTEGRIDAD-CRIPTOGRAFICA.md) |
+| HITO-23 | SP4 Inc 4.6 | 2026-04-16 | Auditoría UI como composición operable de read models | ¿La evidencia del Event Sourcing se vuelve útil recién cuando puede recorrerse desde la UI sin conocer el event store? | [HITO-23](./HITO-23-AUDITORIA-UI-COMPOSICION-QUERIES.md) |
 
 ---
 
@@ -38,7 +39,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | SP1 (La Performance) | 3, 4, 5, 6, 7, 8, 9 | Primer ciclo IEDD completo, fricción del ecosistema, BDD + ES |
 | SP2 (La Competencia) | 10, 11, 12, 13 | Patrones DDD avanzados, quality gates, deuda técnica formal |
 | SP3 (El Torneo) | 15, 16 | Proyecciones CQRS emergentes, secuencialidad del pipeline y gobierno del proceso |
-| SP4 (La Plataforma) | 17, 18, 19, 21, 22 | Datos reales como oráculo, validación UX, captura formal de hallazgos estructurales, gobierno secuencial del tracker e integridad criptográfica sobre el event store |
+| SP4 (La Plataforma) | 17, 18, 19, 21, 22, 23 | Datos reales como oráculo, validación UX, captura formal de hallazgos estructurales, gobierno secuencial del tracker, integridad criptográfica sobre el event store y auditoría navegable por composición de read models |
 
 ---
 
@@ -54,6 +55,7 @@ Todos viven en `docs/contexto/HITO-N-*.md`.
 | La secuencialidad del pipeline es parte del método | HITO-16 | ✅ Confirmada |
 | La secuencialidad del método incluye también al tracker y su evidencia | HITO-21 | ✅ Confirmada |
 | El Event Sourcing puede sostener auditoría e integridad criptográfica con la misma traza | HITO-22 | ✅ Evidencia inicial |
+| La evidencia del Event Sourcing solo se vuelve operable cuando puede navegarse desde read models y UI | HITO-23 | ✅ Evidencia inicial |
 | El incremento es la unidad correcta para leer deuda estructural acumulada | HITO-19 | ✅ Evidencia inicial |
 
 ---

--- a/docs/plans/sp4/US-4.6.3-plan.md
+++ b/docs/plans/sp4/US-4.6.3-plan.md
@@ -1,0 +1,108 @@
+# Plan de Implementacion: US-4.6.3 - UI de auditoria del organizador
+
+**Sprint:** SP4 - La Plataforma  
+**Incremento:** INC-4.6  
+**Bounded Context:** `frontend`  
+**Patron:** `react-vite-tailwind`  
+**Estimacion total:** 4h 20min  
+**Estado:** Pendiente de aprobacion
+
+## Objetivo
+
+Implementar la navegacion y visualizacion de auditoria para organizador,
+mostrando la lista de atletas por competencia, la traza cronologica de una
+performance y el `hash_sha256` de la disciplina cuando el cierre ya fue
+persistido.
+
+## Hallazgo de contexto
+
+- `US-4.6.1` ya expone `GET /competencia/{competencia_id}/performances/{atleta_id}/audit-log`
+- `US-4.6.2` persiste `hash_sha256` en `CompetenciaFinalizada`
+- El frontend de organizador hoy solo tiene `DashboardPage`
+- No existe harness formal de tests frontend en `frontend/package.json`
+- El backend actual expone estado y grilla, pero no un endpoint que devuelva el
+  `hash_sha256` de la disciplina cerrada
+
+## Componentes a ajustar
+
+### 1. Frontend - rutas y pagina de organizador
+
+- [ ] `frontend/src/App.tsx` (20 min)
+  - Agregar rutas protegidas de auditoria para organizador
+  - Mantener redireccion de juez sin tocar flujos existentes
+
+- [ ] `frontend/src/pages/organizador/DashboardPage.tsx` (20 min)
+  - Convertir el dashboard minimo en punto de entrada navegable
+  - Listar torneos y competencias disponibles para llegar a auditoria
+
+- [ ] Nuevas paginas en `frontend/src/pages/organizador/` (55 min)
+  - `AuditoriaCompetenciaPage.tsx`
+  - `AuditoriaPerformancePage.tsx`
+  - Encabezado con disciplina, estado y hash visible solo si corresponde
+  - Timeline de eventos en solo lectura
+
+### 2. Frontend - cliente API y hooks
+
+- [ ] `frontend/src/api/competencia.ts` (35 min)
+  - Agregar DTO y cliente para audit log puntual
+  - Agregar cliente para resumen de auditoria de competencia o endpoint equivalente
+
+- [ ] `frontend/src/hooks/` (35 min)
+  - Crear hooks de carga para auditoria de competencia y performance
+  - Manejar loading, empty state, 403 y 404
+
+### 3. Backend minimo de soporte para hash visible
+
+- [ ] Revisar `src/competencia/application/queries/obtener_estado_competencia.py` y router (35 min)
+  - Extender el read model para incluir `hash_sha256` cuando la competencia este finalizada
+  - Mantener compatibilidad para competencias historicas sin hash
+  - Evitar crear endpoint redundante si el `GET /estado` puede absorber el dato
+
+### 4. UX y navegacion
+
+- [ ] Diseno de lista y timeline (30 min)
+  - Estado visual claro entre `EnEjecucion` y `Finalizada`
+  - Accion copiar con feedback breve
+  - Mostrar hash truncado y conservar valor completo para copia
+
+- [ ] Estados de error y vacio (20 min)
+  - Sin atletas
+  - Audit log inexistente
+  - Acceso no autorizado
+
+### 5. Validacion
+
+- [ ] Ejecutar `npm run build` en `frontend/` (10 min)
+- [ ] Ejecutar `npm run lint` en `frontend/` si el estado base del repo lo permite (10 min)
+- [ ] Ejecutar pytest focalizado del backend si se extiende `GET /estado` (10 min)
+- [ ] Evaluar waiver BDD/frontend por ausencia de harness automatizado actual (10 min)
+
+## Dependencias y decisiones
+
+- La lista de atletas puede reutilizar `GET /competencia/{id}/grilla` como fuente
+  inicial de nombres, estado y orden.
+- La traza puntual consume directamente el endpoint de `US-4.6.1`.
+- El hash visible requiere exponer `hash_sha256` en un read model backend ya
+  existente o crear un endpoint equivalente si la extension resulta forzada.
+- La UI debe seguir restringida a `organizador`; un juez se redirige por
+  `RequireRole`.
+
+## Riesgos
+
+- `US-4.6.3` parece frontend, pero hoy depende de una minima ampliacion backend
+  para mostrar el hash de cierre.
+- No hay framework de tests frontend instalado; la validacion automatizada puede
+  apoyarse en `build`/`lint` y, si aplica, en un waiver BDD similar a `US-4.6.1`.
+- El dashboard organizador es demasiado basico; puede requerir una pequena
+  navegacion intermedia para no hardcodear IDs.
+
+## Checklist de salida
+
+- [ ] Rutas de auditoria disponibles para organizador
+- [ ] Lista de atletas visible con estado de disciplina
+- [ ] Timeline de eventos puntual en orden cronologico
+- [ ] Hash visible solo en competencia finalizada
+- [ ] Copia de hash con feedback visual
+- [ ] Validacion tecnica ejecutada y documentada
+
+*Plan generado: 2026-04-16 - US-4.6.3 INC-4.6 SP4*

--- a/docs/reports/US-4.6.3-bdd-waiver.md
+++ b/docs/reports/US-4.6.3-bdd-waiver.md
@@ -1,0 +1,31 @@
+# Waiver BDD — US-4.6.3
+## UI de auditoria del organizador
+
+**Fecha:** `2026-04-16`
+**Decisión:** `BDD no automatizado`
+
+## Justificación
+
+`US-4.6.3` agrega comportamiento observable en frontend y por eso se generó el
+feature `tests/features/US-4.6.3-ui-auditoria-organizador.feature`, pero el
+repositorio no cuenta hoy con harness automatizado para UI React
+(`vitest`, `playwright` o equivalente) ni con step definitions reutilizables
+para navegación del organizador.
+
+Implementar esa infraestructura en esta US hubiera desviado el alcance hacia una
+base de testing frontend transversal en lugar de cerrar la funcionalidad de
+auditoría del incremento.
+
+## Validación sustitutiva
+
+- Tests unitarios backend de `ObtenerEstadoCompetenciaHandler`
+- Tests backend existentes de `CompetenciaFinalizada` y persistencia de hash
+- `npm run build` en `frontend/`
+- `npm run lint` en `frontend/`
+- Quality gate focalizado con `codeguard` sobre backend tocado
+
+## Alcance del waiver
+
+- Se mantiene Fase 1 con generación del `.feature`
+- Se reemplaza la automatización de Fase 6 por validación backend + build/lint frontend
+- No exime Fases 7, 8 y 9

--- a/docs/reports/US-4.6.3-report.md
+++ b/docs/reports/US-4.6.3-report.md
@@ -1,0 +1,176 @@
+# Reporte de Implementación — US-4.6.3
+## UI de auditoría del organizador
+
+**Sprint:** SP4 — La Plataforma  
+**Incremento:** INC-4.6  
+**Branch:** `feature/US-4.6.3-ui-auditoria`  
+**Fecha:** 2026-04-16
+
+---
+
+## Resumen
+
+Se implementó la tercera US de `INC-4.6` en el frontend de organizador: una
+navegación de auditoría que permite recorrer torneos, entrar a competencias,
+ver la lista de atletas y abrir la traza cronológica de eventos de una
+performance puntual.
+
+La solución reutiliza `US-4.6.1` para el audit log puntual, expone el
+`hash_sha256` de `US-4.6.2` dentro del read model de estado de competencia y
+agrega una UI de solo lectura con acción de copia para el hash cuando la
+disciplina ya fue finalizada.
+
+---
+
+## Cambios implementados
+
+### Código
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/competencia/domain/aggregates/competencia.py` | El aggregate reconstituye y expone `hash_sha256` desde `CompetenciaFinalizada` |
+| `src/competencia/application/queries/obtener_estado_competencia.py` | `EstadoCompetenciaDTO` ahora incluye `hash_sha256` |
+| `src/competencia/api/router.py` | `GET /competencia/{id}/estado` expone el hash de cierre cuando existe |
+| `frontend/src/App.tsx` | Nuevas rutas protegidas de organizador para competencias y auditoría |
+| `frontend/src/pages/organizador/*.tsx` | Dashboard navegable, lista de competencias, auditoría de competencia y traza puntual |
+| `frontend/src/hooks/useAuditLog.ts` | Nuevo hook para consumir el audit log puntual |
+| `frontend/src/hooks/useAuditoriaCompetencia.ts` | Nuevo hook para combinar estado, grilla y ranking |
+| `frontend/src/api/resultados.ts` | Nuevo cliente frontend para ranking de competencia |
+
+### Tests y validación
+
+| Archivo / comando | Cobertura |
+|-------------------|-----------|
+| `tests/unit/competencia/application/queries/test_obtener_estado_competencia.py` | Estado finalizado con `hash_sha256` y backward compatibility sin hash |
+| `tests/unit/competencia/domain/test_competencia_finalizar.py` | Persistencia y reconstitución del hash |
+| `tests/integration/competencia/test_competencia_finalizada_integration.py` | Payload real de `CompetenciaFinalizada` con hash |
+| `npm run build` | Validación de compilación del frontend |
+| `npm run lint` | Validación estática del frontend |
+
+### Artefactos de proceso
+
+| Archivo | Propósito |
+|---------|-----------|
+| `tests/features/US-4.6.3-ui-auditoria-organizador.feature` | Escenarios BDD de la US |
+| `docs/plans/sp4/US-4.6.3-plan.md` | Plan aprobado de implementación |
+| `docs/reports/US-4.6.3-bdd-waiver.md` | Sustitución explícita de automatización BDD frontend |
+| `docs/traceability/matrix.md` | Registro de `US-4.6.3` dentro de `INC-4.6` |
+| `quality/reports/codeguard/US-4.6.3-codeguard.json` | Evidencia del quality gate backend focalizado |
+
+---
+
+## Decisiones de diseño
+
+### 1. Extensión mínima del backend en lugar de endpoint nuevo
+
+La UI necesitaba el `hash_sha256` de cierre, pero no existía un endpoint
+específico para eso. En vez de abrir una query nueva, se extendió el read model
+de `GET /estado`, que ya era la fuente natural del encabezado de competencia.
+
+### 2. La auditoría se apoya en fuentes ya existentes
+
+La lista principal reutiliza `grilla` y `ranking`, mientras que la traza puntual
+consume directamente `US-4.6.1`. Esto evitó duplicar endpoints de auditoría
+agregada cuando ya había información suficiente en las APIs vigentes.
+
+### 3. Ranking opcional, no dependencia dura
+
+La pantalla no falla si el ranking aún no está disponible. En ese caso, muestra
+estado operativo por atleta y usa el ranking solo como enriquecimiento del
+“resultado final”.
+
+---
+
+## Validación ejecutada
+
+### Pytest focalizado backend
+
+Comando ejecutado:
+
+```bash
+./.venv/bin/pytest \
+  tests/unit/competencia/application/queries/test_obtener_estado_competencia.py \
+  tests/unit/competencia/domain/test_competencia_finalizar.py \
+  tests/integration/competencia/test_competencia_finalizada_integration.py
+```
+
+Resultado:
+
+```text
+13 passed in 2.58s
+```
+
+### Frontend
+
+Comandos ejecutados:
+
+```bash
+npm run build
+npm run lint
+```
+
+Resultado:
+
+```text
+build OK
+lint OK
+```
+
+### CodeGuard focalizado
+
+Comando ejecutado:
+
+```bash
+./.venv/bin/codeguard \
+  src/competencia/application/queries/obtener_estado_competencia.py \
+  src/competencia/api/router.py \
+  src/competencia/domain/aggregates/competencia.py \
+  tests/unit/competencia/application/queries/test_obtener_estado_competencia.py \
+  tests/unit/competencia/domain/test_competencia_finalizar.py \
+  tests/integration/competencia/test_competencia_finalizada_integration.py \
+  -c pyproject.toml -a pre-commit -t 15 --format json \
+  > quality/reports/codeguard/US-4.6.3-codeguard.json
+```
+
+Resultado:
+
+```text
+0 errors
+4 warnings
+43 infos
+```
+
+Los warnings remanentes corresponden a `assert` en tests, no a código productivo.
+
+---
+
+## Estado respecto de la spec
+
+### Cumplido
+
+- Acceso restringido a rutas de organizador con `RequireRole`
+- Lista navegable de torneos y competencias
+- Pantalla de auditoría por competencia
+- Trazas puntuales en orden cronológico ascendente
+- Hash visible solo si la disciplina está finalizada
+- Acción de copiar hash con feedback visual
+- Juez redirigido fuera de la pantalla de auditoría
+
+### Diferencia menor respecto de la redacción original
+
+- La navegación arranca desde un dashboard de organizador con lista de torneos
+  y luego una pantalla de competencias por torneo. Es consistente con el flujo
+  propuesto, aunque la primera pantalla original estaba redactada de forma más
+  conceptual que implementativa.
+
+---
+
+## Riesgos y próximos pasos
+
+- La lista usa `ranking` como enriquecimiento opcional del resultado final; si
+  en el futuro se necesita una vista más rica, puede convenir una query agregada
+  específica de auditoría de competencia.
+- `US-4.6.4` puede reutilizar esta navegación como punto de entrada para
+  exportación por disciplina.
+- Falta todavía infraestructura formal de tests frontend; hoy la evidencia se
+  apoya en build/lint más validación backend.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -350,6 +350,7 @@ Deben resolverse antes del SP que los involucra. No bloquean SP1 ni SP2.
 |----|------|----------------------------|---------------------|--------|
 | US-4.6.1 | 4.6 | PLAN-SP4 §INC-4.6 · ADR-001 · ADR-008 | Query `ObtenerAuditLog` por performance · endpoint `GET /competencia/{competencia_id}/performances/{atleta_id}/audit-log` · respuesta cronológica con `sequence`, `tipo`, `timestamp`, `datos` · acceso restringido a `organizador/admin` | ✅ Done |
 | US-4.6.2 | 4.6 | PLAN-SP4 §INC-4.6 · ADR-001 · ADR-008 | Servicio `CalculadorHashCompetencia` · `CompetenciaFinalizada.hash_sha256` persistido en event store · cálculo canónico en política `P-08` antes del cierre · hash vacío conocido para disciplina sin performances | ✅ Done |
+| US-4.6.3 | 4.6 | PLAN-SP4 §INC-4.6 · US-4.6.1 · US-4.6.2 | Rutas y pantallas de organizador para auditoría · lista de atletas por competencia · timeline puntual por performance · visibilidad y copia de `hash_sha256` cuando la disciplina está finalizada | ✅ Done |
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,9 @@ import { DisciplinasPage } from './pages/juez/DisciplinasPage'
 import { GrillaPage } from './pages/juez/GrillaPage'
 import { PerformanceFlowPage } from './pages/juez/PerformanceFlowPage'
 import { DashboardPage } from './pages/organizador/DashboardPage'
+import { TorneoCompetenciasPage } from './pages/organizador/TorneoCompetenciasPage'
+import { AuditoriaCompetenciaPage } from './pages/organizador/AuditoriaCompetenciaPage'
+import { AuditoriaPerformancePage } from './pages/organizador/AuditoriaPerformancePage'
 import { HealthCheck } from './components/HealthCheck'
 
 function RootRedirect() {
@@ -58,6 +61,30 @@ function App() {
           element={
             <RequireRole role="organizador">
               <DashboardPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/organizador/torneos/:torneoId/competencias"
+          element={
+            <RequireRole role="organizador">
+              <TorneoCompetenciasPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/organizador/competencias/:competenciaId/auditoria"
+          element={
+            <RequireRole role="organizador">
+              <AuditoriaCompetenciaPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/organizador/competencias/:competenciaId/auditoria/:atletaId"
+          element={
+            <RequireRole role="organizador">
+              <AuditoriaPerformancePage />
             </RequireRole>
           }
         />

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -21,6 +21,7 @@ export interface EstadoCompetenciaDto {
   intervalo_minutos: number | null
   grilla_confirmada: boolean
   torneo_id: string | null
+  hash_sha256: string | null
 }
 
 export interface GrillaAtletaDto {
@@ -48,6 +49,21 @@ export interface PerformanceActualDto {
 export interface PenalizacionPayload {
   tipo: string
   deduccion: string
+}
+
+export interface AuditLogEventoDto {
+  sequence: number
+  tipo: string
+  timestamp: string
+  datos: Record<string, unknown>
+}
+
+export interface AuditLogDto {
+  competencia_id: string
+  atleta_id: string
+  atleta_nombre: string
+  disciplina: string
+  eventos: AuditLogEventoDto[]
 }
 
 function buildHeaders() {
@@ -100,6 +116,19 @@ export async function fetchEstadoCompetencia(
     `/competencia/${competenciaId}/estado?disciplina=${encodeURIComponent(disciplina)}`,
   )
   return parseResponse<EstadoCompetenciaDto>(response)
+}
+
+export async function fetchAuditLog(
+  competenciaId: string,
+  atletaId: string,
+): Promise<AuditLogDto> {
+  const response = await fetch(
+    `/competencia/${competenciaId}/performances/${atletaId}/audit-log`,
+    {
+      headers: buildHeaders(),
+    },
+  )
+  return parseResponse<AuditLogDto>(response)
 }
 
 export async function fetchGrillaCompetencia(

--- a/frontend/src/api/resultados.ts
+++ b/frontend/src/api/resultados.ts
@@ -1,0 +1,34 @@
+export interface RankingEntradaDto {
+  posicion: number
+  atleta_id: string
+  rp: string | null
+  unidad: string | null
+  tarjeta: string | null
+  es_dns: boolean
+  en_podio: boolean
+}
+
+export interface RankingCategoriaDto {
+  categoria: string
+  entradas: RankingEntradaDto[]
+}
+
+export interface RankingCompetenciaDto {
+  calculado: boolean
+  rankings: RankingCategoriaDto[]
+}
+
+export async function fetchRankingCompetencia(
+  competenciaId: string,
+  disciplina: string,
+): Promise<RankingCompetenciaDto> {
+  const response = await fetch(
+    `/resultados/${competenciaId}/ranking?disciplina=${encodeURIComponent(disciplina)}`,
+  )
+
+  if (!response.ok) {
+    throw new Error(`Error al obtener ranking: ${response.status}`)
+  }
+
+  return response.json() as Promise<RankingCompetenciaDto>
+}

--- a/frontend/src/components/organizador/OrganizadorLayout.tsx
+++ b/frontend/src/components/organizador/OrganizadorLayout.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+
+interface OrganizadorLayoutProps {
+  title: string
+  subtitle: string
+  actions?: ReactNode
+  children: ReactNode
+}
+
+export function OrganizadorLayout({
+  title,
+  subtitle,
+  actions,
+  children,
+}: OrganizadorLayoutProps) {
+  return (
+    <div className="min-h-screen bg-[linear-gradient(180deg,#f7f1e3_0%,#f2e9da_45%,#e7dcc9_100%)] text-stone-900">
+      <div className="mx-auto max-w-6xl px-5 py-6 sm:px-8 lg:px-10">
+        <header className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-6 shadow-[0_20px_60px_rgba(120,93,54,0.08)] backdrop-blur">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="max-w-3xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-800">
+                Organizador
+              </p>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-stone-900">
+                {title}
+              </h1>
+              <p className="mt-2 text-sm text-stone-600">{subtitle}</p>
+            </div>
+            {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+          </div>
+        </header>
+
+        <main className="mt-6 flex flex-col gap-4">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAuditLog.ts
+++ b/frontend/src/hooks/useAuditLog.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchAuditLog } from '../api/competencia'
+
+export function useAuditLog(competenciaId: string | undefined, atletaId: string | undefined) {
+  return useQuery({
+    queryKey: ['audit-log', competenciaId, atletaId],
+    queryFn: () => fetchAuditLog(competenciaId!, atletaId!),
+    enabled: Boolean(competenciaId && atletaId),
+  })
+}

--- a/frontend/src/hooks/useAuditoriaCompetencia.ts
+++ b/frontend/src/hooks/useAuditoriaCompetencia.ts
@@ -1,0 +1,58 @@
+import { useQueries } from '@tanstack/react-query'
+import {
+  fetchEstadoCompetencia,
+  fetchGrillaCompetencia,
+  type EstadoCompetenciaDto,
+  type GrillaAtletaDto,
+} from '../api/competencia'
+import {
+  fetchRankingCompetencia,
+  type RankingCompetenciaDto,
+} from '../api/resultados'
+
+interface UseAuditoriaCompetenciaArgs {
+  competenciaId: string | undefined
+  disciplina: string | undefined
+}
+
+interface UseAuditoriaCompetenciaResult {
+  estado: EstadoCompetenciaDto | undefined
+  grilla: GrillaAtletaDto[] | undefined
+  ranking: RankingCompetenciaDto | undefined
+  isLoading: boolean
+  hasError: boolean
+}
+
+export function useAuditoriaCompetencia({
+  competenciaId,
+  disciplina,
+}: UseAuditoriaCompetenciaArgs): UseAuditoriaCompetenciaResult {
+  const enabled = Boolean(competenciaId && disciplina)
+  const [estadoQuery, grillaQuery, rankingQuery] = useQueries({
+    queries: [
+      {
+        queryKey: ['estado-competencia', competenciaId, disciplina],
+        queryFn: () => fetchEstadoCompetencia(competenciaId!, disciplina!),
+        enabled,
+      },
+      {
+        queryKey: ['grilla-competencia', competenciaId, disciplina],
+        queryFn: () => fetchGrillaCompetencia(competenciaId!, disciplina!),
+        enabled,
+      },
+      {
+        queryKey: ['ranking-competencia', competenciaId, disciplina],
+        queryFn: () => fetchRankingCompetencia(competenciaId!, disciplina!),
+        enabled,
+      },
+    ],
+  })
+
+  return {
+    estado: estadoQuery.data,
+    grilla: grillaQuery.data,
+    ranking: rankingQuery.data,
+    isLoading: estadoQuery.isLoading || grillaQuery.isLoading || rankingQuery.isLoading,
+    hasError: estadoQuery.isError || grillaQuery.isError,
+  }
+}

--- a/frontend/src/pages/organizador/AuditoriaCompetenciaPage.tsx
+++ b/frontend/src/pages/organizador/AuditoriaCompetenciaPage.tsx
@@ -1,0 +1,200 @@
+import { useMemo, useState } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import type { GrillaAtletaDto } from '../../api/competencia'
+import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
+import { useAuditoriaCompetencia } from '../../hooks/useAuditoriaCompetencia'
+
+function formatEstado(estado: string) {
+  if (estado === 'EnEjecucion') return 'En ejecucion'
+  if (estado === 'Finalizada') return 'Finalizada'
+  if (estado === 'Confirmada') return 'Confirmada'
+  return estado
+}
+
+function formatResultadoFinal(
+  atleta: GrillaAtletaDto,
+  rankingMap: Map<string, string>,
+) {
+  const ranking = rankingMap.get(atleta.atleta_id)
+  if (ranking) return ranking
+  if (atleta.estado === 'DNS') return 'DNS'
+  if (atleta.estado === 'Ejecutada') return 'Ejecutada'
+  if (atleta.estado === 'EnRevision') return 'Revision'
+  if (atleta.estado === 'ResultadoRegistrado') return 'Resultado'
+  if (atleta.estado === 'Llamada') return 'Llamada'
+  return 'Pendiente'
+}
+
+function truncateHash(value: string) {
+  if (value.length <= 16) return value
+  return `${value.slice(0, 16)}...`
+}
+
+export function AuditoriaCompetenciaPage() {
+  const { competenciaId } = useParams()
+  const [searchParams] = useSearchParams()
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null)
+  const disciplina = searchParams.get('disciplina') ?? undefined
+  const torneoId = searchParams.get('torneo_id') ?? undefined
+
+  const { estado, grilla, ranking, isLoading, hasError } = useAuditoriaCompetencia({
+    competenciaId,
+    disciplina,
+  })
+
+  const rankingMap = useMemo(() => {
+    const entries = ranking?.rankings.flatMap((grupo) => grupo.entradas) ?? []
+    return new Map(
+      entries.map((entry) => [
+        entry.atleta_id,
+        entry.es_dns ? 'DNS' : (entry.tarjeta ?? (entry.rp ? `RP ${entry.rp}` : 'Pendiente')),
+      ]),
+    )
+  }, [ranking])
+
+  async function handleCopyHash() {
+    if (!estado?.hash_sha256) return
+    await navigator.clipboard.writeText(estado.hash_sha256)
+    setCopyFeedback('Copiado')
+    window.setTimeout(() => setCopyFeedback(null), 1600)
+  }
+
+  if (!competenciaId || !disciplina) {
+    return (
+      <OrganizadorLayout
+        title="Auditoria"
+        subtitle="Faltan parametros de navegacion"
+        actions={
+          <Link
+            to="/organizador/dashboard"
+            className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-700"
+          >
+            Volver
+          </Link>
+        }
+      >
+        <section className="rounded-[2rem] border border-red-300/60 bg-red-50 p-5 text-sm text-red-900">
+          No se pudo determinar la disciplina de la competencia.
+        </section>
+      </OrganizadorLayout>
+    )
+  }
+
+  return (
+    <OrganizadorLayout
+      title={`Auditoria - ${disciplina}`}
+      subtitle={`Competencia ${competenciaId}`}
+      actions={
+        <>
+          <Link
+            to={torneoId ? `/organizador/torneos/${torneoId}/competencias` : '/organizador/dashboard'}
+            className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-700"
+          >
+            Volver
+          </Link>
+          <Link
+            to="/organizador/dashboard"
+            className="rounded-full bg-stone-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-50"
+          >
+            Dashboard
+          </Link>
+        </>
+      }
+    >
+      {isLoading ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+          Cargando auditoria de competencia...
+        </section>
+      ) : null}
+
+      {hasError ? (
+        <section className="rounded-[2rem] border border-red-300/60 bg-red-50 p-5 text-sm text-red-900">
+          No se pudo cargar la auditoria de la competencia.
+        </section>
+      ) : null}
+
+      {!isLoading && !hasError && estado ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                Estado de disciplina
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-stone-900">
+                {formatEstado(estado.estado)}
+              </h2>
+            </div>
+
+            {estado.estado === 'Finalizada' && estado.hash_sha256 ? (
+              <div className="rounded-[1.5rem] border border-emerald-200 bg-emerald-50 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-800">
+                  Hash SHA-256
+                </p>
+                <div className="mt-2 flex flex-wrap items-center gap-3">
+                  <code
+                    title={estado.hash_sha256}
+                    className="rounded-full bg-white px-3 py-2 text-sm text-emerald-950"
+                  >
+                    {truncateHash(estado.hash_sha256)}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() => void handleCopyHash()}
+                    className="rounded-full bg-emerald-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white"
+                  >
+                    Copiar
+                  </button>
+                  {copyFeedback ? (
+                    <span className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-900">
+                      {copyFeedback}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      {!isLoading && !hasError && (grilla?.length ?? 0) === 0 ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+          No hay atletas registrados para esta competencia.
+        </section>
+      ) : null}
+
+      {!isLoading && !hasError
+        ? grilla?.map((atleta) => (
+            <Link
+              key={atleta.performance_id}
+              to={`/organizador/competencias/${competenciaId}/auditoria/${atleta.atleta_id}?disciplina=${encodeURIComponent(disciplina)}&torneo_id=${encodeURIComponent(torneoId ?? '')}`}
+              className="block rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)] transition hover:-translate-y-0.5 hover:border-stone-400"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                    Atleta
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold text-stone-900">
+                    {atleta.nombre_atleta}
+                  </h3>
+                  <p className="mt-2 text-sm text-stone-600">
+                    Posicion {atleta.posicion} · Andarivel {atleta.andarivel}
+                  </p>
+                </div>
+
+                <div className="text-left sm:text-right">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                    Resultado final
+                  </p>
+                  <p className="mt-2 text-lg font-semibold text-stone-900">
+                    {formatResultadoFinal(atleta, rankingMap)}
+                  </p>
+                  <p className="mt-2 text-sm text-stone-600">Estado {atleta.estado}</p>
+                </div>
+              </div>
+            </Link>
+          ))
+        : null}
+    </OrganizadorLayout>
+  )
+}

--- a/frontend/src/pages/organizador/AuditoriaPerformancePage.tsx
+++ b/frontend/src/pages/organizador/AuditoriaPerformancePage.tsx
@@ -1,0 +1,102 @@
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import type { AuditLogEventoDto } from '../../api/competencia'
+import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
+import { useAuditLog } from '../../hooks/useAuditLog'
+
+function formatTimestamp(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('es-AR', {
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+function formatDatos(evento: AuditLogEventoDto) {
+  const datos = evento.datos
+  if ('valor_ap' in datos) return `AP: ${String(datos.valor_ap)}`
+  if ('valor_rp' in datos) return `RP: ${String(datos.valor_rp)}`
+  if ('tipo' in datos) return `Tarjeta: ${String(datos.tipo)}`
+  if ('resolucion' in datos) return `Resolucion: ${String(datos.resolucion)}`
+  if ('penalizaciones' in datos) return `Penalizaciones: ${JSON.stringify(datos.penalizaciones)}`
+  if ('motivo_dq' in datos && datos.motivo_dq) return `Motivo DQ: ${String(datos.motivo_dq)}`
+  return JSON.stringify(datos)
+}
+
+export function AuditoriaPerformancePage() {
+  const { competenciaId, atletaId } = useParams()
+  const [searchParams] = useSearchParams()
+  const disciplina = searchParams.get('disciplina')
+  const torneoId = searchParams.get('torneo_id')
+  const auditLogQuery = useAuditLog(competenciaId, atletaId)
+
+  return (
+    <OrganizadorLayout
+      title="Traza de performance"
+      subtitle={
+        auditLogQuery.data
+          ? `${auditLogQuery.data.atleta_nombre} · ${auditLogQuery.data.disciplina}`
+          : 'Auditoria puntual de eventos'
+      }
+      actions={
+        <Link
+          to={`/organizador/competencias/${competenciaId}/auditoria?disciplina=${encodeURIComponent(disciplina ?? '')}&torneo_id=${encodeURIComponent(torneoId ?? '')}`}
+          className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-700"
+        >
+          Volver
+        </Link>
+      }
+    >
+      {auditLogQuery.isLoading ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+          Cargando traza de eventos...
+        </section>
+      ) : null}
+
+      {auditLogQuery.isError ? (
+        <section className="rounded-[2rem] border border-red-300/60 bg-red-50 p-5 text-sm text-red-900">
+          No se pudo cargar la traza de auditoria de la performance.
+        </section>
+      ) : null}
+
+      {!auditLogQuery.isLoading && !auditLogQuery.isError && auditLogQuery.data ? (
+        <>
+          <section className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+              Performance
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-stone-900">
+              {auditLogQuery.data.atleta_nombre}
+            </h2>
+            <p className="mt-2 text-sm text-stone-600">
+              Competencia {auditLogQuery.data.competencia_id} · Atleta {auditLogQuery.data.atleta_id}
+            </p>
+          </section>
+
+          {auditLogQuery.data.eventos.map((evento) => (
+            <article
+              key={`${evento.sequence}-${evento.tipo}`}
+              className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]"
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                    Evento #{evento.sequence}
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold text-stone-900">{evento.tipo}</h3>
+                </div>
+                <p className="text-sm text-stone-600">{formatTimestamp(evento.timestamp)}</p>
+              </div>
+              <p className="mt-4 text-sm leading-6 text-stone-700">{formatDatos(evento)}</p>
+            </article>
+          ))}
+        </>
+      ) : null}
+    </OrganizadorLayout>
+  )
+}

--- a/frontend/src/pages/organizador/DashboardPage.tsx
+++ b/frontend/src/pages/organizador/DashboardPage.tsx
@@ -1,19 +1,75 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { fetchTorneos } from '../../api/torneo'
+import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 import useAuthStore from '../../stores/useAuthStore'
 
 export function DashboardPage() {
   const logout = useAuthStore((s) => s.logout)
   const email = useAuthStore((s) => s.email)
+  const torneosQuery = useQuery({
+    queryKey: ['torneos-organizador'],
+    queryFn: fetchTorneos,
+  })
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center gap-4 p-8">
-      <h1 className="text-2xl font-bold text-gray-800">Panel del Organizador</h1>
-      <p className="text-gray-500">Dashboard — {email}</p>
-      <button
-        onClick={logout}
-        className="text-sm text-red-600 hover:underline"
-      >
-        Cerrar sesión
-      </button>
-    </div>
+    <OrganizadorLayout
+      title="Panel del organizador"
+      subtitle={email ? `Sesion activa: ${email}` : 'Gestion de auditoria y seguimiento'}
+      actions={
+        <button
+          type="button"
+          onClick={logout}
+          className="rounded-full bg-stone-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-50"
+        >
+          Cerrar sesion
+        </button>
+      }
+    >
+      {torneosQuery.isLoading ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+          Cargando torneos...
+        </section>
+      ) : null}
+
+      {torneosQuery.isError ? (
+        <section className="rounded-[2rem] border border-red-300/60 bg-red-50 p-5 text-sm text-red-900">
+          No se pudieron cargar los torneos.
+        </section>
+      ) : null}
+
+      {!torneosQuery.isLoading && !torneosQuery.isError && torneosQuery.data?.length === 0 ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+          No hay torneos disponibles para auditoria.
+        </section>
+      ) : null}
+
+      {!torneosQuery.isLoading && !torneosQuery.isError
+        ? torneosQuery.data?.map((torneo) => (
+            <article
+              key={torneo.torneo_id}
+              className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]"
+            >
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                    Torneo
+                  </p>
+                  <h2 className="mt-2 text-xl font-semibold text-stone-900">{torneo.nombre}</h2>
+                  <p className="mt-2 text-sm text-stone-600">
+                    {torneo.sede.nombre}, {torneo.sede.ciudad} · {torneo.estado}
+                  </p>
+                </div>
+                <Link
+                  to={`/organizador/torneos/${torneo.torneo_id}/competencias`}
+                  className="rounded-full border border-stone-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-900"
+                >
+                  Ver competencias
+                </Link>
+              </div>
+            </article>
+          ))
+        : null}
+    </OrganizadorLayout>
   )
 }

--- a/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
+++ b/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router-dom'
+import { fetchCompetenciasPorTorneo } from '../../api/competencia'
+import { fetchTorneos } from '../../api/torneo'
+import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
+
+export function TorneoCompetenciasPage() {
+  const { torneoId } = useParams()
+
+  const torneosQuery = useQuery({
+    queryKey: ['torneos-organizador'],
+    queryFn: fetchTorneos,
+  })
+  const competenciasQuery = useQuery({
+    queryKey: ['competencias-torneo', torneoId],
+    queryFn: () => fetchCompetenciasPorTorneo(torneoId!),
+    enabled: Boolean(torneoId),
+  })
+
+  const torneo = useMemo(
+    () => torneosQuery.data?.find((item) => item.torneo_id === torneoId) ?? null,
+    [torneoId, torneosQuery.data],
+  )
+
+  return (
+    <OrganizadorLayout
+      title="Competencias del torneo"
+      subtitle={torneo ? `${torneo.nombre} · ${torneo.sede.ciudad}` : 'Seleccion de competencias'}
+      actions={
+        <Link
+          to="/organizador/dashboard"
+          className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-700"
+        >
+          Volver
+        </Link>
+      }
+    >
+      {competenciasQuery.isLoading ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+          Cargando competencias...
+        </section>
+      ) : null}
+
+      {competenciasQuery.isError ? (
+        <section className="rounded-[2rem] border border-red-300/60 bg-red-50 p-5 text-sm text-red-900">
+          No se pudieron cargar las competencias del torneo.
+        </section>
+      ) : null}
+
+      {!competenciasQuery.isLoading &&
+      !competenciasQuery.isError &&
+      (competenciasQuery.data?.length ?? 0) === 0 ? (
+        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+          Este torneo no tiene competencias configuradas.
+        </section>
+      ) : null}
+
+      {!competenciasQuery.isLoading && !competenciasQuery.isError
+        ? competenciasQuery.data?.map((competencia) => (
+            <article
+              key={competencia.competencia_id}
+              className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]"
+            >
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                    Competencia
+                  </p>
+                  <h2 className="mt-2 text-xl font-semibold text-stone-900">
+                    {competencia.disciplina}
+                  </h2>
+                  <p className="mt-2 text-sm text-stone-600">
+                    ID {competencia.competencia_id}
+                  </p>
+                </div>
+                <Link
+                  to={`/organizador/competencias/${competencia.competencia_id}/auditoria?disciplina=${encodeURIComponent(competencia.disciplina)}&torneo_id=${encodeURIComponent(competencia.torneo_id)}`}
+                  className="rounded-full bg-stone-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-50"
+                >
+                  Ver auditoria
+                </Link>
+              </div>
+            </article>
+          ))
+        : null}
+    </OrganizadorLayout>
+  )
+}

--- a/quality/reports/codeguard/US-4.6.3-codeguard.json
+++ b/quality/reports/codeguard/US-4.6.3-codeguard.json
@@ -1,0 +1,1020 @@
+{
+  "summary": {
+    "total_files": 6,
+    "checks_executed": 6,
+    "elapsed_seconds": 12.98,
+    "timestamp": "2026-04-16T10:20:12.291268",
+    "total_issues": 47,
+    "errors": 0,
+    "warnings": 4,
+    "infos": 43
+  },
+  "results": [
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/competencia/domain/aggregates/competencia.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/competencia/domain/aggregates/competencia.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/competencia/domain/aggregates/competencia.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+      "line": 66
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+      "line": 67
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+      "line": 68
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+      "line": 98
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+      "line": 99
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 65
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 66
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 79
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 93
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 94
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 95
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 96
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 97
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 98
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 99
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 166
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 182
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": 183
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 217
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 223
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 248
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 266
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 294
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 301
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 302
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 303
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 304
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 305
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 306
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 307
+    },
+    {
+      "check": "PEP8",
+      "severity": "warning",
+      "message": "PEP8: F401 'competencia.domain.exceptions.CompetenciaNoFinalizable' imported but unused",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 23
+    },
+    {
+      "check": "PEP8",
+      "severity": "warning",
+      "message": "PEP8: F401 'competencia.domain.aggregates.competencia.Competencia' imported but unused",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 36
+    },
+    {
+      "check": "PEP8",
+      "severity": "warning",
+      "message": "PEP8: F811 redefinition of unused 'Competencia' from line 36",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 179
+    },
+    {
+      "check": "Complexity",
+      "severity": "warning",
+      "message": "Complexity: test_competencia_finalizada_payload_correcto has cyclomatic complexity 12 (grade C). Consider refactoring into smaller functions.",
+      "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+      "line": 272
+    }
+  ],
+  "by_severity": {
+    "errors": [],
+    "warnings": [
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: F401 'competencia.domain.exceptions.CompetenciaNoFinalizable' imported but unused",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 23
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: F401 'competencia.domain.aggregates.competencia.Competencia' imported but unused",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 36
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: F811 redefinition of unused 'Competencia' from line 36",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 179
+      },
+      {
+        "check": "Complexity",
+        "severity": "warning",
+        "message": "Complexity: test_competencia_finalizada_payload_correcto has cyclomatic complexity 12 (grade C). Consider refactoring into smaller functions.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 272
+      }
+    ],
+    "infos": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 66
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 67
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 68
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 98
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 99
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 65
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 66
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 79
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 93
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 94
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 95
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 96
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 97
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 98
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 99
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 166
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 182
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 183
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 217
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 223
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 248
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 266
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 294
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 301
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 302
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 303
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 304
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 305
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 306
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 307
+      }
+    ]
+  },
+  "by_package": {
+    "aggregates": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/domain/aggregates/competencia.py",
+        "line": null
+      }
+    ],
+    "api": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/api/router.py",
+        "line": null
+      }
+    ],
+    "competencia": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 217
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 223
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 248
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 266
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 294
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 301
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 302
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 303
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 304
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 305
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 306
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 307
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: F401 'competencia.domain.exceptions.CompetenciaNoFinalizable' imported but unused",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 23
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: F401 'competencia.domain.aggregates.competencia.Competencia' imported but unused",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 36
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: F811 redefinition of unused 'Competencia' from line 36",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 179
+      },
+      {
+        "check": "Complexity",
+        "severity": "warning",
+        "message": "Complexity: test_competencia_finalizada_payload_correcto has cyclomatic complexity 12 (grade C). Consider refactoring into smaller functions.",
+        "file": "tests/integration/competencia/test_competencia_finalizada_integration.py",
+        "line": 272
+      }
+    ],
+    "domain": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 65
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 66
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 79
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 93
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 94
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 95
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 96
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 97
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 98
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 99
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 166
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 182
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": 183
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "tests/unit/competencia/domain/test_competencia_finalizar.py",
+        "line": null
+      }
+    ],
+    "queries": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/competencia/application/queries/obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 66
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 67
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 68
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 98
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "Security [B101]: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": 99
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "tests/unit/competencia/application/queries/test_obtener_estado_competencia.py",
+        "line": null
+      }
+    ]
+  }
+}

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -927,6 +927,7 @@ async def get_estado_competencia(
             "intervalo_minutos": dto.intervalo_minutos,
             "grilla_confirmada": dto.grilla_confirmada,
             "torneo_id": str(dto.torneo_id) if dto.torneo_id else None,
+            "hash_sha256": dto.hash_sha256,
         },
         status_code=200,
     )

--- a/src/competencia/application/queries/obtener_estado_competencia.py
+++ b/src/competencia/application/queries/obtener_estado_competencia.py
@@ -18,6 +18,7 @@ class EstadoCompetenciaDTO:
     intervalo_minutos: int | None
     grilla_confirmada: bool
     torneo_id: UUID | None = None
+    hash_sha256: str | None = None
 
 
 @dataclass(frozen=True)  # pylint: disable=too-few-public-methods
@@ -54,4 +55,5 @@ class ObtenerEstadoCompetenciaHandler:
             ),
             grilla_confirmada=competencia.grilla_confirmada,
             torneo_id=competencia.torneo_id,
+            hash_sha256=competencia.hash_sha256,
         )

--- a/src/competencia/domain/aggregates/competencia.py
+++ b/src/competencia/domain/aggregates/competencia.py
@@ -61,6 +61,7 @@ class Competencia(AggregateRoot):
         self._estado: EstadoCompetencia = EstadoCompetencia.Preparacion
         self._intervalo: IntervaloDisciplina | None = None
         self._grilla_confirmada: bool = False
+        self._hash_sha256: str | None = None
         self._grilla = GrillaDeSalida()
 
     # ── Propiedades ───────────────────────────────────────────────────────────
@@ -99,6 +100,11 @@ class Competencia(AggregateRoot):
     def grilla_confirmada(self) -> bool:
         """True si la grilla fue confirmada de forma irreversible."""
         return self._grilla_confirmada
+
+    @property
+    def hash_sha256(self) -> str | None:
+        """Hash SHA-256 persistido al cierre, o None si la competencia no finalizó."""
+        return self._hash_sha256
 
     # ── Comandos de dominio ───────────────────────────────────────────────────
 
@@ -367,6 +373,7 @@ class Competencia(AggregateRoot):
             hash_sha256=hash_sha256,
         )
         self._estado = EstadoCompetencia.Finalizada
+        self._hash_sha256 = hash_sha256
         self._record(event)
 
     # ── Reconstitución desde eventos ──────────────────────────────────────────
@@ -430,8 +437,9 @@ class Competencia(AggregateRoot):
     def _apply_competencia_iniciada(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
         self._estado = EstadoCompetencia.EnEjecucion
 
-    def _apply_competencia_finalizada(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
+    def _apply_competencia_finalizada(self, payload: dict[str, Any]) -> None:
         self._estado = EstadoCompetencia.Finalizada
+        self._hash_sha256 = payload.get("hash_sha256")
 
     @staticmethod
     def _parse_payload(payload: Any) -> dict[str, Any]:

--- a/tests/features/US-4.6.3-ui-auditoria-organizador.feature
+++ b/tests/features/US-4.6.3-ui-auditoria-organizador.feature
@@ -1,0 +1,41 @@
+Feature: US-4.6.3 - UI auditoria del organizador
+
+  Background:
+    Given el usuario esta autenticado como organizador
+    And existe la competencia "comp-abc" con disciplina DNF
+    And el atleta "Martin Garcia" tiene 3 eventos en el audit log
+
+  Scenario: organizador navega a la pantalla de auditoria de la disciplina
+    Given la disciplina esta cerrada con hash SHA-256 "a3f7c2d1e5f9"
+    When accede a /organizador/competencias/comp-abc/auditoria
+    Then ve la lista de atletas de la disciplina con su resultado final
+    And el encabezado muestra el estado "Finalizada"
+    And el hash SHA-256 es visible con accion de copiar
+
+  Scenario: hash no visible si la disciplina sigue en ejecucion
+    Given la disciplina esta en estado "EnEjecucion"
+    When accede a /organizador/competencias/comp-abc/auditoria
+    Then el encabezado muestra el estado "EnEjecucion"
+    And el campo hash SHA-256 no aparece
+
+  Scenario: organizador ve la traza cronologica de una performance
+    When accede a /organizador/competencias/comp-abc/auditoria/ath-001
+    Then ve 3 eventos en orden cronologico ascendente
+    And el primer evento es "PerformanceRegistrada"
+    And el ultimo evento es "TarjetaAsignada"
+
+  Scenario: traza con correccion muestra todos los eventos
+    Given la performance de "Ana Flores" incluye un evento "ResultadoCorregido"
+    When accede a su traza de auditoria
+    Then el evento "ResultadoCorregido" aparece despues del resultado original
+
+  Scenario: juez no puede acceder a la auditoria del organizador
+    Given el usuario esta autenticado como juez
+    When intenta acceder a /organizador/competencias/comp-abc/auditoria
+    Then es redirigido a la ruta /juez/disciplinas
+
+  Scenario: copiar hash entrega feedback visual
+    Given la disciplina esta cerrada con hash SHA-256 "a3f7c2d1e5f9"
+    When pulsa la accion copiar hash
+    Then el hash completo queda disponible para copiar
+    And aparece el feedback "Copiado"

--- a/tests/unit/competencia/application/queries/test_obtener_estado_competencia.py
+++ b/tests/unit/competencia/application/queries/test_obtener_estado_competencia.py
@@ -1,0 +1,99 @@
+"""Tests unitarios de ObtenerEstadoCompetenciaHandler."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from competencia.application.queries.obtener_estado_competencia import (
+    ObtenerEstadoCompetenciaHandler,
+    ObtenerEstadoCompetenciaQuery,
+)
+from competencia.domain.value_objects.disciplina import Disciplina
+
+
+def _event(event_type: str, payload: dict[str, object]) -> dict[str, object]:
+    return {
+        "event_type": event_type,
+        "payload": payload,
+        "version": 1,
+        "occurred_at": datetime(2026, 4, 16, 10, 0, 0).isoformat(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_retorna_hash_sha256_si_la_competencia_finalizo() -> None:
+    competencia_id = uuid4()
+    hash_sha256 = "a" * 64
+    store = AsyncMock()
+    store.load.return_value = [
+        _event(
+            "IntervaloOTConfigurado",
+            {
+                "competencia_id": str(competencia_id),
+                "disciplina": Disciplina.DNF.value,
+                "intervalo_minutos": 7,
+                "configurado_por": "org-1",
+                "torneo_id": None,
+            },
+        ),
+        _event(
+            "CompetenciaFinalizada",
+            {
+                "competencia_id": str(competencia_id),
+                "disciplina": Disciplina.DNF.value,
+                "total_performances": 2,
+                "ejecutadas": 2,
+                "dns_count": 0,
+                "finalizada_en": datetime(2026, 4, 16, 12, 0, 0).isoformat(),
+                "hash_sha256": hash_sha256,
+                "occurred_at": datetime(2026, 4, 16, 12, 0, 0).isoformat(),
+            },
+        ),
+    ]
+    handler = ObtenerEstadoCompetenciaHandler(store)
+
+    dto = await handler.handle(
+        ObtenerEstadoCompetenciaQuery(
+            competencia_id=competencia_id,
+            disciplina=Disciplina.DNF,
+        )
+    )
+
+    assert dto.estado == "Finalizada"
+    assert dto.intervalo_minutos == 7
+    assert dto.hash_sha256 == hash_sha256
+
+
+@pytest.mark.asyncio
+async def test_retorna_hash_nulo_para_stream_historico_sin_campo() -> None:
+    competencia_id = uuid4()
+    store = AsyncMock()
+    store.load.return_value = [
+        _event(
+            "CompetenciaFinalizada",
+            {
+                "competencia_id": str(competencia_id),
+                "disciplina": Disciplina.STA.value,
+                "total_performances": 0,
+                "ejecutadas": 0,
+                "dns_count": 0,
+                "finalizada_en": datetime(2026, 4, 16, 12, 0, 0).isoformat(),
+                "occurred_at": datetime(2026, 4, 16, 12, 0, 0).isoformat(),
+            },
+        )
+    ]
+    handler = ObtenerEstadoCompetenciaHandler(store)
+
+    dto = await handler.handle(
+        ObtenerEstadoCompetenciaQuery(
+            competencia_id=competencia_id,
+            disciplina=Disciplina.STA,
+        )
+    )
+
+    assert dto.estado == "Finalizada"
+    assert dto.hash_sha256 is None


### PR DESCRIPTION
## Resumen
- agrega navegacion de auditoria para organizador
- muestra hash_sha256 al extender GET /competencia/{id}/estado
- incorpora timeline puntual, hooks, reporte y HITO-23

## Validacion
- pytest focalizado: 13 passed
- frontend build: OK
- frontend lint: OK
- codeguard focalizado: 0 errors