### PR TITLE
feat(frontend): mostrar inscriptos con estado AP [US-5.1.3]

### DIFF
--- a/.claude/tracking/US-5.1.3-tracking.json
+++ b/.claude/tracking/US-5.1.3-tracking.json
@@ -1,0 +1,178 @@
+{
+  "metadata": {
+    "us_id": "US-5.1.3",
+    "us_title": "Vista de inscriptos con estado de AP",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-20T14:28:25.862110+00:00",
+    "completed_at": "2026-04-20T14:45:31.591018+00:00",
+    "total_elapsed_seconds": 1025,
+    "effective_seconds": 1025,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-20T14:29:24.322065+00:00",
+      "completed_at": "2026-04-20T14:30:16.633440+00:00",
+      "elapsed_seconds": 52,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-20T14:30:43.357336+00:00",
+      "completed_at": "2026-04-20T14:31:23.007740+00:00",
+      "elapsed_seconds": 39,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-20T14:31:53.449926+00:00",
+      "completed_at": "2026-04-20T14:32:36.909924+00:00",
+      "elapsed_seconds": 43,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada",
+      "started_at": "2026-04-20T14:33:08.589622+00:00",
+      "completed_at": "2026-04-20T14:38:09.662703+00:00",
+      "elapsed_seconds": 301,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "api_registro",
+          "task_name": "Crear API client de registro",
+          "task_type": "frontend",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-20T14:33:51.957570+00:00",
+          "completed_at": "2026-04-20T14:34:19.478365+00:00",
+          "elapsed_seconds": 27,
+          "actual_minutes": 0.45,
+          "variance_minutes": -24.55,
+          "file_created": "frontend/src/api/registro.ts",
+          "status": "completed"
+        },
+        {
+          "task_id": "componentes_inscriptos",
+          "task_name": "Crear componentes de tabla de inscriptos",
+          "task_type": "frontend",
+          "estimated_minutes": 40.0,
+          "started_at": "2026-04-20T14:34:30.327139+00:00",
+          "completed_at": "2026-04-20T14:35:12.596873+00:00",
+          "elapsed_seconds": 42,
+          "actual_minutes": 0.7,
+          "variance_minutes": -39.3,
+          "file_created": "frontend/src/components/organizador/TablaInscriptos.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "integrar_tab",
+          "task_name": "Integrar tab Inscriptos",
+          "task_type": "frontend",
+          "estimated_minutes": 45.0,
+          "started_at": "2026-04-20T14:35:38.687975+00:00",
+          "completed_at": "2026-04-20T14:36:27.194316+00:00",
+          "elapsed_seconds": 48,
+          "actual_minutes": 0.8,
+          "variance_minutes": -44.2,
+          "file_created": "frontend/src/components/organizador/InscriptosPanel.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-20T14:38:37.491260+00:00",
+      "completed_at": "2026-04-20T14:39:07.449499+00:00",
+      "elapsed_seconds": 29,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-20T14:39:28.966267+00:00",
+      "completed_at": "2026-04-20T14:39:49.352716+00:00",
+      "elapsed_seconds": 20,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-20T14:40:18.796087+00:00",
+      "completed_at": "2026-04-20T14:40:53.678781+00:00",
+      "elapsed_seconds": 34,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-20T14:41:43.891762+00:00",
+      "completed_at": "2026-04-20T14:43:12.136694+00:00",
+      "elapsed_seconds": 88,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-20T14:43:43.071934+00:00",
+      "completed_at": "2026-04-20T14:44:07.170190+00:00",
+      "elapsed_seconds": 24,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-20T14:44:31.822917+00:00",
+      "completed_at": "2026-04-20T14:45:22.556092+00:00",
+      "elapsed_seconds": 50,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 10,
+    "estimated_total_minutes": 110.0,
+    "actual_total_minutes": 1.95,
+    "variance_minutes": -108.05,
+    "variance_percent": -98.23
+  }
+}

--- a/docs/plans/sp5/US-5.1.3-plan.md
+++ b/docs/plans/sp5/US-5.1.3-plan.md
@@ -1,0 +1,56 @@
+# Plan de Implementacion — US-5.1.3 Vista de Inscriptos con Estado AP
+
+**Sprint:** SP5  
+**Incremento:** INC-5.1  
+**Producto:** frontend  
+**Patron:** React/Vite PWA consumiendo BCs `registro` y `competencia` existentes  
+**Estimacion:** 3 puntos
+
+## Alcance
+
+Implementar el tab `Inscriptos` del detalle de torneo con una tabla read-only de atletas
+inscriptos y estado AP por disciplina.
+
+## Tareas
+
+### 1. API Registro
+
+- [ ] Crear `frontend/src/api/registro.ts`.
+- [ ] Implementar `listarInscriptos(torneoId)`.
+- [ ] Implementar `fetchAtleta(atletaId)`.
+- [ ] Reutilizar bearer token mediante `getToken`.
+
+### 2. Componentes UI
+
+- [ ] Crear `EstadoAPBadge`.
+- [ ] Crear `TablaInscriptos`.
+- [ ] Mostrar filtro de disciplina con opcion `Todas`.
+- [ ] Mostrar estado AP por disciplina en cada fila.
+- [ ] Mostrar mensaje vacio si no hay inscriptos.
+
+### 3. Integracion en DetalleTorneo
+
+- [ ] Reemplazar placeholder del tab `Inscriptos`.
+- [ ] Cargar inscriptos desde Registro.
+- [ ] Cargar datos de atleta por `atleta_id`.
+- [ ] Cargar competencias por torneo y grillas por disciplina en paralelo.
+- [ ] Cruzar `atleta_id` + disciplina para determinar AP registrado.
+
+### 4. Validacion
+
+- [ ] `npm run build`.
+- [ ] `npx eslint src`.
+- [ ] Documentar limitacion de `npm run lint` global por `.vite/deps` generado.
+
+## Riesgos y Decisiones
+
+- El endpoint de atleta no expone genero; la UI mostrara `Sin dato`.
+- Si no existe competencia/grilla para una disciplina, se mostrara `Sin AP` para esa disciplina.
+- No se modifica backend en esta US.
+
+## DoD
+
+- El organizador ve inscriptos en el tab correspondiente.
+- Puede filtrar por disciplina.
+- Cada disciplina muestra AP registrado con valor o Sin AP.
+- La vista es read-only.

--- a/docs/reports/US-5.1.3-bdd-waiver.md
+++ b/docs/reports/US-5.1.3-bdd-waiver.md
@@ -1,0 +1,22 @@
+# US-5.1.3 — BDD Validation Waiver
+
+## Feature
+
+- `tests/features/US-5.1.3-vista-inscriptos-ap.feature`
+
+## Estado
+
+Escenarios BDD generados y persistidos en disco. No se ejecutan automaticamente en esta US
+porque el proyecto no tiene steps ni harness E2E/browser para flujos React.
+
+## Cobertura Funcional del Feature
+
+- Lista de inscriptos con AP mixto.
+- Filtro por disciplina.
+- Estado vacio sin inscriptos.
+- Atleta multidisciplina con AP parcial.
+
+## Evidencia Sustitutiva
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.

--- a/docs/reports/US-5.1.3-context.md
+++ b/docs/reports/US-5.1.3-context.md
@@ -1,0 +1,53 @@
+# US-5.1.3 — Contexto Validado
+
+**Historia de Usuario:** Vista de inscriptos con estado de AP por atleta  
+**Sprint:** SP5 — La Puesta en Marcha  
+**Incremento:** INC-5.1  
+**Producto:** frontend  
+**Puntos:** 3  
+**Estado inicial:** To Do
+
+## Arquitectura
+
+- Contexto obligatorio leido: `docs/contexto/ATARAXIADIVE-CONTEXT.md`.
+- US-IEDD encontrada: `docs/specs/sp5/US-5.1.3.md`.
+- Patron vigente: frontend React/Vite consumiendo BCs existentes.
+- No requiere cambios backend segun spec.
+
+## Alcance Validado
+
+- Crear `frontend/src/api/registro.ts`.
+- Reutilizar `frontend/src/api/competencia.ts`:
+  - `fetchCompetenciasPorTorneo`
+  - `fetchGrillaCompetencia`
+- Extender el tab `Inscriptos` de `DetalleTorneoPage`.
+- Crear componentes:
+  - `TablaInscriptos`
+  - `EstadoAPBadge`
+
+## Contratos Disponibles
+
+- `GET /registro/torneos/{torneo_id}/inscriptos`
+  - Devuelve `inscripcion_id`, `atleta_id`, `torneo_id`, `disciplinas`, `estado`, `fecha_inscripcion`.
+- `GET /registro/atletas/{atleta_id}`
+  - Devuelve nombre, apellido, email, categoria, club y brevet.
+- `GET /competencia?torneo_id={id}`
+  - Devuelve competencias por torneo con disciplina.
+- `GET /competencia/{competencia_id}/grilla?disciplina={disciplina}`
+  - Devuelve entradas de grilla con `atleta_id`, `ap_declarado` y `unidad`.
+
+## Brecha Detectada
+
+La spec pide columna `Genero`, pero el endpoint `GET /registro/atletas/{id}` no expone genero.
+La UI mostrara `Sin dato` para no inventar informacion ni cambiar backend fuera del alcance.
+
+## Quality Gates
+
+- `CLAUDE.md` presente.
+- `tests/features/` presente.
+- `frontend/package.json` presente.
+- `pyproject.toml` contiene `tool.coverage`, `tool.codeguard` y `tool.designreviewer`.
+
+## Listo Para Fase 1
+
+Se puede proceder con escenarios BDD en `tests/features/US-5.1.3-vista-inscriptos-ap.feature`.

--- a/docs/reports/US-5.1.3-integration.md
+++ b/docs/reports/US-5.1.3-integration.md
@@ -1,0 +1,27 @@
+# US-5.1.3 — Integracion
+
+## Superficie Integrada
+
+- `frontend/src/api/registro.ts`
+- `frontend/src/components/organizador/EstadoAPBadge.tsx`
+- `frontend/src/components/organizador/TablaInscriptos.tsx`
+- `frontend/src/components/organizador/InscriptosPanel.tsx`
+- `frontend/src/pages/organizador/DetalleTorneoPage.tsx`
+
+## Comportamiento Integrado
+
+- El tab `Inscriptos` carga inscripciones del torneo.
+- Para cada inscripto se carga el atleta asociado.
+- Se cargan competencias del torneo y grillas por disciplina en paralelo.
+- La UI cruza `atleta_id` + disciplina para mostrar AP registrado o Sin AP.
+- El filtro de disciplina permite ver `Todas` o una disciplina especifica.
+- Si no hay inscriptos se muestra mensaje vacio.
+
+## Limitacion Documentada
+
+El contrato actual de Registro no expone genero del atleta. La columna `Genero` muestra `Sin dato`.
+
+## Validacion Ejecutada
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.

--- a/docs/reports/US-5.1.3-report.md
+++ b/docs/reports/US-5.1.3-report.md
@@ -1,0 +1,56 @@
+# US-5.1.3 — Reporte Final
+
+**US:** Vista de inscriptos en Preparacion — estado de AP por atleta  
+**Sprint:** SP5  
+**Incremento:** INC-5.1  
+**Branch:** `feature/US-5.1.3-vista-inscriptos`  
+**Producto:** frontend  
+**Estado:** Implementada
+
+## Resultado
+
+Se implemento el tab `Inscriptos` del detalle del torneo:
+
+- Cliente `registro.ts` para listar inscriptos y obtener datos de atleta.
+- `InscriptosPanel` que cruza inscripciones, atletas, competencias y grillas.
+- `TablaInscriptos` read-only con filtro por disciplina.
+- `EstadoAPBadge` para AP registrado o Sin AP.
+- Mensajes de carga, error y estado vacio.
+- Integracion en `DetalleTorneoPage`.
+
+## Archivos Principales
+
+- `frontend/src/api/registro.ts`
+- `frontend/src/components/organizador/EstadoAPBadge.tsx`
+- `frontend/src/components/organizador/TablaInscriptos.tsx`
+- `frontend/src/components/organizador/InscriptosPanel.tsx`
+- `frontend/src/pages/organizador/DetalleTorneoPage.tsx`
+
+## Artefactos del Pipeline
+
+- `docs/reports/US-5.1.3-context.md`
+- `tests/features/US-5.1.3-vista-inscriptos-ap.feature`
+- `docs/plans/sp5/US-5.1.3-plan.md`
+- `docs/reports/US-5.1.3-test-strategy.md`
+- `docs/reports/US-5.1.3-integration.md`
+- `docs/reports/US-5.1.3-bdd-waiver.md`
+- `quality/reports/codeguard/US-5.1.3-quality.json`
+- `docs/traceability/matrix.md`
+- `.claude/tracking/US-5.1.3-tracking.json`
+
+## Validacion
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.
+- `npm run lint`: no aprobado por archivos generados preexistentes en `frontend/.vite/deps/react-router-dom.js`, fuera del codigo fuente modificado.
+
+## Decisiones
+
+- No se modifico backend. La vista usa contratos existentes.
+- El campo `Genero` muestra `Sin dato` porque Registro no expone genero en `GET /registro/atletas/{id}`.
+- Si no existe competencia o grilla para una disciplina, la UI muestra `Sin AP`.
+
+## Pendientes Para US Posteriores
+
+- Exponer genero desde Registro cuando se implemente el formulario completo de inscripcion.
+- `US-5.1.4`: usar el estado AP para habilitar flujo de grilla.

--- a/docs/reports/US-5.1.3-test-strategy.md
+++ b/docs/reports/US-5.1.3-test-strategy.md
@@ -1,0 +1,34 @@
+# US-5.1.3 — Estrategia de Tests
+
+## Tipo de US
+
+Frontend React/Vite para visualizar inscriptos y estado AP por disciplina.
+
+## Unit Tests
+
+No se agregan tests unitarios automatizados de componentes porque el frontend no tiene runner
+unitario configurado en `package.json` (no hay Vitest/Jest/Testing Library). Introducirlo en
+esta US ampliaria el alcance tecnico.
+
+Validacion aplicada:
+
+- `npm run build`: TypeScript + bundle Vite.
+- `npx eslint src`: lint acotado a codigo fuente.
+
+## Integracion
+
+La integracion cubierta por la implementacion cruza datos de:
+
+- `GET /registro/torneos/{torneo_id}/inscriptos`
+- `GET /registro/atletas/{atleta_id}`
+- `GET /competencia?torneo_id={id}`
+- `GET /competencia/{competencia_id}/grilla?disciplina={disciplina}`
+
+## BDD
+
+Escenarios generados en:
+
+- `tests/features/US-5.1.3-vista-inscriptos-ap.feature`
+
+No se agregan step definitions ejecutables porque el proyecto no tiene harness E2E/browser
+frontend configurado.

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -459,6 +459,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 | US-4.6.4 | unit/resultados/application (ExportarResultados) + integration/resultados · UAT INC-4.6 | ✅ UAT SP4 2026-04-18 |
 | US-5.1.1 | frontend (build + eslint src) · features/US-5.1.1 | ✅ Implementada (lint global bloqueado por `.vite/deps` generado) |
 | US-5.1.2 | frontend (build + eslint src) · features/US-5.1.2 | ✅ Implementada (lint global bloqueado por `.vite/deps` generado) |
+| US-5.1.3 | frontend (build + eslint src) · features/US-5.1.3 | ✅ Implementada (lint global bloqueado por `.vite/deps` generado) |
 
 ---
 
@@ -489,6 +490,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 *v1.17 — 2026-04-18: SP4 cerrado (v0.5.0 · BL-004) · SP-ADJ-06 §18 agregado (7 US) · US→Tests completado (INC-4.4/4.5/4.6) · §§ renumerados 18..22 · §2 cobertura actualizada*
 *v1.18 — 2026-04-20: SP5 iniciado · US-5.1.1 implementada · trazabilidad frontend de creacion de torneo agregada*
 *v1.19 — 2026-04-20: US-5.1.2 implementada · trazabilidad frontend de gestion de fases agregada*
+*v1.20 — 2026-04-20: US-5.1.3 implementada · trazabilidad frontend de inscriptos/AP agregada*
 *v1.15 — 2026-04-13: INC-4.4 especificado (§15 nuevo — 3 US offline-first) · §§ renumerados 16..19 · §2 cobertura actualizada*
 *v1.14 — 2026-04-13: INC-4.3 completado (§14 — 5/5 US ✅, UAT BA 2025) · RF-NT §3.7 INC corregido (4.2→4.5) · US-4.3.x en §18*
 *v1.13 — 2026-04-11: US-4.2.2 implementada y mergeada · DesignReviewer consolidado INC-4.2 OK · validación manual pendiente*

--- a/frontend/src/api/registro.ts
+++ b/frontend/src/api/registro.ts
@@ -1,0 +1,77 @@
+import { getToken } from './tokenProvider'
+
+export class ApiError extends Error {
+  status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
+export interface InscriptoDto {
+  inscripcion_id: string
+  atleta_id: string
+  torneo_id: string
+  disciplinas: string[]
+  estado: string
+  fecha_inscripcion: string
+}
+
+export interface AtletaDto {
+  atleta_id: string
+  nombre: string
+  apellido: string
+  email: string
+  fecha_nacimiento: string
+  categoria: string
+  club: string
+  brevet: string | null
+}
+
+function buildHeaders(): Record<string, string> {
+  const token = getToken()
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  return headers
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  if (response.ok) {
+    if (response.status === 204) {
+      return undefined as T
+    }
+    return response.json() as Promise<T>
+  }
+
+  let detail = `Error de API: ${response.status}`
+  try {
+    const payload = (await response.json()) as { detail?: string }
+    if (payload.detail) {
+      detail = payload.detail
+    }
+  } catch {
+    // sin body JSON util
+  }
+  throw new ApiError(response.status, detail)
+}
+
+export async function listarInscriptos(torneoId: string): Promise<InscriptoDto[]> {
+  const response = await fetch(`/registro/torneos/${torneoId}/inscriptos`, {
+    headers: buildHeaders(),
+  })
+  return parseResponse<InscriptoDto[]>(response)
+}
+
+export async function fetchAtleta(atletaId: string): Promise<AtletaDto> {
+  const response = await fetch(`/registro/atletas/${atletaId}`, {
+    headers: buildHeaders(),
+  })
+  return parseResponse<AtletaDto>(response)
+}

--- a/frontend/src/components/organizador/EstadoAPBadge.tsx
+++ b/frontend/src/components/organizador/EstadoAPBadge.tsx
@@ -1,0 +1,22 @@
+interface EstadoAPBadgeProps {
+  ap?: string | null
+  unidad?: string | null
+}
+
+export function EstadoAPBadge({ ap, unidad }: EstadoAPBadgeProps) {
+  const hasAp = Boolean(ap && ap.trim())
+  if (!hasAp) {
+    return (
+      <span className="inline-flex min-h-8 items-center rounded-lg border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-900">
+        Sin AP
+      </span>
+    )
+  }
+
+  return (
+    <span className="inline-flex min-h-8 items-center rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-900">
+      AP registrado · {ap}
+      {unidad ? unidad : ''}
+    </span>
+  )
+}

--- a/frontend/src/components/organizador/InscriptosPanel.tsx
+++ b/frontend/src/components/organizador/InscriptosPanel.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  fetchCompetenciasPorTorneo,
+  fetchGrillaCompetencia,
+  type GrillaAtletaDto,
+} from '../../api/competencia'
+import { fetchAtleta, listarInscriptos } from '../../api/registro'
+import { TablaInscriptos, type InscriptoRow } from './TablaInscriptos'
+
+interface InscriptosPanelProps {
+  torneoId: string
+}
+
+function buildApMap(grillas: Array<{ disciplina: string; entradas: GrillaAtletaDto[] }>) {
+  const map = new Map<string, { ap: string | null; unidad: string | null }>()
+  for (const grilla of grillas) {
+    for (const entrada of grilla.entradas) {
+      map.set(`${entrada.atleta_id}:${grilla.disciplina}`, {
+        ap: entrada.ap_declarado,
+        unidad: entrada.unidad,
+      })
+    }
+  }
+  return map
+}
+
+async function loadInscriptos(torneoId: string) {
+  const [inscriptos, competencias] = await Promise.all([
+    listarInscriptos(torneoId),
+    fetchCompetenciasPorTorneo(torneoId),
+  ])
+  const atletas = await Promise.all(inscriptos.map((inscripto) => fetchAtleta(inscripto.atleta_id)))
+  const atletaPorId = new Map(atletas.map((atleta) => [atleta.atleta_id, atleta]))
+  const disciplinas = Array.from(
+    new Set(inscriptos.flatMap((inscripto) => inscripto.disciplinas)),
+  ).sort()
+  const competenciasPorDisciplina = new Map(
+    competencias.map((competencia) => [competencia.disciplina, competencia]),
+  )
+  const grillas = await Promise.all(
+    disciplinas.map(async (disciplina) => {
+      const competencia = competenciasPorDisciplina.get(disciplina)
+      if (!competencia) {
+        return { disciplina, entradas: [] }
+      }
+      try {
+        const entradas = await fetchGrillaCompetencia(competencia.competencia_id, disciplina)
+        return { disciplina, entradas }
+      } catch {
+        return { disciplina, entradas: [] }
+      }
+    }),
+  )
+  const apMap = buildApMap(grillas)
+  const rows: InscriptoRow[] = inscriptos.map((inscripto) => {
+    const atleta = atletaPorId.get(inscripto.atleta_id)
+    const estadoApPorDisciplina = Object.fromEntries(
+      inscripto.disciplinas.map((disciplina) => [
+        disciplina,
+        apMap.get(`${inscripto.atleta_id}:${disciplina}`) ?? { ap: null, unidad: null },
+      ]),
+    )
+
+    return {
+      inscripcionId: inscripto.inscripcion_id,
+      atletaId: inscripto.atleta_id,
+      nombre: atleta ? `${atleta.apellido}, ${atleta.nombre}` : 'Atleta sin datos',
+      club: atleta?.club ?? 'Sin dato',
+      categoria: atleta?.categoria ?? 'Sin dato',
+      genero: 'Sin dato',
+      disciplinas: inscripto.disciplinas,
+      estadoApPorDisciplina,
+    }
+  })
+
+  return { rows, disciplinas }
+}
+
+export function InscriptosPanel({ torneoId }: InscriptosPanelProps) {
+  const query = useQuery({
+    queryKey: ['torneo-inscriptos-ap', torneoId],
+    queryFn: () => loadInscriptos(torneoId),
+  })
+
+  if (query.isLoading) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+        Cargando inscriptos...
+      </div>
+    )
+  }
+
+  if (query.isError) {
+    return (
+      <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+        No se pudieron cargar los inscriptos del torneo.
+      </div>
+    )
+  }
+
+  return <TablaInscriptos rows={query.data?.rows ?? []} disciplinas={query.data?.disciplinas ?? []} />
+}

--- a/frontend/src/components/organizador/TablaInscriptos.tsx
+++ b/frontend/src/components/organizador/TablaInscriptos.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react'
+import { EstadoAPBadge } from './EstadoAPBadge'
+
+export interface EstadoAP {
+  ap: string | null
+  unidad: string | null
+}
+
+export interface InscriptoRow {
+  inscripcionId: string
+  atletaId: string
+  nombre: string
+  club: string
+  categoria: string
+  genero: string
+  disciplinas: string[]
+  estadoApPorDisciplina: Record<string, EstadoAP>
+}
+
+interface TablaInscriptosProps {
+  rows: InscriptoRow[]
+  disciplinas: string[]
+}
+
+export function TablaInscriptos({ rows, disciplinas }: TablaInscriptosProps) {
+  const [disciplinaFiltro, setDisciplinaFiltro] = useState('TODAS')
+  const disciplinasVisibles =
+    disciplinaFiltro === 'TODAS' ? disciplinas : disciplinas.filter((d) => d === disciplinaFiltro)
+  const rowsFiltradas = useMemo(() => {
+    if (disciplinaFiltro === 'TODAS') return rows
+    return rows.filter((row) => row.disciplinas.includes(disciplinaFiltro))
+  }, [disciplinaFiltro, rows])
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+        No hay atletas inscriptos en este torneo
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-stone-600">{rows.length} atletas inscriptos</p>
+        <label className="text-sm font-semibold text-stone-900">
+          Disciplina
+          <select
+            value={disciplinaFiltro}
+            onChange={(event) => setDisciplinaFiltro(event.target.value)}
+            className="ml-0 mt-2 min-h-10 rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm sm:ml-3 sm:mt-0"
+          >
+            <option value="TODAS">Todas</option>
+            {disciplinas.map((disciplina) => (
+              <option key={disciplina} value={disciplina}>
+                {disciplina}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {rowsFiltradas.length === 0 ? (
+        <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+          No hay atletas inscriptos en la disciplina seleccionada
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-stone-200">
+          <table className="min-w-full divide-y divide-stone-200 text-left text-sm">
+            <thead className="bg-stone-50 text-xs font-semibold uppercase text-stone-500">
+              <tr>
+                <th className="px-4 py-3">Atleta</th>
+                <th className="px-4 py-3">Club</th>
+                <th className="px-4 py-3">Categoria</th>
+                <th className="px-4 py-3">Genero</th>
+                {disciplinasVisibles.map((disciplina) => (
+                  <th key={disciplina} className="px-4 py-3">
+                    {disciplina}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-stone-200 bg-white">
+              {rowsFiltradas.map((row) => (
+                <tr key={row.inscripcionId}>
+                  <td className="px-4 py-3 font-semibold text-stone-950">{row.nombre}</td>
+                  <td className="px-4 py-3 text-stone-700">{row.club}</td>
+                  <td className="px-4 py-3 text-stone-700">{row.categoria}</td>
+                  <td className="px-4 py-3 text-stone-700">{row.genero}</td>
+                  {disciplinasVisibles.map((disciplina) => {
+                    if (!row.disciplinas.includes(disciplina)) {
+                      return (
+                        <td key={disciplina} className="px-4 py-3 text-stone-400">
+                          No inscripto
+                        </td>
+                      )
+                    }
+                    const estado = row.estadoApPorDisciplina[disciplina]
+                    return (
+                      <td key={disciplina} className="px-4 py-3">
+                        <EstadoAPBadge ap={estado?.ap} unidad={estado?.unidad} />
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/organizador/DetalleTorneoPage.tsx
+++ b/frontend/src/pages/organizador/DetalleTorneoPage.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from 'react-router-dom'
 import { fetchTorneo } from '../../api/torneo'
 import { AccionesPanel } from '../../components/organizador/AccionesPanel'
 import { FaseBadge } from '../../components/organizador/FaseBadge'
+import { InscriptosPanel } from '../../components/organizador/InscriptosPanel'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 
 const TABS = ['Detalle', 'Inscriptos', 'Grilla', 'Jueces', 'Ejecucion'] as const
@@ -105,11 +106,19 @@ export function DetalleTorneoPage() {
                   </dd>
                 </div>
               </dl>
-            ) : (
+            ) : null}
+
+            {activeTab === 'Inscriptos' ? (
+              <div className="mt-6">
+                <InscriptosPanel torneoId={torneoQuery.data.torneo_id} />
+              </div>
+            ) : null}
+
+            {activeTab !== 'Detalle' && activeTab !== 'Inscriptos' ? (
               <div className="mt-6 rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
                 {activeTab} quedara disponible en las siguientes US de INC-5.1.
               </div>
-            )}
+            ) : null}
           </section>
 
           {transitionError ? (

--- a/quality/reports/codeguard/US-5.1.3-quality.json
+++ b/quality/reports/codeguard/US-5.1.3-quality.json
@@ -1,0 +1,25 @@
+{
+  "us_id": "US-5.1.3",
+  "producto": "frontend",
+  "status": "passed_with_note",
+  "checks": [
+    {
+      "name": "frontend_build",
+      "command": "npm run build",
+      "status": "passed"
+    },
+    {
+      "name": "frontend_eslint_src",
+      "command": "npx eslint src",
+      "status": "passed"
+    },
+    {
+      "name": "frontend_lint_package",
+      "command": "npm run lint",
+      "status": "failed_external_generated_files",
+      "note": "Falla por frontend/.vite/deps/react-router-dom.js, archivo generado preexistente fuera de src."
+    }
+  ],
+  "codeguard_applicable": false,
+  "note": "CodeGuard esta orientado a Python src/. Para esta US frontend se usaron build TypeScript y ESLint sobre src."
+}

--- a/tests/features/US-5.1.3-vista-inscriptos-ap.feature
+++ b/tests/features/US-5.1.3-vista-inscriptos-ap.feature
@@ -1,0 +1,32 @@
+Feature: US-5.1.3 - Vista de inscriptos con estado de AP
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And el torneo "BA 2026" con id "T1" esta en estado "PREPARACION"
+    And la disciplina "DNF" tiene competencia_id "C1"
+
+  Scenario: lista de inscriptos con estado de AP mixto
+    Given hay 3 atletas inscriptos en "DNF": "Garcia" con AP "75m", "Lopez" sin AP y "Ruiz" con AP "60m"
+    When el organizador accede al tab "Inscriptos" del torneo "T1"
+    Then ve 3 filas en la tabla
+    And "Garcia" muestra badge verde "AP registrado" con valor "75m"
+    And "Lopez" muestra badge amarillo "Sin AP"
+    And "Ruiz" muestra badge verde "AP registrado" con valor "60m"
+
+  Scenario: filtrar por disciplina cuando el torneo tiene multiples disciplinas
+    Given el torneo "T1" tiene disciplinas "DNF" y "STA"
+    And hay atletas inscriptos en ambas disciplinas
+    When el organizador selecciona el filtro "DNF"
+    Then solo ve atletas inscriptos en "DNF"
+
+  Scenario: sin inscriptos muestra mensaje vacio
+    Given no hay atletas inscriptos en el torneo "T1"
+    When el organizador accede al tab "Inscriptos"
+    Then ve el mensaje "No hay atletas inscriptos en este torneo"
+
+  Scenario: atleta inscripto en varias disciplinas muestra estado por disciplina
+    Given el atleta "Garcia" esta inscripto en "DNF" y "STA"
+    And tiene AP en "DNF" pero no en "STA"
+    When el organizador ve la tabla
+    Then "Garcia" muestra "DNF: AP registrado"
+    And "Garcia" muestra "STA: Sin AP" en la misma fila


### PR DESCRIPTION
## Resumen
- Agrega api/registro.ts para listar inscriptos y obtener datos de atleta.
- Implementa el tab Inscriptos del detalle de torneo.
- Cruza inscripciones, atletas, competencias y grillas para mostrar estado AP por disciplina.
- Agrega TablaInscriptos con filtro por disciplina y EstadoAPBadge.
- Persiste artefactos del pipeline implement-us: feature BDD, plan, reportes, quality report, tracker y trazabilidad.

## Validacion
- npm run build: OK
- npx eslint src: OK
- npm run lint: falla por frontend/.vite/deps/react-router-dom.js generado/preexistente fuera de src

## Notas
- El contrato actual de Registro no expone genero; la UI muestra Sin dato en esa columna.
- Si no existe competencia/grilla para una disciplina, se muestra Sin AP.