### PR TITLE
feat: implementar US-5.2.2 finalización manual

### DIFF
--- a/.claude/tracking/US-5.2.2-tracking.json
+++ b/.claude/tracking/US-5.2.2-tracking.json
@@ -1,0 +1,149 @@
+{
+  "metadata": {
+    "us_id": "US-5.2.2",
+    "us_title": "Finalizacion manual de prueba por disciplina",
+    "us_points": 3,
+    "producto": "AtaraxiaDive",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-22T15:04:59.383254+00:00",
+    "completed_at": "2026-04-22T15:12:31.825104+00:00",
+    "total_elapsed_seconds": 452,
+    "effective_seconds": 452,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Fase 0 - Contexto",
+      "started_at": "2026-04-22T15:05:09.341468+00:00",
+      "completed_at": "2026-04-22T15:05:52.684555+00:00",
+      "elapsed_seconds": 43,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Fase 1 - Diseno",
+      "started_at": "2026-04-22T15:05:55.971763+00:00",
+      "completed_at": "2026-04-22T15:06:43.895117+00:00",
+      "elapsed_seconds": 47,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Fase 2 - Plan",
+      "started_at": "2026-04-22T15:06:46.786488+00:00",
+      "completed_at": "2026-04-22T15:06:49.721893+00:00",
+      "elapsed_seconds": 2,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Fase 3 - Implementacion",
+      "started_at": "2026-04-22T15:06:53.086536+00:00",
+      "completed_at": "2026-04-22T15:11:18.063241+00:00",
+      "elapsed_seconds": 264,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Fase 4 - Tests",
+      "started_at": "2026-04-22T15:11:22.239114+00:00",
+      "completed_at": "2026-04-22T15:11:26.586891+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Fase 5 - Refactor",
+      "started_at": "2026-04-22T15:11:31.357473+00:00",
+      "completed_at": "2026-04-22T15:11:35.437159+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Fase 6 - Integracion",
+      "started_at": "2026-04-22T15:11:41.902776+00:00",
+      "completed_at": "2026-04-22T15:11:46.620432+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Fase 7 - Validacion",
+      "started_at": "2026-04-22T15:11:51.437769+00:00",
+      "completed_at": "2026-04-22T15:11:57.367058+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Fase 8 - Documentacion",
+      "started_at": "2026-04-22T15:12:00.950235+00:00",
+      "completed_at": "2026-04-22T15:12:04.276056+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Fase 9 - Reporte",
+      "started_at": "2026-04-22T15:12:07.858003+00:00",
+      "completed_at": "2026-04-22T15:12:14.503929+00:00",
+      "elapsed_seconds": 6,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 10,
+      "phase_name": "Fase 10 - Cierre",
+      "started_at": "2026-04-22T15:12:18.447331+00:00",
+      "completed_at": "2026-04-22T15:12:23.281823+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 11,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/plans/sp5/US-5.2.2-docs.md
+++ b/docs/plans/sp5/US-5.2.2-docs.md
@@ -1,0 +1,46 @@
+# US-5.2.2 — Documentacion de Cambios
+
+**Fecha:** 2026-04-22
+**Incremento:** INC-5.2 — Ejecucion por Disciplina
+
+## Contrato API agregado
+
+```http
+POST /competencia/{competencia_id}/finalizar
+Content-Type: application/json
+
+{
+  "disciplina": "DNF"
+}
+```
+
+Respuesta exitosa: `204 No Content`.
+
+Errores esperados:
+
+- `409` si la competencia no esta en `EnEjecucion`.
+- `409` si quedan performances pendientes.
+- `204` sin duplicar eventos si la competencia ya estaba finalizada.
+
+## Evento extendido
+
+`CompetenciaFinalizada` agrega:
+
+- `origen`: `automatico` o `manual`;
+- `finalizada_por`: email/id del organizador cuando el origen es manual.
+
+Eventos historicos sin esos campos siguen siendo validos y se leen como
+`origen="automatico"`.
+
+## UI
+
+El tab `Ejecucion` del panel organizador muestra la accion `Finalizar prueba`
+cuando la disciplina seleccionada esta en ejecucion.
+
+La accion queda habilitada solo si:
+
+- `progreso.total > 0`;
+- `progreso.completadas == progreso.total`.
+
+Si quedan pendientes, el detalle muestra la cantidad pendiente y no dispara el
+endpoint.

--- a/docs/plans/sp5/US-5.2.2-fase0.md
+++ b/docs/plans/sp5/US-5.2.2-fase0.md
@@ -1,0 +1,49 @@
+# US-5.2.2 — Fase 0
+
+**Fecha:** 2026-04-22
+**Incremento:** INC-5.2 — Ejecucion por Disciplina
+**US:** Finalizacion manual de prueba por disciplina
+
+## Objetivo
+
+Implementar el cierre manual de una disciplina desde el panel del organizador,
+permitiendo la accion solo cuando la competencia esta en ejecucion y todas sus
+performances estan cerradas.
+
+El cierre manual debe convivir con P-08, que sigue cerrando automaticamente al
+registrar DNS o tarjeta final.
+
+## Fuentes revisadas
+
+- `docs/specs/sp5/US-5.2.2.md`
+- `docs/plans/sp5/PLAN-SP5.md`
+- `docs/plans/WORKFLOW-DESARROLLO.md`
+- `src/competencia/application/_p08_finalizacion.py`
+- `src/competencia/domain/aggregates/competencia.py`
+- `src/competencia/domain/events/competencia_finalizada.py`
+- `frontend/src/components/organizador/EjecucionPanel.tsx`
+- `frontend/src/api/competencia.ts`
+
+## Estado inicial observado
+
+- El aggregate `Competencia` ya tiene `finalizar()`.
+- P-08 usa `trigger_finalizacion_si_corresponde()` y calcula el hash SHA-256.
+- `CompetenciaFinalizada` persiste `hash_sha256`, pero no distingue origen.
+- No existe endpoint `POST /competencia/{competencia_id}/finalizar`.
+- El frontend muestra detalle maestro-detalle, pero no accion `Finalizar prueba`.
+
+## Decisiones de alcance
+
+- Reutilizar `Competencia.finalizar()` para cierre manual y automatico.
+- Extender `CompetenciaFinalizada` con `origen` y `finalizada_por`, manteniendo
+  compatibilidad con eventos previos sin esos campos.
+- Agregar `FinalizarCompetenciaManualCommand` y handler.
+- El frontend habilita la accion solo con `completadas == total`, pero el backend
+  conserva la validacion final.
+
+## Riesgos
+
+- Cambiar el payload de `CompetenciaFinalizada` puede impactar consumidores de
+  resultados/notificaciones si no se mantiene backward compatibility.
+- Si la competencia ya fue cerrada automaticamente antes de que el organizador
+  pulse la accion, el backend debe responder sin duplicar eventos.

--- a/docs/plans/sp5/US-5.2.2-implementation-notes.md
+++ b/docs/plans/sp5/US-5.2.2-implementation-notes.md
@@ -1,0 +1,68 @@
+# US-5.2.2 — Notas de Implementacion
+
+**Fecha:** 2026-04-22
+**Fase:** 3 — Implementacion
+
+## Enfoque
+
+La US agrega un camino manual para el mismo cierre de dominio que ya existia por
+P-08. La regla central es no duplicar semantica: la accion del organizador debe
+terminar en `Competencia.finalizar()`.
+
+## Cambios esperados
+
+- `CompetenciaFinalizada`
+  - nuevo `origen`;
+  - nuevo `finalizada_por` opcional;
+  - compatibilidad con eventos previos sin esos campos.
+
+- `Competencia.finalizar()`
+  - valida estado `EnEjecucion`;
+  - valida pendientes;
+  - emite `CompetenciaFinalizada` con origen.
+
+- `FinalizarCompetenciaManualHandler`
+  - consulta estado de performances;
+  - calcula hash;
+  - reconstituye aggregate;
+  - ejecuta cierre con origen `manual`.
+
+- `EjecucionPanel`
+  - boton `Finalizar prueba`;
+  - bloqueo textual si quedan pendientes;
+  - recarga de estado y detalle despues del cierre.
+
+## Validaciones a registrar al cierre
+
+- Tests unitarios de dominio/aplicacion — OK.
+- Tests de integracion focalizados de CompetenciaFinalizada — OK.
+- Build frontend — OK.
+- Lint frontend — OK.
+
+## Cambios realizados
+
+- `CompetenciaFinalizada`
+  - agrega `origen`;
+  - agrega `finalizada_por`;
+  - mantiene compatibilidad: eventos historicos sin `origen` se leen como
+    `automatico`.
+
+- `Competencia.finalizar()`
+  - acepta origen y solicitante opcional;
+  - conserva la validacion de performances pendientes.
+
+- `FinalizarCompetenciaManualHandler`
+  - valida competencia en `EnEjecucion`;
+  - retorna no-op si ya esta `Finalizada`;
+  - rechaza con `CompetenciaNoFinalizable` si quedan pendientes;
+  - calcula hash SHA-256 igual que P-08;
+  - persiste `CompetenciaFinalizada(origen="manual")`.
+
+- `P-08`
+  - explicita `origen="automatico"`.
+
+- `EjecucionPanel`
+  - muestra `Finalizar prueba` en disciplinas en ejecucion;
+  - habilita solo con `total > 0` y `completadas == total`;
+  - muestra bloqueo con pendientes;
+  - invalida queries tras cerrar.

--- a/docs/plans/sp5/US-5.2.2-plan.md
+++ b/docs/plans/sp5/US-5.2.2-plan.md
@@ -1,0 +1,46 @@
+# US-5.2.2 — Plan de Implementacion
+
+**Fecha:** 2026-04-22
+**US:** Finalizacion manual de prueba por disciplina
+
+## Tareas
+
+1. Dominio
+   - Extender `CompetenciaFinalizada` con `origen` y `finalizada_por`.
+   - Ajustar `Competencia.finalizar()` para recibir origen de cierre.
+   - Mantener `from_payload()` compatible con eventos historicos.
+
+2. Aplicacion
+   - Agregar `FinalizarCompetenciaManualCommand`.
+   - Reutilizar `PerformancesEstadoPort`, `CalculadorHashCompetencia` y
+     `Competencia.finalizar()`.
+   - Rechazar cierre si quedan pendientes o si no hay performances.
+   - Manejar competencia ya finalizada como no-op controlado.
+   - Marcar P-08 con `origen="automatico"`.
+
+3. API
+   - Agregar body `FinalizarCompetenciaBody`.
+   - Agregar endpoint `POST /competencia/{competencia_id}/finalizar`.
+   - Usar `OrganizadorDep` y `user["email"]` como `solicitado_por`.
+
+4. Frontend
+   - Agregar cliente `finalizarCompetencia()`.
+   - Mostrar accion `Finalizar prueba` en detalle de disciplina en ejecucion.
+   - Habilitar solo si `progreso.total > 0` y `completadas == total`.
+   - Mostrar bloqueo con cantidad de pendientes.
+   - Invalidar queries tras cierre.
+
+5. Tests y documentacion
+   - Agregar feature BDD de `US-5.2.2`.
+   - Agregar tests unitarios de dominio/handler/P-08.
+   - Agregar notas y reporte de cierre.
+   - Ejecutar tests backend focalizados y build frontend.
+
+## Criterio de listo
+
+- El cierre manual persiste `CompetenciaFinalizada` con `origen="manual"`.
+- El cierre automatico persiste `origen="automatico"`.
+- El endpoint responde 204 al cerrar o ante no-op controlado de competencia ya
+  finalizada.
+- Con pendientes, backend responde 409 y frontend no dispara la accion.
+- `npm run build` y tests focalizados pasan.

--- a/docs/plans/sp5/US-5.2.2-test-notes.md
+++ b/docs/plans/sp5/US-5.2.2-test-notes.md
@@ -1,0 +1,36 @@
+# US-5.2.2 — Notas de Testing
+
+**Fecha:** 2026-04-22
+
+## Validaciones ejecutadas
+
+```bash
+./.venv/bin/pytest \
+  tests/unit/competencia/domain/test_competencia_finalizar.py \
+  tests/unit/competencia/application/test_p08_finalizacion.py \
+  tests/unit/competencia/application/test_finalizar_competencia_manual.py \
+  tests/integration/competencia/test_competencia_finalizada_integration.py
+```
+
+Resultado: `25 passed`.
+
+```bash
+npm run build
+```
+
+Resultado: OK.
+
+```bash
+npm run lint
+```
+
+Resultado: OK.
+
+## Cobertura funcional
+
+- Dominio: payload manual y compatibilidad de eventos historicos.
+- Aplicacion: cierre manual exitoso, rechazo con pendientes y no-op si ya estaba
+  finalizada.
+- P-08: cierre automatico conserva comportamiento y registra origen automatico.
+- Frontend: validacion estatica por build/lint; no hay harness automatizado de UI
+  para esta pantalla.

--- a/docs/reports/US-5.2.2-report.md
+++ b/docs/reports/US-5.2.2-report.md
@@ -1,0 +1,32 @@
+# US-5.2.2 — Reporte de Implementacion
+
+**Fecha:** 2026-04-22
+**Incremento:** INC-5.2 — Ejecucion por Disciplina
+**Estado:** Implementada
+
+## Resumen
+
+Se implemento la finalizacion manual de una prueba por disciplina desde el panel
+del organizador, manteniendo la convivencia con el cierre automatico P-08.
+
+## Cambios principales
+
+- Nuevo comando `FinalizarCompetenciaManualCommand`.
+- Nuevo handler `FinalizarCompetenciaManualHandler`.
+- Nuevo endpoint `POST /competencia/{competencia_id}/finalizar`.
+- `CompetenciaFinalizada` distingue `origen="manual"` y `origen="automatico"`.
+- `EjecucionPanel` agrega la accion `Finalizar prueba` con bloqueo por
+  performances pendientes.
+
+## Validaciones
+
+- `./.venv/bin/pytest tests/unit/competencia/domain/test_competencia_finalizar.py tests/unit/competencia/application/test_p08_finalizacion.py tests/unit/competencia/application/test_finalizar_competencia_manual.py tests/integration/competencia/test_competencia_finalizada_integration.py` — OK, `25 passed`.
+- `npm run build` — OK.
+- `npm run lint` — OK.
+
+## Notas
+
+- El backend es la fuente de verdad: aunque la UI bloquee el boton con pendientes,
+  el endpoint vuelve a validar con `PerformancesEstadoPort`.
+- La competencia ya finalizada se trata como no-op controlado para evitar doble
+  emision de `CompetenciaFinalizada`.

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -260,6 +260,21 @@ export async function iniciarCompetencia(payload: {
   await parseResponse<void>(response)
 }
 
+export async function finalizarCompetencia(payload: {
+  competenciaId: string
+  disciplina: string
+}): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/finalizar`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      disciplina: payload.disciplina,
+    }),
+  })
+
+  await parseResponse<void>(response)
+}
+
 export async function fetchPerformanceActual(
   competenciaId: string,
 ): Promise<PerformanceActualDto | null> {

--- a/frontend/src/components/organizador/EjecucionPanel.tsx
+++ b/frontend/src/components/organizador/EjecucionPanel.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react'
 import {
   fetchCompetenciasPorTorneo,
   fetchEstadoCompetencia,
+  finalizarCompetencia,
   fetchGrillaCompetencia,
   fetchPerformanceActual,
   fetchProgresoCompetencia,
@@ -218,6 +219,25 @@ export function EjecucionPanel({ torneoId }: EjecucionPanelProps) {
     onError: (mutationError) => setError((mutationError as Error).message),
   })
 
+  const finalizarMutation = useMutation({
+    mutationFn: async (item: DisciplinaEjecucionItem) => {
+      if (!item.competencia) return
+      await finalizarCompetencia({
+        competenciaId: item.competencia.competencia_id,
+        disciplina: item.disciplina.disciplina,
+      })
+    },
+    onSuccess: async () => {
+      setError('')
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['ejecucion-disciplinas', torneoId] }),
+        queryClient.invalidateQueries({ queryKey: ['ejecucion-detalle'] }),
+        queryClient.invalidateQueries({ queryKey: ['monitor-ejecucion', torneoId] }),
+      ])
+    },
+    onError: (mutationError) => setError((mutationError as Error).message),
+  })
+
   if (ejecucionQuery.isLoading) {
     return (
       <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
@@ -286,7 +306,9 @@ export function EjecucionPanel({ torneoId }: EjecucionPanelProps) {
           isLoading={detalleQuery.isLoading}
           isError={detalleQuery.isError}
           isStarting={iniciarMutation.isPending}
+          isFinishing={finalizarMutation.isPending}
           onIniciar={(item) => iniciarMutation.mutate(item)}
+          onFinalizar={(item) => finalizarMutation.mutate(item)}
         />
       </div>
     </div>
@@ -362,7 +384,9 @@ interface DisciplinaDetalleProps {
   isLoading: boolean
   isError: boolean
   isStarting: boolean
+  isFinishing: boolean
   onIniciar: (item: DisciplinaEjecucionItem) => void
+  onFinalizar: (item: DisciplinaEjecucionItem) => void
 }
 
 function DisciplinaDetalle({
@@ -371,7 +395,9 @@ function DisciplinaDetalle({
   isLoading,
   isError,
   isStarting,
+  isFinishing,
   onIniciar,
+  onFinalizar,
 }: DisciplinaDetalleProps) {
   if (!item) {
     return (
@@ -382,6 +408,7 @@ function DisciplinaDetalle({
   }
 
   const canStart = item.estadoOperativo === 'lista_para_iniciar'
+  const canFinish = puedeFinalizar(item, detalle)
   const hash = item.estado?.hash_sha256
 
   return (
@@ -425,6 +452,18 @@ function DisciplinaDetalle({
               {isStarting ? 'Habilitando...' : 'Habilitar disciplina'}
             </button>
           ) : null}
+          {item.estadoOperativo === 'en_ejecucion' ? (
+            <button
+              type="button"
+              disabled={!canFinish || isFinishing}
+              onClick={() => {
+                if (canFinish) onFinalizar(item)
+              }}
+              className="min-h-10 rounded-lg bg-stone-900 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-stone-300"
+            >
+              {isFinishing ? 'Finalizando...' : 'Finalizar prueba'}
+            </button>
+          ) : null}
         </div>
       </div>
 
@@ -441,13 +480,32 @@ function DisciplinaDetalle({
 }
 
 function detalleBloqueo(item: DisciplinaEjecucionItem): string {
+  const progreso = item.progreso
   if (item.estadoOperativo === 'sin_competencia') return 'Configurar competencia antes de habilitar.'
   if (item.estadoOperativo === 'sin_grilla') return 'Confirmar grilla antes de habilitar.'
   if (item.estadoOperativo === 'sin_juez') return 'Asignar juez antes de habilitar.'
   if (item.estadoOperativo === 'lista_para_iniciar') return 'La disciplina esta lista para iniciar.'
+  if (item.estadoOperativo === 'en_ejecucion' && progreso) {
+    const pendientes = Math.max(progreso.total - progreso.completadas, 0)
+    if (pendientes > 0) return `Quedan ${pendientes} performances pendientes.`
+    if (progreso.total > 0) return 'La disciplina puede finalizarse manualmente.'
+  }
   if (item.estadoOperativo === 'en_ejecucion') return 'La disciplina esta en ejecucion.'
   if (item.estadoOperativo === 'finalizada') return 'La disciplina finalizo y queda en modo lectura.'
   return 'La disciplina no esta disponible para habilitar.'
+}
+
+function puedeFinalizar(
+  item: DisciplinaEjecucionItem,
+  detalle: DetalleDisciplinaData | null,
+): boolean {
+  const progreso = detalle?.progreso ?? item.progreso
+  return Boolean(
+    item.estadoOperativo === 'en_ejecucion' &&
+      progreso &&
+      progreso.total > 0 &&
+      progreso.completadas === progreso.total,
+  )
 }
 
 interface DetalleConCompetenciaProps {

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -38,6 +38,10 @@ from competencia.application.commands.generar_grilla import (
     GenerarGrillaCommand,
     GenerarGrillaHandler,
 )
+from competencia.application.commands.finalizar_competencia_manual import (
+    FinalizarCompetenciaManualCommand,
+    FinalizarCompetenciaManualHandler,
+)
 from competencia.application.commands.llamar_atleta import (
     AndarivelesConflicto,
     CompetenciaNoEnEjecucion,
@@ -167,6 +171,12 @@ class IniciarCompetenciaBody(BaseModel):
 
     disciplina: Disciplina
     juez_id: str
+
+
+class FinalizarCompetenciaBody(BaseModel):
+    """Body del endpoint POST /finalizar."""
+
+    disciplina: Disciplina
 
 
 class GenerarGrillaBody(BaseModel):
@@ -486,6 +496,14 @@ def get_iniciar_competencia_handler(event_store: EventStoreDep) -> IniciarCompet
     return IniciarCompetenciaHandler(event_store)
 
 
+def get_finalizar_competencia_manual_handler(
+    event_store: EventStoreDep,
+    performances_estado: PerformancesEstadoAdapterDep,
+) -> FinalizarCompetenciaManualHandler:
+    """Dependency: handler para finalizar manualmente la competencia."""
+    return FinalizarCompetenciaManualHandler(event_store, performances_estado)
+
+
 def get_obtener_grilla_handler(event_store: EventStoreDep) -> ObtenerGrillaHandler:
     """Dependency: handler de consulta de la grilla."""
     return ObtenerGrillaHandler(event_store, AtletaNombreAdapter())
@@ -503,6 +521,10 @@ ConfirmarGrillaHandlerDep = Annotated[ConfirmarGrillaHandler, Depends(get_confir
 GenerarGrillaHandlerDep = Annotated[GenerarGrillaHandler, Depends(get_generar_grilla_handler)]
 IniciarCompetenciaHandlerDep = Annotated[
     IniciarCompetenciaHandler, Depends(get_iniciar_competencia_handler)
+]
+FinalizarCompetenciaManualHandlerDep = Annotated[
+    FinalizarCompetenciaManualHandler,
+    Depends(get_finalizar_competencia_manual_handler),
 ]
 ObtenerGrillaHandlerDep = Annotated[ObtenerGrillaHandler, Depends(get_obtener_grilla_handler)]
 ObtenerEstadoCompetenciaHandlerDep = Annotated[
@@ -983,6 +1005,24 @@ async def post_iniciar_competencia(
             competencia_id=competencia_id,
             disciplina=body.disciplina,
             juez_id=body.juez_id,
+        )
+    )
+    return Response(status_code=204)
+
+
+@router.post("/{competencia_id}/finalizar", response_class=JSONResponse)
+async def post_finalizar_competencia(
+    competencia_id: UUID,
+    body: FinalizarCompetenciaBody,
+    handler: FinalizarCompetenciaManualHandlerDep,
+    user: OrganizadorDep,
+) -> JSONResponse:
+    """Finaliza manualmente una competencia sin performances pendientes."""
+    await handler.handle(
+        FinalizarCompetenciaManualCommand(
+            competencia_id=competencia_id,
+            disciplina=body.disciplina,
+            solicitado_por=user["email"],
         )
     )
     return Response(status_code=204)

--- a/src/competencia/application/_p08_finalizacion.py
+++ b/src/competencia/application/_p08_finalizacion.py
@@ -57,6 +57,7 @@ async def trigger_finalizacion_si_corresponde(
         ejecutadas=estado.ejecutadas,
         dns_count=estado.dns_count,
         hash_sha256=hash_sha256,
+        origen="automatico",
     )
 
     for event in competencia.pull_events():

--- a/src/competencia/application/commands/finalizar_competencia_manual.py
+++ b/src/competencia/application/commands/finalizar_competencia_manual.py
@@ -1,0 +1,102 @@
+"""Command y Handler para finalizacion manual de competencia — US-5.2.2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from competencia.application.commands._stream_ids import competencia_stream_id
+from competencia.domain.aggregates.competencia import Competencia
+from competencia.domain.exceptions import CompetenciaNoFinalizable
+from competencia.domain.ports.event_store_port import EventStorePort
+from competencia.domain.ports.performances_estado_port import PerformancesEstadoPort
+from competencia.domain.services.calculador_hash_competencia import CalculadorHashCompetencia
+from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.estado_competencia import EstadoCompetencia
+
+
+@dataclass(frozen=True)
+class FinalizarCompetenciaManualCommand:
+    """Comando para cerrar explicitamente una competencia desde organizador."""
+
+    competencia_id: UUID
+    disciplina: Disciplina
+    solicitado_por: str
+
+
+class FinalizarCompetenciaManualHandler:
+    """Handler de cierre manual de disciplina.
+
+    Reutiliza el mismo aggregate y calculo de hash que P-08, pero agrega una
+    precondicion operativa: solo una competencia en ejecucion y sin pendientes
+    puede cerrarse manualmente.
+    """
+
+    def __init__(
+        self,
+        event_store: EventStorePort,
+        performances_estado: PerformancesEstadoPort,
+    ) -> None:
+        self._event_store = event_store
+        self._performances_estado = performances_estado
+
+    async def handle(self, command: FinalizarCompetenciaManualCommand) -> None:
+        """Ejecuta el cierre manual de competencia.
+
+        Raises:
+            CompetenciaNoFinalizable: si la competencia no esta en ejecucion o
+                quedan performances pendientes.
+        """
+        stream_id = competencia_stream_id(command.competencia_id)
+        events = await self._event_store.load(stream_id)
+        competencia = Competencia.reconstitute(
+            competencia_id=command.competencia_id,
+            disciplina=command.disciplina,
+            events=events,
+        )
+
+        if competencia.estado == EstadoCompetencia.Finalizada:
+            return
+
+        if competencia.estado != EstadoCompetencia.EnEjecucion:
+            raise CompetenciaNoFinalizable(
+                f"Competencia {command.competencia_id}: se requiere estado EnEjecucion "
+                f"para finalizar manualmente; estado actual '{competencia.estado}'"
+            )
+
+        estado = await self._performances_estado.get_estado(
+            command.competencia_id,
+            command.disciplina,
+        )
+        if not estado.todas_finalizadas:
+            pendientes = estado.total - estado.ejecutadas - estado.dns_count
+            raise CompetenciaNoFinalizable(
+                f"Competencia {command.competencia_id}: INV-C-04 — "
+                f"{pendientes} performance(s) aún pendientes"
+            )
+
+        performance_events = await self._event_store.load_all_events_ordered(
+            f"performance-{command.competencia_id}-"
+        )
+        eventos_disciplina = [
+            event
+            for event in performance_events
+            if event["stream_id"].endswith(f"-{command.disciplina.value}")
+        ]
+        hash_sha256 = CalculadorHashCompetencia.calcular(eventos_disciplina)
+
+        competencia.finalizar(
+            total_performances=estado.total,
+            ejecutadas=estado.ejecutadas,
+            dns_count=estado.dns_count,
+            hash_sha256=hash_sha256,
+            origen="manual",
+            finalizada_por=command.solicitado_por,
+        )
+
+        for event in competencia.pull_events():
+            await self._event_store.append(
+                stream_id=stream_id,
+                event_type=event.event_type,
+                payload=event.to_payload(),
+            )

--- a/src/competencia/domain/aggregates/competencia.py
+++ b/src/competencia/domain/aggregates/competencia.py
@@ -338,6 +338,8 @@ class Competencia(AggregateRoot):
         ejecutadas: int,
         dns_count: int,
         hash_sha256: str,
+        origen: str = "automatico",
+        finalizada_por: str | None = None,
     ) -> None:
         """Finaliza la Competencia cuando todas las performances están completas (INV-C-04).
 
@@ -348,6 +350,8 @@ class Competencia(AggregateRoot):
             ejecutadas: Cantidad en estado Ejecutada.
             dns_count: Cantidad en estado DNS.
             hash_sha256: Hash SHA-256 de la secuencia canónica de eventos de la disciplina.
+            origen: Origen auditable del cierre.
+            finalizada_por: Usuario que solicito el cierre manual, si aplica.
 
         Raises:
             CompetenciaNoFinalizable: INV-C-04 — quedan performances en AnunciadaAP o Llamada.
@@ -371,6 +375,8 @@ class Competencia(AggregateRoot):
             dns_count=dns_count,
             finalizada_en=now.isoformat(),
             hash_sha256=hash_sha256,
+            origen=origen,
+            finalizada_por=finalizada_por,
         )
         self._estado = EstadoCompetencia.Finalizada
         self._hash_sha256 = hash_sha256

--- a/src/competencia/domain/events/competencia_finalizada.py
+++ b/src/competencia/domain/events/competencia_finalizada.py
@@ -28,6 +28,8 @@ class CompetenciaFinalizada(DomainEvent):
         ejecutadas: Cantidad en estado Ejecutada (tarjeta asignada).
         dns_count: Cantidad en estado DNS.
         finalizada_en: Timestamp de finalización.
+        origen: Origen auditable del cierre: automatico o manual.
+        finalizada_por: Identificador opcional del usuario que solicito el cierre manual.
     """
 
     competencia_id: str
@@ -37,6 +39,8 @@ class CompetenciaFinalizada(DomainEvent):
     dns_count: int
     finalizada_en: str
     hash_sha256: str | None = None
+    origen: str = "automatico"
+    finalizada_por: str | None = None
 
     def to_payload(self) -> dict[str, Any]:
         """Serializa el evento a payload JSON-serializable para el Event Store."""
@@ -48,6 +52,8 @@ class CompetenciaFinalizada(DomainEvent):
             "dns_count": self.dns_count,
             "finalizada_en": self.finalizada_en,
             "hash_sha256": self.hash_sha256,
+            "origen": self.origen,
+            "finalizada_por": self.finalizada_por,
             "occurred_at": self.occurred_at.isoformat(),
         }
 
@@ -65,4 +71,6 @@ class CompetenciaFinalizada(DomainEvent):
             dns_count=payload["dns_count"],
             finalizada_en=payload["finalizada_en"],
             hash_sha256=payload.get("hash_sha256"),
+            origen=payload.get("origen", "automatico"),
+            finalizada_por=payload.get("finalizada_por"),
         )

--- a/tests/features/US-5.2.2-finalizacion-manual.feature
+++ b/tests/features/US-5.2.2-finalizacion-manual.feature
@@ -1,0 +1,33 @@
+Feature: US-5.2.2 — Finalizacion manual de prueba por disciplina
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And el torneo "BA 2026" con id T1 esta en estado EJECUCION
+    And la disciplina DNF tiene competencia C1 en estado EnEjecucion
+
+  Scenario: finalizar manualmente una disciplina sin pendientes
+    Given C1 tiene 10 performances totales
+    And 8 performances estan ejecutadas
+    And 2 performances estan DNS
+    When el organizador selecciona DNF en el tab "Ejecucion"
+    Then ve la accion "Finalizar prueba" habilitada
+    When toca "Finalizar prueba"
+    Then el frontend envia POST /competencia/C1/finalizar con disciplina DNF
+    And la competencia C1 queda en estado Finalizada
+    And se registra CompetenciaFinalizada con origen "manual"
+
+  Scenario: no se puede finalizar si quedan performances pendientes
+    Given C1 tiene 10 performances totales
+    And 7 performances estan completadas
+    And 3 performances estan pendientes
+    When el organizador selecciona DNF en el tab "Ejecucion"
+    Then la accion "Finalizar prueba" esta deshabilitada
+    And el detalle muestra "Quedan 3 performances pendientes"
+    And no se envia POST /competencia/C1/finalizar
+
+  Scenario: cierre automatico sigue funcionando
+    Given C1 tiene 10 performances totales
+    And 9 performances ya estan cerradas
+    When el juez asigna la tarjeta final de la ultima performance
+    Then P-08 emite CompetenciaFinalizada automaticamente
+    And el evento queda registrado con origen "automatico"

--- a/tests/integration/competencia/test_competencia_finalizada_integration.py
+++ b/tests/integration/competencia/test_competencia_finalizada_integration.py
@@ -305,3 +305,5 @@ async def test_competencia_finalizada_payload_correcto(
     assert payload["dns_count"] == 1
     assert "hash_sha256" in payload
     assert len(payload["hash_sha256"]) == 64
+    assert payload["origen"] == "automatico"
+    assert payload["finalizada_por"] is None

--- a/tests/unit/competencia/application/test_finalizar_competencia_manual.py
+++ b/tests/unit/competencia/application/test_finalizar_competencia_manual.py
@@ -1,0 +1,137 @@
+"""Tests unitarios del cierre manual de competencia — US-5.2.2."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from competencia.application.commands.finalizar_competencia_manual import (
+    FinalizarCompetenciaManualCommand,
+    FinalizarCompetenciaManualHandler,
+)
+from competencia.domain.exceptions import CompetenciaNoFinalizable
+from competencia.domain.ports.performances_estado_port import PerformancesEstadoData
+from competencia.domain.value_objects.disciplina import Disciplina
+
+
+def _competencia_events(competencia_id: Any) -> list[dict[str, Any]]:
+    return [
+        {
+            "event_type": "GrillaConfirmada",
+            "payload": {
+                "competencia_id": str(competencia_id),
+                "disciplina": Disciplina.STA.value,
+                "confirmada_en": datetime(2026, 4, 22, 9, 0, 0).isoformat(),
+                "occurred_at": datetime(2026, 4, 22, 9, 0, 0).isoformat(),
+            },
+        },
+        {
+            "event_type": "CompetenciaIniciada",
+            "payload": {
+                "competencia_id": str(competencia_id),
+                "disciplina": Disciplina.STA.value,
+                "juez_id": "juez-1",
+                "iniciada_en": datetime(2026, 4, 22, 10, 0, 0).isoformat(),
+                "occurred_at": datetime(2026, 4, 22, 10, 0, 0).isoformat(),
+            },
+        },
+    ]
+
+
+def _competencia_finalizada_events(competencia_id: Any) -> list[dict[str, Any]]:
+    return [
+        *_competencia_events(competencia_id),
+        {
+            "event_type": "CompetenciaFinalizada",
+            "payload": {
+                "competencia_id": str(competencia_id),
+                "disciplina": Disciplina.STA.value,
+                "total_performances": 1,
+                "ejecutadas": 1,
+                "dns_count": 0,
+                "finalizada_en": datetime(2026, 4, 22, 11, 0, 0).isoformat(),
+                "hash_sha256": "a" * 64,
+                "origen": "automatico",
+                "finalizada_por": None,
+                "occurred_at": datetime(2026, 4, 22, 11, 0, 0).isoformat(),
+            },
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_finalizar_manual_persiste_origen_manual() -> None:
+    competencia_id = uuid4()
+    store = AsyncMock()
+    store.load.return_value = _competencia_events(competencia_id)
+    store.load_all_events_ordered.return_value = [
+        {
+            "sequence": 1,
+            "stream_id": f"performance-{competencia_id}-{uuid4()}-{Disciplina.STA.value}",
+            "event_type": "TarjetaAsignada",
+            "payload": {"tipo": "Blanca"},
+            "occurred_at": "2026-04-22T11:00:00",
+        }
+    ]
+    estado = AsyncMock()
+    estado.get_estado.return_value = PerformancesEstadoData(total=2, ejecutadas=1, dns_count=1)
+    handler = FinalizarCompetenciaManualHandler(store, estado)
+
+    await handler.handle(
+        FinalizarCompetenciaManualCommand(
+            competencia_id=competencia_id,
+            disciplina=Disciplina.STA,
+            solicitado_por="org@ataraxia.com",
+        )
+    )
+
+    payload = store.append.call_args.kwargs["payload"]
+    assert store.append.call_args.kwargs["event_type"] == "CompetenciaFinalizada"
+    assert payload["origen"] == "manual"
+    assert payload["finalizada_por"] == "org@ataraxia.com"
+    assert len(payload["hash_sha256"]) == 64
+
+
+@pytest.mark.asyncio
+async def test_finalizar_manual_rechaza_si_quedan_pendientes() -> None:
+    competencia_id = uuid4()
+    store = AsyncMock()
+    store.load.return_value = _competencia_events(competencia_id)
+    estado = AsyncMock()
+    estado.get_estado.return_value = PerformancesEstadoData(total=3, ejecutadas=1, dns_count=1)
+    handler = FinalizarCompetenciaManualHandler(store, estado)
+
+    with pytest.raises(CompetenciaNoFinalizable, match="1 performance"):
+        await handler.handle(
+            FinalizarCompetenciaManualCommand(
+                competencia_id=competencia_id,
+                disciplina=Disciplina.STA,
+                solicitado_por="org@ataraxia.com",
+            )
+        )
+
+    store.append.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_finalizar_manual_finalizada_es_noop() -> None:
+    competencia_id = uuid4()
+    store = AsyncMock()
+    store.load.return_value = _competencia_finalizada_events(competencia_id)
+    estado = AsyncMock()
+    handler = FinalizarCompetenciaManualHandler(store, estado)
+
+    await handler.handle(
+        FinalizarCompetenciaManualCommand(
+            competencia_id=competencia_id,
+            disciplina=Disciplina.STA,
+            solicitado_por="org@ataraxia.com",
+        )
+    )
+
+    estado.get_estado.assert_not_called()
+    store.append.assert_not_called()

--- a/tests/unit/competencia/application/test_p08_finalizacion.py
+++ b/tests/unit/competencia/application/test_p08_finalizacion.py
@@ -252,6 +252,8 @@ async def test_asignar_con_port_finalizado_persiste_hash_sha256(
     )
     assert "hash_sha256" in competencia_finalizada
     assert len(competencia_finalizada["hash_sha256"]) == 64
+    assert competencia_finalizada["origen"] == "automatico"
+    assert competencia_finalizada["finalizada_por"] is None
 
 
 # ── Tests RegistrarDNSHandler + P-08 ──────────────────────────────────────────

--- a/tests/unit/competencia/domain/test_competencia_finalizar.py
+++ b/tests/unit/competencia/domain/test_competencia_finalizar.py
@@ -95,8 +95,28 @@ def test_finalizar_payload_correcto() -> None:
     assert evento.ejecutadas == 3
     assert evento.dns_count == 1
     assert evento.hash_sha256 == "c" * 64
+    assert evento.origen == "automatico"
+    assert evento.finalizada_por is None
     assert evento.competencia_id == str(_CID)
     assert evento.disciplina == _DISC.value
+
+
+def test_finalizar_payload_manual() -> None:
+    """El cierre manual deja origen y solicitante en el evento."""
+    competencia = _competencia_en_ejecucion()
+    competencia.finalizar(
+        total_performances=4,
+        ejecutadas=3,
+        dns_count=1,
+        hash_sha256="m" * 64,
+        origen="manual",
+        finalizada_por="org@ataraxia.com",
+    )
+
+    evento = competencia.pull_events()[0]
+    assert isinstance(evento, CompetenciaFinalizada)
+    assert evento.origen == "manual"
+    assert evento.finalizada_por == "org@ataraxia.com"
 
 
 def test_finalizar_rechaza_si_quedan_pendientes() -> None:
@@ -164,6 +184,25 @@ def test_reconstitute_aplica_competencia_finalizada() -> None:
     competencia = Competencia.reconstitute(competencia_id=_CID, disciplina=_DISC, events=events)
 
     assert competencia.estado == EstadoCompetencia.Finalizada
+
+
+def test_competencia_finalizada_from_payload_backward_compatible() -> None:
+    """Eventos historicos sin origen se leen como cierre automatico."""
+    event = CompetenciaFinalizada.from_payload(
+        {
+            "competencia_id": str(_CID),
+            "disciplina": _DISC.value,
+            "total_performances": 2,
+            "ejecutadas": 1,
+            "dns_count": 1,
+            "finalizada_en": datetime(2026, 3, 22, 12, 0, 0).isoformat(),
+            "hash_sha256": "f" * 64,
+            "occurred_at": datetime(2026, 3, 22, 12, 0, 0).isoformat(),
+        }
+    )
+
+    assert event.origen == "automatico"
+    assert event.finalizada_por is None
 
 
 def test_finalizar_acepta_hash_del_conjunto_vacio() -> None:


### PR DESCRIPTION
## Resumen
- Agrega cierre manual de competencia por disciplina desde el panel del organizador.
- Incorpora endpoint POST /competencia/{competencia_id}/finalizar con validación backend de pendientes.
- Extiende CompetenciaFinalizada con origen manual/automatico y compatibilidad histórica.

## Validaciones
- ./.venv/bin/pytest tests/unit/competencia/domain/test_competencia_finalizar.py tests/unit/competencia/application/test_p08_finalizacion.py tests/unit/competencia/application/test_finalizar_competencia_manual.py tests/integration/competencia/test_competencia_finalizada_integration.py -> 25 passed
- npm run build -> OK
- npm run lint -> OK