### PR TITLE
US-5.1.8: Componer disciplinas en Ver competencias

### DIFF
--- a/.claude/tracking/US-5.1.8-tracking.json
+++ b/.claude/tracking/US-5.1.8-tracking.json
@@ -1,0 +1,165 @@
+{
+  "metadata": {
+    "us_id": "US-5.1.8",
+    "us_title": "Componer disciplinas y competencias",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-21T22:34:15.399977+00:00",
+    "completed_at": "2026-04-21T22:38:37.048462+00:00",
+    "total_elapsed_seconds": 261,
+    "effective_seconds": 261,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de Contexto",
+      "started_at": "2026-04-21T22:34:18.390949+00:00",
+      "completed_at": "2026-04-21T22:34:27.566994+00:00",
+      "elapsed_seconds": 9,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generacion de Escenarios BDD",
+      "started_at": "2026-04-21T22:34:31.986666+00:00",
+      "completed_at": "2026-04-21T22:34:49.143216+00:00",
+      "elapsed_seconds": 17,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementacion",
+      "started_at": "2026-04-21T22:34:53.589094+00:00",
+      "completed_at": "2026-04-21T22:35:08.458815+00:00",
+      "elapsed_seconds": 14,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementacion",
+      "started_at": "2026-04-21T22:35:12.533015+00:00",
+      "completed_at": "2026-04-21T22:36:27.389409+00:00",
+      "elapsed_seconds": 74,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Componer disciplinas y competencias",
+          "task_type": "frontend",
+          "estimated_minutes": 35.0,
+          "started_at": "2026-04-21T22:35:27.028947+00:00",
+          "completed_at": "2026-04-21T22:36:06.025220+00:00",
+          "elapsed_seconds": 38,
+          "actual_minutes": 0.63,
+          "variance_minutes": -34.37,
+          "file_created": "frontend/src/pages/organizador/TorneoCompetenciasPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Actualizar artefactos de US",
+          "task_type": "documentation",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-04-21T22:36:10.234920+00:00",
+          "completed_at": "2026-04-21T22:36:23.193756+00:00",
+          "elapsed_seconds": 12,
+          "actual_minutes": 0.2,
+          "variance_minutes": -4.8,
+          "file_created": "docs/plans/sp5/US-5.1.8-plan.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-21T22:36:35.166484+00:00",
+      "completed_at": "2026-04-21T22:36:45.269927+00:00",
+      "elapsed_seconds": 10,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integracion",
+      "started_at": "2026-04-21T22:36:48.499795+00:00",
+      "completed_at": "2026-04-21T22:36:58.028787+00:00",
+      "elapsed_seconds": 9,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validacion BDD",
+      "started_at": "2026-04-21T22:37:02.315005+00:00",
+      "completed_at": "2026-04-21T22:37:14.698913+00:00",
+      "elapsed_seconds": 12,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-21T22:37:19.417541+00:00",
+      "completed_at": "2026-04-21T22:37:58.256794+00:00",
+      "elapsed_seconds": 38,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentacion",
+      "started_at": "2026-04-21T22:38:02.633642+00:00",
+      "completed_at": "2026-04-21T22:38:11.740998+00:00",
+      "elapsed_seconds": 9,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-21T22:38:17.847139+00:00",
+      "completed_at": "2026-04-21T22:38:36.897332+00:00",
+      "elapsed_seconds": 19,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 2,
+    "completed_tasks": 2,
+    "total_phases": 10,
+    "estimated_total_minutes": 40.0,
+    "actual_total_minutes": 0.83,
+    "variance_minutes": -39.17,
+    "variance_percent": -97.92
+  }
+}

--- a/docs/plans/inc-5.1-adj/PLAN-INC-5.1-ADJ.md
+++ b/docs/plans/inc-5.1-adj/PLAN-INC-5.1-ADJ.md
@@ -123,7 +123,7 @@ US-5.1.10 ← acciones de fase (independiente, pero conveniente validar con tabs
 ## Criterio de cierre de INC-5.1-ADJ
 
 - [x] US-5.1.7 — tabs habilitadas correctamente por fase; `CANCELADO` muestra solo resumen
-- [ ] US-5.1.8 — `Ver competencias` muestra disciplinas configuradas aunque no existan competencias
+- [x] US-5.1.8 — `Ver competencias` muestra disciplinas configuradas aunque no existan competencias
 - [ ] US-5.1.9 — selector de juez bloqueado si disciplina no tiene grilla generada
 - [ ] US-5.1.10 — `Iniciar Ejecución` oculto en `EJECUCION`; acción de premiación visible
 - [ ] UAT de regresión: flujo completo del organizador sin errores visibles

--- a/docs/plans/sp5/US-5.1.8-plan.md
+++ b/docs/plans/sp5/US-5.1.8-plan.md
@@ -1,0 +1,45 @@
+# Plan de Implementacion - US-5.1.8 Componer disciplinas y competencias
+
+**Sprint:** SP5
+**Incremento:** INC-5.1-ADJ
+**Producto:** frontend
+**Tipo:** fix funcional post-UAT
+**Estimacion:** 2 puntos
+
+## Alcance
+
+Corregir `TorneoCompetenciasPage` para que use las disciplinas configuradas del
+torneo como fuente primaria y las competencias existentes solo como enriquecimiento.
+
+## Tareas
+
+### 1. Queries frontend
+
+- [x] Reutilizar `listarDisciplinasTorneo(torneoId)`.
+- [x] Mantener `fetchCompetenciasPorTorneo(torneoId)` como fuente secundaria.
+- [x] Manejar loading/error de ambas queries.
+
+### 2. Composicion
+
+- [x] Cruzar disciplinas y competencias por `disciplina`.
+- [x] Renderizar una card por disciplina configurada.
+- [x] Marcar card como `Competencia pendiente` si no existe `competencia_id`.
+
+### 3. Acciones UI
+
+- [x] Habilitar `Ver auditoria` solo con `competencia_id`.
+- [x] Mostrar indicacion de usar el tab `Grilla` si la competencia esta pendiente.
+- [x] Conservar estado vacio solo cuando el torneo no tiene disciplinas configuradas.
+
+### 4. Validacion
+
+- [x] `npm run build`.
+- [x] `npm run lint`.
+- [x] Registrar waiver BDD/UI si no existe harness browser automatizado.
+- [x] Registrar reporte final en `docs/reports/US-5.1.8-report.md`.
+
+## DoD
+
+- En estados tempranos, `Ver competencias` muestra disciplinas configuradas aunque no existan competencias.
+- `Ver auditoria` queda deshabilitado para disciplinas sin competencia materializada.
+- El mensaje de pantalla vacia solo aparece si no hay disciplinas configuradas.

--- a/docs/reports/US-5.1.8-bdd-validation.md
+++ b/docs/reports/US-5.1.8-bdd-validation.md
@@ -1,0 +1,19 @@
+# Validacion BDD - US-5.1.8
+
+## Feature
+
+`tests/features/US-5.1.8-componer-competencias.feature`
+
+## Resultado
+
+Waiver de ejecucion automatizada.
+
+Los escenarios BDD fueron materializados desde la spec, pero el frontend no tiene
+steps ejecutables para montar la UI React con DOM/browser y mocks HTTP.
+
+## Criterios cubiertos por revision manual
+
+- Se renderiza una card por disciplina configurada.
+- La competencia materializada enriquece la card correspondiente.
+- `Ver auditoria` queda habilitado solo con `competencia_id`.
+- El estado pendiente reemplaza el falso vacio cuando aun no hay competencias.

--- a/docs/reports/US-5.1.8-integration.md
+++ b/docs/reports/US-5.1.8-integration.md
@@ -1,0 +1,26 @@
+# Integracion - US-5.1.8
+
+## Estado
+
+Waiver de automatizacion.
+
+La US requiere montar una page React con dos queries:
+
+- `GET /torneos/{id}/disciplinas`
+- `GET /competencia?torneo_id={id}`
+
+El repo no tiene harness E2E/browser configurado para simular esos endpoints y validar
+el DOM resultante.
+
+## Flujo critico a validar manualmente
+
+- Torneo con disciplinas y sin competencias: una card por disciplina, estado
+  `Competencia pendiente`, auditoria deshabilitada.
+- Torneo con competencia para una disciplina: auditoria habilitada solo en esa card.
+- Torneo sin disciplinas: mensaje de ausencia de disciplinas configuradas.
+- Error en disciplinas o competencias: mensaje de error de carga.
+
+## Gates sustitutos
+
+- `npm run build`
+- `npm run lint`

--- a/docs/reports/US-5.1.8-report.md
+++ b/docs/reports/US-5.1.8-report.md
@@ -1,0 +1,41 @@
+# Reporte de Implementacion - US-5.1.8
+
+## Resumen
+
+Se corrigio `TorneoCompetenciasPage` para mostrar una card por disciplina configurada
+del torneo, aunque la competencia aun no exista en `competencia.db`.
+
+## Componentes modificados
+
+- `frontend/src/pages/organizador/TorneoCompetenciasPage.tsx`
+  - Agrega query a `listarDisciplinasTorneo(torneoId)`.
+  - Mantiene `fetchCompetenciasPorTorneo(torneoId)` como fuente secundaria.
+  - Compone disciplinas y competencias por codigo `disciplina`.
+  - Renderiza `Competencia pendiente` cuando no existe `competencia_id`.
+  - Deshabilita `Ver auditoria` para disciplinas sin competencia.
+
+## Artefactos
+
+- Spec: `docs/specs/sp5/US-5.1.8.md`
+- Plan: `docs/plans/sp5/US-5.1.8-plan.md`
+- Feature: `tests/features/US-5.1.8-componer-competencias.feature`
+- Test strategy: `docs/reports/US-5.1.8-test-strategy.md`
+- Integracion: `docs/reports/US-5.1.8-integration.md`
+- BDD validation: `docs/reports/US-5.1.8-bdd-validation.md`
+
+## Validacion
+
+- `npm run build` - OK
+- `npm run lint` - OK
+
+## Criterios de aceptacion
+
+- En estados tempranos, `Ver competencias` muestra disciplinas aunque no existan competencias.
+- `Ver auditoria` queda habilitado solo cuando existe `competencia_id`.
+- La pantalla vacia queda reservada para torneos sin disciplinas configuradas.
+- Errores de carga de disciplinas o competencias muestran mensaje de error.
+
+## Riesgo residual
+
+No hay harness automatizado de UI/browser para ejecutar los escenarios BDD. La cobertura
+automatizada disponible para esta US queda limitada a TypeScript y ESLint.

--- a/docs/reports/US-5.1.8-test-strategy.md
+++ b/docs/reports/US-5.1.8-test-strategy.md
@@ -1,0 +1,25 @@
+# Estrategia de Tests - US-5.1.8
+
+## Alcance
+
+US-5.1.8 modifica `TorneoCompetenciasPage` para componer disciplinas configuradas
+del torneo con competencias materializadas.
+
+## Unit tests
+
+**Estado:** waiver.
+
+El frontend no tiene harness de tests unitarios React configurado
+(Vitest/Jest/Testing Library). La logica agregada queda validada por TypeScript,
+ESLint y revision manual contra la feature BDD.
+
+## Validacion aplicada
+
+- TypeScript via `npm run build`.
+- ESLint via `npm run lint`.
+- Feature BDD materializado en `tests/features/US-5.1.8-componer-competencias.feature`.
+
+## Riesgo residual
+
+No hay prueba automatizada que monte la page con mocks de React Query/Router. El riesgo
+es aceptado para INC-5.1-ADJ por ausencia de harness UI en el repo.

--- a/docs/specs/sp5/US-5.1.8.md
+++ b/docs/specs/sp5/US-5.1.8.md
@@ -1,6 +1,6 @@
 # US-5.1.8: Componer disciplinas + competencias en "Ver competencias"
 
-**Estado**: `To Do`
+**Estado**: `Done`
 **Sprint**: SP5 — La Puesta en Marcha
 **Incremento**: INC-5.1-ADJ
 **Bounded Context**: `frontend` (consume `torneo/api/` + `competencia/api/`)

--- a/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
+++ b/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
@@ -1,9 +1,21 @@
 import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
-import { fetchCompetenciasPorTorneo } from '../../api/competencia'
-import { fetchTorneos } from '../../api/torneo'
+import {
+  fetchCompetenciasPorTorneo,
+  type CompetenciaResumenDto,
+} from '../../api/competencia'
+import {
+  fetchTorneos,
+  listarDisciplinasTorneo,
+  type DisciplinaTorneoDto,
+} from '../../api/torneo'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
+
+interface DisciplinaCompetenciaCard {
+  disciplina: string
+  competencia: CompetenciaResumenDto | null
+}
 
 export function TorneoCompetenciasPage() {
   const { torneoId } = useParams()
@@ -17,11 +29,22 @@ export function TorneoCompetenciasPage() {
     queryFn: () => fetchCompetenciasPorTorneo(torneoId!),
     enabled: Boolean(torneoId),
   })
+  const disciplinasQuery = useQuery({
+    queryKey: ['torneo-disciplinas', torneoId],
+    queryFn: () => listarDisciplinasTorneo(torneoId!),
+    enabled: Boolean(torneoId),
+  })
 
   const torneo = useMemo(
     () => torneosQuery.data?.find((item) => item.torneo_id === torneoId) ?? null,
     [torneoId, torneosQuery.data],
   )
+  const disciplinasCompetencias = useMemo(
+    () => componerDisciplinasCompetencias(disciplinasQuery.data ?? [], competenciasQuery.data ?? []),
+    [competenciasQuery.data, disciplinasQuery.data],
+  )
+  const isLoading = disciplinasQuery.isLoading || competenciasQuery.isLoading
+  const isError = disciplinasQuery.isError || competenciasQuery.isError
 
   return (
     <OrganizadorLayout
@@ -36,51 +59,78 @@ export function TorneoCompetenciasPage() {
         </Link>
       }
     >
-      {competenciasQuery.isLoading ? (
+      {isLoading ? (
         <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
           Cargando competencias...
         </section>
       ) : null}
 
-      {competenciasQuery.isError ? (
+      {isError ? (
         <section className="rounded-[2rem] border border-red-300/60 bg-red-50 p-5 text-sm text-red-900">
-          No se pudieron cargar las competencias del torneo.
+          No se pudieron cargar las disciplinas o competencias del torneo.
         </section>
       ) : null}
 
-      {!competenciasQuery.isLoading &&
-      !competenciasQuery.isError &&
-      (competenciasQuery.data?.length ?? 0) === 0 ? (
+      {!isLoading && !isError && disciplinasCompetencias.length === 0 ? (
         <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
-          Este torneo no tiene competencias configuradas.
+          Este torneo no tiene disciplinas configuradas.
         </section>
       ) : null}
 
-      {!competenciasQuery.isLoading && !competenciasQuery.isError
-        ? competenciasQuery.data?.map((competencia) => (
+      {!isLoading && !isError
+        ? disciplinasCompetencias.map((item) => (
             <article
-              key={competencia.competencia_id}
+              key={item.disciplina}
               className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]"
             >
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
-                    Competencia
+                    Disciplina
                   </p>
                   <h2 className="mt-2 text-xl font-semibold text-stone-900">
-                    {competencia.disciplina}
+                    {item.disciplina}
                   </h2>
+                  <p className="mt-2 text-sm text-stone-600">
+                    {item.competencia
+                      ? `Competencia ${item.competencia.competencia_id}`
+                      : 'Competencia pendiente: generar grilla desde el tab Grilla'}
+                  </p>
                 </div>
-                <Link
-                  to={`/organizador/competencias/${competencia.competencia_id}/auditoria?disciplina=${encodeURIComponent(competencia.disciplina)}&torneo_id=${encodeURIComponent(competencia.torneo_id)}`}
-                  className="rounded-full bg-stone-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-50"
-                >
-                  Ver auditoria
-                </Link>
+                {item.competencia ? (
+                  <Link
+                    to={`/organizador/competencias/${item.competencia.competencia_id}/auditoria?disciplina=${encodeURIComponent(item.disciplina)}&torneo_id=${encodeURIComponent(item.competencia.torneo_id)}`}
+                    className="rounded-full bg-stone-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-50"
+                  >
+                    Ver auditoria
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    disabled
+                    className="cursor-not-allowed rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-400"
+                  >
+                    Ver auditoria
+                  </button>
+                )}
               </div>
             </article>
           ))
         : null}
     </OrganizadorLayout>
   )
+}
+
+function componerDisciplinasCompetencias(
+  disciplinas: DisciplinaTorneoDto[],
+  competencias: CompetenciaResumenDto[],
+): DisciplinaCompetenciaCard[] {
+  const competenciasPorDisciplina = new Map(
+    competencias.map((competencia) => [competencia.disciplina, competencia]),
+  )
+
+  return disciplinas.map((disciplina) => ({
+    disciplina: disciplina.disciplina,
+    competencia: competenciasPorDisciplina.get(disciplina.disciplina) ?? null,
+  }))
 }

--- a/tests/features/US-5.1.8-componer-competencias.feature
+++ b/tests/features/US-5.1.8-componer-competencias.feature
@@ -1,0 +1,31 @@
+Feature: US-5.1.8 - Composicion disciplinas + competencias en Ver competencias
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+
+  Scenario: torneo en INSCRIPCION_ABIERTA muestra disciplinas aunque no haya competencias
+    Given el torneo T1 esta en INSCRIPCION_ABIERTA con disciplinas DNF y STA
+    And no existen competencias en competencia.db para T1
+    When el organizador navega a "Ver competencias" de T1
+    Then se muestran dos cards: una para DNF y otra para STA
+    And ambas cards muestran estado "Competencia pendiente"
+    And el boton "Ver auditoria" esta deshabilitado en ambas
+
+  Scenario: torneo en EJECUCION muestra disciplinas con y sin competencia
+    Given el torneo T1 esta en EJECUCION con disciplinas DNF y STA
+    And existe competencia C1 para disciplina DNF en T1
+    And no existe competencia para disciplina STA en T1
+    When el organizador navega a "Ver competencias" de T1
+    Then la card de DNF muestra "Ver auditoria" habilitado con link a C1
+    And la card de STA muestra estado "Competencia pendiente"
+
+  Scenario: pantalla vacia reemplazada por disciplinas configuradas
+    Given el torneo T1 en INSCRIPCION_ABIERTA tiene disciplina DNF
+    When el organizador navega a "Ver competencias"
+    Then no se muestra el mensaje "Este torneo no tiene competencias configuradas"
+    And si se muestra la card de DNF
+
+  Scenario: error al cargar disciplinas muestra mensaje de error
+    Given el endpoint GET /torneos/T1/disciplinas falla con 500
+    When el organizador navega a "Ver competencias"
+    Then se muestra un mensaje de error de carga


### PR DESCRIPTION
## Resumen
- Usa disciplinas configuradas del torneo como fuente primaria en Ver competencias.
- Cruza disciplinas con competencias materializadas por codigo de disciplina.
- Deshabilita Ver auditoria cuando la competencia aun esta pendiente.
- Agrega feature BDD, plan, reportes y tracking de US-5.1.8.

## Validacion
- npm run build
- npm run lint

## Nota
- BDD/UI automatizado queda con waiver porque el frontend no tiene harness browser/DOM configurado.