### PR TITLE
US-5.1.4: Generación y ajuste de grilla desde UI

### DIFF
--- a/.claude/tracking/US-5.1.4-tracking.json
+++ b/.claude/tracking/US-5.1.4-tracking.json
@@ -1,0 +1,219 @@
+{
+  "metadata": {
+    "us_id": "US-5.1.4",
+    "us_title": "Generación y ajuste de grilla desde la UI del organizador",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-20T19:54:35.939269+00:00",
+    "completed_at": "2026-04-20T20:14:27.094785+00:00",
+    "total_elapsed_seconds": 1191,
+    "effective_seconds": 1191,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-20T19:54:39.747556+00:00",
+      "completed_at": "2026-04-20T19:55:30.155873+00:00",
+      "elapsed_seconds": 50,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-20T19:55:34.257479+00:00",
+      "completed_at": "2026-04-20T19:55:59.461705+00:00",
+      "elapsed_seconds": 25,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-20T19:56:04.871464+00:00",
+      "completed_at": "2026-04-20T19:57:36.773741+00:00",
+      "elapsed_seconds": 91,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-20T19:58:15.100128+00:00",
+      "completed_at": "2026-04-20T20:06:29.503244+00:00",
+      "elapsed_seconds": 494,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Endpoint generar grilla",
+          "task_type": "backend",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-20T19:59:34.591373+00:00",
+          "completed_at": "2026-04-20T20:00:39.420680+00:00",
+          "elapsed_seconds": 64,
+          "actual_minutes": 1.07,
+          "variance_minutes": -23.93,
+          "file_created": "src/competencia/api/router.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "API client frontend",
+          "task_type": "frontend",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-20T20:00:44.760920+00:00",
+          "completed_at": "2026-04-20T20:01:08.025543+00:00",
+          "elapsed_seconds": 23,
+          "actual_minutes": 0.38,
+          "variance_minutes": -24.62,
+          "file_created": "frontend/src/api/competencia.ts",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Componentes de grilla",
+          "task_type": "frontend",
+          "estimated_minutes": 70.0,
+          "started_at": "2026-04-20T20:01:14.372018+00:00",
+          "completed_at": "2026-04-20T20:02:36.299758+00:00",
+          "elapsed_seconds": 81,
+          "actual_minutes": 1.35,
+          "variance_minutes": -68.65,
+          "file_created": "frontend/src/components/organizador/GrillaPanel.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_004",
+          "task_name": "Integrar tab Grilla",
+          "task_type": "frontend",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-04-20T20:02:41.930858+00:00",
+          "completed_at": "2026-04-20T20:03:04.330281+00:00",
+          "elapsed_seconds": 22,
+          "actual_minutes": 0.37,
+          "variance_minutes": -14.63,
+          "file_created": "frontend/src/pages/organizador/DetalleTorneoPage.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-20T20:06:41.102195+00:00",
+      "completed_at": "2026-04-20T20:08:38.283540+00:00",
+      "elapsed_seconds": 117,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_005",
+          "task_name": "Test unitario endpoint",
+          "task_type": "test",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-20T20:07:17.872128+00:00",
+          "completed_at": "2026-04-20T20:08:26.632337+00:00",
+          "elapsed_seconds": 68,
+          "actual_minutes": 1.13,
+          "variance_minutes": -23.87,
+          "file_created": "tests/unit/competencia/api/test_generar_grilla_endpoint.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-20T20:08:43.216855+00:00",
+      "completed_at": "2026-04-20T20:10:26.043048+00:00",
+      "elapsed_seconds": 102,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_006",
+          "task_name": "Test integración endpoint",
+          "task_type": "test",
+          "estimated_minutes": 30.0,
+          "started_at": "2026-04-20T20:09:31.620853+00:00",
+          "completed_at": "2026-04-20T20:10:16.418615+00:00",
+          "elapsed_seconds": 44,
+          "actual_minutes": 0.73,
+          "variance_minutes": -29.27,
+          "file_created": "tests/integration/competencia/test_generar_grilla_api.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-20T20:10:32.837774+00:00",
+      "completed_at": "2026-04-20T20:11:04.580290+00:00",
+      "elapsed_seconds": 31,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-20T20:11:10.548220+00:00",
+      "completed_at": "2026-04-20T20:13:15.360404+00:00",
+      "elapsed_seconds": 124,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-20T20:13:21.163451+00:00",
+      "completed_at": "2026-04-20T20:13:43.915020+00:00",
+      "elapsed_seconds": 22,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-20T20:13:52.452701+00:00",
+      "completed_at": "2026-04-20T20:14:22.565244+00:00",
+      "elapsed_seconds": 30,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 6,
+    "completed_tasks": 6,
+    "total_phases": 10,
+    "estimated_total_minutes": 190.0,
+    "actual_total_minutes": 5.03,
+    "variance_minutes": -184.97,
+    "variance_percent": -97.35
+  }
+}

--- a/docs/plans/sp5/US-5.1.4-fase0.md
+++ b/docs/plans/sp5/US-5.1.4-fase0.md
@@ -1,0 +1,38 @@
+# Fase 0 — Validación de Contexto: US-5.1.4
+
+**Historia de Usuario:** US-5.1.4 — Generación y ajuste de grilla desde la UI del organizador
+**Producto:** frontend
+**Puntos:** 3
+**Prioridad:** Media
+
+## Arquitectura
+
+- Patrón: frontend React/Vite consumiendo API hexagonal DDD BC-first.
+- Contexto obligatorio leído: `docs/contexto/ATARAXIADIVE-CONTEXT.md`.
+- Spec canónica encontrada: `docs/specs/sp5/US-5.1.4.md`.
+- Documentación arquitectónica encontrada:
+  - `docs/adr/ADR-005-bounded-contexts-ddd-estrategico.md`
+  - `docs/adr/ADR-006-estructura-bc-first.md`
+  - `docs/design/architecture.md`
+  - `docs/design/domain-model.md`
+
+## Estructura validada
+
+- Implementación frontend: `frontend/src/`.
+- Página afectada: `frontend/src/pages/organizador/DetalleTorneoPage.tsx`.
+- API client afectado: `frontend/src/api/competencia.ts`.
+- Componentes organizador existentes: `frontend/src/components/organizador/`.
+- Tab `Grilla` existe como placeholder desde US-5.1.2.
+
+## Quality Gates
+
+- `frontend/package.json` define `npm run build` y `npm run lint`.
+- Para esta US frontend, los gates Python del skill se sustituyen por build/lint frontend.
+- Validación BDD/UI será documental/manual salvo que exista harness browser automatizado.
+
+## Observaciones
+
+- La spec indica usar `@dnd-kit/core`, pero no aparece declarado en `frontend/package.json`.
+- El plan de Fase 2 debe decidir entre agregar esa dependencia o implementar reordenamiento con drag nativo HTML5 para evitar instalar paquetes.
+
+**Estado:** contexto validado para continuar con Fase 1.

--- a/docs/plans/sp5/US-5.1.4-implementation-notes.md
+++ b/docs/plans/sp5/US-5.1.4-implementation-notes.md
@@ -1,0 +1,54 @@
+# Notas de Implementacion — US-5.1.4
+
+## Endpoint agregado
+
+Se agrego `POST /competencia/{competencia_id}/generar-grilla` en
+`src/competencia/api/router.py`.
+
+Body:
+
+```json
+{
+  "disciplina": "DNF",
+  "ot_inicio": "2026-04-20T09:00:00Z",
+  "andariveles": 1
+}
+```
+
+El endpoint delega en `GenerarGrillaHandler`, reutilizando:
+
+- `PerformancesAPAdapter`
+- `DisciplinaDescriptorAdapter`
+- `EventStorePort`
+
+## Frontend
+
+El tab `Grilla` de `DetalleTorneoPage` ahora renderiza `GrillaPanel`.
+
+Componentes nuevos:
+
+- `ConfigurarGrillaForm`: intervalo OT, primer OT y accion `Generar grilla`.
+- `TablaGrilla`: tabla con drag HTML nativo para reordenar posiciones.
+- `GrillaPanel`: orquesta disciplina, competencia, estado, grilla, ajustes y confirmacion.
+
+API client extendido:
+
+- `crearCompetencia`
+- `generarGrilla`
+- `ajustarGrilla`
+- `confirmarGrilla`
+
+## Validaciones
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.
+- `npm run lint`: falla por `frontend/.vite/deps/react-router-dom.js`, artefacto generado
+  preexistente fuera de `src`.
+- `python3 -m py_compile`: aprobado para router y tests nuevos.
+- `pytest`: bloqueado por dependencia Python faltante `aiosqlite`.
+
+## Decisiones
+
+- No se agrego `@dnd-kit/core`; el reordenamiento usa Drag and Drop nativo para evitar
+  modificar dependencias durante la US.
+- El primer OT se envia como ISO datetime construido desde el campo `time` de la UI.

--- a/docs/plans/sp5/US-5.1.4-plan.md
+++ b/docs/plans/sp5/US-5.1.4-plan.md
@@ -1,0 +1,110 @@
+# Plan de Implementacion — US-5.1.4 Generacion y ajuste de grilla UI
+
+**Sprint:** SP5
+**Incremento:** INC-5.1
+**Producto:** frontend
+**Patron:** React/Vite PWA consumiendo `competencia/api/`
+**Estimacion:** 3 puntos
+
+## Alcance
+
+Implementar el tab `Grilla` del detalle de torneo para que el organizador seleccione
+disciplina, cree o consulte la competencia asociada, visualice la grilla, reordene
+posiciones antes de confirmar y confirme la grilla.
+
+## Contratos Disponibles
+
+- `GET /competencia?torneo_id=...` lista competencias por torneo.
+- `POST /competencia` crea/configura competencia con intervalo OT.
+- `GET /competencia/{competencia_id}/estado?disciplina=...` obtiene estado.
+- `GET /competencia/{competencia_id}/grilla?disciplina=...` obtiene grilla.
+- `POST /competencia/{competencia_id}/ajustar-grilla` ajusta posiciones.
+- `POST /competencia/{competencia_id}/confirmar-grilla` confirma grilla.
+
+## Brecha Detectada
+
+La spec requiere que la UI envie `primer OT` y que luego la tabla muestre OT calculado
+desde ese valor. En el backend actual existe `GenerarGrillaCommand(ot_inicio=...)`, pero
+no hay endpoint HTTP expuesto para ejecutarlo. `POST /competencia` solo configura el
+intervalo y no recibe `primer_ot`.
+
+**Decision requerida antes de Fase 3:** aprobar una de estas opciones:
+
+1. Implementar solo frontend contra contratos existentes. La accion `Generar grilla`
+   creara la competencia y consultara `GET /grilla`; si el backend no genero grilla,
+   la UI mostrara estado vacio/error operativo.
+2. Agregar un endpoint backend minimo para generar grilla desde la UI, por ejemplo
+   `POST /competencia/{competencia_id}/generar-grilla` con `{ disciplina, ot_inicio,
+   andariveles }`, y luego consumirlo desde el frontend.
+
+Recomendacion tecnica: opcion 2, porque es la unica que satisface el criterio
+"primer OT 09:00 produce OT 09:00, 09:08, 09:16" de forma verificable.
+
+## Tareas
+
+### 1. API Frontend
+
+- [ ] Extender `frontend/src/api/competencia.ts` con payloads tipados:
+  - `crearCompetencia({ competenciaId, disciplina, intervaloMinutos, configuradoPor, torneoId })`.
+  - `obtenerCompetenciasPorTorneo(torneoId, disciplina?)` o filtrado local por disciplina.
+  - `ajustarGrilla({ competenciaId, disciplina, cambios })`.
+  - `confirmarGrilla({ competenciaId, disciplina })`.
+  - Si se aprueba opcion 2: `generarGrilla({ competenciaId, disciplina, otInicio, andariveles })`.
+- [ ] Normalizar errores con `ApiError` existente.
+- [ ] Mantener bearer token con `buildHeaders()`.
+
+### 2. Componentes UI
+
+- [ ] Crear `frontend/src/components/organizador/ConfigurarGrillaForm.tsx`.
+  - Campo intervalo OT numerico.
+  - Campo primer OT `HH:MM`.
+  - Boton `Generar grilla`.
+  - Estados disabled/loading/error.
+- [ ] Crear `frontend/src/components/organizador/TablaGrilla.tsx`.
+  - Tabla con posicion, atleta, AP, andarivel y OT.
+  - Reordenamiento manual solo en estado `Configurada`.
+  - Recalculo local de posiciones 1..N al mover filas.
+  - Envio de cambios en un unico `POST ajustar-grilla`.
+  - Modo solo lectura si `grilla_confirmada` o estado `GrillaConfirmada`.
+- [ ] Implementar drag sin nueva dependencia usando HTML Drag and Drop nativo, salvo que se
+  apruebe instalar `@dnd-kit/core` y actualizar `package.json`.
+
+### 3. Panel Grilla
+
+- [ ] Crear `frontend/src/components/organizador/GrillaPanel.tsx`.
+- [ ] Obtener competencias del torneo y resolver competencia por disciplina seleccionada.
+- [ ] Mostrar selector de disciplina.
+- [ ] Si no hay competencia, mostrar `ConfigurarGrillaForm`.
+- [ ] Si hay competencia, consultar estado y grilla.
+- [ ] Mostrar boton `Confirmar grilla` solo si hay atletas y la grilla no esta confirmada.
+- [ ] Invalidar/refrescar queries tras generar, reordenar o confirmar.
+
+### 4. Integracion en DetalleTorneo
+
+- [ ] Reemplazar placeholder del tab `Grilla` en `DetalleTorneoPage.tsx`.
+- [ ] Pasar `torneoId` a `GrillaPanel`.
+- [ ] Mantener estilo visual consistente con `InscriptosPanel`.
+
+### 5. Validacion
+
+- [ ] Ejecutar `npm run build` en `frontend/`.
+- [ ] Ejecutar `npm run lint` en `frontend/` si no queda bloqueado por artefactos generados.
+- [ ] Validar manualmente los escenarios de `tests/features/US-5.1.4-generacion-ajuste-grilla.feature`.
+- [ ] Documentar evidencia en `docs/reports/US-5.1.4-report.md` en Fase 9.
+
+## Riesgos y Decisiones
+
+- `@dnd-kit/core` no esta declarado en `frontend/package.json`, aunque la spec dice que ya existe.
+- El contrato HTTP actual no permite enviar `primer OT` para generar la grilla; sin endpoint nuevo,
+  la aceptacion principal queda parcialmente bloqueada.
+- La UI no debe permitir reordenar ni confirmar si la competencia ya esta en `GrillaConfirmada`.
+- Si una disciplina no tiene atletas/AP, el boton de confirmar debe quedar deshabilitado.
+
+## DoD
+
+- El organizador puede seleccionar disciplina en el tab `Grilla`.
+- Puede crear/configurar la competencia para la disciplina desde la UI.
+- Ve la grilla ordenada con AP, posicion, andarivel y OT.
+- Puede reordenar filas antes de confirmar y persistir cambios.
+- Puede confirmar la grilla y la tabla queda solo lectura.
+- Build frontend aprobado.

--- a/docs/reports/US-5.1.4-bdd-validation.md
+++ b/docs/reports/US-5.1.4-bdd-validation.md
@@ -1,0 +1,17 @@
+# Validacion BDD — US-5.1.4
+
+**Feature:** `tests/features/US-5.1.4-generacion-ajuste-grilla.feature`
+
+## Resultado
+
+- Escenarios BDD creados en lenguaje de negocio.
+- La US pertenece a frontend React/Vite.
+- El repositorio no tiene harness automatizado de browser para ejecutar interacciones UI
+  como drag and drop del tab `Grilla`.
+- La validacion automatizada se cubre con:
+  - `npm run build` para integracion TypeScript/Vite.
+  - Tests Python creados para el endpoint backend nuevo.
+
+## Estado
+
+Validacion BDD documental/manual pendiente de UAT visual.

--- a/docs/reports/US-5.1.4-report.md
+++ b/docs/reports/US-5.1.4-report.md
@@ -1,0 +1,53 @@
+# Reporte Final — US-5.1.4
+
+**US:** Generacion y ajuste de grilla desde la UI del organizador
+**Producto:** frontend + `competencia/api`
+**Branch:** `feature/US-5.1.4-grilla-ui`
+
+## Implementacion
+
+- Se agrego `POST /competencia/{competencia_id}/generar-grilla` para exponer
+  `GenerarGrillaCommand` con `ot_inicio` y `andariveles`.
+- Se extendio `frontend/src/api/competencia.ts` con crear competencia, generar grilla,
+  ajustar grilla y confirmar grilla.
+- Se agrego el tab funcional `Grilla` en `DetalleTorneoPage`.
+- Se crearon `ConfigurarGrillaForm`, `TablaGrilla` y `GrillaPanel`.
+- La tabla permite reordenar posiciones con Drag and Drop HTML nativo y persiste cambios
+  en un unico `POST ajustar-grilla`.
+- La confirmacion deja la grilla en modo solo lectura y oculta la accion de confirmar.
+
+## Artefactos
+
+- Feature BDD: `tests/features/US-5.1.4-generacion-ajuste-grilla.feature`
+- Plan: `docs/plans/sp5/US-5.1.4-plan.md`
+- Fase 0: `docs/plans/sp5/US-5.1.4-fase0.md`
+- Notas: `docs/plans/sp5/US-5.1.4-implementation-notes.md`
+- BDD validation: `docs/reports/US-5.1.4-bdd-validation.md`
+- Quality report: `quality/reports/codeguard/US-5.1.4-quality.json`
+
+## Validacion
+
+- `npm run build`: aprobado.
+- `npx eslint src`: aprobado.
+- `python3 -m py_compile src/competencia/api/router.py tests/unit/competencia/api/test_generar_grilla_endpoint.py tests/integration/competencia/test_generar_grilla_api.py`: aprobado.
+- `npm run lint`: falla por `frontend/.vite/deps/react-router-dom.js`, archivo generado preexistente.
+- `pytest tests/unit/competencia/api/test_generar_grilla_endpoint.py`: bloqueado por `ModuleNotFoundError: aiosqlite`.
+- `pytest tests/integration/competencia/test_generar_grilla_api.py`: bloqueado por `ModuleNotFoundError: aiosqlite`.
+
+## Tests agregados
+
+- `tests/unit/competencia/api/test_generar_grilla_endpoint.py`
+- `tests/integration/competencia/test_generar_grilla_api.py`
+
+## Decisiones
+
+- Se aprobo agregar endpoint backend minimo para satisfacer el criterio de primer OT.
+- No se agrego `@dnd-kit/core`; se uso Drag and Drop nativo para evitar cambiar dependencias.
+- La validacion BDD UI queda documental/manual por ausencia de harness browser automatizado.
+
+## Estado
+
+Implementacion completa con gates disponibles aprobados. Tests Python pendientes de ejecutar
+cuando el entorno tenga `aiosqlite` instalado.
+
+*Generado en Fase 9 de /implement-us US-5.1.4*

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -16,6 +16,24 @@ export interface CompetenciaResumenDto {
   torneo_id: string
 }
 
+export interface CrearCompetenciaPayload {
+  competenciaId: string
+  disciplina: string
+  intervaloMinutos: number
+  configuradoPor: string
+  torneoId: string
+}
+
+export interface CrearCompetenciaResponse {
+  competencia_id: string
+}
+
+export interface CambioGrillaPayload {
+  performance_id: string
+  campo: 'posicion_grilla' | 'andarivel'
+  valor_nuevo: number
+}
+
 export interface EstadoCompetenciaDto {
   estado: string
   intervalo_minutos: number | null
@@ -109,6 +127,24 @@ export async function fetchCompetenciasPorTorneo(
   return parseResponse<CompetenciaResumenDto[]>(response)
 }
 
+export async function crearCompetencia(
+  payload: CrearCompetenciaPayload,
+): Promise<CrearCompetenciaResponse> {
+  const response = await fetch('/competencia', {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      competencia_id: payload.competenciaId,
+      disciplina: payload.disciplina,
+      intervalo_minutos: payload.intervaloMinutos,
+      configurado_por: payload.configuradoPor,
+      torneo_id: payload.torneoId,
+    }),
+  })
+
+  return parseResponse<CrearCompetenciaResponse>(response)
+}
+
 export async function fetchEstadoCompetencia(
   competenciaId: string,
   disciplina: string,
@@ -140,6 +176,57 @@ export async function fetchGrillaCompetencia(
     `/competencia/${competenciaId}/grilla?disciplina=${encodeURIComponent(disciplina)}`,
   )
   return parseResponse<GrillaAtletaDto[]>(response)
+}
+
+export async function generarGrilla(payload: {
+  competenciaId: string
+  disciplina: string
+  otInicio: string
+  andariveles?: number
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/generar-grilla`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      disciplina: payload.disciplina,
+      ot_inicio: payload.otInicio,
+      andariveles: payload.andariveles ?? 1,
+    }),
+  })
+
+  await parseResponse<void>(response)
+}
+
+export async function ajustarGrilla(payload: {
+  competenciaId: string
+  disciplina: string
+  cambios: CambioGrillaPayload[]
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/ajustar-grilla`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      disciplina: payload.disciplina,
+      cambios: payload.cambios,
+    }),
+  })
+
+  await parseResponse<void>(response)
+}
+
+export async function confirmarGrilla(payload: {
+  competenciaId: string
+  disciplina: string
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/confirmar-grilla`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      disciplina: payload.disciplina,
+    }),
+  })
+
+  await parseResponse<void>(response)
 }
 
 export async function fetchPerformanceActual(

--- a/frontend/src/components/organizador/ConfigurarGrillaForm.tsx
+++ b/frontend/src/components/organizador/ConfigurarGrillaForm.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+
+interface ConfigurarGrillaFormProps {
+  disciplina: string
+  isSubmitting: boolean
+  onSubmit: (payload: { intervaloMinutos: number; primerOt: string }) => void
+}
+
+export function ConfigurarGrillaForm({
+  disciplina,
+  isSubmitting,
+  onSubmit,
+}: ConfigurarGrillaFormProps) {
+  const [intervaloMinutos, setIntervaloMinutos] = useState('8')
+  const [primerOt, setPrimerOt] = useState('09:00')
+  const [error, setError] = useState('')
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const intervalo = Number(intervaloMinutos)
+    if (!Number.isInteger(intervalo) || intervalo <= 0) {
+      setError('El intervalo OT debe ser mayor a cero.')
+      return
+    }
+    if (!primerOt) {
+      setError('El primer OT es obligatorio.')
+      return
+    }
+    setError('')
+    onSubmit({ intervaloMinutos: intervalo, primerOt })
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="grid gap-4 rounded-lg border border-stone-200 bg-stone-50 p-4 sm:grid-cols-[1fr_1fr_auto]"
+    >
+      <label className="text-sm font-semibold text-stone-900">
+        Intervalo OT
+        <input
+          type="number"
+          min="1"
+          step="1"
+          value={intervaloMinutos}
+          onChange={(event) => setIntervaloMinutos(event.target.value)}
+          className="mt-2 min-h-10 w-full rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm"
+        />
+      </label>
+      <label className="text-sm font-semibold text-stone-900">
+        Primer OT
+        <input
+          type="time"
+          value={primerOt}
+          onChange={(event) => setPrimerOt(event.target.value)}
+          className="mt-2 min-h-10 w-full rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={isSubmitting || !disciplina}
+        className="min-h-10 self-end rounded-lg bg-stone-900 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-stone-300"
+      >
+        {isSubmitting ? 'Generando...' : 'Generar grilla'}
+      </button>
+      {error ? <p className="text-sm text-red-700 sm:col-span-3">{error}</p> : null}
+    </form>
+  )
+}

--- a/frontend/src/components/organizador/GrillaPanel.tsx
+++ b/frontend/src/components/organizador/GrillaPanel.tsx
@@ -1,0 +1,187 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import {
+  ajustarGrilla,
+  confirmarGrilla,
+  crearCompetencia,
+  fetchCompetenciasPorTorneo,
+  fetchEstadoCompetencia,
+  fetchGrillaCompetencia,
+  generarGrilla,
+  type CambioGrillaPayload,
+  type GrillaAtletaDto,
+} from '../../api/competencia'
+import { ConfigurarGrillaForm } from './ConfigurarGrillaForm'
+import { TablaGrilla } from './TablaGrilla'
+
+interface GrillaPanelProps {
+  torneoId: string
+}
+
+const DISCIPLINAS = ['STA', 'DNF', 'DYN', 'DBF', 'SPE_2X50', 'SPE_4X50', 'SPE_8X50', 'SPE_16X50']
+
+function buildOtIso(time: string) {
+  const [hours, minutes] = time.split(':').map(Number)
+  const date = new Date()
+  date.setHours(hours, minutes, 0, 0)
+  return date.toISOString()
+}
+
+export function GrillaPanel({ torneoId }: GrillaPanelProps) {
+  const queryClient = useQueryClient()
+  const [disciplina, setDisciplina] = useState('DNF')
+  const [localRows, setLocalRows] = useState<GrillaAtletaDto[] | null>(null)
+  const [error, setError] = useState('')
+
+  const competenciasQuery = useQuery({
+    queryKey: ['competencias-torneo', torneoId],
+    queryFn: () => fetchCompetenciasPorTorneo(torneoId),
+  })
+
+  const competencia = useMemo(
+    () => competenciasQuery.data?.find((item) => item.disciplina === disciplina) ?? null,
+    [competenciasQuery.data, disciplina],
+  )
+
+  const estadoQuery = useQuery({
+    queryKey: ['competencia-estado', competencia?.competencia_id, disciplina],
+    queryFn: () => fetchEstadoCompetencia(competencia?.competencia_id ?? '', disciplina),
+    enabled: Boolean(competencia),
+  })
+
+  const grillaQuery = useQuery({
+    queryKey: ['competencia-grilla', competencia?.competencia_id, disciplina],
+    queryFn: () => fetchGrillaCompetencia(competencia?.competencia_id ?? '', disciplina),
+    enabled: Boolean(competencia),
+  })
+
+  const rows = localRows ?? grillaQuery.data ?? []
+  const readOnly = estadoQuery.data?.grilla_confirmada || estadoQuery.data?.estado === 'GrillaConfirmada'
+  const canConfirm = Boolean(competencia && rows.length > 0 && !readOnly)
+
+  async function refresh() {
+    setLocalRows(null)
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['competencias-torneo', torneoId] }),
+      queryClient.invalidateQueries({ queryKey: ['competencia-estado'] }),
+      queryClient.invalidateQueries({ queryKey: ['competencia-grilla'] }),
+    ])
+  }
+
+  const generarMutation = useMutation({
+    mutationFn: async (payload: { intervaloMinutos: number; primerOt: string }) => {
+      const competenciaId = crypto.randomUUID()
+      await crearCompetencia({
+        competenciaId,
+        disciplina,
+        intervaloMinutos: payload.intervaloMinutos,
+        configuradoPor: 'organizador-ui',
+        torneoId,
+      })
+      await generarGrilla({
+        competenciaId,
+        disciplina,
+        otInicio: buildOtIso(payload.primerOt),
+        andariveles: 1,
+      })
+    },
+    onSuccess: refresh,
+    onError: (mutationError) => setError((mutationError as Error).message),
+  })
+
+  const ajustarMutation = useMutation({
+    mutationFn: async (payload: { rows: GrillaAtletaDto[]; cambios: CambioGrillaPayload[] }) => {
+      if (!competencia) return
+      setLocalRows(payload.rows)
+      await ajustarGrilla({
+        competenciaId: competencia.competencia_id,
+        disciplina,
+        cambios: payload.cambios,
+      })
+    },
+    onSuccess: refresh,
+    onError: (mutationError) => setError((mutationError as Error).message),
+  })
+
+  const confirmarMutation = useMutation({
+    mutationFn: async () => {
+      if (!competencia) return
+      await confirmarGrilla({ competenciaId: competencia.competencia_id, disciplina })
+    },
+    onSuccess: refresh,
+    onError: (mutationError) => setError((mutationError as Error).message),
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <label className="text-sm font-semibold text-stone-900">
+          Disciplina
+          <select
+            value={disciplina}
+            onChange={(event) => {
+              setDisciplina(event.target.value)
+              setLocalRows(null)
+              setError('')
+            }}
+            className="ml-0 mt-2 min-h-10 rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm sm:ml-3 sm:mt-0"
+          >
+            {DISCIPLINAS.map((item) => (
+              <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </select>
+        </label>
+        {estadoQuery.data ? (
+          <span className="rounded-lg border border-stone-300 px-3 py-2 text-sm font-semibold text-stone-800">
+            {estadoQuery.data.grilla_confirmada ? 'Grilla confirmada' : estadoQuery.data.estado}
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+          {error}
+        </div>
+      ) : null}
+
+      {competenciasQuery.isLoading ? (
+        <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+          Cargando competencias...
+        </div>
+      ) : null}
+
+      {!competenciasQuery.isLoading && !competencia ? (
+        <ConfigurarGrillaForm
+          disciplina={disciplina}
+          isSubmitting={generarMutation.isPending}
+          onSubmit={(payload) => generarMutation.mutate(payload)}
+        />
+      ) : null}
+
+      {competencia ? (
+        <>
+          <TablaGrilla
+            rows={rows}
+            readOnly={Boolean(readOnly)}
+            isSaving={ajustarMutation.isPending}
+            onReorder={(nextRows, cambios) => ajustarMutation.mutate({ rows: nextRows, cambios })}
+          />
+          <div className="flex justify-end">
+            {!readOnly ? (
+              <button
+                type="button"
+                disabled={!canConfirm || confirmarMutation.isPending}
+                onClick={() => confirmarMutation.mutate()}
+                className="min-h-10 rounded-lg bg-emerald-800 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-stone-300"
+              >
+                {confirmarMutation.isPending ? 'Confirmando...' : 'Confirmar grilla'}
+              </button>
+            ) : null}
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/organizador/TablaGrilla.tsx
+++ b/frontend/src/components/organizador/TablaGrilla.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import type { CambioGrillaPayload, GrillaAtletaDto } from '../../api/competencia'
+
+interface TablaGrillaProps {
+  rows: GrillaAtletaDto[]
+  readOnly: boolean
+  isSaving: boolean
+  onReorder: (rows: GrillaAtletaDto[], cambios: CambioGrillaPayload[]) => void
+}
+
+function formatOt(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 5)
+  }
+  return new Intl.DateTimeFormat('es-AR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date)
+}
+
+function moveRow(rows: GrillaAtletaDto[], fromIndex: number, toIndex: number) {
+  const next = [...rows]
+  const [moved] = next.splice(fromIndex, 1)
+  next.splice(toIndex, 0, moved)
+  return next.map((row, index) => ({ ...row, posicion: index + 1 }))
+}
+
+export function TablaGrilla({ rows, readOnly, isSaving, onReorder }: TablaGrillaProps) {
+  const [draggedId, setDraggedId] = useState<string | null>(null)
+  const [overId, setOverId] = useState<string | null>(null)
+
+  function handleDrop(targetId: string) {
+    if (readOnly || !draggedId || draggedId === targetId) {
+      setDraggedId(null)
+      setOverId(null)
+      return
+    }
+
+    const fromIndex = rows.findIndex((row) => row.performance_id === draggedId)
+    const toIndex = rows.findIndex((row) => row.performance_id === targetId)
+    if (fromIndex < 0 || toIndex < 0) return
+
+    const reordered = moveRow(rows, fromIndex, toIndex)
+    const cambios = reordered
+      .filter((row) => rows.find((original) => original.performance_id === row.performance_id)?.posicion !== row.posicion)
+      .map((row) => ({
+        performance_id: row.performance_id,
+        campo: 'posicion_grilla' as const,
+        valor_nuevo: row.posicion,
+      }))
+
+    setDraggedId(null)
+    setOverId(null)
+    if (cambios.length > 0) {
+      onReorder(reordered, cambios)
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+        No hay atletas en la grilla de esta disciplina.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-stone-200">
+      <table className="min-w-full divide-y divide-stone-200 text-left text-sm">
+        <thead className="bg-stone-50 text-xs font-semibold uppercase text-stone-500">
+          <tr>
+            <th className="px-4 py-3">Posicion</th>
+            <th className="px-4 py-3">Atleta</th>
+            <th className="px-4 py-3">AP</th>
+            <th className="px-4 py-3">Andarivel</th>
+            <th className="px-4 py-3">OT</th>
+            <th className="px-4 py-3">Estado</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-stone-200 bg-white">
+          {rows.map((row) => (
+            <tr
+              key={row.performance_id}
+              draggable={!readOnly && !isSaving}
+              onDragStart={() => setDraggedId(row.performance_id)}
+              onDragOver={(event) => {
+                if (!readOnly) {
+                  event.preventDefault()
+                  setOverId(row.performance_id)
+                }
+              }}
+              onDragLeave={() => setOverId(null)}
+              onDrop={() => handleDrop(row.performance_id)}
+              className={[
+                !readOnly ? 'cursor-grab active:cursor-grabbing' : '',
+                overId === row.performance_id ? 'bg-emerald-50' : '',
+              ].join(' ')}
+            >
+              <td className="px-4 py-3 font-semibold text-stone-950">{row.posicion}</td>
+              <td className="px-4 py-3 text-stone-900">{row.nombre_atleta}</td>
+              <td className="px-4 py-3 text-stone-700">
+                {row.ap_declarado} {row.unidad}
+              </td>
+              <td className="px-4 py-3 text-stone-700">{row.andarivel}</td>
+              <td className="px-4 py-3 font-semibold text-stone-900">
+                {formatOt(row.ot_programado)}
+              </td>
+              <td className="px-4 py-3 text-stone-700">{row.estado}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/pages/organizador/DetalleTorneoPage.tsx
+++ b/frontend/src/pages/organizador/DetalleTorneoPage.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from 'react-router-dom'
 import { fetchTorneo } from '../../api/torneo'
 import { AccionesPanel } from '../../components/organizador/AccionesPanel'
 import { FaseBadge } from '../../components/organizador/FaseBadge'
+import { GrillaPanel } from '../../components/organizador/GrillaPanel'
 import { InscriptosPanel } from '../../components/organizador/InscriptosPanel'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 
@@ -114,7 +115,13 @@ export function DetalleTorneoPage() {
               </div>
             ) : null}
 
-            {activeTab !== 'Detalle' && activeTab !== 'Inscriptos' ? (
+            {activeTab === 'Grilla' ? (
+              <div className="mt-6">
+                <GrillaPanel torneoId={torneoQuery.data.torneo_id} />
+              </div>
+            ) : null}
+
+            {activeTab !== 'Detalle' && activeTab !== 'Inscriptos' && activeTab !== 'Grilla' ? (
               <div className="mt-6 rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
                 {activeTab} quedara disponible en las siguientes US de INC-5.1.
               </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -59,6 +59,10 @@ export default defineConfig(({ mode }) => {
           target: apiUrl,
           changeOrigin: true,
         },
+        '/registro': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
         '/competencia': {
           target: apiUrl,
           changeOrigin: true,

--- a/quality/reports/codeguard/US-5.1.4-quality.json
+++ b/quality/reports/codeguard/US-5.1.4-quality.json
@@ -1,0 +1,8 @@
+{
+  "us_id": "US-5.1.4",
+  "frontend_build": "passed",
+  "frontend_lint_src": "passed",
+  "frontend_lint_global": "failed_generated_vite_deps",
+  "python_py_compile": "passed",
+  "pytest": "blocked_missing_aiosqlite"
+}

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -34,6 +34,10 @@ from competencia.application.commands.configurar_intervalo_ot import (
     ConfigurarIntervaloOTCommand,
     ConfigurarIntervaloOTHandler,
 )
+from competencia.application.commands.generar_grilla import (
+    GenerarGrillaCommand,
+    GenerarGrillaHandler,
+)
 from competencia.application.commands.llamar_atleta import (
     AndarivelesConflicto,
     CompetenciaNoEnEjecucion,
@@ -123,6 +127,7 @@ from competencia.infrastructure.repositories.disciplina_descriptor_adapter impor
 from competencia.infrastructure.repositories.performances_estado_adapter import (
     PerformancesEstadoAdapter,
 )
+from competencia.infrastructure.repositories.performances_ap_adapter import PerformancesAPAdapter
 from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
     SQLiteCompetenciasPorTorneo,
 )
@@ -162,6 +167,14 @@ class IniciarCompetenciaBody(BaseModel):
 
     disciplina: Disciplina
     juez_id: str
+
+
+class GenerarGrillaBody(BaseModel):
+    """Body del endpoint POST /generar-grilla."""
+
+    disciplina: Disciplina
+    ot_inicio: datetime
+    andariveles: int = 1
 
 
 class ConfigurarOTBody(BaseModel):
@@ -456,6 +469,18 @@ def get_confirmar_grilla_handler(event_store: EventStoreDep) -> ConfirmarGrillaH
     return ConfirmarGrillaHandler(event_store)
 
 
+def get_generar_grilla_handler(
+    event_store: EventStoreDep,
+    disciplina_descriptor: DisciplinaDescriptorDep,
+) -> GenerarGrillaHandler:
+    """Dependency: handler para generar la grilla."""
+    return GenerarGrillaHandler(
+        event_store,
+        PerformancesAPAdapter(event_store),
+        disciplina_descriptor,
+    )
+
+
 def get_iniciar_competencia_handler(event_store: EventStoreDep) -> IniciarCompetenciaHandler:
     """Dependency: handler para iniciar la competencia."""
     return IniciarCompetenciaHandler(event_store)
@@ -475,6 +500,7 @@ def get_obtener_estado_competencia_handler(
 
 AjustarGrillaHandlerDep = Annotated[AjustarGrillaHandler, Depends(get_ajustar_grilla_handler)]
 ConfirmarGrillaHandlerDep = Annotated[ConfirmarGrillaHandler, Depends(get_confirmar_grilla_handler)]
+GenerarGrillaHandlerDep = Annotated[GenerarGrillaHandler, Depends(get_generar_grilla_handler)]
 IniciarCompetenciaHandlerDep = Annotated[
     IniciarCompetenciaHandler, Depends(get_iniciar_competencia_handler)
 ]
@@ -712,6 +738,25 @@ async def post_ajustar_grilla(
             competencia_id=competencia_id,
             disciplina=body.disciplina,
             cambios=cambios,
+        )
+    )
+    return Response(status_code=204)
+
+
+@router.post("/{competencia_id}/generar-grilla", response_class=JSONResponse)
+async def post_generar_grilla(
+    competencia_id: UUID,
+    body: GenerarGrillaBody,
+    handler: GenerarGrillaHandlerDep,
+    _: OrganizadorDep,
+) -> JSONResponse:
+    """Genera la Grilla de Salida desde el primer OT definido por organizador."""
+    await handler.handle(
+        GenerarGrillaCommand(
+            competencia_id=competencia_id,
+            disciplina=body.disciplina,
+            ot_inicio=body.ot_inicio,
+            andariveles=body.andariveles,
         )
     )
     return Response(status_code=204)

--- a/tests/features/US-5.1.4-generacion-ajuste-grilla.feature
+++ b/tests/features/US-5.1.4-generacion-ajuste-grilla.feature
@@ -1,0 +1,44 @@
+Feature: US-5.1.4 - Generacion y ajuste de grilla desde el panel organizador
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And el torneo "BA 2026" con id "T1" esta en estado Preparacion
+    And la disciplina "DNF" tiene 3 atletas con AP registrado
+
+  Scenario: crear y visualizar grilla automatica
+    Given no existe competencia para "DNF" en el torneo "T1"
+    When el organizador accede al tab "Grilla" del torneo "T1"
+    And selecciona la disciplina "DNF"
+    And completa intervalo OT "8" minutos y primer OT "09:00"
+    And toca "Generar grilla"
+    Then el backend recibe POST "/competencia" con disciplina "DNF", intervalo "8" y torneo_id "T1"
+    And la tabla muestra 3 atletas ordenados por posicion
+    And los OT visibles son "09:00", "09:08" y "09:16"
+
+  Scenario: reordenar posiciones de la grilla
+    Given existe competencia "C1" para "DNF" en estado Configurada
+    And la grilla tiene "Garcia" posicion 1, "Lopez" posicion 2 y "Ruiz" posicion 3
+    When el organizador mueve la fila de "Ruiz" a la posicion 1
+    Then el backend recibe POST "/competencia/C1/ajustar-grilla" con cambios de posicion
+    And la tabla se actualiza con "Ruiz" posicion 1, "Lopez" posicion 2 y "Garcia" posicion 3
+    And los OT visibles son "09:00", "09:08" y "09:16"
+
+  Scenario: confirmar grilla
+    Given existe competencia "C1" para "DNF" en estado Configurada con 3 atletas
+    When el organizador toca "Confirmar grilla"
+    Then el backend recibe POST "/competencia/C1/confirmar-grilla"
+    And la tabla pasa a modo solo lectura
+    And el estado de la competencia muestra "Grilla confirmada"
+
+  Scenario: grilla confirmada es solo lectura
+    Given existe competencia "C1" para "DNF" en estado GrillaConfirmada
+    When el organizador accede al tab "Grilla"
+    And selecciona la disciplina "DNF"
+    Then ve la grilla sin controles de reordenamiento
+    And el boton "Confirmar grilla" no aparece
+
+  Scenario: sin atletas en grilla el boton confirmar esta deshabilitado
+    Given existe competencia "C1" para "DNF" en estado Configurada sin atletas
+    When el organizador accede al tab "Grilla"
+    And selecciona la disciplina "DNF"
+    Then el boton "Confirmar grilla" esta deshabilitado

--- a/tests/integration/competencia/test_generar_grilla_api.py
+++ b/tests/integration/competencia/test_generar_grilla_api.py
@@ -1,0 +1,114 @@
+"""Tests de integración API — POST /competencia/{id}/generar-grilla."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import aiosqlite
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app
+from competencia.api.router import get_event_store
+from competencia.application.commands.configurar_intervalo_ot import (
+    ConfigurarIntervaloOTCommand,
+    ConfigurarIntervaloOTHandler,
+)
+from competencia.application.commands.registrar_ap import RegistrarAPCommand, RegistrarAPHandler
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.unidad_medida import UnidadMedida
+from competencia.infrastructure.competencia_estado_stub import StubCompetenciaEstadoAdapter
+from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from competencia.infrastructure.repositories.disciplina_descriptor_adapter import (
+    DisciplinaDescriptorAdapter,
+)
+from identidad.api.dependencies import get_current_user
+
+
+CREATE_EVENTS_TABLE = """
+    CREATE TABLE events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream_id   TEXT    NOT NULL,
+        event_type  TEXT    NOT NULL,
+        payload     TEXT    NOT NULL,
+        version     INTEGER NOT NULL,
+        occurred_at TEXT    NOT NULL
+            DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (stream_id, version)
+    )
+"""
+
+
+@pytest.fixture
+async def store(tmp_path: pytest.TempPathFactory) -> SQLiteEventStore:
+    db_path = str(tmp_path / "competencia_generar_grilla_api.db")
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(CREATE_EVENTS_TABLE)
+        await db.commit()
+    return SQLiteEventStore(db_path)
+
+
+@pytest.fixture
+def client(store: SQLiteEventStore) -> TestClient:
+    app.dependency_overrides[get_event_store] = lambda: store
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "organizador-01",
+        "email": "org@ataraxia.com",
+        "rol": "ORGANIZADOR",
+    }
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+async def _seed_competencia_con_ap(store: SQLiteEventStore, competencia_id: UUID) -> None:
+    await ConfigurarIntervaloOTHandler(store).handle(
+        ConfigurarIntervaloOTCommand(
+            competencia_id=competencia_id,
+            disciplina=Disciplina.DNF,
+            intervalo_minutos=8,
+            configurado_por="organizador-01",
+        )
+    )
+    handler = RegistrarAPHandler(
+        store,
+        StubCompetenciaEstadoAdapter(),
+        DisciplinaDescriptorAdapter(),
+    )
+    for valor in ("50", "60", "70"):
+        await handler.handle(
+            RegistrarAPCommand(
+                competencia_id=competencia_id,
+                participante_id=uuid4(),
+                disciplina=Disciplina.DNF,
+                valor_ap=Decimal(valor),
+                unidad=UnidadMedida.Metros,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_post_generar_grilla_expone_ot_calculados(
+    store: SQLiteEventStore,
+    client: TestClient,
+) -> None:
+    competencia_id = uuid4()
+    await _seed_competencia_con_ap(store, competencia_id)
+
+    response = client.post(
+        f"/competencia/{competencia_id}/generar-grilla",
+        json={
+            "disciplina": "DNF",
+            "ot_inicio": "2026-04-20T09:00:00Z",
+            "andariveles": 1,
+        },
+    )
+    grilla_response = client.get(f"/competencia/{competencia_id}/grilla?disciplina=DNF")
+
+    assert response.status_code == 204
+    assert grilla_response.status_code == 200
+    grilla = grilla_response.json()
+    assert len(grilla) == 3
+    assert grilla[0]["ot_programado"].startswith("2026-04-20T09:00:00")
+    assert grilla[1]["ot_programado"].startswith("2026-04-20T09:08:00")
+    assert grilla[2]["ot_programado"].startswith("2026-04-20T09:16:00")

--- a/tests/unit/competencia/api/test_generar_grilla_endpoint.py
+++ b/tests/unit/competencia/api/test_generar_grilla_endpoint.py
@@ -1,0 +1,55 @@
+"""Tests unitarios del endpoint POST /competencia/{id}/generar-grilla."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from competencia.api.router import get_generar_grilla_handler, router
+from competencia.application.commands.generar_grilla import GenerarGrillaCommand
+from identidad.api.dependencies import get_current_user
+
+
+COMPETENCIA_ID = UUID("00000000-0000-0000-0000-000000005114")
+
+
+class SpyGenerarGrillaHandler:
+    """Handler espía para verificar traducción HTTP -> command."""
+
+    def __init__(self) -> None:
+        self.command: GenerarGrillaCommand | None = None
+
+    async def handle(self, command: GenerarGrillaCommand) -> None:
+        self.command = command
+
+
+def test_post_generar_grilla_traduce_body_a_command() -> None:
+    handler = SpyGenerarGrillaHandler()
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_generar_grilla_handler] = lambda: handler
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "organizador-01",
+        "email": "org@ataraxia.com",
+        "rol": "ORGANIZADOR",
+    }
+    client = TestClient(app)
+
+    response = client.post(
+        f"/competencia/{COMPETENCIA_ID}/generar-grilla",
+        json={
+            "disciplina": "DNF",
+            "ot_inicio": "2026-04-20T09:00:00Z",
+            "andariveles": 2,
+        },
+    )
+
+    assert response.status_code == 204
+    assert handler.command is not None
+    assert handler.command.competencia_id == COMPETENCIA_ID
+    assert handler.command.disciplina.value == "DNF"
+    assert handler.command.ot_inicio == datetime(2026, 4, 20, 9, 0, tzinfo=timezone.utc)
+    assert handler.command.andariveles == 2


### PR DESCRIPTION
## Resumen
- Agrega endpoint POST /competencia/{competencia_id}/generar-grilla para exponer GenerarGrillaCommand.
- Implementa tab Grilla en el panel organizador con creación, visualización, reordenamiento y confirmación.
- Agrega feature BDD, tests del endpoint y reportes/artefactos del flujo implement-us.
- Corrige proxy Vite para /registro, necesario para que Inscriptos cargue contra backend.

## Validación
- npm run build
- npx eslint src
- python3 -m py_compile src/competencia/api/router.py tests/unit/competencia/api/test_generar_grilla_endpoint.py tests/integration/competencia/test_generar_grilla_api.py

## Pendiente / entorno
- pytest quedó bloqueado localmente por ModuleNotFoundError: aiosqlite en el entorno inicial.
- npm run lint global falla por frontend/.vite/deps/react-router-dom.js generado; npx eslint src pasa.