### PR TITLE
fix: restringir operaciones por torneo y fase

### DIFF
--- a/.claude/tracking/US-ADJ-8.2-tracking.json
+++ b/.claude/tracking/US-ADJ-8.2-tracking.json
@@ -1,0 +1,220 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-8.2",
+    "us_title": "Restringir operaciones por torneo y fase",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-22T18:10:08.649164+00:00",
+    "completed_at": "2026-04-22T18:22:57.663358+00:00",
+    "total_elapsed_seconds": 769,
+    "effective_seconds": 769,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-22T18:10:15.040154+00:00",
+      "completed_at": "2026-04-22T18:10:34.676175+00:00",
+      "elapsed_seconds": 19,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-22T18:11:26.329788+00:00",
+      "completed_at": "2026-04-22T18:11:48.178201+00:00",
+      "elapsed_seconds": 21,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-22T18:11:58.206360+00:00",
+      "completed_at": "2026-04-22T18:13:42.309221+00:00",
+      "elapsed_seconds": 104,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada por Tareas",
+      "started_at": "2026-04-22T18:13:56.856969+00:00",
+      "completed_at": "2026-04-22T18:16:36.560725+00:00",
+      "elapsed_seconds": 159,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Filtrar selector de grilla por torneo",
+          "task_type": "frontend",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-22T18:14:01.554460+00:00",
+          "completed_at": "2026-04-22T18:14:37.060633+00:00",
+          "elapsed_seconds": 35,
+          "actual_minutes": 0.58,
+          "variance_minutes": -24.42,
+          "file_created": "frontend/src/components/organizador/GrillaPanel.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Bloquear premiación en frontend",
+          "task_type": "frontend",
+          "estimated_minutes": 35.0,
+          "started_at": "2026-04-22T18:14:41.410168+00:00",
+          "completed_at": "2026-04-22T18:15:29.215248+00:00",
+          "elapsed_seconds": 47,
+          "actual_minutes": 0.78,
+          "variance_minutes": -34.22,
+          "file_created": "frontend/src/pages/organizador/DetalleTorneoPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Validar precondición backend de premiación",
+          "task_type": "backend",
+          "estimated_minutes": 45.0,
+          "started_at": "2026-04-22T18:15:34.792565+00:00",
+          "completed_at": "2026-04-22T18:16:29.411491+00:00",
+          "elapsed_seconds": 54,
+          "actual_minutes": 0.9,
+          "variance_minutes": -44.1,
+          "file_created": "src/app.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-22T18:16:45.955987+00:00",
+      "completed_at": "2026-04-22T18:17:40.481508+00:00",
+      "elapsed_seconds": 54,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_004",
+          "task_name": "Tests unitarios precondición premiación",
+          "task_type": "test",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-22T18:16:52.493677+00:00",
+          "completed_at": "2026-04-22T18:17:22.833566+00:00",
+          "elapsed_seconds": 30,
+          "actual_minutes": 0.5,
+          "variance_minutes": -24.5,
+          "file_created": "tests/unit/torneo/application/test_premiacion_precondition.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-22T18:17:52.597126+00:00",
+      "completed_at": "2026-04-22T18:18:47.482427+00:00",
+      "elapsed_seconds": 54,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_005",
+          "task_name": "Test integración endpoint premiación",
+          "task_type": "test",
+          "estimated_minutes": 30.0,
+          "started_at": "2026-04-22T18:17:57.168101+00:00",
+          "completed_at": "2026-04-22T18:18:36.422311+00:00",
+          "elapsed_seconds": 39,
+          "actual_minutes": 0.65,
+          "variance_minutes": -29.35,
+          "file_created": "tests/integration/torneo/test_premiacion_precondicion.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-22T18:18:54.199008+00:00",
+      "completed_at": "2026-04-22T18:19:05.298759+00:00",
+      "elapsed_seconds": 11,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-22T18:19:12.509832+00:00",
+      "completed_at": "2026-04-22T18:21:30.506991+00:00",
+      "elapsed_seconds": 137,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-22T18:21:34.940581+00:00",
+      "completed_at": "2026-04-22T18:22:25.685086+00:00",
+      "elapsed_seconds": 50,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_006",
+          "task_name": "Actualizar documentación US-ADJ-8.2",
+          "task_type": "docs",
+          "estimated_minutes": 20.0,
+          "started_at": "2026-04-22T18:21:38.577740+00:00",
+          "completed_at": "2026-04-22T18:22:21.432276+00:00",
+          "elapsed_seconds": 42,
+          "actual_minutes": 0.7,
+          "variance_minutes": -19.3,
+          "file_created": "docs/plans/sp-adj-08/US-ADJ-8.2-implementation-notes.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-22T18:22:31.911867+00:00",
+      "completed_at": "2026-04-22T18:22:53.171634+00:00",
+      "elapsed_seconds": 21,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 6,
+    "completed_tasks": 6,
+    "total_phases": 10,
+    "estimated_total_minutes": 180.0,
+    "actual_total_minutes": 4.12,
+    "variance_minutes": -175.88,
+    "variance_percent": -97.71
+  }
+}

--- a/docs/plans/sp-adj-08/PLAN-SP-ADJ-08.md
+++ b/docs/plans/sp-adj-08/PLAN-SP-ADJ-08.md
@@ -108,7 +108,7 @@ UAT de regresion INC-5.2
 
 ## Criterio de cierre de SP-ADJ-08
 
-- [ ] US-ADJ-8.2 — selector de grilla filtrado por torneo y premiacion bloqueada hasta competencias finalizadas.
+- [x] US-ADJ-8.2 — selector de grilla filtrado por torneo y premiacion bloqueada hasta competencias finalizadas.
 - [ ] US-ADJ-8.1 — estados vacios/loading/error claros, mensajes accionables y lenguaje de fase preciso.
 - [ ] US-ADJ-8.3 — cancelacion en zona de peligro con confirmacion por nombre exacto.
 - [ ] UAT de regresion INC-5.2 sin hallazgos Alta abiertos.

--- a/docs/plans/sp-adj-08/US-ADJ-8.2-bdd-skip.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.2-bdd-skip.md
@@ -1,0 +1,28 @@
+# US-ADJ-8.2 — Validacion BDD acotada
+
+**Fase:** 6 — Validacion BDD
+**Estado:** Omitida como ejecucion automatizada
+**Fecha:** 2026-04-22
+
+## Motivo
+
+La US cubre comportamiento observable de frontend organizador:
+
+- selector de grilla filtrado por disciplinas del torneo;
+- bloqueo visual de `Pasar a premiacion`;
+- no disparar la transicion si hay disciplinas pendientes.
+
+El repositorio no tiene harness automatizado de browser/DOM para ejecutar steps BDD de
+componentes React. Crear ese harness excede el alcance de esta US de ajuste.
+
+## Evidencia sustituida
+
+- Se creo el feature BDD:
+  `tests/features/US-ADJ-8.2-restringir-operaciones-torneo-fase.feature`.
+- La regla backend critica queda cubierta por tests unitarios e integracion HTTP.
+- La validacion frontend se cubre con `npm run build` y `npm run lint`.
+
+## Pendiente si se agrega harness UI
+
+Implementar steps para verificar selectores, botones bloqueados y mensajes visibles
+en `DetalleTorneoPage`, `GrillaPanel` y `AccionesPanel`.

--- a/docs/plans/sp-adj-08/US-ADJ-8.2-implementation-notes.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.2-implementation-notes.md
@@ -1,0 +1,41 @@
+# US-ADJ-8.2 — Notas de implementacion
+
+**Fecha:** 2026-04-22
+**Fase:** 8 — Documentacion
+
+## Cambios realizados
+
+- `GrillaPanel`
+  - consulta `GET /torneos/{torneo_id}/disciplinas`;
+  - elimina la lista global hardcodeada como fuente del selector;
+  - muestra estados de carga, error y vacio para disciplinas del torneo.
+
+- `DetalleTorneoPage` + `AccionesPanel`
+  - calculan disciplinas pendientes cruzando disciplinas configuradas, competencias y estado;
+  - renombran la accion `Iniciar premiacion` a `Pasar a premiacion`;
+  - bloquean la accion con detalle de disciplinas no finalizadas.
+
+- Backend `torneo`
+  - agrega `PremiacionNoPermitida`;
+  - expone callback configurable previo a `IniciarPremiacionHandler`;
+  - `src/app.py` cablea la precondicion leyendo Torneo + Competencia.
+
+## Decision de frontera BC
+
+La validacion de premiacion necesita datos de `torneo` y `competencia`. Para no acoplar
+`torneo/domain` con `competencia`, la regla cross-BC se implemento en el composition root:
+
+1. `torneo.api.router` define un callback opcional.
+2. `src/app.py` construye el callback con repositorios/adaptadores reales.
+3. El dominio de Torneo conserva solo la maquina de estados local.
+
+## Validaciones
+
+- `./.venv/bin/pytest tests/unit/torneo/application/test_premiacion_precondition.py tests/unit/torneo/application/test_transiciones_handlers.py tests/integration/torneo/test_premiacion_precondicion.py` — OK, `13 passed`.
+- `npm run lint` — OK.
+- `npm run build` — OK.
+
+## Fases acotadas
+
+- BDD UI no ejecutado por falta de harness browser; feature creado como especificacion.
+- Quality gates acotados a cambios de la US.

--- a/docs/plans/sp-adj-08/US-ADJ-8.2-plan.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.2-plan.md
@@ -1,0 +1,107 @@
+# Plan de Implementacion: US-ADJ-8.2 — Restringir operaciones por torneo y fase
+
+| Campo | Valor |
+|-------|-------|
+| **Sprint** | SP-ADJ-08 |
+| **Tipo** | Fix de regla funcional frontend + validacion de fase |
+| **Branch** | `feature/US-ADJ-8.2-restringir-operaciones` |
+| **BC** | frontend organizador + `torneo` + `competencia` via composition root |
+| **Estimacion** | 3-4 h |
+| **Estado** | Implementada |
+
+---
+
+## Alcance
+
+Implementar dos restricciones operativas detectadas por UAT:
+
+- El selector de grilla debe mostrar solo disciplinas configuradas en el torneo actual.
+- La transicion `EJECUCION -> PREMIACION` debe bloquearse mientras existan disciplinas
+  del torneo sin competencia finalizada.
+
+Hallazgos cubiertos: `UAT-5.2-02`, `UAT-5.2-05`, `UAT-5.2-07`.
+
+---
+
+## Decisiones de implementacion
+
+- Usar `GET /torneos/{torneo_id}/disciplinas` como fuente primaria del selector de grilla.
+- En frontend, cruzar disciplinas configuradas con `GET /competencia?torneo_id=...` y
+  `GET /competencia/{id}/estado` para derivar disciplinas pendientes de cierre.
+- En backend, no importar `competencia` desde `torneo/domain`.
+- Agregar un callback configurable en `torneo.api.router` para validar precondiciones
+  de premiacion; cablearlo en `src/app.py` usando adaptadores/queries de `competencia`.
+- Si no hay callback configurado, mantener compatibilidad de tests aislados del router.
+
+---
+
+## Tareas
+
+### 1. Frontend — selector de grilla
+
+- [x] Modificar `GrillaPanel` para consultar `listarDisciplinasTorneo(torneoId)`.
+- [x] Eliminar lista global hardcodeada como fuente del selector.
+- [x] Inicializar/ajustar seleccion cuando carguen las disciplinas del torneo.
+- [x] Mostrar estado vacio si el torneo no tiene disciplinas configuradas.
+- [x] Evitar crear/generar grilla si no hay disciplina valida seleccionada.
+
+### 2. Frontend — bloqueo de premiacion
+
+- [x] Extender `AccionesPanel` para recibir disciplinas pendientes de cierre.
+- [x] En `DetalleTorneoPage`, calcular cierre de torneo desde disciplinas configuradas,
+  competencias por torneo y estado de cada competencia.
+- [x] Cambiar texto `Iniciar premiacion` por `Pasar a premiacion`.
+- [x] Bloquear la accion si hay disciplinas no finalizadas.
+- [x] Mostrar motivo con cantidad y nombres de disciplinas pendientes.
+- [x] No disparar `iniciarPremiacion` si el bloqueo esta activo.
+
+### 3. Backend — precondicion de premiacion
+
+- [x] Agregar excepcion `PremiacionNoPermitida` en `torneo.domain.exceptions`.
+- [x] Registrar handler HTTP 409 para `PremiacionNoPermitida`.
+- [x] Agregar callback configurable en `torneo.api.router` antes de `IniciarPremiacionHandler`.
+- [x] Cablear callback en `src/app.py`:
+  - leer torneo y disciplinas configuradas;
+  - listar competencias por torneo;
+  - obtener estado de cada competencia;
+  - rechazar si alguna disciplina configurada no esta `Finalizada`.
+- [x] Incluir disciplinas sin competencia como pendientes.
+
+### 4. Tests
+
+- [x] Unit backend: callback/handler rechaza premiacion con pendientes y permite con todas finalizadas.
+- [x] Integracion backend: `PUT /torneos/{id}/iniciar-premiacion` retorna 409 si el callback detecta pendientes.
+- [x] Frontend: no hay harness automatizado actual; validar con `npm run build` y `npm run lint`.
+- [x] BDD: mantener feature como especificacion ejecutable futura; omitir steps si no hay harness UI para browser.
+
+### 5. Documentacion y reporte
+
+- [x] Actualizar `docs/specs/sp-adj-08/US-ADJ-8.2.md` a `Implementada`.
+- [x] Actualizar checklist de `PLAN-SP-ADJ-08`.
+- [x] Generar `docs/reports/US-ADJ-8.2-report.md`.
+
+---
+
+## Fases omitidas o acotadas
+
+- Fase 4 queda acotada a tests Python de backend si se toca validacion de fase.
+- Fase 5 queda acotada al endpoint de `torneo`; no se crea E2E completo de navegador.
+- Fase 6 queda como validacion documental BDD: se crea `.feature`, pero no se implementan
+  steps UI por falta de harness browser en el repo.
+- Fase 7 usa `npm run build`, `npm run lint` y tests Python focalizados; CodeGuard completo
+  puede generar ruido fuera del alcance de esta US.
+
+---
+
+## Validacion minima esperada
+
+```bash
+npm run build
+npm run lint
+pytest tests/unit/torneo/application/test_transiciones_handlers.py
+pytest tests/integration/torneo/test_premiacion_precondicion.py
+```
+
+---
+
+*Creado: 2026-04-22 — Fase 2 para UAT-5.2 reglas operativas*

--- a/docs/reports/US-ADJ-8.2-report.md
+++ b/docs/reports/US-ADJ-8.2-report.md
@@ -1,0 +1,42 @@
+# US-ADJ-8.2 — Reporte de Implementacion
+
+**Fecha:** 2026-04-22
+**Sprint:** SP-ADJ-08
+**Estado:** Implementada
+
+## Resumen
+
+Se implementaron restricciones operativas para el flujo organizador:
+
+- el selector de grilla ahora usa solo disciplinas configuradas en el torneo actual;
+- la accion `Pasar a premiacion` se bloquea si quedan disciplinas sin competencia finalizada;
+- el backend tambien rechaza `EJECUCION -> PREMIACION` cuando la app esta cableada con
+  la precondicion cross-BC desde `src/app.py`.
+
+## Cambios principales
+
+- `GrillaPanel` consume `listarDisciplinasTorneo(torneoId)` y elimina el selector global.
+- `DetalleTorneoPage` calcula disciplinas pendientes cruzando Torneo + Competencia.
+- `AccionesPanel` cambia `Iniciar premiacion` por `Pasar a premiacion`, bloquea la accion
+  y muestra el detalle de pendientes.
+- `torneo.api.router` permite configurar una precondicion async antes de iniciar premiacion.
+- `src/app.py` cablea la precondicion con Torneo y Competencia.
+- Nueva excepcion `PremiacionNoPermitida` con respuesta HTTP 409.
+
+## Validaciones
+
+- `./.venv/bin/pytest tests/unit/torneo/application/test_premiacion_precondition.py tests/unit/torneo/application/test_transiciones_handlers.py tests/integration/torneo/test_premiacion_precondicion.py` — OK, `13 passed`.
+- `npm run lint` — OK.
+- `npm run build` — OK.
+
+## Fases acotadas
+
+- BDD automatizado UI omitido: no existe harness browser/DOM en el repo.
+- Se dejo feature BDD en `tests/features/US-ADJ-8.2-restringir-operaciones-torneo-fase.feature`.
+- Quality gates acotados al alcance modificado.
+
+## Notas
+
+- La regla cross-BC no se puso en `torneo/domain`; queda cableada en composition root
+  para conservar la frontera de bounded contexts.
+- Disciplinas configuradas sin competencia cuentan como pendientes de cierre.

--- a/docs/specs/sp-adj-08/US-ADJ-8.2.md
+++ b/docs/specs/sp-adj-08/US-ADJ-8.2.md
@@ -1,6 +1,6 @@
 # US-ADJ-8.2: Restringir operaciones por torneo y fase — UAT-5.2 reglas operativas
 
-**Estado**: `Pendiente`
+**Estado**: `Implementada`
 **Iteracion / Sprint**: SP-ADJ-08
 **Tipo**: fix de regla funcional frontend + validacion de fase
 **Agregado principal afectado**: `Torneo` / `Competencia`
@@ -141,6 +141,9 @@ Feature: Restricciones operativas por torneo y fase
 2. Usar `GET /torneos/{torneo_id}/disciplinas` como fuente de verdad de disciplinas esperadas.
 3. Cruzar contra `GET /competencia?torneo_id=...` para determinar estado por disciplina.
 4. Si existen disciplinas configuradas sin participantes y se decide excluirlas del cierre, documentar la regla explicitamente antes de implementarla.
+5. Implementado: el backend valida la precondicion mediante callback configurable en
+   `torneo.api.router`, cableado desde `src/app.py` para consultar Competencia sin romper
+   la frontera del dominio de Torneo.
 
 ---
 

--- a/frontend/src/components/organizador/AccionesPanel.tsx
+++ b/frontend/src/components/organizador/AccionesPanel.tsx
@@ -24,7 +24,7 @@ const ACCIONES_POR_ESTADO: Partial<Record<EstadoTorneo, AccionFase[]>> = {
   PREPARACION: [{ label: 'Iniciar ejecucion', run: iniciarEjecucion, variant: 'primary' }],
   EJECUCION: [
     { label: 'Volver a preparacion', run: volverPreparacion, variant: 'secondary' },
-    { label: 'Iniciar premiacion', run: iniciarPremiacion, variant: 'primary' },
+    { label: 'Pasar a premiacion', run: iniciarPremiacion, variant: 'primary' },
   ],
   PREMIACION: [{ label: 'Cerrar torneo', run: cerrarTorneo, variant: 'primary' }],
 }
@@ -35,6 +35,8 @@ interface AccionesPanelProps {
   torneoId: string
   torneoNombre: string
   estado: EstadoTorneo
+  premiacionPendientes?: string[] | null
+  isPremiacionStatusLoading?: boolean
   onSuccess: () => Promise<void>
   onError: (message: string) => void
 }
@@ -58,6 +60,8 @@ export function AccionesPanel({
   torneoId,
   torneoNombre,
   estado,
+  premiacionPendientes,
+  isPremiacionStatusLoading = false,
   onSuccess,
   onError,
 }: AccionesPanelProps) {
@@ -65,8 +69,14 @@ export function AccionesPanel({
   const [showCancelDialog, setShowCancelDialog] = useState(false)
   const acciones = ACCIONES_POR_ESTADO[estado] ?? []
   const puedeCancelar = !ESTADOS_TERMINALES.has(estado)
+  const bloqueoPremiacion =
+    estado === 'EJECUCION' &&
+    (isPremiacionStatusLoading || (premiacionPendientes?.length ?? 0) > 0)
 
   async function runAction(action: AccionFase) {
+    if (action.label === 'Pasar a premiacion' && bloqueoPremiacion) {
+      return
+    }
     setRunningAction(action.label)
     onError('')
     try {
@@ -112,7 +122,10 @@ export function AccionesPanel({
               key={action.label}
               type="button"
               onClick={() => void runAction(action)}
-              disabled={runningAction !== null}
+              disabled={
+                runningAction !== null ||
+                (action.label === 'Pasar a premiacion' && bloqueoPremiacion)
+              }
               className={buttonClass(action.variant ?? 'primary')}
             >
               {runningAction === action.label ? 'Procesando...' : action.label}
@@ -130,6 +143,20 @@ export function AccionesPanel({
           ) : null}
         </div>
       </div>
+
+      {estado === 'EJECUCION' && isPremiacionStatusLoading ? (
+        <p className="mt-3 text-sm font-semibold text-stone-600">
+          Verificando cierre de disciplinas antes de pasar a premiacion...
+        </p>
+      ) : null}
+
+      {estado === 'EJECUCION' && premiacionPendientes && premiacionPendientes.length > 0 ? (
+        <p className="mt-3 text-sm font-semibold text-amber-800">
+          Falta cerrar {premiacionPendientes.length}{' '}
+          {premiacionPendientes.length === 1 ? 'disciplina' : 'disciplinas'}:{' '}
+          {premiacionPendientes.join(', ')}.
+        </p>
+      ) : null}
 
       {showCancelDialog ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/40 px-4">

--- a/frontend/src/components/organizador/GrillaPanel.tsx
+++ b/frontend/src/components/organizador/GrillaPanel.tsx
@@ -11,14 +11,16 @@ import {
   type CambioGrillaPayload,
   type GrillaAtletaDto,
 } from '../../api/competencia'
+import {
+  listarDisciplinasTorneo,
+  type DisciplinaCodigo,
+} from '../../api/torneo'
 import { ConfigurarGrillaForm } from './ConfigurarGrillaForm'
 import { TablaGrilla } from './TablaGrilla'
 
 interface GrillaPanelProps {
   torneoId: string
 }
-
-const DISCIPLINAS = ['STA', 'DNF', 'DYN', 'DBF', 'SPE_2X50', 'SPE_4X50', 'SPE_8X50', 'SPE_16X50']
 
 function buildOtIso(time: string) {
   const [hours, minutes] = time.split(':').map(Number)
@@ -29,9 +31,23 @@ function buildOtIso(time: string) {
 
 export function GrillaPanel({ torneoId }: GrillaPanelProps) {
   const queryClient = useQueryClient()
-  const [disciplina, setDisciplina] = useState('DNF')
+  const [disciplinaSeleccionada, setDisciplinaSeleccionada] = useState<DisciplinaCodigo | ''>('')
   const [localRows, setLocalRows] = useState<GrillaAtletaDto[] | null>(null)
   const [error, setError] = useState('')
+
+  const disciplinasQuery = useQuery({
+    queryKey: ['torneo-disciplinas', torneoId],
+    queryFn: () => listarDisciplinasTorneo(torneoId),
+  })
+
+  const disciplinas = useMemo(
+    () => disciplinasQuery.data?.map((item) => item.disciplina) ?? [],
+    [disciplinasQuery.data],
+  )
+  const disciplina =
+    disciplinaSeleccionada && disciplinas.includes(disciplinaSeleccionada)
+      ? disciplinaSeleccionada
+      : disciplinas[0] ?? ''
 
   const competenciasQuery = useQuery({
     queryKey: ['competencias-torneo', torneoId],
@@ -39,20 +55,23 @@ export function GrillaPanel({ torneoId }: GrillaPanelProps) {
   })
 
   const competencia = useMemo(
-    () => competenciasQuery.data?.find((item) => item.disciplina === disciplina) ?? null,
+    () =>
+      disciplina
+        ? competenciasQuery.data?.find((item) => item.disciplina === disciplina) ?? null
+        : null,
     [competenciasQuery.data, disciplina],
   )
 
   const estadoQuery = useQuery({
     queryKey: ['competencia-estado', competencia?.competencia_id, disciplina],
     queryFn: () => fetchEstadoCompetencia(competencia?.competencia_id ?? '', disciplina),
-    enabled: Boolean(competencia),
+    enabled: Boolean(competencia && disciplina),
   })
 
   const grillaQuery = useQuery({
     queryKey: ['competencia-grilla', competencia?.competencia_id, disciplina],
     queryFn: () => fetchGrillaCompetencia(competencia?.competencia_id ?? '', disciplina),
-    enabled: Boolean(competencia),
+    enabled: Boolean(competencia && disciplina),
   })
 
   const rows = localRows ?? grillaQuery.data ?? []
@@ -70,6 +89,9 @@ export function GrillaPanel({ torneoId }: GrillaPanelProps) {
 
   const generarMutation = useMutation({
     mutationFn: async (payload: { intervaloMinutos: number; primerOt: string }) => {
+      if (!disciplina) {
+        throw new Error('El torneo no tiene disciplinas configuradas para generar grilla.')
+      }
       const competenciaId = crypto.randomUUID()
       await crearCompetencia({
         competenciaId,
@@ -91,7 +113,7 @@ export function GrillaPanel({ torneoId }: GrillaPanelProps) {
 
   const ajustarMutation = useMutation({
     mutationFn: async (payload: { rows: GrillaAtletaDto[]; cambios: CambioGrillaPayload[] }) => {
-      if (!competencia) return
+      if (!competencia || !disciplina) return
       setLocalRows(payload.rows)
       await ajustarGrilla({
         competenciaId: competencia.competencia_id,
@@ -105,7 +127,7 @@ export function GrillaPanel({ torneoId }: GrillaPanelProps) {
 
   const confirmarMutation = useMutation({
     mutationFn: async () => {
-      if (!competencia) return
+      if (!competencia || !disciplina) return
       await confirmarGrilla({ competenciaId: competencia.competencia_id, disciplina })
     },
     onSuccess: refresh,
@@ -120,13 +142,14 @@ export function GrillaPanel({ torneoId }: GrillaPanelProps) {
           <select
             value={disciplina}
             onChange={(event) => {
-              setDisciplina(event.target.value)
+              setDisciplinaSeleccionada(event.target.value as DisciplinaCodigo)
               setLocalRows(null)
               setError('')
             }}
+            disabled={disciplinasQuery.isLoading || disciplinas.length === 0}
             className="ml-0 mt-2 min-h-10 rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm sm:ml-3 sm:mt-0"
           >
-            {DISCIPLINAS.map((item) => (
+            {disciplinas.map((item) => (
               <option key={item} value={item}>
                 {item}
               </option>
@@ -146,13 +169,31 @@ export function GrillaPanel({ torneoId }: GrillaPanelProps) {
         </div>
       ) : null}
 
+      {disciplinasQuery.isLoading ? (
+        <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+          Cargando disciplinas del torneo...
+        </div>
+      ) : null}
+
+      {disciplinasQuery.isError ? (
+        <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+          No se pudieron cargar las disciplinas del torneo.
+        </div>
+      ) : null}
+
+      {!disciplinasQuery.isLoading && !disciplinasQuery.isError && disciplinas.length === 0 ? (
+        <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+          Este torneo no tiene disciplinas configuradas para generar grilla.
+        </div>
+      ) : null}
+
       {competenciasQuery.isLoading ? (
         <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
           Cargando competencias...
         </div>
       ) : null}
 
-      {!competenciasQuery.isLoading && !competencia ? (
+      {disciplina && !competenciasQuery.isLoading && !competencia ? (
         <ConfigurarGrillaForm
           disciplina={disciplina}
           isSubmitting={generarMutation.isPending}

--- a/frontend/src/pages/organizador/DetalleTorneoPage.tsx
+++ b/frontend/src/pages/organizador/DetalleTorneoPage.tsx
@@ -1,7 +1,16 @@
-import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useQueries, useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { fetchTorneo, type EstadoTorneo, type TorneoDto } from '../../api/torneo'
+import {
+  fetchCompetenciasPorTorneo,
+  fetchEstadoCompetencia,
+} from '../../api/competencia'
+import {
+  fetchTorneo,
+  listarDisciplinasTorneo,
+  type EstadoTorneo,
+  type TorneoDto,
+} from '../../api/torneo'
 import { AccionesPanel } from '../../components/organizador/AccionesPanel'
 import { EjecucionPanel } from '../../components/organizador/EjecucionPanel'
 import { FaseBadge } from '../../components/organizador/FaseBadge'
@@ -31,6 +40,56 @@ export function DetalleTorneoPage() {
     queryFn: () => fetchTorneo(torneoId ?? ''),
     enabled: Boolean(torneoId),
   })
+  const disciplinasQuery = useQuery({
+    queryKey: ['torneo-disciplinas', torneoId],
+    queryFn: () => listarDisciplinasTorneo(torneoId ?? ''),
+    enabled: Boolean(torneoId) && torneoQuery.data?.estado === 'EJECUCION',
+  })
+  const competenciasQuery = useQuery({
+    queryKey: ['competencias-torneo', torneoId],
+    queryFn: () => fetchCompetenciasPorTorneo(torneoId ?? ''),
+    enabled: Boolean(torneoId) && torneoQuery.data?.estado === 'EJECUCION',
+  })
+  const estadoCompetenciasQueries = useQueries({
+    queries:
+      competenciasQuery.data?.map((competencia) => ({
+        queryKey: ['competencia-estado', competencia.competencia_id, competencia.disciplina],
+        queryFn: () =>
+          fetchEstadoCompetencia(competencia.competencia_id, competencia.disciplina),
+        enabled: torneoQuery.data?.estado === 'EJECUCION',
+      })) ?? [],
+  })
+  const isPremiacionStatusLoading =
+    torneoQuery.data?.estado === 'EJECUCION' &&
+    (disciplinasQuery.isLoading ||
+      competenciasQuery.isLoading ||
+      estadoCompetenciasQueries.some((query) => query.isLoading))
+  const premiacionPendientes = useMemo(() => {
+    if (torneoQuery.data?.estado !== 'EJECUCION') return null
+    const disciplinas = disciplinasQuery.data ?? []
+    const competencias = competenciasQuery.data ?? []
+    const estadosPorCompetencia = new Map(
+      estadoCompetenciasQueries.map((query, index) => [
+        competencias[index]?.competencia_id,
+        query.data?.estado,
+      ]),
+    )
+
+    return disciplinas
+      .filter((disciplinaTorneo) => {
+        const competencia = competencias.find(
+          (item) => item.disciplina === disciplinaTorneo.disciplina,
+        )
+        if (!competencia) return true
+        return estadosPorCompetencia.get(competencia.competencia_id) !== 'Finalizada'
+      })
+      .map((disciplinaTorneo) => disciplinaTorneo.disciplina)
+  }, [
+    competenciasQuery.data,
+    disciplinasQuery.data,
+    estadoCompetenciasQueries,
+    torneoQuery.data?.estado,
+  ])
   const isCancelado = torneoQuery.data?.estado === 'CANCELADO'
 
   return (
@@ -116,6 +175,8 @@ export function DetalleTorneoPage() {
               torneoId={torneoQuery.data.torneo_id}
               torneoNombre={torneoQuery.data.nombre}
               estado={torneoQuery.data.estado}
+              premiacionPendientes={premiacionPendientes}
+              isPremiacionStatusLoading={isPremiacionStatusLoading}
               onSuccess={async () => {
                 setTransitionError('')
                 await torneoQuery.refetch()

--- a/quality/reports/codeguard/US-ADJ-8.2-quality.json
+++ b/quality/reports/codeguard/US-ADJ-8.2-quality.json
@@ -1,0 +1,25 @@
+{
+  "us_id": "US-ADJ-8.2",
+  "date": "2026-04-22",
+  "scope": "frontend organizador + precondicion backend de premiacion",
+  "checks": [
+    {
+      "command": "./.venv/bin/pytest tests/unit/torneo/application/test_premiacion_precondition.py tests/unit/torneo/application/test_transiciones_handlers.py tests/integration/torneo/test_premiacion_precondicion.py",
+      "result": "13 passed"
+    },
+    {
+      "command": "npm run lint",
+      "cwd": "frontend",
+      "result": "OK"
+    },
+    {
+      "command": "npm run build",
+      "cwd": "frontend",
+      "result": "OK"
+    }
+  ],
+  "notes": [
+    "Fase 7 acotada a cambios de la US; no se ejecuto DesignReviewer manual completo.",
+    "La primera corrida de npm run lint detecto setState dentro de effect en GrillaPanel; fue corregido y el rerun paso."
+  ]
+}

--- a/src/app.py
+++ b/src/app.py
@@ -58,7 +58,11 @@ from registro.api.router import (
 from registro.domain.aggregates.inscripcion import Inscripcion
 from registro.infrastructure.repositories.sqlite_atleta_repository import SQLiteAtletaRepository
 from torneo.api.exception_handlers import register_torneo_exception_handlers
-from torneo.api.router import router as torneo_router
+from torneo.api.router import (
+    configure_premiacion_precondition,
+    router as torneo_router,
+)
+from torneo.domain.exceptions import PremiacionNoPermitida
 from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
 from resultados.application.commands.calcular_ranking import (
     CalcularRankingCommand,
@@ -354,7 +358,11 @@ async def _calcular_overall_si_corresponde(
     if torneo_id is None:
         return
 
-    if not await _verificar_todas_disciplinas_finalizadas(torneo_id, competencia_event_store):
+    if await _obtener_disciplinas_pendientes_premiacion(
+        torneo_id,
+        competencia_event_store,
+        torneo_db_path,
+    ):
         return
 
     disciplinas = await _obtener_disciplinas_torneo(torneo_id, torneo_db_path)
@@ -370,21 +378,63 @@ async def _calcular_overall_si_corresponde(
     )
 
 
-async def _verificar_todas_disciplinas_finalizadas(
+def build_premiacion_precondition(
+    competencia_event_store: SQLiteEventStore | None = None,
+    torneo_db_path: str | None = None,
+) -> Callable[[UUID], Awaitable[None]]:
+    """Construye la precondicion para pasar un torneo a premiacion."""
+    event_store = competencia_event_store or SQLiteEventStore(
+        os.getenv("COMPETENCIA_DB_PATH", "data/competencia.db")
+    )
+    torneos_path = torneo_db_path or os.getenv("TORNEO_DB_PATH", "data/torneo.db")
+
+    async def _precondition(torneo_id: UUID) -> None:
+        pendientes = await _obtener_disciplinas_pendientes_premiacion(
+            torneo_id,
+            event_store,
+            torneos_path,
+        )
+        if pendientes:
+            detalle = ", ".join(pendientes)
+            cantidad = len(pendientes)
+            etiqueta = "disciplina" if cantidad == 1 else "disciplinas"
+            raise PremiacionNoPermitida(
+                f"No se puede pasar a premiacion: falta cerrar {cantidad} {etiqueta}: "
+                f"{detalle}"
+            )
+
+    return _precondition
+
+
+async def _obtener_disciplinas_pendientes_premiacion(
     torneo_id: UUID,
     competencia_event_store: SQLiteEventStore,
-) -> bool:
-    """Helper de P-09: verifica si todas las competencias del torneo finalizaron."""
-    handler = ObtenerCompetenciasPorTorneoHandler(SQLiteCompetenciasPorTorneo())
-    competencias = await handler.handle(ObtenerCompetenciasPorTorneoQuery(torneo_id=torneo_id))
-    if not competencias:
-        return False
+    torneo_db_path: str,
+) -> list[str]:
+    """Retorna disciplinas configuradas que aun no tienen competencia finalizada."""
+    disciplinas = await _obtener_disciplinas_torneo(torneo_id, torneo_db_path)
+    if not disciplinas:
+        return []
 
-    for competencia in competencias:
-        events = await competencia_event_store.load(f"competencia-{competencia.competencia_id}")
+    competencias = await ObtenerCompetenciasPorTorneoHandler(SQLiteCompetenciasPorTorneo()).handle(
+        ObtenerCompetenciasPorTorneoQuery(torneo_id=torneo_id)
+    )
+    competencias_por_disciplina = {
+        competencia.disciplina: competencia.competencia_id for competencia in competencias
+    }
+
+    pendientes: list[str] = []
+    for disciplina in disciplinas:
+        competencia_id = competencias_por_disciplina.get(disciplina.value)
+        if competencia_id is None:
+            pendientes.append(disciplina.value)
+            continue
+
+        events = await competencia_event_store.load(f"competencia-{competencia_id}")
         if not any(event["event_type"] == "CompetenciaFinalizada" for event in events):
-            return False
-    return True
+            pendientes.append(disciplina.value)
+
+    return pendientes
 
 
 async def _obtener_disciplinas_torneo(
@@ -397,6 +447,9 @@ async def _obtener_disciplinas_torneo(
     if torneo is None:
         return []
     return [Disciplina(disciplina.disciplina) for disciplina in torneo.disciplinas_torneo]
+
+
+configure_premiacion_precondition(build_premiacion_precondition())
 
 
 @app.get("/health", response_class=JSONResponse)

--- a/src/torneo/api/exception_handlers.py
+++ b/src/torneo/api/exception_handlers.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 
 from torneo.domain.exceptions import (
     DisciplinaObsoleta,
+    PremiacionNoPermitida,
     TorneoCerrado,
     TorneoNoEncontrado,
     TransicionEstadoInvalida,
@@ -35,6 +36,20 @@ def register_torneo_exception_handlers(app: FastAPI) -> None:
             content={
                 "type": "https://ataraxiadive.com/errors/transicion-invalida",
                 "title": "Transición de estado inválida",
+                "status": 409,
+                "detail": str(exc),
+            },
+        )
+
+    @app.exception_handler(PremiacionNoPermitida)
+    async def premiacion_no_permitida_handler(
+        request: Request, exc: PremiacionNoPermitida
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "type": "https://ataraxiadive.com/errors/premiacion-no-permitida",
+                "title": "Premiación no permitida",
                 "status": 409,
                 "detail": str(exc),
             },

--- a/src/torneo/api/router.py
+++ b/src/torneo/api/router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Awaitable, Callable
 from datetime import date
 from uuid import UUID
 
@@ -39,6 +40,14 @@ from torneo.domain.exceptions import AsignacionNoPermitida, DisciplinaNoEnTorneo
 from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
 
 router = APIRouter(prefix="/torneos", tags=["torneos"])
+PremiacionPrecondition = Callable[[UUID], Awaitable[None]]
+_premiacion_precondition: PremiacionPrecondition | None = None
+
+
+def configure_premiacion_precondition(precondition: PremiacionPrecondition | None) -> None:
+    """Configura validacion externa antes de pasar un torneo a premiacion."""
+    global _premiacion_precondition  # noqa: PLW0603
+    _premiacion_precondition = precondition
 
 
 # ── Schemas ───────────────────────────────────────────────────────────────────
@@ -178,6 +187,8 @@ async def volver_preparacion(torneo_id: UUID, _: OrganizadorDep) -> JSONResponse
 
 @router.put("/{torneo_id}/iniciar-premiacion", status_code=200)
 async def iniciar_premiacion(torneo_id: UUID, _: OrganizadorDep) -> JSONResponse:
+    if _premiacion_precondition is not None:
+        await _premiacion_precondition(torneo_id)
     await IniciarPremiacionHandler(_repo()).handle(TransicionarTorneoCommand(torneo_id))
     return JSONResponse(status_code=200, content={"ok": True})
 

--- a/src/torneo/domain/exceptions.py
+++ b/src/torneo/domain/exceptions.py
@@ -6,6 +6,10 @@ class TransicionEstadoInvalida(Exception):
     pass
 
 
+class PremiacionNoPermitida(Exception):
+    pass
+
+
 class TorneoCerrado(Exception):
     pass
 

--- a/tests/features/US-ADJ-8.2-restringir-operaciones-torneo-fase.feature
+++ b/tests/features/US-ADJ-8.2-restringir-operaciones-torneo-fase.feature
@@ -1,0 +1,39 @@
+Feature: US-ADJ-8.2 - Restricciones operativas por torneo y fase
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+
+  Scenario: Selector de grilla usa solo disciplinas del torneo actual
+    Given el torneo "BA 2026" con id T1 tiene disciplinas STA y DNF configuradas
+    And el sistema conoce tambien las disciplinas CWT y FIM
+    When el organizador abre el selector de disciplinas para generar grilla de T1
+    Then el selector muestra STA y DNF
+    And el selector no muestra CWT
+    And el selector no muestra FIM
+
+  Scenario: No se puede pasar a premiacion con una competencia en ejecucion
+    Given el torneo "BA 2026" con id T1 esta en estado EJECUCION
+    And la disciplina DNF tiene competencia C1 en estado Finalizada
+    And la disciplina STA tiene competencia C2 en estado EnEjecucion
+    When el organizador ve las acciones de fase de T1
+    Then la accion "Pasar a premiacion" esta bloqueada
+    And el panel indica que falta cerrar STA
+    And no se solicita la transicion a PREMIACION
+
+  Scenario: No se puede pasar a premiacion si falta crear una competencia esperada
+    Given el torneo "BA 2026" con id T1 esta en estado EJECUCION
+    And el torneo T1 tiene disciplinas DNF y STA configuradas
+    And solo DNF tiene competencia en estado Finalizada
+    When el organizador ve las acciones de fase de T1
+    Then la accion "Pasar a premiacion" esta bloqueada
+    And el panel indica que falta cerrar STA
+    And no se solicita la transicion a PREMIACION
+
+  Scenario: Se puede pasar a premiacion con todas las competencias finalizadas
+    Given el torneo "BA 2026" con id T1 esta en estado EJECUCION
+    And la disciplina DNF tiene competencia C1 en estado Finalizada
+    And la disciplina STA tiene competencia C2 en estado Finalizada
+    When el organizador ve las acciones de fase de T1
+    Then la accion "Pasar a premiacion" esta habilitada
+    When el organizador ejecuta "Pasar a premiacion"
+    Then el frontend solicita la transicion a PREMIACION

--- a/tests/integration/torneo/test_premiacion_precondicion.py
+++ b/tests/integration/torneo/test_premiacion_precondicion.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import build_premiacion_precondition
+from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
+    SQLiteCompetenciasPorTorneo,
+)
+from identidad.api.dependencies import get_current_user
+from shared.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.api.router import configure_premiacion_precondition, router
+
+
+@pytest.fixture
+def client(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    torneo_db = str(tmp_path / "torneo.db")
+    competencia_db = str(tmp_path / "competencia.db")
+    monkeypatch.setenv("TORNEO_DB_PATH", torneo_db)
+    monkeypatch.setenv("COMPETENCIA_DB_PATH", competencia_db)
+
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "test-user",
+        "email": "test@test.com",
+        "rol": "ORGANIZADOR",
+    }
+    configure_premiacion_precondition(
+        build_premiacion_precondition(SQLiteEventStore(competencia_db), torneo_db)
+    )
+    yield TestClient(app)
+    configure_premiacion_precondition(None)
+    app.dependency_overrides.clear()
+
+
+def _crear_torneo_en_ejecucion(client: TestClient) -> UUID:
+    response = client.post(
+        "/torneos",
+        json={
+            "nombre": "BA 2026",
+            "descripcion": "Torneo",
+            "fecha_inicio": "2026-06-01",
+            "fecha_fin": "2026-06-03",
+            "sede": {"nombre": "Piscina", "ciudad": "BA", "pais": "AR"},
+            "entidad_organizadora": {"nombre": "AIDA", "tipo": "FEDERACION"},
+        },
+    )
+    assert response.status_code == 201
+    torneo_id = UUID(response.json()["torneo_id"])
+
+    disciplinas_response = client.put(
+        f"/torneos/{torneo_id}/disciplinas",
+        json={"disciplinas": ["DNF", "STA"]},
+    )
+    assert disciplinas_response.status_code == 200
+    assert client.put(f"/torneos/{torneo_id}/abrir-inscripcion").status_code == 200
+    assert client.put(f"/torneos/{torneo_id}/cerrar-inscripcion").status_code == 200
+    assert client.put(f"/torneos/{torneo_id}/iniciar-ejecucion").status_code == 200
+    return torneo_id
+
+
+async def _registrar_competencia_finalizada(
+    competencia_db: str,
+    torneo_id: UUID,
+    disciplina: str,
+) -> None:
+    competencia_id = uuid4()
+    await SQLiteCompetenciasPorTorneo(competencia_db).guardar(
+        competencia_id=competencia_id,
+        disciplina=disciplina,
+        torneo_id=torneo_id,
+    )
+    await SQLiteEventStore(competencia_db).append(
+        f"competencia-{competencia_id}",
+        "CompetenciaFinalizada",
+        {"competencia_id": str(competencia_id), "disciplina": disciplina},
+    )
+
+
+@pytest.mark.asyncio
+async def test_iniciar_premiacion_retorna_409_si_faltan_competencias(
+    client: TestClient,
+) -> None:
+    torneo_id = _crear_torneo_en_ejecucion(client)
+
+    response = client.put(f"/torneos/{torneo_id}/iniciar-premiacion")
+
+    assert response.status_code == 409
+    assert "DNF" in response.json()["detail"]
+    assert "STA" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_iniciar_premiacion_permite_todas_las_competencias_finalizadas(
+    client: TestClient,
+) -> None:
+    competencia_db = os.environ["COMPETENCIA_DB_PATH"]
+    torneo_id = _crear_torneo_en_ejecucion(client)
+    await _registrar_competencia_finalizada(competencia_db, torneo_id, "DNF")
+    await _registrar_competencia_finalizada(competencia_db, torneo_id, "STA")
+
+    response = client.put(f"/torneos/{torneo_id}/iniciar-premiacion")
+
+    assert response.status_code == 200

--- a/tests/unit/torneo/application/test_premiacion_precondition.py
+++ b/tests/unit/torneo/application/test_premiacion_precondition.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from app import build_premiacion_precondition
+from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
+    SQLiteCompetenciasPorTorneo,
+)
+from shared.domain.value_objects.disciplina import Disciplina
+from shared.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
+from torneo.domain.aggregates.torneo import Torneo
+from torneo.domain.exceptions import PremiacionNoPermitida
+from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
+from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+from torneo.domain.value_objects.sede import Sede
+from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
+
+
+def _torneo() -> Torneo:
+    torneo = Torneo(
+        nombre="BA 2026",
+        descripcion="Torneo",
+        fecha_inicio=date(2026, 6, 1),
+        fecha_fin=date(2026, 6, 3),
+        sede=Sede("Piscina", "BA", "AR"),
+        entidad_organizadora=EntidadOrganizadora("AIDA", "FEDERACION"),
+    )
+    torneo.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF}))
+    torneo.estado = EstadoTorneo.EJECUCION
+    return torneo
+
+
+@pytest.mark.asyncio
+async def test_precondicion_rechaza_si_falta_competencia_configurada(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torneo_db = str(tmp_path / "torneo.db")
+    competencia_db = str(tmp_path / "competencia.db")
+    monkeypatch.setenv("COMPETENCIA_DB_PATH", competencia_db)
+    torneo = _torneo()
+    await SQLiteTorneoRepository(torneo_db).save(torneo)
+
+    competencia_id = uuid4()
+    await SQLiteCompetenciasPorTorneo(competencia_db).guardar(
+        competencia_id=competencia_id,
+        disciplina="DNF",
+        torneo_id=torneo.torneo_id,
+    )
+    event_store = SQLiteEventStore(competencia_db)
+    await event_store.append(
+        f"competencia-{competencia_id}",
+        "CompetenciaFinalizada",
+        {"competencia_id": str(competencia_id), "disciplina": "DNF"},
+    )
+
+    precondition = build_premiacion_precondition(event_store, torneo_db)
+
+    with pytest.raises(PremiacionNoPermitida) as exc_info:
+        await precondition(torneo.torneo_id)
+
+    assert "STA" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_precondicion_permite_si_todas_las_competencias_finalizaron(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torneo_db = str(tmp_path / "torneo.db")
+    competencia_db = str(tmp_path / "competencia.db")
+    monkeypatch.setenv("COMPETENCIA_DB_PATH", competencia_db)
+    torneo = _torneo()
+    await SQLiteTorneoRepository(torneo_db).save(torneo)
+    event_store = SQLiteEventStore(competencia_db)
+    projection = SQLiteCompetenciasPorTorneo(competencia_db)
+
+    for disciplina in ("DNF", "STA"):
+        competencia_id = uuid4()
+        await projection.guardar(
+            competencia_id=competencia_id,
+            disciplina=disciplina,
+            torneo_id=torneo.torneo_id,
+        )
+        await event_store.append(
+            f"competencia-{competencia_id}",
+            "CompetenciaFinalizada",
+            {"competencia_id": str(competencia_id), "disciplina": disciplina},
+        )
+
+    precondition = build_premiacion_precondition(event_store, torneo_db)
+
+    await precondition(torneo.torneo_id)


### PR DESCRIPTION
## Resumen
- Filtra el selector de grilla por disciplinas configuradas del torneo actual.
- Bloquea `Pasar a premiacion` si quedan disciplinas sin competencia finalizada.
- Agrega precondicion backend para rechazar `EJECUCION -> PREMIACION` con pendientes, cableada desde `src/app.py`.

## Validaciones
- ./.venv/bin/pytest tests/unit/torneo/application/test_premiacion_precondition.py tests/unit/torneo/application/test_transiciones_handlers.py tests/integration/torneo/test_premiacion_precondicion.py -> 13 passed
- npm run lint -> OK
- npm run build -> OK

## Notas
- BDD UI automatizado omitido por falta de harness browser; queda feature en tests/features.
- Regla cross-BC implementada en composition root para no acoplar torneo/domain con competencia.