### PR TITLE
feat: implement US-5.2.1 disciplina execution

### DIFF
--- a/.claude/tracking/US-5.2.1-tracking.json
+++ b/.claude/tracking/US-5.2.1-tracking.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {
+    "us_id": "US-5.2.1",
+    "us_title": "Vista maestro-detalle de disciplinas en ejecucion",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-22T13:51:35.976482+00:00",
+    "completed_at": "2026-04-22T14:06:23.417645+00:00",
+    "total_elapsed_seconds": 887,
+    "effective_seconds": 887,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-22T13:53:16.001727+00:00",
+      "completed_at": "2026-04-22T13:55:26.591159+00:00",
+      "elapsed_seconds": 130,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-22T13:55:36.229648+00:00",
+      "completed_at": "2026-04-22T13:56:08.333092+00:00",
+      "elapsed_seconds": 32,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-22T13:56:34.374453+00:00",
+      "completed_at": "2026-04-22T13:57:18.637409+00:00",
+      "elapsed_seconds": 44,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-22T13:57:34.788690+00:00",
+      "completed_at": "2026-04-22T14:02:04.897996+00:00",
+      "elapsed_seconds": 270,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-22T14:02:12.017806+00:00",
+      "completed_at": "2026-04-22T14:02:46.416094+00:00",
+      "elapsed_seconds": 34,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-22T14:02:51.795628+00:00",
+      "completed_at": "2026-04-22T14:03:32.017996+00:00",
+      "elapsed_seconds": 40,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-22T14:03:40.269881+00:00",
+      "completed_at": "2026-04-22T14:03:49.540317+00:00",
+      "elapsed_seconds": 9,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-22T14:03:58.141601+00:00",
+      "completed_at": "2026-04-22T14:04:53.006074+00:00",
+      "elapsed_seconds": 54,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-22T14:04:58.484123+00:00",
+      "completed_at": "2026-04-22T14:05:14.362223+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-22T14:05:42.956923+00:00",
+      "completed_at": "2026-04-22T14:06:19.033353+00:00",
+      "elapsed_seconds": 36,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 10,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/plans/sp5/US-5.2.1-docs.md
+++ b/docs/plans/sp5/US-5.2.1-docs.md
@@ -1,0 +1,52 @@
+# US-5.2.1 — Documentacion Funcional
+
+## Vista maestro-detalle de ejecucion
+
+El tab `Ejecucion` del panel organizador deja de mostrar solamente competencias ya iniciadas.
+Ahora funciona como una vista maestro-detalle:
+
+- **Maestro:** lista todas las disciplinas configuradas del torneo.
+- **Detalle:** muestra el estado operativo y datos de la disciplina seleccionada.
+
+La fuente primaria del maestro es `GET /torneos/{torneo_id}/disciplinas`. La proyeccion
+`GET /competencia?torneo_id={id}` se usa para enriquecer cada disciplina cuando ya existe una
+competencia materializada.
+
+## Estados operativos
+
+La UI deriva un estado operativo por disciplina:
+
+| Estado | Significado |
+|---|---|
+| `Configurar competencia` | La disciplina existe en el torneo pero aun no tiene competencia. |
+| `Confirmar grilla antes de habilitar` | La competencia existe pero la grilla no esta confirmada. |
+| `Asignar juez antes de habilitar` | La grilla esta confirmada pero falta juez asignado. |
+| `Lista para iniciar` | La competencia esta confirmada, con grilla confirmada y juez asignado. |
+| `En ejecucion` | La competencia ya fue iniciada. |
+| `Finalizada` | La competencia cerro y queda en modo lectura. |
+
+## Habilitacion de disciplina
+
+La accion `Habilitar disciplina` se muestra solo cuando el estado operativo es
+`Lista para iniciar`.
+
+La accion llama:
+
+```http
+POST /competencia/{competencia_id}/iniciar
+```
+
+con body:
+
+```json
+{
+  "disciplina": "DNF",
+  "juez_id": "..."
+}
+```
+
+El `juez_id` proviene de la asignacion del torneo. No se solicita manualmente en esta pantalla.
+
+## Limite de alcance
+
+Esta US no implementa `Finalizar prueba`. Ese cierre manual corresponde a `US-5.2.2`.

--- a/docs/plans/sp5/US-5.2.1-fase0.md
+++ b/docs/plans/sp5/US-5.2.1-fase0.md
@@ -1,0 +1,92 @@
+# US-5.2.1 — Fase 0: Validacion de Contexto
+
+**Fecha:** 2026-04-22
+**Branch:** `feature/US-5.2.1-ejecucion-disciplinas`
+**Producto:** `frontend`
+**Incremento:** INC-5.2 — Ejecucion por Disciplina
+
+---
+
+## Historia de Usuario
+
+**US:** US-5.2.1 — Vista maestro-detalle de disciplinas en ejecucion
+
+Como **organizador**, quiero **ver todas las disciplinas del torneo en ejecucion en una vista maestro-detalle y habilitar individualmente cada prueba** para **controlar el inicio operativo de cada disciplina y monitorear su avance desde un unico lugar**.
+
+**Spec canonica:** `docs/specs/sp5/US-5.2.1.md`
+
+---
+
+## Contexto Validado
+
+### Arquitectura
+
+- Patron confirmado: Hexagonal DDD BC-first.
+- Producto principal de implementacion: `frontend`.
+- BCs consumidos por HTTP:
+  - `torneo/api/` para disciplinas configuradas y juez asignado.
+  - `competencia/api/` para competencias, estado, grilla, progreso e inicio.
+- No se requieren cambios de dominio backend para esta US: `POST /competencia/{id}/iniciar` ya existe.
+
+### Artefactos arquitectonicos encontrados
+
+- `docs/contexto/ATARAXIADIVE-CONTEXT.md`
+- `docs/adr/ADR-005-bounded-contexts-ddd-estrategico.md`
+- `docs/adr/ADR-006-estructura-bc-first.md`
+- `docs/design/architecture.md`
+- `docs/design/domain-model.md`
+
+### Estructura verificada
+
+- `frontend/src/components/organizador/`
+- `frontend/src/api/competencia.ts`
+- `frontend/src/api/torneo.ts`
+- `src/competencia/domain/`
+- `src/competencia/application/`
+- `src/competencia/api/`
+- `tests/features/`
+
+---
+
+## Estado Actual Relevante
+
+### Frontend
+
+- `EjecucionPanel` hoy carga `GET /competencia?torneo_id={id}` y filtra solo competencias en `EnEjecucion`.
+- `MonitorDisciplina` ya muestra progreso, atleta actual, proximos y grilla para una competencia activa.
+- `torneo.ts` ya expone `listarDisciplinasTorneo(torneoId)`, que devuelve disciplina y `juez_id`.
+- `competencia.ts` no expone aun wrapper para `POST /competencia/{id}/iniciar`.
+
+### Backend
+
+- `POST /competencia/{competencia_id}/iniciar` existe en `src/competencia/api/router.py`.
+- `IniciarCompetenciaHandler` existe en `src/competencia/application/commands/iniciar_competencia.py`.
+- `Competencia.iniciar_competencia()` exige estado `Confirmada`.
+
+---
+
+## Quality Gates
+
+- `CLAUDE.md` encontrado.
+- `pyproject.toml` encontrado.
+- `[tool.codeguard]` configurado.
+- `[tool.designreviewer]` configurado.
+- Tests configurados en `tests/`.
+- Para frontend, el ajuste local de `implement-us` indica sustituir gates Python por:
+  - `npm run build`
+  - `npm run lint` si aplica.
+
+---
+
+## Riesgos Detectados
+
+- El maestro debe componer dos fuentes: disciplinas del torneo y competencias materializadas.
+- El estado operativo es derivado; debe evitarse mezclar estado de torneo (`EJECUCION`) con estado de competencia (`Confirmada`, `EnEjecucion`, `Finalizada`).
+- La accion `Habilitar disciplina` necesita `juez_id`; debe obtenerlo desde `torneo/api`, no pedirlo manualmente.
+- La UI actual usa cards del monitor solo para disciplinas activas; la nueva vista debe representar tambien pendientes, bloqueadas, listas y finalizadas.
+
+---
+
+## Resultado
+
+Contexto validado. La US esta lista para Fase 1: escenarios BDD.

--- a/docs/plans/sp5/US-5.2.1-implementation-notes.md
+++ b/docs/plans/sp5/US-5.2.1-implementation-notes.md
@@ -1,0 +1,55 @@
+# US-5.2.1 — Notas de Implementacion
+
+**Fecha:** 2026-04-22
+**Fase:** 3 — Implementacion
+
+---
+
+## Cambios realizados
+
+- `frontend/src/api/competencia.ts`
+  - Agregado `iniciarCompetencia()` para `POST /competencia/{competencia_id}/iniciar`.
+
+- `frontend/src/components/organizador/EjecucionPanel.tsx`
+  - Reemplazado el monitor de solo disciplinas activas por una vista maestro-detalle.
+  - El maestro compone:
+    - `listarDisciplinasTorneo(torneoId)`
+    - `fetchCompetenciasPorTorneo(torneoId)`
+    - `fetchEstadoCompetencia()`
+    - `fetchProgresoCompetencia()`
+  - El detalle muestra:
+    - estado operativo derivado;
+    - juez asignado;
+    - hash SHA-256 si la competencia finalizo;
+    - grilla OT para estados no activos;
+    - `MonitorDisciplina` para competencias en ejecucion.
+  - Agregada accion `Habilitar disciplina` solo para estado operativo `lista_para_iniciar`.
+
+---
+
+## Estados operativos derivados
+
+- `sin_competencia`
+- `sin_grilla`
+- `sin_juez`
+- `lista_para_iniciar`
+- `en_ejecucion`
+- `finalizada`
+- `no_disponible`
+
+La decision de habilitar inicio queda en frontend, pero el backend sigue siendo fuente de verdad:
+si la competencia no esta en estado `Confirmada`, `POST /competencia/{id}/iniciar` responde error.
+
+---
+
+## Validaciones ejecutadas
+
+- `npm run build` — OK
+- `npm run lint` — OK tras eliminar `setState` sincronico dentro de `useEffect`
+
+---
+
+## Pendiente para US-5.2.2
+
+No se implementa cierre manual. El detalle queda preparado visualmente para acciones por disciplina,
+pero la accion `Finalizar prueba` corresponde a `US-5.2.2`.

--- a/docs/plans/sp5/US-5.2.1-plan.md
+++ b/docs/plans/sp5/US-5.2.1-plan.md
@@ -1,0 +1,133 @@
+# Plan de Implementacion: US-5.2.1 — Vista maestro-detalle de disciplinas en ejecucion
+
+**Patron:** React/Vite frontend consumiendo APIs hexagonales existentes
+**Producto:** `frontend`
+**Branch:** `feature/US-5.2.1-ejecucion-disciplinas`
+**Estimacion total:** 3h 20min
+**Estado:** 0/12 tareas completadas
+
+---
+
+## Objetivo Tecnico
+
+Convertir `EjecucionPanel` de un monitor de competencias ya activas a una vista maestro-detalle
+que compone disciplinas configuradas del torneo, competencias materializadas, estado de grilla,
+juez asignado y progreso. Desde el detalle, el organizador puede habilitar una disciplina lista
+para iniciar usando `POST /competencia/{competencia_id}/iniciar`.
+
+---
+
+## Componentes a Implementar
+
+### 1. API frontend
+
+- [ ] `frontend/src/api/competencia.ts` — agregar `iniciarCompetencia()` (10 min)
+  - Payload: `{ competenciaId, disciplina, juezId }`
+  - Endpoint: `POST /competencia/{competencia_id}/iniciar`
+  - Body: `{ disciplina, juez_id }`
+  - Reutilizar `buildHeaders()` y `parseResponse<void>()`
+
+### 2. Modelo de vista local para ejecucion
+
+- [ ] `frontend/src/components/organizador/EjecucionPanel.tsx` — definir tipos internos (20 min)
+  - `DisciplinaEjecucionItem`
+  - `EstadoOperativoDisciplina`
+  - `DetalleDisciplinaData`
+  - Evitar exponer estos tipos fuera del componente salvo necesidad real.
+
+- [ ] Implementar helpers de estado operativo (25 min)
+  - Derivar estados: `sin_competencia`, `sin_grilla`, `sin_juez`, `lista_para_iniciar`, `en_ejecucion`, `finalizada`.
+  - Reutilizar la regla `estado.grilla_confirmada`.
+  - Considerar estados backend actuales: `Preparacion`, `Confirmada`, `EnEjecucion`, `Finalizada`.
+
+### 3. Carga compuesta maestro-detalle
+
+- [ ] Reemplazar `loadMonitorData()` por `loadEjecucionData()` (35 min)
+  - `listarDisciplinasTorneo(torneoId)` como fuente primaria.
+  - `fetchCompetenciasPorTorneo(torneoId)` como enrichment opcional.
+  - Para cada competencia, cargar `fetchEstadoCompetencia()` y `fetchProgresoCompetencia()`.
+  - El maestro debe renderizar disciplinas aunque no tengan competencia.
+
+- [ ] Implementar carga de detalle para disciplina seleccionada (25 min)
+  - Si no hay `competencia_id`, no llamar endpoints de competencia.
+  - Si hay competencia, cargar grilla, performance actual, proximas y progreso.
+  - Mantener refetch cada 30s para datos vivos.
+
+### 4. UI maestro
+
+- [ ] Construir lista/card maestro por disciplina (35 min)
+  - Mostrar disciplina, juez asignado o bloqueo, estado operativo y progreso resumido.
+  - Permitir seleccionar disciplina.
+  - Seleccionar por defecto la primera disciplina disponible.
+  - Mantener layout estable en mobile/desktop.
+
+- [ ] Estados vacio/error/cargando (15 min)
+  - Sin disciplinas configuradas.
+  - Error al cargar disciplinas/competencias.
+  - Loading inicial.
+
+### 5. UI detalle operativo
+
+- [ ] Adaptar/reutilizar `MonitorDisciplina` para detalle seleccionado (35 min)
+  - Mostrar grilla, progreso, atleta actual y proximos.
+  - Mostrar estado `Finalizada` con hash si existe.
+  - Mostrar bloqueos cuando falte competencia, grilla o juez.
+
+- [ ] Agregar accion `Habilitar disciplina` (25 min)
+  - Habilitada solo con competencia, grilla confirmada, juez asignado y estado `Confirmada`.
+  - Mutacion llama `iniciarCompetencia()`.
+  - En success, invalidar queries de ejecucion y recargar detalle.
+  - Mostrar error inline si backend devuelve 409/404.
+
+### 6. Tests
+
+- [ ] Tests unitarios frontend para helpers de estado operativo si se extraen a modulo testeable (20 min)
+  - Si los helpers quedan internos al componente, cubrir mediante build/lint y BDD manual.
+
+- [ ] Validacion BDD/manual de escenarios `US-5.2.1-ejecucion-disciplinas.feature` (20 min)
+  - Maestro con todas las disciplinas.
+  - Detalle operativo.
+  - Habilitacion exitosa.
+  - Bloqueos por falta de juez/grilla.
+  - Finalizada en modo lectura.
+
+### 7. Quality gates
+
+- [ ] `npm run build` en `frontend/` (10 min)
+- [ ] `npm run lint` en `frontend/` si no hay deuda previa bloqueante (10 min)
+- [ ] Registrar resultado en reporte final (10 min)
+
+---
+
+## Dependencias y Restricciones
+
+- Backend no cambia en esta US.
+- `POST /competencia/{competencia_id}/iniciar` ya existe.
+- `listarDisciplinasTorneo()` devuelve `disciplina` y `juez_id`; es la fuente para asignacion de juez.
+- `fetchCompetenciasPorTorneo()` puede devolver menos filas que disciplinas configuradas.
+- No implementar cierre manual en esta US; reservar accion/espacio para US-5.2.2 si el diseño lo permite sin acoplar.
+
+---
+
+## Riesgos y Mitigaciones
+
+- **Riesgo:** duplicar logica de composicion usada en `JuecesPanel`.
+  - **Mitigacion:** reutilizar patrones simples, pero no extraer abstraccion compartida hasta ver duplicacion estable.
+
+- **Riesgo:** estado operativo incorrecto por mismatch de strings backend.
+  - **Mitigacion:** centralizar sets de estado en helpers locales y cubrir casos actuales (`Confirmada`, `EnEjecucion`, `Finalizada`).
+
+- **Riesgo:** UI demasiado densa en mobile.
+  - **Mitigacion:** maestro en columna, detalle debajo; evitar tablas anchas para el maestro.
+
+---
+
+## Orden de Ejecucion
+
+1. Agregar wrapper `iniciarCompetencia()`.
+2. Reescribir carga compuesta de `EjecucionPanel`.
+3. Implementar maestro y seleccion.
+4. Implementar detalle y accion de habilitacion.
+5. Ajustar estados visuales y mensajes de bloqueo.
+6. Ejecutar build/lint.
+7. Documentar resultados.

--- a/docs/plans/sp5/US-5.2.1-test-notes.md
+++ b/docs/plans/sp5/US-5.2.1-test-notes.md
@@ -1,0 +1,46 @@
+# US-5.2.1 — Notas de Tests
+
+**Fecha:** 2026-04-22
+
+---
+
+## Fase 4 — Tests Unitarios
+
+El frontend no tiene harness unitario configurado:
+
+- no existe `vitest.config.*`;
+- `frontend/package.json` no define script `test`;
+- las dependencias no incluyen runner unitario de React.
+
+Por el ajuste local de `implement-us` para producto `frontend`, la validacion unitaria se sustituye
+por compilacion TypeScript y lint:
+
+- `npm run build` — OK
+- `npm run lint` — OK
+
+No se agrega Vitest/Testing Library en esta US para evitar ampliar el alcance del incremento.
+
+---
+
+## Fase 5 — Integracion
+
+La integracion cubierta por esta US es cliente HTTP + React Query:
+
+- `listarDisciplinasTorneo()` como fuente primaria de disciplinas.
+- `fetchCompetenciasPorTorneo()` como enrichment de competencias existentes.
+- `fetchEstadoCompetencia()` y `fetchProgresoCompetencia()` para maestro.
+- `fetchGrillaCompetencia()`, `fetchPerformanceActual()` y `fetchProximasPerformances()` para detalle.
+- `iniciarCompetencia()` para la accion de habilitacion.
+
+La validacion automatizada disponible es `npm run build`, que confirma tipos y wiring de imports.
+
+---
+
+## Fase 6 — BDD/UI
+
+Los escenarios BDD estan en:
+
+- `tests/features/US-5.2.1-ejecucion-disciplinas.feature`
+
+No existe harness automatizado de browser para ejecutar estos escenarios contra la UI. La validacion
+BDD queda como manual/UI, consistente con el ajuste local de `implement-us`.

--- a/docs/reports/US-5.2.1-report.md
+++ b/docs/reports/US-5.2.1-report.md
@@ -1,0 +1,99 @@
+# Reporte de Implementacion: US-5.2.1
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** US-5.2.1 — Vista maestro-detalle de disciplinas en ejecucion
+- **Incremento:** INC-5.2 — Ejecucion por Disciplina
+- **Producto:** `frontend`
+- **Puntos estimados:** 3
+- **Tiempo real tracker:** ~14 min al iniciar Fase 9
+- **Estado:** Completado
+- **Fecha:** 2026-04-22
+
+---
+
+## Componentes Implementados
+
+- `frontend/src/api/competencia.ts`
+  - Agregado `iniciarCompetencia()`.
+  - Integra `POST /competencia/{competencia_id}/iniciar`.
+  - Envia `disciplina` y `juez_id` usando headers autenticados existentes.
+
+- `frontend/src/components/organizador/EjecucionPanel.tsx`
+  - Convertido de monitor de disciplinas activas a vista maestro-detalle.
+  - Maestro basado en disciplinas configuradas del torneo.
+  - Enrichment con competencias materializadas, estado de competencia y progreso.
+  - Detalle con grilla OT, progreso, atleta actual/proximos y hash de cierre si existe.
+  - Accion `Habilitar disciplina` solo para disciplinas listas para iniciar.
+
+---
+
+## Artefactos Creados
+
+- `docs/plans/sp5/US-5.2.1-fase0.md`
+- `docs/plans/sp5/US-5.2.1-plan.md`
+- `docs/plans/sp5/US-5.2.1-implementation-notes.md`
+- `docs/plans/sp5/US-5.2.1-test-notes.md`
+- `docs/plans/sp5/US-5.2.1-docs.md`
+- `tests/features/US-5.2.1-ejecucion-disciplinas.feature`
+- `docs/reports/US-5.2.1-report.md`
+
+---
+
+## Criterios de Aceptacion
+
+- [x] El maestro muestra todas las disciplinas configuradas del torneo.
+- [x] Cada disciplina muestra estado operativo derivado.
+- [x] La seleccion de una disciplina abre detalle operativo.
+- [x] El detalle muestra grilla, progreso y datos de ejecucion cuando hay competencia.
+- [x] `Habilitar disciplina` se muestra solo cuando hay competencia, grilla confirmada y juez asignado.
+- [x] La accion llama `POST /competencia/{id}/iniciar` con `disciplina` y `juez_id`.
+- [x] Disciplinas sin juez o sin grilla quedan bloqueadas visualmente.
+- [x] Disciplinas finalizadas se muestran en modo lectura con hash si esta disponible.
+
+---
+
+## Validaciones
+
+| Validacion | Resultado |
+|---|---|
+| `npm run lint` | OK |
+| `npm run build` | OK |
+| BDD feature creado | OK |
+| BDD automatizado UI | No disponible en el repo |
+
+El frontend no tiene runner unitario ni harness browser configurado. Segun el ajuste local de
+`implement-us`, la validacion tecnica para producto `frontend` se realizo con build/lint y la
+validacion BDD queda como manual UI.
+
+---
+
+## Decisiones de Implementacion
+
+- No se modifico backend: el endpoint de inicio ya existia.
+- No se extrajo logica compartida con `JuecesPanel`; la duplicacion todavia es baja y especifica.
+- El estado operativo se deriva localmente en `EjecucionPanel` para mantener el cambio acotado.
+- La fuente primaria del maestro es `listarDisciplinasTorneo()`, no la proyeccion de competencias.
+
+---
+
+## Fuera de Alcance
+
+- Cierre manual de disciplina (`Finalizar prueba`) queda para US-5.2.2.
+- Tests automatizados de UI quedan pendientes hasta incorporar un harness frontend.
+- No se agregan dependencias nuevas.
+
+---
+
+## Archivos de Codigo Modificados
+
+- `frontend/src/api/competencia.ts`
+- `frontend/src/components/organizador/EjecucionPanel.tsx`
+
+---
+
+## Proximos Pasos
+
+- Ejecutar UAT manual del tab `Ejecucion` con un torneo en estado `EJECUCION`.
+- Continuar con US-5.2.2 para cierre manual de prueba.
+- Considerar Vitest/Testing Library o Playwright si SP5 requiere regresion frontend automatizada.

--- a/docs/reports/documentation-consistency-review-2026-04-22.md
+++ b/docs/reports/documentation-consistency-review-2026-04-22.md
@@ -1,0 +1,348 @@
+# Revisión de Consistencia Documental — 2026-04-22
+
+## Alcance
+
+Esta revisión contrasta la documentación funcional y técnica del proyecto contra
+la implementación disponible en el repositorio al inicio de `INC-5.2`.
+
+Incluye:
+
+- estado de proyecto, baselines y plan SP5;
+- documentación de arquitectura y diseño;
+- matriz de trazabilidad funcional;
+- contratos API observables en código;
+- estado real del frontend PWA/offline-first;
+- alcance implementado hasta `INC-5.1` y trabajo local de `US-5.2.1`.
+
+No incluye correcciones sobre los documentos fuente. Este reporte es un
+diagnóstico y una propuesta de saneamiento.
+
+## Método
+
+1. Inventario de documentación en `README.md`, `CLAUDE.md`, `.cm/`, `docs/`.
+2. Lectura comparativa de planes, baselines, arquitectura y trazabilidad.
+3. Verificación contra implementación en `src/`, `frontend/src/` y `tests/`.
+4. Clasificación de hallazgos por severidad e impacto operativo.
+
+## Resumen ejecutivo
+
+La documentación del proyecto es abundante y preserva bien el razonamiento
+histórico IEDD, pero hoy hay varias fuentes que se presentan como vigentes y
+dicen cosas incompatibles entre sí.
+
+El mayor riesgo no es técnico sino de gobernanza documental: un nuevo
+desarrollador, un agente o una revisión externa puede tomar como actual un
+documento desactualizado y ejecutar contra un mapa incorrecto del producto.
+
+La prioridad recomendada es establecer una jerarquía explícita de fuentes:
+
+1. `docs/plans/sp5/PLAN-SP5.md` como fuente de alcance vigente del SP5.
+2. `.cm/baselines/` como fuente de estado de cierre por subproyecto.
+3. `docs/architecture/` como arquitectura vigente.
+4. `docs/design/` y `docs/dominio/` como modelado/historia, salvo documentos
+   marcados explícitamente como actuales.
+
+## Hallazgos
+
+### H1 — Estado del proyecto inconsistente entre README, CLAUDE y baselines
+
+**Severidad:** Alta
+
+`README.md` informa que `SP4` y `SP5` están pendientes, y además dice que el
+estado del producto quedó en `SP3`/`v0.4.0`.
+
+Evidencia:
+
+- `README.md:14` marca `SP4 — La Plataforma` como pendiente.
+- `README.md:15` marca `SP5 — La Puesta en Marcha` como pendiente.
+- `README.md:17` describe cierre en `SP3` con tag `v0.4.0`.
+- `CLAUDE.md` documenta `SP4` cerrado el 2026-04-18 con tag `v0.5.0`.
+- `.cm/baselines/BL-004.md` registra el cierre de `SP4`.
+- `.cm/baselines/BL-005-draft.md` registra `SP5` en construcción con `INC-5.1`
+  cerrado.
+
+Impacto:
+
+- El `README.md` es el primer punto de entrada del repositorio y hoy induce a
+  operar como si el frontend y SP4 no existieran.
+- Afecta onboarding, revisión documental y cualquier automatización que use el
+  README como estado resumido.
+
+Recomendación:
+
+- Actualizar `README.md` para reflejar `SP4` cerrado y `SP5` en curso.
+- Convertir el README en índice hacia `.cm/baselines/` y `docs/plans/sp5/`.
+
+### H2 — Arquitectura offline-first declarada como no implementada, pero ya existe
+
+**Severidad:** Alta
+
+`docs/architecture/50-offline-sync.md` dice que el modo offline-first todavía no
+aparece materializado con Service Worker, IndexedDB ni cola de sincronización.
+
+Evidencia documental:
+
+- `docs/architecture/50-offline-sync.md:35-37` declara ausencia de Service
+  Worker, IndexedDB y cola de sincronización.
+
+Evidencia de implementación:
+
+- `frontend/src/sw.ts`
+- `frontend/src/db/index.ts`
+- `frontend/src/db/schema.ts`
+- `frontend/src/db/queries.ts`
+- `frontend/src/hooks/useComandoQueue.ts`
+- `frontend/src/hooks/useGrillaQueue.ts`
+- `frontend/src/hooks/usePrecarga.ts`
+- `frontend/src/hooks/useSyncQueue.ts`
+
+Impacto:
+
+- La carpeta `docs/architecture/` se define a sí misma como arquitectura
+  vigente, por lo que este desvío es especialmente costoso.
+- Puede ocultar deuda real porque mezcla una afirmación obsoleta con una
+  arquitectura objetivo todavía útil.
+
+Recomendación:
+
+- Reescribir la sección "Estado actual" como estado implementado en SP4.
+- Separar claramente capacidades ya implementadas, límites conocidos y
+  arquitectura objetivo futura.
+
+### H3 — `docs/design/architecture.md` conserva contratos API obsoletos
+
+**Severidad:** Alta
+
+`docs/design/architecture.md` se presenta como arquitectura del sistema y
+mantiene endpoints que ya no coinciden con la API real.
+
+Evidencia documental:
+
+- `docs/design/architecture.md:205` usa `/competencias/{id}/...` y
+  `/competencias/{id}/finalizar`.
+- `docs/design/architecture.md:206` usa endpoints separados bajo
+  `/performances/{id}/...`.
+
+Evidencia de implementación:
+
+- `src/competencia/api/router.py:138` define `APIRouter(prefix="/competencia")`.
+- Los endpoints reales son, entre otros:
+  - `POST /competencia`
+  - `GET /competencia`
+  - `POST /competencia/{competencia_id}/generar-grilla`
+  - `POST /competencia/{competencia_id}/confirmar-grilla`
+  - `POST /competencia/{competencia_id}/iniciar`
+  - `POST /competencia/{competencia_id}/registrar-resultado`
+  - `POST /competencia/{competencia_id}/registrar-dns`
+  - `POST /competencia/{competencia_id}/asignar-tarjeta`
+  - `GET /competencia/{competencia_id}/grilla`
+  - `GET /competencia/{competencia_id}/estado`
+
+Impacto:
+
+- Un consumidor técnico puede implementar contra rutas inexistentes.
+- La documentación de diseño compite con la arquitectura vigente de
+  `docs/architecture/`.
+
+Recomendación:
+
+- Marcar `docs/design/architecture.md` como histórico o superseded.
+- Mover el contrato API actual a un documento canónico, o enlazar OpenAPI como
+  fuente de verdad técnica.
+
+### H4 — Roadmap SP5 desalineado entre `PLAN-SP5` y `BL-005-draft`
+
+**Severidad:** Alta
+
+El plan vigente de SP5 y el baseline draft usan una numeración y un alcance
+distintos a partir de `INC-5.4`.
+
+Evidencia:
+
+- `docs/plans/sp5/PLAN-SP5.md:221-236` define `INC-5.5` como algoritmo de
+  puntaje y rankings por categoría/género.
+- `docs/plans/sp5/PLAN-SP5.md:240-251` define `INC-5.6` como Portal del Atleta.
+- `docs/plans/sp5/PLAN-SP5.md:255-266` define `INC-5.7` como polish y
+  demo-readiness.
+- `.cm/baselines/BL-005-draft.md:42-44` define `INC-5.4` como algoritmo de
+  puntaje FAAS, `INC-5.5` como resultados y premiación, e `INC-5.6` como UAT
+  demo completo.
+
+Impacto:
+
+- El tracker y los commits pueden quedar asociados a incrementos incorrectos.
+- Riesgo alto de generar specs o reportes con IDs válidos pero semántica
+  equivocada.
+
+Recomendación:
+
+- Actualizar `BL-005-draft.md` para copiar la estructura de `PLAN-SP5`.
+- Registrar explícitamente que Integración FAAS/importación CSV quedó fuera de
+  scope SP5.
+
+### H5 — Matriz de trazabilidad no refleja el alcance vigente del SP5
+
+**Severidad:** Alta
+
+`docs/traceability/matrix.md` fue actualizada el 2026-04-22, pero conserva
+mapeos incompatibles con el plan vigente.
+
+Evidencia:
+
+- `docs/traceability/matrix.md:41` asigna `SP5` pendiente a Integración externa
+  `RF-IG-01..04` y `RF-IN-07`.
+- `docs/plans/sp5/PLAN-SP5.md:286-294` declara Integración FAAS/importación CSV
+  fuera de scope SP5.
+- `docs/traceability/matrix.md:69-71` ubica apto médico, constancia de pago y
+  conflicto con BD FAAS fuera del incremento `INC-5.4` del plan actual.
+- `docs/traceability/matrix.md:114-119` marca fórmula de puntos y rankings por
+  categoría/género como definidos/implementados, mientras `PLAN-SP5` los ubica
+  en `INC-5.5`.
+
+Impacto:
+
+- La trazabilidad deja de ser confiable para planificar el trabajo restante.
+- Puede producir una falsa sensación de cobertura funcional.
+
+Recomendación:
+
+- Reconciliar la matriz contra `PLAN-SP5`.
+- Distinguir "definido conceptualmente", "implementado técnicamente" y
+  "expuesto en producto final".
+- Marcar `RF-IG-01..04` como futuro/fuera de alcance SP5.
+
+### H6 — `docs/architecture/README.md` lista una estructura objetivo que ya no existe
+
+**Severidad:** Media
+
+El README de arquitectura se declara como descripción vigente, pero su estructura
+objetivo lista nombres antiguos.
+
+Evidencia:
+
+- `docs/architecture/README.md:50-64` lista `04-runtime-interactions.md`,
+  `05-deployment-view.md`, `06-cross-cutting-concerns.md` y
+  `07-offline-sync.md`.
+- La carpeta real usa documentos como `30-runtime-interactions.md`,
+  `40-cross-cutting-concerns.md` y `50-offline-sync.md`.
+
+Impacto:
+
+- Menor que los hallazgos anteriores, pero deteriora la confianza en la carpeta
+  que se supone canónica.
+
+Recomendación:
+
+- Actualizar la estructura documentada con los nombres reales.
+- Si existen documentos planificados no creados, listarlos en una sección
+  separada de pendientes.
+
+### H7 — BC Competencia documenta un `Participante ACL`/entidad local que no aparece como tal
+
+**Severidad:** Media
+
+La documentación arquitectónica de Competencia describe un `Participante ACL`
+que traduce `AtletaInscripto` a `Participante` local. La implementación actual
+usa puertos, adaptadores y proyecciones, pero no se observa una entidad
+`Participante` en `src/competencia/domain/entities`.
+
+Evidencia documental:
+
+- `docs/architecture/10-bc-competencia.md:92-94` muestra `Participante ACL`.
+- `docs/design/architecture.md:212` describe `ParticipanteACL`.
+
+Evidencia de implementación:
+
+- `src/competencia/domain/entities/` contiene `grilla_de_salida.py` y
+  `__init__.py`.
+- No hay archivo de entidad `participante` en esa carpeta.
+
+Impacto:
+
+- El diseño documentado parece más explícito que el código real.
+- Puede ser deuda de documentación o deuda de modelado; requiere decisión.
+
+Recomendación:
+
+- Verificar si el concepto vive con otro nombre en DTOs/proyecciones.
+- Si el diseño actual es correcto, actualizar el documento para hablar de
+  puertos/adaptadores/proyecciones reales.
+- Si el documento expresa una intención vigente, abrir deuda técnica para
+  materializar el ACL como componente explícito.
+
+### H8 — Documentos históricos no están claramente marcados como históricos
+
+**Severidad:** Media
+
+Hay documentos de dominio, diseño y specs tempranas que contienen decisiones,
+preguntas o rutas anteriores. Esto es valioso para IEDD, pero algunos pueden ser
+leídos como estado actual.
+
+Ejemplos:
+
+- `docs/dominio/05-requerimientos_funcionales.md` conserva preguntas y
+  pendientes de elicitación originales.
+- Specs antiguas mencionan rutas del tipo `/competencias`.
+- Documentos de diseño de SP3/SP4 mezclan objetivo, estado de ese momento y
+  arquitectura que luego evolucionó.
+
+Impacto:
+
+- No es un error preservar historia; el problema es no etiquetar qué documentos
+  son históricos y cuáles son operativos.
+
+Recomendación:
+
+- Agregar banner estándar: `Histórico`, `Vigente`, `Superseded` o `Referencia`.
+- Crear un índice documental con fuente canónica por tema.
+
+## Alineaciones correctas observadas
+
+- `CLAUDE.md` y `.cm/baselines/BL-004.md` reflejan el cierre de SP4.
+- `docs/plans/sp5/PLAN-SP5.md` describe de forma coherente el alcance actual de
+  SP5 y sus dependencias.
+- `docs/architecture/15-bc-notificaciones.md` distingue correctamente email
+  implementado con Resend y push como evolución futura.
+- La deuda de testing frontend está documentada en reportes/waivers; no aparece
+  como inconsistencia oculta.
+- Las specs recientes de `US-5.2.1` y `US-5.2.2` están alineadas con el
+  incremento `INC-5.2`.
+
+## Matriz resumida
+
+| Área | Documento principal | Estado frente a implementación | Acción recomendada |
+|------|---------------------|-------------------------------|--------------------|
+| Estado del proyecto | `README.md` | Desactualizado | Corregir primero |
+| Estado operativo | `CLAUDE.md` | Mayormente vigente | Mantener como índice operativo |
+| Baseline SP4 | `.cm/baselines/BL-004.md` | Vigente | Usar como cierre canónico |
+| Baseline SP5 | `.cm/baselines/BL-005-draft.md` | Parcialmente desalineado | Reconciliar contra `PLAN-SP5` |
+| Plan SP5 | `docs/plans/sp5/PLAN-SP5.md` | Vigente | Fuente de alcance |
+| Arquitectura vigente | `docs/architecture/` | Parcialmente vigente | Corregir offline/estructura/Competencia |
+| Diseño histórico | `docs/design/` | Mixto | Etiquetar o superseder documentos |
+| Dominio original | `docs/dominio/` | Histórico | Etiquetar como fuente de elicitación |
+| Trazabilidad | `docs/traceability/matrix.md` | Desalineada con SP5 | Recalibrar por RF |
+
+## Orden sugerido de saneamiento
+
+1. Actualizar `README.md` y `BL-005-draft.md`.
+2. Corregir `docs/architecture/50-offline-sync.md` y
+   `docs/architecture/README.md`.
+3. Marcar `docs/design/architecture.md` como histórico/superseded o actualizarlo
+   completamente.
+4. Reconciliar `docs/traceability/matrix.md` con `PLAN-SP5`.
+5. Agregar banners de vigencia a documentos históricos de `docs/dominio/` y
+   specs antiguas.
+6. Crear un índice "fuentes canónicas" para evitar ambigüedad futura.
+
+## Decisión pendiente
+
+Antes de corregir documentos fuente conviene decidir si la estrategia documental
+será:
+
+1. **Corrección mínima:** actualizar solo documentos que hoy bloquean trabajo
+   operativo (`README`, `BL-005-draft`, `offline-sync`, trazabilidad).
+2. **Saneamiento completo:** además de lo anterior, etiquetar todo documento
+   histórico y consolidar un índice canónico.
+
+Para continuar con `INC-5.2`, la opción mínima alcanza. Para preparar una
+revisión externa del proyecto, conviene el saneamiento completo.

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -243,6 +243,23 @@ export async function confirmarGrilla(payload: {
   await parseResponse<void>(response)
 }
 
+export async function iniciarCompetencia(payload: {
+  competenciaId: string
+  disciplina: string
+  juezId: string
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/iniciar`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      disciplina: payload.disciplina,
+      juez_id: payload.juezId,
+    }),
+  })
+
+  await parseResponse<void>(response)
+}
+
 export async function fetchPerformanceActual(
   competenciaId: string,
 ): Promise<PerformanceActualDto | null> {

--- a/frontend/src/components/organizador/EjecucionPanel.tsx
+++ b/frontend/src/components/organizador/EjecucionPanel.tsx
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
 import {
   fetchCompetenciasPorTorneo,
   fetchEstadoCompetencia,
@@ -6,6 +7,7 @@ import {
   fetchPerformanceActual,
   fetchProgresoCompetencia,
   fetchProximasPerformances,
+  iniciarCompetencia,
   type CompetenciaResumenDto,
   type EstadoCompetenciaDto,
   type GrillaAtletaDto,
@@ -13,169 +15,522 @@ import {
   type ProgresoCompetenciaDto,
   type ProximoAtletaDto,
 } from '../../api/competencia'
+import { listarDisciplinasTorneo, type DisciplinaTorneoDto } from '../../api/torneo'
 import { MonitorDisciplina } from './MonitorDisciplina'
+import { ProgressBar } from './ProgressBar'
 
 interface EjecucionPanelProps {
   torneoId: string
 }
 
+type EstadoOperativo =
+  | 'sin_competencia'
+  | 'sin_grilla'
+  | 'sin_juez'
+  | 'lista_para_iniciar'
+  | 'en_ejecucion'
+  | 'finalizada'
+  | 'no_disponible'
+
 interface CompetenciaConEstado {
   competencia: CompetenciaResumenDto
   estado: EstadoCompetenciaDto
+  progreso: ProgresoCompetenciaDto | null
 }
 
-interface MonitorDisciplinaData {
-  competencia: CompetenciaResumenDto
-  progreso: ProgresoCompetenciaDto
+interface DisciplinaEjecucionItem {
+  disciplina: DisciplinaTorneoDto
+  competencia: CompetenciaResumenDto | null
+  estado: EstadoCompetenciaDto | null
+  progreso: ProgresoCompetenciaDto | null
+  estadoOperativo: EstadoOperativo
+}
+
+interface EjecucionData {
+  disciplinas: DisciplinaEjecucionItem[]
+  todasFinalizadas: boolean
+}
+
+interface DetalleDisciplinaData {
+  grilla: GrillaAtletaDto[]
   performanceActual: PerformanceActualDto | null
   proximas: ProximoAtletaDto[]
-  grilla: GrillaAtletaDto[]
-}
-
-interface MonitorData {
-  totalCompetencias: number
-  todasFinalizadas: boolean
-  disciplinasActivas: MonitorDisciplinaData[]
+  progreso: ProgresoCompetenciaDto
 }
 
 const FINAL_STATES = new Set(['Finalizada', 'CompetenciaFinalizada'])
+const RUNNING_STATES = new Set(['EnEjecucion'])
+const READY_STATES = new Set(['Confirmada', 'GrillaConfirmada'])
 
-function isEnEjecucion(item: CompetenciaConEstado) {
-  return item.estado.estado === 'EnEjecucion'
+function tieneGrillaConfirmada(estado: EstadoCompetenciaDto | null): boolean {
+  return Boolean(estado?.grilla_confirmada || (estado && READY_STATES.has(estado.estado)))
 }
 
-function isFinalizada(item: CompetenciaConEstado) {
-  return FINAL_STATES.has(item.estado.estado)
+function estadoOperativoDe(
+  disciplina: DisciplinaTorneoDto,
+  competencia: CompetenciaResumenDto | null,
+  estado: EstadoCompetenciaDto | null,
+): EstadoOperativo {
+  if (!competencia || !estado) return 'sin_competencia'
+  if (FINAL_STATES.has(estado.estado)) return 'finalizada'
+  if (RUNNING_STATES.has(estado.estado)) return 'en_ejecucion'
+  if (!tieneGrillaConfirmada(estado)) return 'sin_grilla'
+  if (!disciplina.juez_id) return 'sin_juez'
+  if (READY_STATES.has(estado.estado)) return 'lista_para_iniciar'
+  return 'no_disponible'
 }
 
-async function loadMonitorData(torneoId: string): Promise<MonitorData> {
+function estadoLabel(estado: EstadoOperativo): string {
+  const labels: Record<EstadoOperativo, string> = {
+    sin_competencia: 'Configurar competencia',
+    sin_grilla: 'Confirmar grilla antes de habilitar',
+    sin_juez: 'Asignar juez antes de habilitar',
+    lista_para_iniciar: 'Lista para iniciar',
+    en_ejecucion: 'En ejecucion',
+    finalizada: 'Finalizada',
+    no_disponible: 'No disponible',
+  }
+  return labels[estado]
+}
+
+function estadoClasses(estado: EstadoOperativo): string {
+  if (estado === 'lista_para_iniciar') return 'border-sky-700 bg-sky-50 text-sky-900'
+  if (estado === 'en_ejecucion') return 'border-emerald-700 bg-emerald-50 text-emerald-900'
+  if (estado === 'finalizada') return 'border-stone-700 bg-stone-100 text-stone-900'
+  return 'border-amber-300 bg-amber-50 text-amber-900'
+}
+
+async function fetchCompetenciasConEstado(torneoId: string): Promise<CompetenciaConEstado[]> {
   const competencias = await fetchCompetenciasPorTorneo(torneoId)
-  const conEstado = await Promise.all(
-    competencias.map(async (competencia) => ({
-      competencia,
-      estado: await fetchEstadoCompetencia(competencia.competencia_id, competencia.disciplina),
-    })),
-  )
 
-  const activas = conEstado.filter(isEnEjecucion)
-  const disciplinasActivas = await Promise.all(
-    activas.map(async ({ competencia }) => {
-      const [progreso, performanceActual, proximas, grilla] = await Promise.all([
-        fetchProgresoCompetencia(competencia.competencia_id),
-        fetchPerformanceActual(competencia.competencia_id),
-        fetchProximasPerformances(competencia.competencia_id, competencia.disciplina),
-        fetchGrillaCompetencia(competencia.competencia_id, competencia.disciplina),
-      ])
-
-      return {
-        competencia,
-        progreso,
-        performanceActual,
-        proximas,
-        grilla,
-      }
+  return Promise.all(
+    competencias.map(async (competencia) => {
+      const estado = await fetchEstadoCompetencia(competencia.competencia_id, competencia.disciplina)
+      const progreso = await fetchProgresoCompetencia(competencia.competencia_id)
+      return { competencia, estado, progreso }
     }),
   )
+}
+
+async function loadEjecucionData(torneoId: string): Promise<EjecucionData> {
+  const [disciplinas, competenciasConEstado] = await Promise.all([
+    listarDisciplinasTorneo(torneoId),
+    fetchCompetenciasConEstado(torneoId),
+  ])
+  const competenciasPorDisciplina = new Map(
+    competenciasConEstado.map((item) => [item.competencia.disciplina, item]),
+  )
+
+  const items = disciplinas.map((disciplina) => {
+    const competenciaConEstado = competenciasPorDisciplina.get(disciplina.disciplina)
+    const competencia = competenciaConEstado?.competencia ?? null
+    const estado = competenciaConEstado?.estado ?? null
+
+    return {
+      disciplina,
+      competencia,
+      estado,
+      progreso: competenciaConEstado?.progreso ?? null,
+      estadoOperativo: estadoOperativoDe(disciplina, competencia, estado),
+    }
+  })
 
   return {
-    totalCompetencias: competencias.length,
-    todasFinalizadas: conEstado.length > 0 && conEstado.every(isFinalizada),
-    disciplinasActivas,
+    disciplinas: items,
+    todasFinalizadas:
+      items.length > 0 && items.every((item) => item.estadoOperativo === 'finalizada'),
   }
 }
 
-export function EjecucionPanel({ torneoId }: EjecucionPanelProps) {
-  const monitorQuery = useQuery({
-    queryKey: ['monitor-ejecucion', torneoId],
-    queryFn: () => loadMonitorData(torneoId),
-    refetchInterval: 30000,
-  })
-
-  if (monitorQuery.isLoading) {
-    return (
-      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
-        Cargando monitor de ejecucion...
-      </div>
-    )
+async function loadDetalleDisciplina(item: DisciplinaEjecucionItem): Promise<DetalleDisciplinaData> {
+  if (!item.competencia) {
+    throw new Error('La disciplina no tiene competencia configurada.')
   }
 
-  if (monitorQuery.isError) {
-    return (
-      <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
-        No se pudo cargar el monitor de ejecucion.
-      </div>
-    )
-  }
+  const [grilla, performanceActual, proximas, progreso] = await Promise.all([
+    fetchGrillaCompetencia(item.competencia.competencia_id, item.disciplina.disciplina),
+    fetchPerformanceActual(item.competencia.competencia_id),
+    fetchProximasPerformances(item.competencia.competencia_id, item.disciplina.disciplina),
+    fetchProgresoCompetencia(item.competencia.competencia_id),
+  ])
 
-  const data = monitorQuery.data
-  const lastUpdated = dataUpdatedLabel(monitorQuery.dataUpdatedAt)
-
-  if (!data || data.totalCompetencias === 0) {
-    return (
-      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
-        Ninguna disciplina en ejecucion
-      </div>
-    )
-  }
-
-  if (data.todasFinalizadas) {
-    return (
-      <div className="rounded-lg border border-emerald-700 bg-emerald-50 p-5 text-sm text-emerald-950">
-        <p className="text-lg font-semibold">Todas las disciplinas completadas</p>
-        <p className="mt-2">
-          La transicion a premiacion queda disponible desde el panel de acciones del torneo.
-        </p>
-      </div>
-    )
-  }
-
-  if (data.disciplinasActivas.length === 0) {
-    return (
-      <div className="space-y-3">
-        <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
-          Ninguna disciplina en ejecucion
-        </div>
-        {lastUpdated ? (
-          <p className="text-xs font-semibold uppercase text-stone-500">
-            Ultima actualizacion {lastUpdated}
-          </p>
-        ) : null}
-      </div>
-    )
-  }
-
-  return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-stone-600">
-          {data.disciplinasActivas.length} disciplinas en ejecucion
-        </p>
-        {lastUpdated ? (
-          <p className="text-xs font-semibold uppercase text-stone-500">
-            Ultima actualizacion {lastUpdated}
-          </p>
-        ) : null}
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-2">
-        {data.disciplinasActivas.map((disciplina) => (
-          <MonitorDisciplina
-            key={disciplina.competencia.competencia_id}
-            competencia={disciplina.competencia}
-            progreso={disciplina.progreso}
-            performanceActual={disciplina.performanceActual}
-            proximas={disciplina.proximas}
-            grilla={disciplina.grilla}
-          />
-        ))}
-      </div>
-    </div>
-  )
+  return { grilla, performanceActual, proximas, progreso }
 }
 
 function dataUpdatedLabel(timestamp: number) {
   if (!timestamp) return null
   return new Date(timestamp).toLocaleTimeString('es-AR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+export function EjecucionPanel({ torneoId }: EjecucionPanelProps) {
+  const queryClient = useQueryClient()
+  const [selectedDisciplina, setSelectedDisciplina] = useState<string | null>(null)
+  const [error, setError] = useState('')
+
+  const ejecucionQuery = useQuery({
+    queryKey: ['ejecucion-disciplinas', torneoId],
+    queryFn: () => loadEjecucionData(torneoId),
+    refetchInterval: 30000,
+  })
+
+  const disciplinas = useMemo(
+    () => ejecucionQuery.data?.disciplinas ?? [],
+    [ejecucionQuery.data],
+  )
+
+  const selectedItem =
+    disciplinas.find((item) => item.disciplina.disciplina === selectedDisciplina) ??
+    disciplinas[0] ??
+    null
+
+  const detalleQuery = useQuery({
+    queryKey: [
+      'ejecucion-detalle',
+      selectedItem?.competencia?.competencia_id,
+      selectedItem?.disciplina.disciplina,
+    ],
+    queryFn: () => loadDetalleDisciplina(selectedItem as DisciplinaEjecucionItem),
+    enabled: Boolean(selectedItem?.competencia),
+    refetchInterval: selectedItem?.estadoOperativo === 'en_ejecucion' ? 30000 : false,
+  })
+
+  const iniciarMutation = useMutation({
+    mutationFn: async (item: DisciplinaEjecucionItem) => {
+      if (!item.competencia || !item.disciplina.juez_id) return
+      await iniciarCompetencia({
+        competenciaId: item.competencia.competencia_id,
+        disciplina: item.disciplina.disciplina,
+        juezId: item.disciplina.juez_id,
+      })
+    },
+    onSuccess: async () => {
+      setError('')
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['ejecucion-disciplinas', torneoId] }),
+        queryClient.invalidateQueries({ queryKey: ['ejecucion-detalle'] }),
+        queryClient.invalidateQueries({ queryKey: ['monitor-ejecucion', torneoId] }),
+      ])
+    },
+    onError: (mutationError) => setError((mutationError as Error).message),
+  })
+
+  if (ejecucionQuery.isLoading) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+        Cargando ejecucion de disciplinas...
+      </div>
+    )
+  }
+
+  if (ejecucionQuery.isError) {
+    return (
+      <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+        No se pudo cargar la ejecucion de disciplinas.
+      </div>
+    )
+  }
+
+  if (disciplinas.length === 0) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+        No hay disciplinas configuradas para ejecutar.
+      </div>
+    )
+  }
+
+  const lastUpdated = dataUpdatedLabel(ejecucionQuery.dataUpdatedAt)
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-stone-600">
+          {disciplinas.length} disciplinas configuradas para ejecucion
+        </p>
+        {lastUpdated ? (
+          <p className="text-xs font-semibold uppercase text-stone-500">
+            Ultima actualizacion {lastUpdated}
+          </p>
+        ) : null}
+      </div>
+
+      {ejecucionQuery.data?.todasFinalizadas ? (
+        <div className="rounded-lg border border-emerald-700 bg-emerald-50 p-4 text-sm text-emerald-950">
+          Todas las disciplinas completadas. La transicion a premiacion queda disponible
+          desde el panel de acciones del torneo.
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(18rem,24rem)_1fr]">
+        <DisciplinaMaestro
+          disciplinas={disciplinas}
+          selectedDisciplina={selectedItem?.disciplina.disciplina ?? null}
+          onSelect={(disciplina) => {
+            setError('')
+            setSelectedDisciplina(disciplina)
+          }}
+        />
+
+        <DisciplinaDetalle
+          item={selectedItem}
+          detalle={detalleQuery.data ?? null}
+          isLoading={detalleQuery.isLoading}
+          isError={detalleQuery.isError}
+          isStarting={iniciarMutation.isPending}
+          onIniciar={(item) => iniciarMutation.mutate(item)}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface DisciplinaMaestroProps {
+  disciplinas: DisciplinaEjecucionItem[]
+  selectedDisciplina: string | null
+  onSelect: (disciplina: string) => void
+}
+
+function DisciplinaMaestro({
+  disciplinas,
+  selectedDisciplina,
+  onSelect,
+}: DisciplinaMaestroProps) {
+  return (
+    <div className="space-y-3">
+      {disciplinas.map((item) => {
+        const selected = item.disciplina.disciplina === selectedDisciplina
+        const progreso = item.progreso
+        return (
+          <button
+            key={item.disciplina.disciplina}
+            type="button"
+            onClick={() => onSelect(item.disciplina.disciplina)}
+            className={[
+              'w-full rounded-lg border bg-white p-4 text-left transition',
+              selected ? 'border-stone-900 shadow-[0_20px_60px_rgba(120,93,54,0.10)]' : 'border-stone-200 hover:border-stone-400',
+            ].join(' ')}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase text-stone-500">Disciplina</p>
+                <h3 className="mt-1 text-lg font-semibold text-stone-950">
+                  {item.disciplina.disciplina}
+                </h3>
+              </div>
+              <span
+                className={[
+                  'rounded-lg border px-3 py-2 text-xs font-semibold',
+                  estadoClasses(item.estadoOperativo),
+                ].join(' ')}
+              >
+                {estadoLabel(item.estadoOperativo)}
+              </span>
+            </div>
+
+            <div className="mt-4 space-y-2 text-sm text-stone-600">
+              <p>Juez: {item.disciplina.juez_id ?? 'Sin juez asignado'}</p>
+              <p>
+                Competencia:{' '}
+                {item.competencia ? item.competencia.competencia_id.slice(0, 8) : 'Pendiente'}
+              </p>
+            </div>
+
+            {progreso ? (
+              <div className="mt-4">
+                <ProgressBar completed={progreso.completadas} total={progreso.total} />
+              </div>
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+interface DisciplinaDetalleProps {
+  item: DisciplinaEjecucionItem | null
+  detalle: DetalleDisciplinaData | null
+  isLoading: boolean
+  isError: boolean
+  isStarting: boolean
+  onIniciar: (item: DisciplinaEjecucionItem) => void
+}
+
+function DisciplinaDetalle({
+  item,
+  detalle,
+  isLoading,
+  isError,
+  isStarting,
+  onIniciar,
+}: DisciplinaDetalleProps) {
+  if (!item) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-5 text-sm text-stone-600">
+        Selecciona una disciplina.
+      </div>
+    )
+  }
+
+  const canStart = item.estadoOperativo === 'lista_para_iniciar'
+  const hash = item.estado?.hash_sha256
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-stone-300 bg-white p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase text-stone-500">Detalle</p>
+            <h3 className="mt-1 text-2xl font-semibold text-stone-950">
+              {item.disciplina.disciplina}
+            </h3>
+            <p className="mt-2 text-sm text-stone-600">
+              Juez asignado: {item.disciplina.juez_id ?? 'Sin juez asignado'}
+            </p>
+          </div>
+          <span
+            className={[
+              'rounded-lg border px-3 py-2 text-sm font-semibold',
+              estadoClasses(item.estadoOperativo),
+            ].join(' ')}
+          >
+            {estadoLabel(item.estadoOperativo)}
+          </span>
+        </div>
+
+        {hash ? (
+          <p className="mt-4 break-all rounded-lg border border-stone-200 bg-stone-50 p-3 text-xs text-stone-700">
+            Hash SHA-256: {hash}
+          </p>
+        ) : null}
+
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-stone-600">{detalleBloqueo(item)}</p>
+          {canStart ? (
+            <button
+              type="button"
+              disabled={isStarting}
+              onClick={() => onIniciar(item)}
+              className="min-h-10 rounded-lg bg-emerald-800 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-stone-300"
+            >
+              {isStarting ? 'Habilitando...' : 'Habilitar disciplina'}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {item.competencia ? (
+        <DetalleConCompetencia
+          item={item}
+          detalle={detalle}
+          isLoading={isLoading}
+          isError={isError}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function detalleBloqueo(item: DisciplinaEjecucionItem): string {
+  if (item.estadoOperativo === 'sin_competencia') return 'Configurar competencia antes de habilitar.'
+  if (item.estadoOperativo === 'sin_grilla') return 'Confirmar grilla antes de habilitar.'
+  if (item.estadoOperativo === 'sin_juez') return 'Asignar juez antes de habilitar.'
+  if (item.estadoOperativo === 'lista_para_iniciar') return 'La disciplina esta lista para iniciar.'
+  if (item.estadoOperativo === 'en_ejecucion') return 'La disciplina esta en ejecucion.'
+  if (item.estadoOperativo === 'finalizada') return 'La disciplina finalizo y queda en modo lectura.'
+  return 'La disciplina no esta disponible para habilitar.'
+}
+
+interface DetalleConCompetenciaProps {
+  item: DisciplinaEjecucionItem
+  detalle: DetalleDisciplinaData | null
+  isLoading: boolean
+  isError: boolean
+}
+
+function DetalleConCompetencia({
+  item,
+  detalle,
+  isLoading,
+  isError,
+}: DetalleConCompetenciaProps) {
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+        Cargando detalle de disciplina...
+      </div>
+    )
+  }
+
+  if (isError || !detalle) {
+    return (
+      <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+        No se pudo cargar el detalle de la disciplina.
+      </div>
+    )
+  }
+
+  if (item.competencia && item.estadoOperativo === 'en_ejecucion') {
+    return (
+      <MonitorDisciplina
+        competencia={item.competencia}
+        progreso={detalle.progreso}
+        performanceActual={detalle.performanceActual}
+        proximas={detalle.proximas}
+        grilla={detalle.grilla}
+      />
+    )
+  }
+
+  return (
+    <div className="rounded-lg border border-stone-300 bg-white p-5">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm font-semibold text-stone-950">Grilla OT</p>
+        <p className="text-sm text-stone-600">
+          {detalle.progreso.completadas} / {detalle.progreso.total} completadas
+        </p>
+      </div>
+
+      <div className="mt-4 overflow-x-auto rounded-lg border border-stone-200">
+        <table className="min-w-full divide-y divide-stone-200 text-left text-sm">
+          <thead className="bg-stone-50 text-xs font-semibold uppercase text-stone-500">
+            <tr>
+              <th className="px-4 py-3">Posicion</th>
+              <th className="px-4 py-3">Atleta</th>
+              <th className="px-4 py-3">OT</th>
+              <th className="px-4 py-3">Estado</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-stone-200 bg-white">
+            {detalle.grilla.map((row) => (
+              <tr key={row.performance_id}>
+                <td className="px-4 py-3 font-semibold text-stone-950">{row.posicion}</td>
+                <td className="px-4 py-3 text-stone-700">{row.nombre_atleta}</td>
+                <td className="px-4 py-3 text-stone-700">{formatOt(row.ot_programado)}</td>
+                <td className="px-4 py-3 text-stone-700">{row.estado}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function formatOt(value?: string) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleTimeString('es-AR', {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,

--- a/tests/features/US-5.2.1-ejecucion-disciplinas.feature
+++ b/tests/features/US-5.2.1-ejecucion-disciplinas.feature
@@ -1,0 +1,60 @@
+Feature: US-5.2.1 - Vista maestro-detalle de ejecucion por disciplina
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And el torneo "BA 2026" con id "T1" esta en estado EJECUCION
+    And el torneo "T1" tiene las disciplinas "DNF" y "STA" configuradas
+
+  Scenario: maestro muestra todas las disciplinas del torneo
+    Given la disciplina "DNF" tiene competencia "C1" en estado Confirmada con grilla confirmada y juez "J1"
+    And la disciplina "STA" tiene competencia "C2" en estado Preparacion sin grilla confirmada y juez "J2"
+    When el organizador accede al tab "Ejecucion" del torneo "T1"
+    Then ve una fila de maestro para la disciplina "DNF"
+    And ve una fila de maestro para la disciplina "STA"
+    And la disciplina "DNF" muestra estado operativo "Lista para iniciar"
+    And la disciplina "STA" muestra bloqueo "Confirmar grilla antes de habilitar"
+
+  Scenario: seleccionar disciplina abre detalle operativo
+    Given la disciplina "DNF" tiene competencia "C1" en estado EnEjecucion con 10 atletas
+    And 4 atletas tienen performance completada
+    When el organizador selecciona la disciplina "DNF" en el maestro
+    Then el detalle muestra la grilla OT de "DNF"
+    And muestra el juez asignado
+    And muestra progreso "4 / 10"
+    And muestra atleta actual si existe
+    And muestra proximas performances
+
+  Scenario: habilitar disciplina lista para iniciar
+    Given la disciplina "DNF" tiene competencia "C1" en estado Confirmada
+    And la disciplina "DNF" tiene grilla confirmada
+    And la disciplina "DNF" tiene juez "J1" asignado
+    When el organizador selecciona la disciplina "DNF" en el maestro
+    And toca "Habilitar disciplina"
+    Then el frontend envia POST "/competencia/C1/iniciar" con disciplina "DNF" y juez_id "J1"
+    And la disciplina "DNF" recarga con estado EnEjecucion
+    And la accion "Habilitar disciplina" deja de mostrarse
+
+  Scenario: disciplina sin juez no puede habilitarse
+    Given la disciplina "DNF" tiene competencia "C1" en estado Confirmada
+    And la disciplina "DNF" tiene grilla confirmada
+    And la disciplina "DNF" no tiene juez asignado
+    When el organizador selecciona la disciplina "DNF" en el maestro
+    Then la accion "Habilitar disciplina" esta deshabilitada
+    And el detalle muestra "Asignar juez antes de habilitar"
+    And no se envia POST "/competencia/C1/iniciar"
+
+  Scenario: disciplina sin grilla confirmada no puede habilitarse
+    Given la disciplina "DNF" tiene competencia "C1" en estado Preparacion
+    And la disciplina "DNF" no tiene grilla confirmada
+    And la disciplina "DNF" tiene juez "J1" asignado
+    When el organizador selecciona la disciplina "DNF" en el maestro
+    Then la accion "Habilitar disciplina" esta deshabilitada
+    And el detalle muestra "Confirmar grilla antes de habilitar"
+    And no se envia POST "/competencia/C1/iniciar"
+
+  Scenario: disciplina finalizada se muestra en modo lectura
+    Given la disciplina "DNF" tiene competencia "C1" en estado Finalizada
+    When el organizador selecciona la disciplina "DNF" en el maestro
+    Then el detalle muestra estado "Finalizada"
+    And muestra el hash SHA-256 si esta disponible
+    And no muestra acciones de habilitacion


### PR DESCRIPTION
## Summary
- Implementa la vista maestro-detalle de ejecucion por disciplina para el panel del organizador.
- Agrega habilitacion de disciplina mediante el endpoint de inicio de competencia.
- Incorpora specs, tracking, feature BDD, reporte de US-5.2.1 y reporte de consistencia documental.

## Verification
- npm run build (frontend)

## Notes
- Quedan fuera del PR artefactos locales no relacionados: .work/, datasets/scripts auxiliares, US-4.5.1-tracking.json y docs/WBS-ATARAXIADIVE.md.