### PR TITLE
US-5.1.9: Bloquear asignacion de jueces sin grilla

### DIFF
--- a/.claude/tracking/US-5.1.9-tracking.json
+++ b/.claude/tracking/US-5.1.9-tracking.json
@@ -1,0 +1,165 @@
+{
+  "metadata": {
+    "us_id": "US-5.1.9",
+    "us_title": "Precondicion grilla en asignacion de jueces",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-21T22:44:12.080862+00:00",
+    "completed_at": "2026-04-21T22:48:26.799025+00:00",
+    "total_elapsed_seconds": 254,
+    "effective_seconds": 254,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de Contexto",
+      "started_at": "2026-04-21T22:44:18.219874+00:00",
+      "completed_at": "2026-04-21T22:44:28.355335+00:00",
+      "elapsed_seconds": 10,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generacion de Escenarios BDD",
+      "started_at": "2026-04-21T22:44:32.860397+00:00",
+      "completed_at": "2026-04-21T22:44:47.953238+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementacion",
+      "started_at": "2026-04-21T22:44:54.271444+00:00",
+      "completed_at": "2026-04-21T22:45:08.610031+00:00",
+      "elapsed_seconds": 14,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementacion",
+      "started_at": "2026-04-21T22:45:32.692293+00:00",
+      "completed_at": "2026-04-21T22:46:20.145454+00:00",
+      "elapsed_seconds": 47,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Bloquear jueces sin grilla",
+          "task_type": "frontend",
+          "estimated_minutes": 40.0,
+          "started_at": "2026-04-21T22:45:32.831437+00:00",
+          "completed_at": "2026-04-21T22:46:04.852609+00:00",
+          "elapsed_seconds": 32,
+          "actual_minutes": 0.53,
+          "variance_minutes": -39.47,
+          "file_created": "frontend/src/components/organizador/JuecesPanel.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Actualizar artefactos de US",
+          "task_type": "documentation",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-04-21T22:46:05.003285+00:00",
+          "completed_at": "2026-04-21T22:46:20.024089+00:00",
+          "elapsed_seconds": 15,
+          "actual_minutes": 0.25,
+          "variance_minutes": -4.75,
+          "file_created": "docs/plans/sp5/US-5.1.9-plan.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-21T22:46:24.891783+00:00",
+      "completed_at": "2026-04-21T22:46:38.517448+00:00",
+      "elapsed_seconds": 13,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integracion",
+      "started_at": "2026-04-21T22:46:38.638007+00:00",
+      "completed_at": "2026-04-21T22:46:52.667729+00:00",
+      "elapsed_seconds": 14,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validacion BDD",
+      "started_at": "2026-04-21T22:46:52.824870+00:00",
+      "completed_at": "2026-04-21T22:47:07.953203+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-21T22:47:08.071505+00:00",
+      "completed_at": "2026-04-21T22:47:52.712318+00:00",
+      "elapsed_seconds": 44,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentacion",
+      "started_at": "2026-04-21T22:47:52.847818+00:00",
+      "completed_at": "2026-04-21T22:48:09.645874+00:00",
+      "elapsed_seconds": 16,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-21T22:48:09.764579+00:00",
+      "completed_at": "2026-04-21T22:48:26.656757+00:00",
+      "elapsed_seconds": 16,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 2,
+    "completed_tasks": 2,
+    "total_phases": 10,
+    "estimated_total_minutes": 45.0,
+    "actual_total_minutes": 0.78,
+    "variance_minutes": -44.22,
+    "variance_percent": -98.26
+  }
+}

--- a/docs/plans/inc-5.1-adj/PLAN-INC-5.1-ADJ.md
+++ b/docs/plans/inc-5.1-adj/PLAN-INC-5.1-ADJ.md
@@ -124,7 +124,7 @@ US-5.1.10 ← acciones de fase (independiente, pero conveniente validar con tabs
 
 - [x] US-5.1.7 — tabs habilitadas correctamente por fase; `CANCELADO` muestra solo resumen
 - [x] US-5.1.8 — `Ver competencias` muestra disciplinas configuradas aunque no existan competencias
-- [ ] US-5.1.9 — selector de juez bloqueado si disciplina no tiene grilla generada
+- [x] US-5.1.9 — selector de juez bloqueado si disciplina no tiene grilla generada
 - [ ] US-5.1.10 — `Iniciar Ejecución` oculto en `EJECUCION`; acción de premiación visible
 - [ ] UAT de regresión: flujo completo del organizador sin errores visibles
 - [ ] DesignReviewer 0 CRITICAL post-INC-5.1-ADJ

--- a/docs/plans/sp5/US-5.1.9-plan.md
+++ b/docs/plans/sp5/US-5.1.9-plan.md
@@ -1,0 +1,46 @@
+# Plan de Implementacion - US-5.1.9 Precondicion grilla en jueces
+
+**Sprint:** SP5
+**Incremento:** INC-5.1-ADJ
+**Producto:** frontend
+**Tipo:** fix funcional post-UAT
+**Estimacion:** 2 puntos
+
+## Alcance
+
+Bloquear la asignacion de jueces para disciplinas que aun no tienen competencia con
+grilla generada, manteniendo visible cualquier asignacion existente.
+
+## Tareas
+
+### 1. Queries frontend
+
+- [x] Reutilizar `listarDisciplinasTorneo(torneoId)`.
+- [x] Agregar `fetchCompetenciasPorTorneo(torneoId)` en `JuecesPanel`.
+- [x] Manejar loading/error combinado de disciplinas, jueces y competencias.
+
+### 2. Politica de habilitacion
+
+- [x] Definir estados de competencia con grilla generada.
+- [x] Cruzar competencias por `disciplina`.
+- [x] Calcular `puedeAsignarJuez` por fila.
+
+### 3. Tabla de jueces
+
+- [x] Pasar estado de habilitacion a `TablaJueces`.
+- [x] Deshabilitar `JuezSelector` si no hay grilla.
+- [x] Mostrar `Generar grilla antes de asignar juez`.
+- [x] Mantener visible juez asignado existente.
+
+### 4. Validacion
+
+- [x] `npm run build`.
+- [x] `npm run lint`.
+- [x] Registrar waiver BDD/UI si no existe harness browser automatizado.
+- [x] Registrar reporte final en `docs/reports/US-5.1.9-report.md`.
+
+## DoD
+
+- Disciplina con competencia en estado de grilla generada permite asignar juez.
+- Disciplina sin competencia bloquea selector y muestra mensaje operativo.
+- Asignacion existente permanece visible aunque el selector este bloqueado.

--- a/docs/reports/US-5.1.9-bdd-validation.md
+++ b/docs/reports/US-5.1.9-bdd-validation.md
@@ -1,0 +1,19 @@
+# Validacion BDD - US-5.1.9
+
+## Feature
+
+`tests/features/US-5.1.9-bloquear-jueces-sin-grilla.feature`
+
+## Resultado
+
+Waiver de ejecucion automatizada.
+
+Los escenarios BDD fueron materializados desde la spec, pero el frontend no tiene
+steps ejecutables para montar la UI React con DOM/browser y mocks HTTP.
+
+## Criterios cubiertos por revision manual
+
+- Selector habilitado solo con competencia en estado de grilla generada.
+- Selector bloqueado para disciplina sin competencia.
+- Asignacion existente visible aunque la fila este bloqueada.
+- Mensaje `Generar grilla antes de asignar juez` visible en filas bloqueadas.

--- a/docs/reports/US-5.1.9-integration.md
+++ b/docs/reports/US-5.1.9-integration.md
@@ -1,0 +1,25 @@
+# Integracion - US-5.1.9
+
+## Estado
+
+Waiver de automatizacion.
+
+La US requiere montar `JuecesPanel` con tres fuentes:
+
+- `GET /torneos/{id}/disciplinas`
+- `GET /usuarios?rol=JUEZ`
+- `GET /competencia?torneo_id={id}` + `GET /competencia/{id}/estado`
+
+El repo no tiene harness browser/DOM para simular esas queries y validar el DOM resultante.
+
+## Flujo critico a validar manualmente
+
+- Disciplina con competencia en estado `GrillaGenerada` o posterior: selector habilitado.
+- Disciplina sin competencia: selector deshabilitado y mensaje operativo.
+- Disciplina con juez existente pero sin grilla: juez visible y selector bloqueado.
+- Error de carga en grillas/competencias: mensaje de error.
+
+## Gates sustitutos
+
+- `npm run build`
+- `npm run lint`

--- a/docs/reports/US-5.1.9-report.md
+++ b/docs/reports/US-5.1.9-report.md
@@ -1,0 +1,43 @@
+# Reporte de Implementacion - US-5.1.9
+
+## Resumen
+
+Se bloqueo la asignacion de jueces para disciplinas que no tienen competencia con
+grilla generada. La UI conserva visible el juez asignado, pero impide cambios hasta
+que exista una programacion oficial.
+
+## Componentes modificados
+
+- `frontend/src/components/organizador/JuecesPanel.tsx`
+  - Carga competencias del torneo.
+  - Consulta estado de cada competencia.
+  - Calcula habilitacion por disciplina segun estados de grilla generada.
+- `frontend/src/components/organizador/TablaJueces.tsx`
+  - Recibe `asignablePorDisciplina`.
+  - Deshabilita `JuezSelector` si la disciplina no es asignable.
+  - Muestra `Generar grilla antes de asignar juez` en filas bloqueadas.
+
+## Artefactos
+
+- Spec: `docs/specs/sp5/US-5.1.9.md`
+- Plan: `docs/plans/sp5/US-5.1.9-plan.md`
+- Feature: `tests/features/US-5.1.9-bloquear-jueces-sin-grilla.feature`
+- Test strategy: `docs/reports/US-5.1.9-test-strategy.md`
+- Integracion: `docs/reports/US-5.1.9-integration.md`
+- BDD validation: `docs/reports/US-5.1.9-bdd-validation.md`
+
+## Validacion
+
+- `npm run build` - OK
+- `npm run lint` - OK
+
+## Criterios de aceptacion
+
+- Disciplina con grilla generada permite asignar juez.
+- Disciplina sin competencia bloquea selector y muestra mensaje operativo.
+- Asignacion existente permanece visible aunque el selector este bloqueado.
+
+## Riesgo residual
+
+No hay harness automatizado de UI/browser para ejecutar los escenarios BDD. La cobertura
+automatizada disponible para esta US queda limitada a TypeScript y ESLint.

--- a/docs/reports/US-5.1.9-test-strategy.md
+++ b/docs/reports/US-5.1.9-test-strategy.md
@@ -1,0 +1,24 @@
+# Estrategia de Tests - US-5.1.9
+
+## Alcance
+
+US-5.1.9 modifica `JuecesPanel` y `TablaJueces` para bloquear la asignacion de jueces
+cuando la disciplina no tiene competencia con grilla generada.
+
+## Unit tests
+
+**Estado:** waiver.
+
+El frontend no tiene harness de tests unitarios React configurado
+(Vitest/Jest/Testing Library). La regla queda validada por TypeScript, ESLint y
+revision manual contra la feature BDD.
+
+## Validacion aplicada
+
+- TypeScript via `npm run build`.
+- ESLint via `npm run lint`.
+- Feature BDD materializado en `tests/features/US-5.1.9-bloquear-jueces-sin-grilla.feature`.
+
+## Riesgo residual
+
+No hay prueba automatizada que monte `JuecesPanel` con mocks de React Query/Router.

--- a/docs/specs/sp5/US-5.1.9.md
+++ b/docs/specs/sp5/US-5.1.9.md
@@ -1,6 +1,6 @@
-c# US-5.1.9: Precondición de grilla en asignación de jueces
+# US-5.1.9: Precondición de grilla en asignación de jueces
 
-**Estado**: `To Do`
+**Estado**: `Done`
 **Sprint**: SP5 — La Puesta en Marcha
 **Incremento**: INC-5.1-ADJ
 **Bounded Context**: `frontend`

--- a/frontend/src/components/organizador/JuecesPanel.tsx
+++ b/frontend/src/components/organizador/JuecesPanel.tsx
@@ -1,5 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
+import {
+  fetchCompetenciasPorTorneo,
+  fetchEstadoCompetencia,
+  type CompetenciaResumenDto,
+  type EstadoCompetenciaDto,
+} from '../../api/competencia'
 import { listarUsuariosPorRol } from '../../api/identidad'
 import {
   asignarJuez,
@@ -10,6 +16,33 @@ import { TablaJueces } from './TablaJueces'
 
 interface JuecesPanelProps {
   torneoId: string
+}
+
+interface CompetenciaConEstado {
+  competencia: CompetenciaResumenDto
+  estado: EstadoCompetenciaDto
+}
+
+const ESTADOS_CON_GRILLA_GENERADA = new Set([
+  'GrillaGenerada',
+  'GrillaConfirmada',
+  'EnEjecucion',
+  'Finalizada',
+  'CompetenciaFinalizada',
+])
+
+function tieneGrillaGenerada(estado: EstadoCompetenciaDto): boolean {
+  return estado.grilla_confirmada || ESTADOS_CON_GRILLA_GENERADA.has(estado.estado)
+}
+
+async function fetchCompetenciasConEstado(torneoId: string): Promise<CompetenciaConEstado[]> {
+  const competencias = await fetchCompetenciasPorTorneo(torneoId)
+  return Promise.all(
+    competencias.map(async (competencia) => ({
+      competencia,
+      estado: await fetchEstadoCompetencia(competencia.competencia_id, competencia.disciplina),
+    })),
+  )
 }
 
 export function JuecesPanel({ torneoId }: JuecesPanelProps) {
@@ -26,12 +59,25 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
     queryKey: ['usuarios-rol', 'JUEZ'],
     queryFn: () => listarUsuariosPorRol('JUEZ'),
   })
+  const competenciasQuery = useQuery({
+    queryKey: ['competencias-estado-jueces', torneoId],
+    queryFn: () => fetchCompetenciasConEstado(torneoId),
+  })
 
   const disciplinas = disciplinasQuery.data ?? []
   const jueces = useMemo(
     () => (juecesQuery.data ?? []).filter((usuario) => usuario.rol === 'JUEZ' && usuario.activo),
     [juecesQuery.data],
   )
+  const asignablePorDisciplina = useMemo(() => {
+    const asignable = new Map<string, boolean>()
+
+    for (const item of competenciasQuery.data ?? []) {
+      asignable.set(item.competencia.disciplina, tieneGrillaGenerada(item.estado))
+    }
+
+    return asignable
+  }, [competenciasQuery.data])
   const todasAsignadas =
     disciplinas.length > 0 && disciplinas.every((disciplina) => Boolean(disciplina.juez_id))
 
@@ -54,7 +100,7 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
     onSettled: () => setSavingDisciplina(null),
   })
 
-  if (disciplinasQuery.isLoading || juecesQuery.isLoading) {
+  if (disciplinasQuery.isLoading || juecesQuery.isLoading || competenciasQuery.isLoading) {
     return (
       <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
         Cargando jueces...
@@ -62,10 +108,10 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
     )
   }
 
-  if (disciplinasQuery.isError || juecesQuery.isError) {
+  if (disciplinasQuery.isError || juecesQuery.isError || competenciasQuery.isError) {
     return (
       <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
-        No se pudieron cargar disciplinas o jueces.
+        No se pudieron cargar disciplinas, jueces o grillas.
       </div>
     )
   }
@@ -98,6 +144,7 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
         disciplinas={disciplinas}
         jueces={jueces}
         savingDisciplina={savingDisciplina}
+        asignablePorDisciplina={asignablePorDisciplina}
         onAsignar={(disciplina, juezId) => asignarMutation.mutate({ disciplina, juezId })}
       />
     </div>

--- a/frontend/src/components/organizador/TablaJueces.tsx
+++ b/frontend/src/components/organizador/TablaJueces.tsx
@@ -6,6 +6,7 @@ interface TablaJuecesProps {
   disciplinas: DisciplinaTorneoDto[]
   jueces: UsuarioDto[]
   savingDisciplina: string | null
+  asignablePorDisciplina: Map<string, boolean>
   onAsignar: (disciplina: DisciplinaTorneoDto, juezId: string) => void
 }
 
@@ -18,6 +19,7 @@ export function TablaJueces({
   disciplinas,
   jueces,
   savingDisciplina,
+  asignablePorDisciplina,
   onAsignar,
 }: TablaJuecesProps) {
   if (disciplinas.length === 0) {
@@ -42,6 +44,7 @@ export function TablaJueces({
         <tbody className="divide-y divide-stone-200 bg-white">
           {disciplinas.map((disciplina) => {
             const saving = savingDisciplina === disciplina.disciplina
+            const puedeAsignar = asignablePorDisciplina.get(disciplina.disciplina) ?? false
             return (
               <tr key={disciplina.disciplina}>
                 <td className="px-4 py-3 font-semibold text-stone-950">
@@ -54,12 +57,18 @@ export function TablaJueces({
                   <JuezSelector
                     jueces={jueces}
                     value={disciplina.juez_id}
-                    disabled={saving || jueces.length === 0}
+                    disabled={saving || jueces.length === 0 || !puedeAsignar}
                     onChange={(juezId) => onAsignar(disciplina, juezId)}
                   />
                 </td>
                 <td className="px-4 py-3 text-stone-700">
-                  {saving ? 'Guardando...' : disciplina.juez_id ? 'Asignado' : 'Pendiente'}
+                  {saving
+                    ? 'Guardando...'
+                    : !puedeAsignar
+                      ? 'Generar grilla antes de asignar juez'
+                      : disciplina.juez_id
+                        ? 'Asignado'
+                        : 'Pendiente'}
                 </td>
               </tr>
             )

--- a/tests/features/US-5.1.9-bloquear-jueces-sin-grilla.feature
+++ b/tests/features/US-5.1.9-bloquear-jueces-sin-grilla.feature
@@ -1,0 +1,30 @@
+Feature: US-5.1.9 - Precondicion de grilla en asignacion de jueces
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And el torneo T1 esta en estado PREPARACION con disciplinas DNF y STA
+
+  Scenario: disciplina con grilla generada tiene selector habilitado
+    Given existe competencia C1 para disciplina DNF en estado GrillaGenerada
+    When el organizador accede al tab Jueces
+    Then la fila de DNF muestra el JuezSelector habilitado
+
+  Scenario: disciplina sin competencia tiene selector bloqueado
+    Given no existe competencia para disciplina STA en T1
+    When el organizador accede al tab Jueces
+    Then la fila de STA muestra el selector deshabilitado
+    And la fila muestra el mensaje "Generar grilla antes de asignar juez"
+
+  Scenario: asignacion existente visible aunque grilla no este generada
+    Given existe una asignacion de juez para STA en torneo.db
+    And no existe competencia para STA en competencia.db
+    When el organizador accede al tab Jueces
+    Then la fila de STA muestra el juez asignado como texto
+    And el selector de STA permanece deshabilitado
+
+  Scenario: asignar juez a disciplina con grilla funciona normalmente
+    Given existe competencia C1 para DNF en estado GrillaConfirmada
+    And no hay juez asignado a DNF
+    When el organizador selecciona un juez en la fila de DNF
+    Then el backend recibe PUT /torneos/T1/disciplinas/DNF/juez
+    And la fila actualiza con el juez asignado


### PR DESCRIPTION
## Resumen
- Carga competencias y estado por disciplina en JuecesPanel.
- Bloquea JuezSelector si la disciplina no tiene grilla generada/confirmada.
- Mantiene visible la asignacion existente y muestra mensaje operativo.
- Corrige typo de spec y agrega feature BDD, plan, reportes y tracking.

## Validacion
- npm run build
- npm run lint

## Nota
- BDD/UI automatizado queda con waiver porque el frontend no tiene harness browser/DOM configurado.