### PR TITLE
feat(frontend): gestionar fases del torneo [US-5.1.2]

### DIFF
--- a/.claude/tracking/US-5.1.2-tracking.json
+++ b/.claude/tracking/US-5.1.2-tracking.json
@@ -1,0 +1,178 @@
+{
+  "metadata": {
+    "us_id": "US-5.1.2",
+    "us_title": "Gestión de fases del torneo",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-20T14:03:03.292886+00:00",
+    "completed_at": "2026-04-20T14:23:39.060753+00:00",
+    "total_elapsed_seconds": 1235,
+    "effective_seconds": 1235,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-20T14:03:13.383953+00:00",
+      "completed_at": "2026-04-20T14:04:38.736015+00:00",
+      "elapsed_seconds": 85,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-20T14:05:25.263154+00:00",
+      "completed_at": "2026-04-20T14:05:48.918372+00:00",
+      "elapsed_seconds": 23,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-20T14:05:56.985869+00:00",
+      "completed_at": "2026-04-20T14:08:36.121707+00:00",
+      "elapsed_seconds": 159,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada",
+      "started_at": "2026-04-20T14:08:43.184272+00:00",
+      "completed_at": "2026-04-20T14:14:39.390864+00:00",
+      "elapsed_seconds": 356,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "api_transiciones",
+          "task_name": "Extender API client con transiciones",
+          "task_type": "frontend",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-20T14:08:49.804715+00:00",
+          "completed_at": "2026-04-20T14:09:42.287638+00:00",
+          "elapsed_seconds": 52,
+          "actual_minutes": 0.87,
+          "variance_minutes": -24.13,
+          "file_created": "frontend/src/api/torneo.ts",
+          "status": "completed"
+        },
+        {
+          "task_id": "componentes_fase",
+          "task_name": "Crear componentes de fase",
+          "task_type": "frontend",
+          "estimated_minutes": 35.0,
+          "started_at": "2026-04-20T14:09:48.775001+00:00",
+          "completed_at": "2026-04-20T14:11:48.772155+00:00",
+          "elapsed_seconds": 119,
+          "actual_minutes": 1.98,
+          "variance_minutes": -33.02,
+          "file_created": "frontend/src/components/organizador/AccionesPanel.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "detalle_fases",
+          "task_name": "Integrar acciones en detalle de torneo",
+          "task_type": "frontend",
+          "estimated_minutes": 40.0,
+          "started_at": "2026-04-20T14:12:34.249856+00:00",
+          "completed_at": "2026-04-20T14:13:27.150012+00:00",
+          "elapsed_seconds": 52,
+          "actual_minutes": 0.87,
+          "variance_minutes": -39.13,
+          "file_created": "frontend/src/pages/organizador/DetalleTorneoPage.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-20T14:14:45.840727+00:00",
+      "completed_at": "2026-04-20T14:15:01.425944+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-20T14:15:09.666481+00:00",
+      "completed_at": "2026-04-20T14:15:27.366875+00:00",
+      "elapsed_seconds": 17,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-20T14:15:33.674889+00:00",
+      "completed_at": "2026-04-20T14:15:49.693808+00:00",
+      "elapsed_seconds": 16,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-20T14:16:07.614418+00:00",
+      "completed_at": "2026-04-20T14:22:26.182294+00:00",
+      "elapsed_seconds": 378,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-20T14:22:33.225349+00:00",
+      "completed_at": "2026-04-20T14:22:47.077253+00:00",
+      "elapsed_seconds": 13,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-20T14:22:54.331926+00:00",
+      "completed_at": "2026-04-20T14:23:16.508272+00:00",
+      "elapsed_seconds": 22,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 10,
+    "estimated_total_minutes": 100.0,
+    "actual_total_minutes": 3.72,
+    "variance_minutes": -96.28,
+    "variance_percent": -96.28
+  }
+}

--- a/docs/plans/sp5/US-5.1.2-plan.md
+++ b/docs/plans/sp5/US-5.1.2-plan.md
@@ -1,0 +1,64 @@
+# Plan de Implementacion — US-5.1.2 Gestion de Fases del Torneo
+
+**Sprint:** SP5  
+**Incremento:** INC-5.1  
+**Producto:** frontend  
+**Patron:** React/Vite PWA consumiendo BC `torneo` existente  
+**Estimacion:** 3 puntos
+
+## Alcance
+
+Extender el detalle del torneo para que el organizador pueda ver la fase actual y ejecutar
+las transiciones validas del ciclo de vida.
+
+## Tareas
+
+### 1. API Frontend
+
+- [ ] Extender `frontend/src/api/torneo.ts` con tipo `EstadoTorneo`.
+- [ ] Implementar `transicionarTorneo(torneoId, endpoint)`.
+- [ ] Exponer funciones:
+  - `abrirInscripcion`
+  - `cerrarInscripcion`
+  - `iniciarEjecucion`
+  - `volverPreparacion`
+  - `iniciarPremiacion`
+  - `cerrarTorneo`
+  - `cancelarTorneo`
+
+### 2. Componentes de Fase
+
+- [ ] Crear `frontend/src/components/organizador/FaseBadge.tsx`.
+- [ ] Crear `frontend/src/components/organizador/AccionesPanel.tsx`.
+- [ ] Mostrar acciones segun estado actual.
+- [ ] Mostrar cancelacion para estados activos.
+- [ ] Usar confirmacion explicita para cancelacion.
+
+### 3. Detalle del Torneo
+
+- [ ] Integrar `FaseBadge` en `DetalleTorneoPage`.
+- [ ] Integrar `AccionesPanel`.
+- [ ] Refrescar `GET /torneos/{id}` despues de transicion exitosa.
+- [ ] Mostrar errores backend inline sin mutar estado local.
+- [ ] Agregar tabs base: Detalle, Inscriptos, Grilla, Jueces, Ejecucion.
+
+### 4. Validacion
+
+- [ ] `npm run build`.
+- [ ] `npx eslint src`.
+- [ ] Documentar limitaciones de `npm run lint` global por `.vite/deps` generado.
+
+## Riesgos
+
+- La UI define el mapa de acciones visible, pero el backend sigue siendo la autoridad:
+  cualquier rechazo `409` se muestra inline y no se fuerza cambio local de estado.
+- Los tabs de futuras US se implementan como placeholders navegables dentro del detalle,
+  sin introducir funcionalidad de inscriptos/grilla/jueces/ejecucion.
+
+## DoD
+
+- El badge refleja la fase actual.
+- Solo aparecen acciones coherentes con el estado.
+- Las transiciones exitosas refrescan el torneo.
+- Los errores backend se muestran sin recargar.
+- Estados terminales no muestran acciones.

--- a/docs/reports/US-5.1.2-bdd-waiver.md
+++ b/docs/reports/US-5.1.2-bdd-waiver.md
@@ -1,0 +1,24 @@
+# US-5.1.2 — BDD Validation Waiver
+
+## Feature
+
+- `tests/features/US-5.1.2-gestion-fases-torneo.feature`
+
+## Estado
+
+Escenarios BDD generados y persistidos en disco. No se ejecutan automaticamente en esta US
+porque el proyecto no tiene steps ni harness E2E/browser para flujos React.
+
+## Cobertura Funcional del Feature
+
+- Estado `CREADO` muestra abrir inscripcion y cancelar.
+- Transicion exitosa `CREADO` a inscripcion.
+- Retroceso `EJECUCION` a preparacion.
+- Cancelacion con confirmacion.
+- Error backend `409` mostrado inline sin recargar estado local.
+- Estados terminales sin acciones de fase.
+
+## Evidencia Sustitutiva
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.

--- a/docs/reports/US-5.1.2-context.md
+++ b/docs/reports/US-5.1.2-context.md
@@ -1,0 +1,46 @@
+# US-5.1.2 — Contexto Validado
+
+**Historia de Usuario:** Gestion de fases del torneo  
+**Sprint:** SP5 — La Puesta en Marcha  
+**Incremento:** INC-5.1  
+**Producto:** frontend  
+**Puntos:** 3  
+**Estado inicial:** To Do
+
+## Arquitectura
+
+- Contexto obligatorio leido: `docs/contexto/ATARAXIADIVE-CONTEXT.md`.
+- US-IEDD encontrada: `docs/specs/sp5/US-5.1.2.md`.
+- Patron vigente: frontend React/Vite consumiendo BC `torneo`.
+- No requiere cambios backend: los endpoints de transicion ya existen en `src/torneo/api/router.py`.
+
+## Alcance Validado
+
+- Extender `frontend/src/api/torneo.ts` con operaciones de transicion.
+- Extender `frontend/src/pages/organizador/DetalleTorneoPage.tsx`.
+- Crear componentes:
+  - `FaseBadge`
+  - `AccionesPanel`
+- Mostrar tabs base del panel organizador para fases futuras.
+
+## Endpoints Consumidos
+
+- `PUT /torneos/{id}/abrir-inscripcion`
+- `PUT /torneos/{id}/cerrar-inscripcion`
+- `PUT /torneos/{id}/iniciar-ejecucion`
+- `PUT /torneos/{id}/volver-preparacion`
+- `PUT /torneos/{id}/iniciar-premiacion`
+- `PUT /torneos/{id}/cerrar`
+- `PUT /torneos/{id}/cancelar`
+- `GET /torneos/{id}` para refresco post-transicion.
+
+## Quality Gates
+
+- `CLAUDE.md` presente.
+- `tests/features/` presente.
+- `frontend/package.json` presente.
+- `pyproject.toml` contiene `tool.coverage`, `tool.codeguard` y `tool.designreviewer`.
+
+## Listo Para Fase 1
+
+Se puede proceder con escenarios BDD en `tests/features/US-5.1.2-gestion-fases-torneo.feature`.

--- a/docs/reports/US-5.1.2-integration.md
+++ b/docs/reports/US-5.1.2-integration.md
@@ -1,0 +1,23 @@
+# US-5.1.2 — Integracion
+
+## Superficie Integrada
+
+- `frontend/src/api/torneo.ts`
+  - funciones de transicion de fase
+- `frontend/src/components/organizador/FaseBadge.tsx`
+- `frontend/src/components/organizador/AccionesPanel.tsx`
+- `frontend/src/pages/organizador/DetalleTorneoPage.tsx`
+
+## Comportamiento Integrado
+
+- El detalle muestra la fase actual con `FaseBadge`.
+- `AccionesPanel` muestra transiciones segun estado actual.
+- Cancelacion se confirma mediante dialogo.
+- Las transiciones exitosas ejecutan `refetch()` de `GET /torneos/{id}`.
+- Los errores backend se muestran inline sin cambiar el estado en pantalla.
+- Estados terminales (`CERRADO`, `CANCELADO`) no muestran acciones.
+
+## Validacion Ejecutada
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.

--- a/docs/reports/US-5.1.2-report.md
+++ b/docs/reports/US-5.1.2-report.md
@@ -1,0 +1,59 @@
+# US-5.1.2 — Reporte Final
+
+**US:** Gestion de fases del torneo — botones de transicion con validaciones  
+**Sprint:** SP5  
+**Incremento:** INC-5.1  
+**Branch:** `feature/US-5.1.2-gestion-fases`  
+**Producto:** frontend  
+**Estado:** Implementada
+
+## Resultado
+
+Se implemento la gestion de fases desde el detalle del torneo:
+
+- `FaseBadge` para visualizar el estado actual.
+- `AccionesPanel` con acciones visibles segun fase.
+- Confirmacion explicita para cancelar torneo.
+- Transiciones via endpoints existentes de `torneo/api`.
+- Refresco automatico del detalle tras transicion exitosa.
+- Error inline si el backend rechaza la transicion.
+- Ocultamiento de acciones en estados terminales.
+- Tabs base del panel organizador: Detalle, Inscriptos, Grilla, Jueces, Ejecucion.
+
+## Archivos Principales
+
+- `frontend/src/api/torneo.ts`
+- `frontend/src/components/organizador/FaseBadge.tsx`
+- `frontend/src/components/organizador/AccionesPanel.tsx`
+- `frontend/src/pages/organizador/DetalleTorneoPage.tsx`
+
+## Artefactos del Pipeline
+
+- `docs/reports/US-5.1.2-context.md`
+- `tests/features/US-5.1.2-gestion-fases-torneo.feature`
+- `docs/plans/sp5/US-5.1.2-plan.md`
+- `docs/reports/US-5.1.2-test-strategy.md`
+- `docs/reports/US-5.1.2-integration.md`
+- `docs/reports/US-5.1.2-bdd-waiver.md`
+- `quality/reports/codeguard/US-5.1.2-quality.json`
+- `docs/traceability/matrix.md`
+- `.claude/tracking/US-5.1.2-tracking.json`
+
+## Validacion
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.
+- `npm run lint`: no aprobado por archivos generados preexistentes en `frontend/.vite/deps/react-router-dom.js`, fuera del codigo fuente modificado.
+
+## Decisiones
+
+- El frontend muestra un mapa fijo de acciones por estado para guiar al usuario.
+- El backend sigue siendo autoridad de transiciones: cualquier `409` se muestra inline y no se muta el estado local.
+- Los tabs de futuras US se agregaron como estructura base sin implementar funcionalidad fuera de alcance.
+
+## Pendientes Para US Posteriores
+
+- `US-5.1.3`: contenido real del tab Inscriptos.
+- `US-5.1.4`: contenido real del tab Grilla.
+- `US-5.1.5`: contenido real del tab Jueces.
+- `US-5.1.6`: contenido real del tab Ejecucion.

--- a/docs/reports/US-5.1.2-test-strategy.md
+++ b/docs/reports/US-5.1.2-test-strategy.md
@@ -1,0 +1,38 @@
+# US-5.1.2 — Estrategia de Tests
+
+## Tipo de US
+
+Frontend React/Vite para gestionar fases del torneo desde el panel del organizador.
+
+## Unit Tests
+
+No se agregan tests unitarios automatizados de componentes porque el frontend no tiene runner
+unitario configurado en `package.json` (no hay Vitest/Jest/Testing Library). Introducirlo en
+esta US ampliaria el alcance tecnico.
+
+Validacion aplicada:
+
+- `npm run build`: TypeScript + bundle Vite.
+- `npx eslint src`: lint acotado a codigo fuente.
+
+## Integracion
+
+La integracion cubierta por la implementacion es UI -> endpoints existentes:
+
+- `PUT /torneos/{id}/abrir-inscripcion`
+- `PUT /torneos/{id}/cerrar-inscripcion`
+- `PUT /torneos/{id}/iniciar-ejecucion`
+- `PUT /torneos/{id}/volver-preparacion`
+- `PUT /torneos/{id}/iniciar-premiacion`
+- `PUT /torneos/{id}/cerrar`
+- `PUT /torneos/{id}/cancelar`
+- `GET /torneos/{id}` para refresco post-transicion.
+
+## BDD
+
+Escenarios generados en:
+
+- `tests/features/US-5.1.2-gestion-fases-torneo.feature`
+
+No se agregan step definitions ejecutables porque el proyecto no tiene harness E2E/browser
+frontend configurado.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -458,6 +458,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 | US-4.6.3 | frontend (build + lint) · UAT INC-4.6 iPad organizador | ✅ UAT SP4 2026-04-18 |
 | US-4.6.4 | unit/resultados/application (ExportarResultados) + integration/resultados · UAT INC-4.6 | ✅ UAT SP4 2026-04-18 |
 | US-5.1.1 | frontend (build + eslint src) · features/US-5.1.1 | ✅ Implementada (lint global bloqueado por `.vite/deps` generado) |
+| US-5.1.2 | frontend (build + eslint src) · features/US-5.1.2 | ✅ Implementada (lint global bloqueado por `.vite/deps` generado) |
 
 ---
 
@@ -487,6 +488,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 *v1.16 — 2026-04-15: INC-4.4 ✅ (US-4.4.1..3 Done · fix robustez) · INC-4.5 ✅ §16 agregado (4 US · PRs #79–82) · §§ renumerados 17..20 · US→ADR ADR-016*
 *v1.17 — 2026-04-18: SP4 cerrado (v0.5.0 · BL-004) · SP-ADJ-06 §18 agregado (7 US) · US→Tests completado (INC-4.4/4.5/4.6) · §§ renumerados 18..22 · §2 cobertura actualizada*
 *v1.18 — 2026-04-20: SP5 iniciado · US-5.1.1 implementada · trazabilidad frontend de creacion de torneo agregada*
+*v1.19 — 2026-04-20: US-5.1.2 implementada · trazabilidad frontend de gestion de fases agregada*
 *v1.15 — 2026-04-13: INC-4.4 especificado (§15 nuevo — 3 US offline-first) · §§ renumerados 16..19 · §2 cobertura actualizada*
 *v1.14 — 2026-04-13: INC-4.3 completado (§14 — 5/5 US ✅, UAT BA 2025) · RF-NT §3.7 INC corregido (4.2→4.5) · US-4.3.x en §18*
 *v1.13 — 2026-04-11: US-4.2.2 implementada y mergeada · DesignReviewer consolidado INC-4.2 OK · validación manual pendiente*

--- a/frontend/src/api/torneo.ts
+++ b/frontend/src/api/torneo.ts
@@ -24,8 +24,17 @@ export interface TorneoDto {
     nombre: string
     tipo: string
   }
-  estado: string
+  estado: EstadoTorneo
 }
+
+export type EstadoTorneo =
+  | 'CREADO'
+  | 'INSCRIPCION_ABIERTA'
+  | 'PREPARACION'
+  | 'EJECUCION'
+  | 'PREMIACION'
+  | 'CERRADO'
+  | 'CANCELADO'
 
 export type DisciplinaCodigo =
   | 'STA'
@@ -135,6 +144,43 @@ export async function asignarDisciplinas(
   })
 
   await parseResponse<{ ok: boolean }>(response)
+}
+
+async function transicionarTorneo(torneoId: string, endpoint: string): Promise<void> {
+  const response = await fetch(`/torneos/${torneoId}/${endpoint}`, {
+    method: 'PUT',
+    headers: buildHeaders(),
+  })
+
+  await parseResponse<{ ok: boolean }>(response)
+}
+
+export async function abrirInscripcion(torneoId: string): Promise<void> {
+  await transicionarTorneo(torneoId, 'abrir-inscripcion')
+}
+
+export async function cerrarInscripcion(torneoId: string): Promise<void> {
+  await transicionarTorneo(torneoId, 'cerrar-inscripcion')
+}
+
+export async function iniciarEjecucion(torneoId: string): Promise<void> {
+  await transicionarTorneo(torneoId, 'iniciar-ejecucion')
+}
+
+export async function volverPreparacion(torneoId: string): Promise<void> {
+  await transicionarTorneo(torneoId, 'volver-preparacion')
+}
+
+export async function iniciarPremiacion(torneoId: string): Promise<void> {
+  await transicionarTorneo(torneoId, 'iniciar-premiacion')
+}
+
+export async function cerrarTorneo(torneoId: string): Promise<void> {
+  await transicionarTorneo(torneoId, 'cerrar')
+}
+
+export async function cancelarTorneo(torneoId: string): Promise<void> {
+  await transicionarTorneo(torneoId, 'cancelar')
 }
 
 export async function fetchDisciplinasDeJuez(

--- a/frontend/src/components/organizador/AccionesPanel.tsx
+++ b/frontend/src/components/organizador/AccionesPanel.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react'
+import {
+  abrirInscripcion,
+  cancelarTorneo,
+  cerrarInscripcion,
+  cerrarTorneo,
+  iniciarEjecucion,
+  iniciarPremiacion,
+  volverPreparacion,
+  type EstadoTorneo,
+} from '../../api/torneo'
+
+interface AccionFase {
+  label: string
+  run: (torneoId: string) => Promise<void>
+  variant?: 'primary' | 'secondary'
+}
+
+const ACCIONES_POR_ESTADO: Partial<Record<EstadoTorneo, AccionFase[]>> = {
+  CREADO: [{ label: 'Abrir inscripcion', run: abrirInscripcion, variant: 'primary' }],
+  INSCRIPCION_ABIERTA: [
+    { label: 'Cerrar inscripcion', run: cerrarInscripcion, variant: 'primary' },
+  ],
+  PREPARACION: [{ label: 'Iniciar ejecucion', run: iniciarEjecucion, variant: 'primary' }],
+  EJECUCION: [
+    { label: 'Volver a preparacion', run: volverPreparacion, variant: 'secondary' },
+    { label: 'Iniciar premiacion', run: iniciarPremiacion, variant: 'primary' },
+  ],
+  PREMIACION: [{ label: 'Cerrar torneo', run: cerrarTorneo, variant: 'primary' }],
+}
+
+const ESTADOS_TERMINALES = new Set<EstadoTorneo>(['CERRADO', 'CANCELADO'])
+
+interface AccionesPanelProps {
+  torneoId: string
+  torneoNombre: string
+  estado: EstadoTorneo
+  onSuccess: () => Promise<void>
+  onError: (message: string) => void
+}
+
+function buttonClass(variant: 'primary' | 'secondary' | 'danger'): string {
+  if (variant === 'danger') {
+    return 'rounded-lg border border-red-700 px-4 py-2 text-sm font-semibold text-red-800 disabled:cursor-not-allowed disabled:opacity-60'
+  }
+  if (variant === 'secondary') {
+    return 'rounded-lg border border-stone-700 px-4 py-2 text-sm font-semibold text-stone-900 disabled:cursor-not-allowed disabled:opacity-60'
+  }
+  return 'rounded-lg bg-stone-900 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-stone-500'
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return 'No se pudo transicionar el torneo'
+}
+
+export function AccionesPanel({
+  torneoId,
+  torneoNombre,
+  estado,
+  onSuccess,
+  onError,
+}: AccionesPanelProps) {
+  const [runningAction, setRunningAction] = useState<string | null>(null)
+  const [showCancelDialog, setShowCancelDialog] = useState(false)
+  const acciones = ACCIONES_POR_ESTADO[estado] ?? []
+  const puedeCancelar = !ESTADOS_TERMINALES.has(estado)
+
+  async function runAction(action: AccionFase) {
+    setRunningAction(action.label)
+    onError('')
+    try {
+      await action.run(torneoId)
+      await onSuccess()
+    } catch (error) {
+      onError(getErrorMessage(error))
+    } finally {
+      setRunningAction(null)
+    }
+  }
+
+  async function confirmCancel() {
+    setRunningAction('Cancelar torneo')
+    onError('')
+    try {
+      await cancelarTorneo(torneoId)
+      setShowCancelDialog(false)
+      await onSuccess()
+    } catch (error) {
+      onError(getErrorMessage(error))
+    } finally {
+      setRunningAction(null)
+    }
+  }
+
+  if (acciones.length === 0 && !puedeCancelar) {
+    return null
+  }
+
+  return (
+    <section className="rounded-lg border border-stone-300 bg-white p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-stone-950">Acciones de fase</h3>
+          <p className="mt-1 text-sm text-stone-600">
+            Ejecuta transiciones permitidas por el ciclo de vida del torneo.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {acciones.map((action) => (
+            <button
+              key={action.label}
+              type="button"
+              onClick={() => void runAction(action)}
+              disabled={runningAction !== null}
+              className={buttonClass(action.variant ?? 'primary')}
+            >
+              {runningAction === action.label ? 'Procesando...' : action.label}
+            </button>
+          ))}
+          {puedeCancelar ? (
+            <button
+              type="button"
+              onClick={() => setShowCancelDialog(true)}
+              disabled={runningAction !== null}
+              className={buttonClass('danger')}
+            >
+              Cancelar torneo
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {showCancelDialog ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/40 px-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="cancelar-torneo-title"
+            className="w-full max-w-md rounded-lg bg-white p-5 shadow-2xl"
+          >
+            <h3 id="cancelar-torneo-title" className="text-lg font-semibold text-stone-950">
+              Cancelar torneo {torneoNombre}
+            </h3>
+            <p className="mt-2 text-sm text-stone-600">Esta accion no se puede deshacer.</p>
+            <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => setShowCancelDialog(false)}
+                disabled={runningAction !== null}
+                className="rounded-lg border border-stone-300 px-4 py-2 text-sm font-semibold text-stone-800"
+              >
+                Mantener torneo
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmCancel()}
+                disabled={runningAction !== null}
+                className="rounded-lg bg-red-700 px-4 py-2 text-sm font-semibold text-white disabled:bg-red-400"
+              >
+                {runningAction === 'Cancelar torneo' ? 'Cancelando...' : 'Confirmar cancelacion'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/frontend/src/components/organizador/FaseBadge.tsx
+++ b/frontend/src/components/organizador/FaseBadge.tsx
@@ -1,0 +1,38 @@
+import type { EstadoTorneo } from '../../api/torneo'
+
+const ESTADO_TORNEO_LABELS: Record<EstadoTorneo, string> = {
+  CREADO: 'Creado',
+  INSCRIPCION_ABIERTA: 'Inscripcion abierta',
+  PREPARACION: 'Preparacion',
+  EJECUCION: 'En ejecucion',
+  PREMIACION: 'Premiacion',
+  CERRADO: 'Cerrado',
+  CANCELADO: 'Cancelado',
+}
+
+const ESTADO_TORNEO_STYLES: Record<EstadoTorneo, string> = {
+  CREADO: 'border-stone-300 bg-stone-100 text-stone-800',
+  INSCRIPCION_ABIERTA: 'border-emerald-300 bg-emerald-50 text-emerald-900',
+  PREPARACION: 'border-amber-300 bg-amber-50 text-amber-900',
+  EJECUCION: 'border-sky-300 bg-sky-50 text-sky-900',
+  PREMIACION: 'border-violet-300 bg-violet-50 text-violet-900',
+  CERRADO: 'border-stone-400 bg-stone-200 text-stone-900',
+  CANCELADO: 'border-red-300 bg-red-50 text-red-900',
+}
+
+interface FaseBadgeProps {
+  estado: EstadoTorneo
+}
+
+export function FaseBadge({ estado }: FaseBadgeProps) {
+  return (
+    <span
+      className={[
+        'inline-flex min-h-9 items-center rounded-lg border px-3 py-1 text-sm font-semibold',
+        ESTADO_TORNEO_STYLES[estado],
+      ].join(' ')}
+    >
+      {ESTADO_TORNEO_LABELS[estado]}
+    </span>
+  )
+}

--- a/frontend/src/pages/organizador/DetalleTorneoPage.tsx
+++ b/frontend/src/pages/organizador/DetalleTorneoPage.tsx
@@ -1,24 +1,17 @@
 import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { fetchTorneo } from '../../api/torneo'
+import { AccionesPanel } from '../../components/organizador/AccionesPanel'
+import { FaseBadge } from '../../components/organizador/FaseBadge'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 
-const ESTADO_LABELS: Record<string, string> = {
-  CREADO: 'Creado',
-  INSCRIPCION_ABIERTA: 'Inscripcion abierta',
-  PREPARACION: 'Preparacion',
-  EJECUCION: 'En ejecucion',
-  PREMIACION: 'Premiacion',
-  CERRADO: 'Cerrado',
-  CANCELADO: 'Cancelado',
-}
-
-function formatEstado(estado: string): string {
-  return ESTADO_LABELS[estado] ?? estado
-}
+const TABS = ['Detalle', 'Inscriptos', 'Grilla', 'Jueces', 'Ejecucion'] as const
 
 export function DetalleTorneoPage() {
   const { torneoId } = useParams<{ torneoId: string }>()
+  const [activeTab, setActiveTab] = useState<(typeof TABS)[number]>('Detalle')
+  const [transitionError, setTransitionError] = useState('')
   const torneoQuery = useQuery({
     queryKey: ['torneo', torneoId],
     queryFn: () => fetchTorneo(torneoId ?? ''),
@@ -51,50 +44,91 @@ export function DetalleTorneoPage() {
       ) : null}
 
       {torneoQuery.data ? (
-        <section className="rounded-lg border border-stone-300 bg-white p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <p className="text-sm font-semibold text-emerald-800">
-                {formatEstado(torneoQuery.data.estado)}
-              </p>
-              <h2 className="mt-2 text-2xl font-semibold text-stone-950">
-                {torneoQuery.data.nombre}
-              </h2>
-              <p className="mt-2 text-sm text-stone-600">
-                {torneoQuery.data.fecha_inicio} a {torneoQuery.data.fecha_fin}
-              </p>
+        <>
+          <section className="rounded-lg border border-stone-300 bg-white p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <FaseBadge estado={torneoQuery.data.estado} />
+                <h2 className="mt-3 text-2xl font-semibold text-stone-950">
+                  {torneoQuery.data.nombre}
+                </h2>
+                <p className="mt-2 text-sm text-stone-600">
+                  {torneoQuery.data.fecha_inicio} a {torneoQuery.data.fecha_fin}
+                </p>
+              </div>
+              <Link
+                to={`/organizador/torneos/${torneoQuery.data.torneo_id}/competencias`}
+                className="rounded-lg bg-stone-900 px-4 py-2 text-center text-sm font-semibold text-white"
+              >
+                Ver competencias
+              </Link>
             </div>
-            <Link
-              to={`/organizador/torneos/${torneoQuery.data.torneo_id}/competencias`}
-              className="rounded-lg bg-stone-900 px-4 py-2 text-center text-sm font-semibold text-white"
-            >
-              Ver competencias
-            </Link>
-          </div>
 
-          <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <div className="rounded-lg border border-stone-200 p-4">
-              <dt className="text-xs font-semibold text-stone-500">Sede</dt>
-              <dd className="mt-1 text-sm text-stone-900">
-                {torneoQuery.data.sede.nombre}, {torneoQuery.data.sede.ciudad},{' '}
-                {torneoQuery.data.sede.pais}
-              </dd>
+            <div className="mt-6 flex gap-2 overflow-x-auto border-b border-stone-200 pb-2">
+              {TABS.map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => setActiveTab(tab)}
+                  className={[
+                    'min-h-10 rounded-lg px-4 py-2 text-sm font-semibold',
+                    activeTab === tab
+                      ? 'bg-stone-900 text-white'
+                      : 'border border-stone-300 text-stone-800',
+                  ].join(' ')}
+                >
+                  {tab}
+                </button>
+              ))}
             </div>
-            <div className="rounded-lg border border-stone-200 p-4">
-              <dt className="text-xs font-semibold text-stone-500">Entidad</dt>
-              <dd className="mt-1 text-sm text-stone-900">
-                {torneoQuery.data.entidad_organizadora.nombre} ·{' '}
-                {torneoQuery.data.entidad_organizadora.tipo}
-              </dd>
-            </div>
-            <div className="rounded-lg border border-stone-200 p-4">
-              <dt className="text-xs font-semibold text-stone-500">Estado</dt>
-              <dd className="mt-1 text-sm text-stone-900">
-                {formatEstado(torneoQuery.data.estado)}
-              </dd>
-            </div>
-          </dl>
-        </section>
+
+            {activeTab === 'Detalle' ? (
+              <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <div className="rounded-lg border border-stone-200 p-4">
+                  <dt className="text-xs font-semibold text-stone-500">Sede</dt>
+                  <dd className="mt-1 text-sm text-stone-900">
+                    {torneoQuery.data.sede.nombre}, {torneoQuery.data.sede.ciudad},{' '}
+                    {torneoQuery.data.sede.pais}
+                  </dd>
+                </div>
+                <div className="rounded-lg border border-stone-200 p-4">
+                  <dt className="text-xs font-semibold text-stone-500">Entidad</dt>
+                  <dd className="mt-1 text-sm text-stone-900">
+                    {torneoQuery.data.entidad_organizadora.nombre} ·{' '}
+                    {torneoQuery.data.entidad_organizadora.tipo}
+                  </dd>
+                </div>
+                <div className="rounded-lg border border-stone-200 p-4">
+                  <dt className="text-xs font-semibold text-stone-500">Estado</dt>
+                  <dd className="mt-1 text-sm text-stone-900">
+                    <FaseBadge estado={torneoQuery.data.estado} />
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <div className="mt-6 rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+                {activeTab} quedara disponible en las siguientes US de INC-5.1.
+              </div>
+            )}
+          </section>
+
+          {transitionError ? (
+            <section className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+              {transitionError}
+            </section>
+          ) : null}
+
+          <AccionesPanel
+            torneoId={torneoQuery.data.torneo_id}
+            torneoNombre={torneoQuery.data.nombre}
+            estado={torneoQuery.data.estado}
+            onSuccess={async () => {
+              setTransitionError('')
+              await torneoQuery.refetch()
+            }}
+            onError={setTransitionError}
+          />
+        </>
       ) : null}
     </OrganizadorLayout>
   )

--- a/quality/reports/codeguard/US-5.1.2-quality.json
+++ b/quality/reports/codeguard/US-5.1.2-quality.json
@@ -1,0 +1,25 @@
+{
+  "us_id": "US-5.1.2",
+  "producto": "frontend",
+  "status": "passed_with_note",
+  "checks": [
+    {
+      "name": "frontend_build",
+      "command": "npm run build",
+      "status": "passed"
+    },
+    {
+      "name": "frontend_eslint_src",
+      "command": "npx eslint src",
+      "status": "passed"
+    },
+    {
+      "name": "frontend_lint_package",
+      "command": "npm run lint",
+      "status": "failed_external_generated_files",
+      "note": "Falla por frontend/.vite/deps/react-router-dom.js, archivo generado preexistente fuera de src."
+    }
+  ],
+  "codeguard_applicable": false,
+  "note": "CodeGuard esta orientado a Python src/. Para esta US frontend se usaron build TypeScript y ESLint sobre src."
+}

--- a/tests/features/US-5.1.2-gestion-fases-torneo.feature
+++ b/tests/features/US-5.1.2-gestion-fases-torneo.feature
@@ -1,0 +1,51 @@
+Feature: US-5.1.2 - Transiciones de fase del torneo
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And existe el torneo "BA 2026" con id "T1"
+
+  Scenario: torneo en Creado muestra abrir inscripcion y cancelar
+    Given el torneo "T1" esta en estado "CREADO"
+    When el organizador accede a "/organizador/torneo/T1"
+    Then ve el badge de estado "Creado"
+    And ve el boton "Abrir inscripcion"
+    And ve el boton "Cancelar torneo"
+    And no ve botones de otras transiciones
+
+  Scenario: transicion exitosa Creado a Inscripcion
+    Given el torneo "T1" esta en estado "CREADO"
+    When el organizador toca "Abrir inscripcion"
+    Then el backend recibe PUT "/torneos/T1/abrir-inscripcion"
+    And la UI recarga el torneo
+    And el badge de estado cambia a "Inscripcion abierta"
+    And aparece el boton "Cerrar inscripcion"
+
+  Scenario: transicion EnEjecucion a Preparacion
+    Given el torneo "T1" esta en estado "EJECUCION"
+    When el organizador toca "Volver a preparacion"
+    Then el backend recibe PUT "/torneos/T1/volver-preparacion"
+    And la UI recarga el torneo
+    And el badge de estado cambia a "Preparacion"
+
+  Scenario: cancelar torneo desde estado activo
+    Given el torneo "T1" esta en estado "PREPARACION"
+    When el organizador toca "Cancelar torneo"
+    Then aparece un dialogo de confirmacion "Cancelar torneo BA 2026"
+    When confirma la cancelacion
+    Then el backend recibe PUT "/torneos/T1/cancelar"
+    And la UI recarga el torneo
+    And el badge de estado cambia a "Cancelado"
+    And todos los botones de transicion desaparecen
+
+  Scenario: error del backend muestra mensaje sin recargar estado
+    Given el torneo "T1" esta en estado "PREPARACION"
+    And el backend devuelve 409 al intentar iniciar ejecucion
+    When el organizador toca "Iniciar ejecucion"
+    Then la UI muestra el mensaje de error devuelto por el backend
+    And el badge de estado sigue mostrando "Preparacion"
+
+  Scenario: torneo terminal no muestra acciones de transicion
+    Given el torneo "T1" esta en estado "CERRADO"
+    When el organizador accede a "/organizador/torneo/T1"
+    Then ve el badge de estado "Cerrado"
+    And no ve botones de transicion de fase


### PR DESCRIPTION
## Resumen
- Agrega FaseBadge para visualizar el estado actual del torneo.
- Agrega AccionesPanel con transiciones validas por fase y confirmacion de cancelacion.
- Extiende api/torneo.ts con funciones para todos los endpoints PUT de transicion.
- Refresca el detalle del torneo tras transiciones exitosas y muestra errores backend inline.
- Agrega tabs base del panel organizador para las siguientes US de INC-5.1.
- Persiste artefactos del pipeline implement-us: feature BDD, plan, reportes, quality report, tracker y trazabilidad.

## Validacion
- npm run build: OK
- npx eslint src: OK
- npm run lint: falla por frontend/.vite/deps/react-router-dom.js generado/preexistente fuera de src

## Notas
- El backend sigue siendo autoridad de transiciones; la UI solo guia acciones visibles y muestra rechazos 409 sin mutar estado local.