### PR TITLE
fix: clarificar estados del panel organizador

### DIFF
--- a/.claude/tracking/US-ADJ-8.1-tracking.json
+++ b/.claude/tracking/US-ADJ-8.1-tracking.json
@@ -1,0 +1,152 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-8.1",
+    "us_title": "Clarificar estados y lenguaje operativo",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-22T18:35:36.530291+00:00",
+    "completed_at": "2026-04-22T18:41:42.568371+00:00",
+    "total_elapsed_seconds": 366,
+    "effective_seconds": 366,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-22T18:35:41.456525+00:00",
+      "completed_at": "2026-04-22T18:35:58.776284+00:00",
+      "elapsed_seconds": 17,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-22T18:36:05.283206+00:00",
+      "completed_at": "2026-04-22T18:36:22.138843+00:00",
+      "elapsed_seconds": 16,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-22T18:36:34.100308+00:00",
+      "completed_at": "2026-04-22T18:37:11.043299+00:00",
+      "elapsed_seconds": 36,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada por Tareas",
+      "started_at": "2026-04-22T18:37:22.294528+00:00",
+      "completed_at": "2026-04-22T18:38:05.616463+00:00",
+      "elapsed_seconds": 43,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Clarificar mensajes frontend",
+          "task_type": "frontend",
+          "estimated_minutes": 35.0,
+          "started_at": "2026-04-22T18:37:27.263722+00:00",
+          "completed_at": "2026-04-22T18:38:01.727194+00:00",
+          "elapsed_seconds": 34,
+          "actual_minutes": 0.57,
+          "variance_minutes": -34.43,
+          "file_created": "frontend/src/components/organizador/EjecucionPanel.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-22T18:38:10.618410+00:00",
+      "completed_at": "2026-04-22T18:38:28.208365+00:00",
+      "elapsed_seconds": 17,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-22T18:38:32.392937+00:00",
+      "completed_at": "2026-04-22T18:38:36.100964+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-22T18:38:41.327915+00:00",
+      "completed_at": "2026-04-22T18:38:46.965932+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-22T18:38:56.822384+00:00",
+      "completed_at": "2026-04-22T18:40:38.240669+00:00",
+      "elapsed_seconds": 101,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-22T18:40:47.897486+00:00",
+      "completed_at": "2026-04-22T18:41:15.652971+00:00",
+      "elapsed_seconds": 27,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-22T18:41:19.908446+00:00",
+      "completed_at": "2026-04-22T18:41:37.978183+00:00",
+      "elapsed_seconds": 18,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 1,
+    "completed_tasks": 1,
+    "total_phases": 10,
+    "estimated_total_minutes": 35.0,
+    "actual_total_minutes": 0.57,
+    "variance_minutes": -34.43,
+    "variance_percent": -98.38
+  }
+}

--- a/docs/plans/sp-adj-08/PLAN-SP-ADJ-08.md
+++ b/docs/plans/sp-adj-08/PLAN-SP-ADJ-08.md
@@ -109,7 +109,7 @@ UAT de regresion INC-5.2
 ## Criterio de cierre de SP-ADJ-08
 
 - [x] US-ADJ-8.2 — selector de grilla filtrado por torneo y premiacion bloqueada hasta competencias finalizadas.
-- [ ] US-ADJ-8.1 — estados vacios/loading/error claros, mensajes accionables y lenguaje de fase preciso.
+- [x] US-ADJ-8.1 — estados vacios/loading/error claros, mensajes accionables y lenguaje de fase preciso.
 - [ ] US-ADJ-8.3 — cancelacion en zona de peligro con confirmacion por nombre exacto.
 - [ ] UAT de regresion INC-5.2 sin hallazgos Alta abiertos.
 - [ ] Frontend build/lint OK.

--- a/docs/plans/sp-adj-08/US-ADJ-8.1-implementation-notes.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.1-implementation-notes.md
@@ -1,0 +1,29 @@
+# US-ADJ-8.1 — Notas de implementacion
+
+**Fecha:** 2026-04-22
+**Fase:** 8 — Documentacion
+
+## Cambios realizados
+
+- `TablaInscriptos`
+  - cambia el estado vacio a `Todavia no hay inscriptos para este torneo`.
+
+- `JuecesPanel` / `TablaJueces`
+  - diferencia error real con `No se pudieron cargar los jueces`;
+  - muestra `Todavia no hay jueces asignados` cuando ninguna disciplina tiene juez;
+  - expresa bloqueo por grilla con accion y tab destino.
+
+- `EjecucionPanel`
+  - refuerza seleccion visual de item maestro y detalle;
+  - reemplaza labels tecnicos por estados operativos;
+  - convierte bloqueos a mensajes accionables con tab destino.
+
+## Validaciones
+
+- `npm run lint` — OK.
+- `npm run build` — OK.
+
+## Fases acotadas
+
+- Sin tests unitarios/integracion por falta de harness React.
+- BDD UI no ejecutado; feature creado como especificacion.

--- a/docs/plans/sp-adj-08/US-ADJ-8.1-plan.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.1-plan.md
@@ -1,0 +1,68 @@
+# Plan de Implementacion: US-ADJ-8.1 — Clarificar estados y lenguaje operativo
+
+| Campo | Valor |
+|-------|-------|
+| **Sprint** | SP-ADJ-08 |
+| **Tipo** | Fix UX funcional frontend |
+| **Branch** | `feature/US-ADJ-8.1-estados-lenguaje` |
+| **BC** | frontend organizador |
+| **Estimacion** | 1-2 h |
+| **Estado** | Implementada |
+
+---
+
+## Alcance
+
+Corregir mensajes y jerarquia visual del panel organizador sin cambiar reglas de dominio.
+
+Hallazgos cubiertos: `UAT-5.2-01`, `UAT-5.2-03`, `UAT-5.2-04`, `UAT-5.2-06`,
+`UAT-5.2-07`.
+
+---
+
+## Decisiones de implementacion
+
+- Mantener la US exclusivamente en frontend.
+- No crear harness browser nuevo; BDD queda como especificacion.
+- Reutilizar estilos actuales, evitando redisenar el panel completo.
+- `Pasar a premiacion` ya quedo implementado en `US-ADJ-8.2`; esta US solo valida y documenta.
+
+---
+
+## Tareas
+
+### 1. Estados vacios/error/loading
+
+- [x] Ajustar estado vacio de inscriptos a `Todavia no hay inscriptos para este torneo`.
+- [x] Ajustar error de jueces a `No se pudieron cargar los jueces`.
+- [x] Mostrar estado vacio de jueces asignados como `Todavia no hay jueces asignados`.
+
+### 2. Ejecucion por disciplina
+
+- [x] Reforzar seleccion visual de item maestro y detalle.
+- [x] Convertir bloqueos tecnicos en mensajes accionables con tab destino.
+- [x] Mantener acciones existentes de habilitar/finalizar sin cambios de comportamiento.
+
+### 3. Validacion
+
+- [x] `npm run lint`.
+- [x] `npm run build`.
+- [x] Registrar BDD UI como omitido por falta de harness.
+
+### 4. Documentacion
+
+- [x] Actualizar spec a `Implementada`.
+- [x] Actualizar `PLAN-SP-ADJ-08`.
+- [x] Generar reporte final.
+
+---
+
+## Fases omitidas o acotadas
+
+- Fases 4 y 5 sin tests unitarios/integracion nuevos: no hay harness de componentes React.
+- Fase 6 sin steps automatizados: feature BDD creado como especificacion.
+- Fase 7 usa `npm run lint` y `npm run build`.
+
+---
+
+*Creado: 2026-04-22 — Fase 2 para UAT-5.2 UX*

--- a/docs/plans/sp-adj-08/US-ADJ-8.1-test-skip.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.1-test-skip.md
@@ -1,0 +1,22 @@
+# US-ADJ-8.1 — Tests automatizados acotados
+
+**Fases:** 4, 5 y 6
+**Estado:** Omitidas como ejecucion automatizada de UI
+**Fecha:** 2026-04-22
+
+## Motivo
+
+La US modifica mensajes, estados visuales y jerarquia de componentes React del panel
+organizador. El repositorio no tiene harness automatizado de componentes/browser para
+assertions de DOM.
+
+## Evidencia sustituida
+
+- Feature BDD creado en `tests/features/US-ADJ-8.1-claridad-operativa-panel-organizador.feature`.
+- Validacion estatica con `npm run lint`.
+- Build TypeScript/Vite con `npm run build`.
+
+## Pendiente si se agrega harness UI
+
+Crear tests de componentes para `InscriptosPanel`, `JuecesPanel`, `TablaJueces` y
+`EjecucionPanel`.

--- a/docs/reports/US-ADJ-8.1-report.md
+++ b/docs/reports/US-ADJ-8.1-report.md
@@ -1,0 +1,33 @@
+# US-ADJ-8.1 — Reporte de Implementacion
+
+**Fecha:** 2026-04-22
+**Sprint:** SP-ADJ-08
+**Estado:** Implementada
+
+## Resumen
+
+Se clarificaron estados, mensajes y jerarquia visual del panel organizador sin cambios
+de reglas backend.
+
+## Cambios principales
+
+- Estado vacio de inscriptos: `Todavia no hay inscriptos para este torneo`.
+- Panel de jueces diferencia carga, error y ausencia de asignaciones.
+- Bloqueos de jueces y ejecucion indican accion concreta y tab destino.
+- La seleccion de disciplina en ejecucion queda asociada visualmente con el detalle.
+
+## Validaciones
+
+- `npm run lint` — OK.
+- `npm run build` — OK.
+
+## Fases acotadas
+
+- Tests unitarios/integracion omitidos por falta de harness React.
+- BDD UI omitido como ejecucion automatizada; feature creado en
+  `tests/features/US-ADJ-8.1-claridad-operativa-panel-organizador.feature`.
+
+## Notas
+
+- El texto `Pasar a premiacion` ya habia quedado aplicado en `US-ADJ-8.2`.
+- Las acciones de habilitar/finalizar disciplina no cambiaron su comportamiento.

--- a/docs/specs/sp-adj-08/US-ADJ-8.1.md
+++ b/docs/specs/sp-adj-08/US-ADJ-8.1.md
@@ -1,6 +1,6 @@
 # US-ADJ-8.1: Clarificar estados y lenguaje operativo del panel organizador — UAT-5.2 UX
 
-**Estado**: `Pendiente`
+**Estado**: `Implementada`
 **Iteracion / Sprint**: SP-ADJ-08
 **Tipo**: fix UX funcional frontend
 **Agregado principal afectado**: `DetalleTorneoPage` / paneles de organizador
@@ -146,6 +146,8 @@ Feature: Claridad operativa del panel organizador
 1. No esconder datos utiles; el cambio es de jerarquia y lenguaje, no de perdida de informacion.
 2. Evitar duplicar strings dispersos si ya existe un componente/helper de estado vacio.
 3. Verificar en viewport mobile y desktop que el destaque de disciplina seleccionada no degrade legibilidad.
+4. Implementado: los cambios se limitaron a componentes frontend del panel organizador;
+   no se modificaron reglas backend.
 
 ---
 

--- a/frontend/src/components/organizador/EjecucionPanel.tsx
+++ b/frontend/src/components/organizador/EjecucionPanel.tsx
@@ -83,9 +83,9 @@ function estadoOperativoDe(
 
 function estadoLabel(estado: EstadoOperativo): string {
   const labels: Record<EstadoOperativo, string> = {
-    sin_competencia: 'Configurar competencia',
-    sin_grilla: 'Confirmar grilla antes de habilitar',
-    sin_juez: 'Asignar juez antes de habilitar',
+    sin_competencia: 'Falta grilla',
+    sin_grilla: 'Grilla pendiente',
+    sin_juez: 'Juez pendiente',
     lista_para_iniciar: 'Lista para iniciar',
     en_ejecucion: 'En ejecucion',
     finalizada: 'Finalizada',
@@ -338,7 +338,9 @@ function DisciplinaMaestro({
             onClick={() => onSelect(item.disciplina.disciplina)}
             className={[
               'w-full rounded-lg border bg-white p-4 text-left transition',
-              selected ? 'border-stone-900 shadow-[0_20px_60px_rgba(120,93,54,0.10)]' : 'border-stone-200 hover:border-stone-400',
+              selected
+                ? 'border-sky-700 bg-sky-50 shadow-[0_20px_60px_rgba(120,93,54,0.10)]'
+                : 'border-stone-200 hover:border-stone-400',
             ].join(' ')}
           >
             <div className="flex items-start justify-between gap-3">
@@ -413,7 +415,7 @@ function DisciplinaDetalle({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-stone-300 bg-white p-5">
+      <div className="rounded-lg border border-sky-700 bg-sky-50/40 p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase text-stone-500">Detalle</p>
@@ -481,9 +483,16 @@ function DisciplinaDetalle({
 
 function detalleBloqueo(item: DisciplinaEjecucionItem): string {
   const progreso = item.progreso
-  if (item.estadoOperativo === 'sin_competencia') return 'Configurar competencia antes de habilitar.'
-  if (item.estadoOperativo === 'sin_grilla') return 'Confirmar grilla antes de habilitar.'
-  if (item.estadoOperativo === 'sin_juez') return 'Asignar juez antes de habilitar.'
+  const disciplina = item.disciplina.disciplina
+  if (item.estadoOperativo === 'sin_competencia') {
+    return `Falta generar la grilla de ${disciplina} en el tab Grilla.`
+  }
+  if (item.estadoOperativo === 'sin_grilla') {
+    return `Falta confirmar la grilla de ${disciplina} en el tab Grilla.`
+  }
+  if (item.estadoOperativo === 'sin_juez') {
+    return `Falta asignar juez a ${disciplina} en el tab Jueces.`
+  }
   if (item.estadoOperativo === 'lista_para_iniciar') return 'La disciplina esta lista para iniciar.'
   if (item.estadoOperativo === 'en_ejecucion' && progreso) {
     const pendientes = Math.max(progreso.total - progreso.completadas, 0)

--- a/frontend/src/components/organizador/JuecesPanel.tsx
+++ b/frontend/src/components/organizador/JuecesPanel.tsx
@@ -80,6 +80,8 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
   }, [competenciasQuery.data])
   const todasAsignadas =
     disciplinas.length > 0 && disciplinas.every((disciplina) => Boolean(disciplina.juez_id))
+  const sinJuecesAsignados =
+    disciplinas.length > 0 && disciplinas.every((disciplina) => !disciplina.juez_id)
 
   const asignarMutation = useMutation({
     mutationFn: async (payload: { disciplina: DisciplinaTorneoDto; juezId: string }) => {
@@ -111,7 +113,7 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
   if (disciplinasQuery.isError || juecesQuery.isError || competenciasQuery.isError) {
     return (
       <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
-        No se pudieron cargar disciplinas, jueces o grillas.
+        No se pudieron cargar los jueces.
       </div>
     )
   }
@@ -137,6 +139,12 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
       {error ? (
         <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
           {error}
+        </div>
+      ) : null}
+
+      {sinJuecesAsignados ? (
+        <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+          Todavia no hay jueces asignados
         </div>
       ) : null}
 

--- a/frontend/src/components/organizador/TablaInscriptos.tsx
+++ b/frontend/src/components/organizador/TablaInscriptos.tsx
@@ -34,7 +34,7 @@ export function TablaInscriptos({ rows, disciplinas }: TablaInscriptosProps) {
   if (rows.length === 0) {
     return (
       <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
-        No hay atletas inscriptos en este torneo
+        Todavia no hay inscriptos para este torneo
       </div>
     )
   }

--- a/frontend/src/components/organizador/TablaJueces.tsx
+++ b/frontend/src/components/organizador/TablaJueces.tsx
@@ -65,7 +65,7 @@ export function TablaJueces({
                   {saving
                     ? 'Guardando...'
                     : !puedeAsignar
-                      ? 'Generar grilla antes de asignar juez'
+                      ? `Falta generar la grilla de ${disciplina.disciplina} en el tab Grilla`
                       : disciplina.juez_id
                         ? 'Asignado'
                         : 'Pendiente'}

--- a/quality/reports/codeguard/US-ADJ-8.1-quality.json
+++ b/quality/reports/codeguard/US-ADJ-8.1-quality.json
@@ -1,0 +1,21 @@
+{
+  "us_id": "US-ADJ-8.1",
+  "date": "2026-04-22",
+  "scope": "frontend organizador",
+  "checks": [
+    {
+      "command": "npm run lint",
+      "cwd": "frontend",
+      "result": "OK"
+    },
+    {
+      "command": "npm run build",
+      "cwd": "frontend",
+      "result": "OK"
+    }
+  ],
+  "notes": [
+    "No se ejecutaron tests unitarios/integracion por falta de harness de componentes React.",
+    "BDD creado como especificacion futura."
+  ]
+}

--- a/tests/features/US-ADJ-8.1-claridad-operativa-panel-organizador.feature
+++ b/tests/features/US-ADJ-8.1-claridad-operativa-panel-organizador.feature
@@ -1,0 +1,41 @@
+Feature: US-ADJ-8.1 - Claridad operativa del panel organizador
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+
+  Scenario: Inscriptos vacios no se muestran como error
+    Given la API de inscriptos responde correctamente con lista vacia
+    When el organizador abre el panel de inscriptos
+    Then ve "Todavia no hay inscriptos para este torneo"
+    And no ve "No se pudieron cargar los inscriptos del torneo"
+
+  Scenario: Error real de inscriptos se muestra como error
+    Given la API de inscriptos falla
+    When el organizador abre el panel de inscriptos
+    Then ve "No se pudieron cargar los inscriptos del torneo"
+
+  Scenario: Jueces diferencia loading, vacio y error
+    Given el panel de jueces esta cargando informacion
+    Then muestra "Cargando jueces..."
+    When la consulta termina exitosamente sin jueces asignados
+    Then muestra "Todavia no hay jueces asignados"
+    When la consulta falla
+    Then muestra "No se pudieron cargar los jueces"
+
+  Scenario: Disciplina seleccionada queda asociada al detalle
+    Given el torneo tiene disciplinas DNF y STA
+    When el organizador selecciona DNF en el tab Ejecucion
+    Then el item DNF queda destacado visualmente
+    And el panel detalle queda asociado visualmente con DNF
+
+  Scenario: Bloqueo operativo indica accion concreta
+    Given DNF no tiene grilla confirmada
+    When el organizador abre el detalle de ejecucion de DNF
+    Then ve "Falta confirmar la grilla de DNF en el tab Grilla"
+    And no ve solo un estado tecnico interno como mensaje principal
+
+  Scenario: Lenguaje de fase es preciso
+    Given el torneo esta en EJECUCION
+    Then la accion visible se llama "Pasar a premiacion"
+    Given el torneo esta en PREMIACION
+    Then la accion visible se llama "Cerrar torneo"


### PR DESCRIPTION
## Resumen
- Ajusta estados vacios/error/loading del panel organizador.
- Convierte bloqueos tecnicos de jueces/ejecucion en mensajes accionables.
- Refuerza la asociacion visual entre disciplina seleccionada y detalle.

## Validaciones
- npm run lint -> OK
- npm run build -> OK

## Notas
- Tests UI/BDD automatizados omitidos por falta de harness React/browser; queda feature BDD como especificacion.