### PR TITLE
fix: fortalecer cancelación de torneo

### DIFF
--- a/.claude/tracking/US-ADJ-8.3-tracking.json
+++ b/.claude/tracking/US-ADJ-8.3-tracking.json
@@ -1,0 +1,152 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-8.3",
+    "us_title": "Fortalecer cancelacion de torneo",
+    "us_points": 1,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-22T18:53:38.634599+00:00",
+    "completed_at": "2026-04-22T18:58:26.432360+00:00",
+    "total_elapsed_seconds": 287,
+    "effective_seconds": 287,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-22T18:53:46.541006+00:00",
+      "completed_at": "2026-04-22T18:53:58.739932+00:00",
+      "elapsed_seconds": 12,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-22T18:54:03.620616+00:00",
+      "completed_at": "2026-04-22T18:54:19.109457+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-22T18:54:19.335355+00:00",
+      "completed_at": "2026-04-22T18:54:33.790910+00:00",
+      "elapsed_seconds": 14,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada por Tareas",
+      "started_at": "2026-04-22T18:54:41.464947+00:00",
+      "completed_at": "2026-04-22T18:55:20.272116+00:00",
+      "elapsed_seconds": 38,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Confirmacion fuerte de cancelacion",
+          "task_type": "frontend",
+          "estimated_minutes": 30.0,
+          "started_at": "2026-04-22T18:54:46.047257+00:00",
+          "completed_at": "2026-04-22T18:55:15.431434+00:00",
+          "elapsed_seconds": 29,
+          "actual_minutes": 0.48,
+          "variance_minutes": -29.52,
+          "file_created": "frontend/src/components/organizador/AccionesPanel.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-22T18:55:25.289507+00:00",
+      "completed_at": "2026-04-22T18:55:40.654018+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-22T18:55:49.362540+00:00",
+      "completed_at": "2026-04-22T18:55:53.945919+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-22T18:55:58.634403+00:00",
+      "completed_at": "2026-04-22T18:56:03.067965+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-22T18:56:09.941433+00:00",
+      "completed_at": "2026-04-22T18:57:38.555591+00:00",
+      "elapsed_seconds": 88,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-22T18:57:43.939792+00:00",
+      "completed_at": "2026-04-22T18:58:04.440484+00:00",
+      "elapsed_seconds": 20,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-22T18:58:11.370510+00:00",
+      "completed_at": "2026-04-22T18:58:22.825961+00:00",
+      "elapsed_seconds": 11,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 1,
+    "completed_tasks": 1,
+    "total_phases": 10,
+    "estimated_total_minutes": 30.0,
+    "actual_total_minutes": 0.48,
+    "variance_minutes": -29.52,
+    "variance_percent": -98.39
+  }
+}

--- a/docs/plans/sp-adj-08/PLAN-SP-ADJ-08.md
+++ b/docs/plans/sp-adj-08/PLAN-SP-ADJ-08.md
@@ -110,10 +110,10 @@ UAT de regresion INC-5.2
 
 - [x] US-ADJ-8.2 — selector de grilla filtrado por torneo y premiacion bloqueada hasta competencias finalizadas.
 - [x] US-ADJ-8.1 — estados vacios/loading/error claros, mensajes accionables y lenguaje de fase preciso.
-- [ ] US-ADJ-8.3 — cancelacion en zona de peligro con confirmacion por nombre exacto.
+- [x] US-ADJ-8.3 — cancelacion en zona de peligro con confirmacion por nombre exacto.
 - [ ] UAT de regresion INC-5.2 sin hallazgos Alta abiertos.
-- [ ] Frontend build/lint OK.
-- [ ] Tests backend/frontend focalizados OK segun alcance real de cada US.
+- [x] Frontend build/lint OK.
+- [x] Tests backend/frontend focalizados OK segun alcance real de cada US.
 
 ---
 

--- a/docs/plans/sp-adj-08/US-ADJ-8.3-implementation-notes.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.3-implementation-notes.md
@@ -1,0 +1,22 @@
+# US-ADJ-8.3 — Notas de implementacion
+
+**Fecha:** 2026-04-22
+**Fase:** 8 — Documentacion
+
+## Cambios realizados
+
+- `AccionesPanel`
+  - mueve `Cancelar torneo` a una zona de peligro separada;
+  - abre confirmacion fuerte con input;
+  - exige coincidencia exacta con el nombre del torneo;
+  - deshabilita la accion final si el texto no coincide;
+  - conserva la llamada existente a `cancelarTorneo`.
+
+## Validaciones
+
+- `npm run lint` — OK.
+- `npm run build` — OK.
+
+## Fases acotadas
+
+- Sin tests UI automatizados por falta de harness React/browser.

--- a/docs/plans/sp-adj-08/US-ADJ-8.3-plan.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.3-plan.md
@@ -1,0 +1,34 @@
+# Plan de Implementacion: US-ADJ-8.3 — Fortalecer cancelacion de torneo
+
+| Campo | Valor |
+|-------|-------|
+| **Sprint** | SP-ADJ-08 |
+| **Tipo** | Hardening UX frontend |
+| **Branch** | `feature/US-ADJ-8.3-cancelacion-fuerte` |
+| **BC** | frontend organizador |
+| **Estimacion** | 1 h |
+| **Estado** | Implementada |
+
+---
+
+## Alcance
+
+Separar `Cancelar torneo` de las acciones normales y exigir confirmacion fuerte
+escribiendo exactamente el nombre del torneo.
+
+## Tareas
+
+- [x] Separar zona de peligro en `AccionesPanel`.
+- [x] Agregar input de confirmacion exacta por nombre.
+- [x] Mantener boton final deshabilitado hasta coincidencia exacta.
+- [x] Validar con `npm run lint` y `npm run build`.
+- [x] Actualizar documentacion y reporte.
+
+## Fases acotadas
+
+- Sin tests automatizados UI por falta de harness React.
+- BDD creado como especificacion.
+
+---
+
+*Creado: 2026-04-22 — Fase 2 para UAT-5.2 accion destructiva*

--- a/docs/plans/sp-adj-08/US-ADJ-8.3-test-skip.md
+++ b/docs/plans/sp-adj-08/US-ADJ-8.3-test-skip.md
@@ -1,0 +1,16 @@
+# US-ADJ-8.3 — Tests automatizados acotados
+
+**Fases:** 4, 5 y 6
+**Estado:** Omitidas como ejecucion automatizada de UI
+**Fecha:** 2026-04-22
+
+## Motivo
+
+La US modifica una interaccion modal React y el repositorio no tiene harness de componentes
+o browser para validar clicks, inputs y estado disabled.
+
+## Evidencia sustituida
+
+- Feature BDD creado en `tests/features/US-ADJ-8.3-cancelacion-fuerte-torneo.feature`.
+- Validacion estatica con `npm run lint`.
+- Build TypeScript/Vite con `npm run build`.

--- a/docs/reports/US-ADJ-8.3-report.md
+++ b/docs/reports/US-ADJ-8.3-report.md
@@ -1,0 +1,27 @@
+# US-ADJ-8.3 — Reporte de Implementacion
+
+**Fecha:** 2026-04-22
+**Sprint:** SP-ADJ-08
+**Estado:** Implementada
+
+## Resumen
+
+Se fortalecio la cancelacion de torneo desde el panel organizador con una zona de peligro
+y confirmacion fuerte por nombre exacto.
+
+## Cambios principales
+
+- `Cancelar torneo` queda separado de acciones normales de fase.
+- El modal exige escribir el nombre exacto del torneo.
+- El boton destructivo final permanece deshabilitado hasta coincidencia exacta.
+- La API de cancelacion existente se mantiene sin cambios.
+
+## Validaciones
+
+- `npm run lint` — OK.
+- `npm run build` — OK.
+
+## Fases acotadas
+
+- Tests UI automatizados omitidos por falta de harness React/browser.
+- Feature BDD creado en `tests/features/US-ADJ-8.3-cancelacion-fuerte-torneo.feature`.

--- a/docs/specs/sp-adj-08/US-ADJ-8.3.md
+++ b/docs/specs/sp-adj-08/US-ADJ-8.3.md
@@ -1,6 +1,6 @@
 # US-ADJ-8.3: Fortalecer cancelacion de torneo — UAT-5.2 accion destructiva
 
-**Estado**: `Pendiente`
+**Estado**: `Implementada`
 **Iteracion / Sprint**: SP-ADJ-08
 **Tipo**: hardening UX de accion destructiva
 **Agregado principal afectado**: `Torneo`
@@ -127,6 +127,7 @@ Feature: Cancelacion fuerte de torneo
 1. La comparacion debe ser exacta contra el nombre mostrado del torneo; no usar coincidencia parcial.
 2. Mantener accesibilidad basica del modal: foco inicial, cierre por cancelar y labels claros.
 3. Evitar que Enter confirme si el texto todavia no coincide.
+4. Implementado en frontend manteniendo la API existente de cancelacion.
 
 ---
 

--- a/frontend/src/components/organizador/AccionesPanel.tsx
+++ b/frontend/src/components/organizador/AccionesPanel.tsx
@@ -67,8 +67,10 @@ export function AccionesPanel({
 }: AccionesPanelProps) {
   const [runningAction, setRunningAction] = useState<string | null>(null)
   const [showCancelDialog, setShowCancelDialog] = useState(false)
+  const [cancelConfirmation, setCancelConfirmation] = useState('')
   const acciones = ACCIONES_POR_ESTADO[estado] ?? []
   const puedeCancelar = !ESTADOS_TERMINALES.has(estado)
+  const canConfirmCancel = cancelConfirmation === torneoNombre
   const bloqueoPremiacion =
     estado === 'EJECUCION' &&
     (isPremiacionStatusLoading || (premiacionPendientes?.length ?? 0) > 0)
@@ -90,6 +92,7 @@ export function AccionesPanel({
   }
 
   async function confirmCancel() {
+    if (!canConfirmCancel) return
     setRunningAction('Cancelar torneo')
     onError('')
     try {
@@ -101,6 +104,17 @@ export function AccionesPanel({
     } finally {
       setRunningAction(null)
     }
+  }
+
+  function openCancelDialog() {
+    setCancelConfirmation('')
+    setShowCancelDialog(true)
+  }
+
+  function closeCancelDialog() {
+    if (runningAction !== null) return
+    setCancelConfirmation('')
+    setShowCancelDialog(false)
   }
 
   if (acciones.length === 0 && !puedeCancelar) {
@@ -131,16 +145,6 @@ export function AccionesPanel({
               {runningAction === action.label ? 'Procesando...' : action.label}
             </button>
           ))}
-          {puedeCancelar ? (
-            <button
-              type="button"
-              onClick={() => setShowCancelDialog(true)}
-              disabled={runningAction !== null}
-              className={buttonClass('danger')}
-            >
-              Cancelar torneo
-            </button>
-          ) : null}
         </div>
       </div>
 
@@ -158,37 +162,75 @@ export function AccionesPanel({
         </p>
       ) : null}
 
+      {puedeCancelar ? (
+        <div className="mt-5 border-t border-red-200 pt-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-red-950">Zona de peligro</p>
+              <p className="mt-1 text-sm text-red-800">
+                Cancelar el torneo detiene el flujo operativo.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={openCancelDialog}
+              disabled={runningAction !== null}
+              className={buttonClass('danger')}
+            >
+              Cancelar torneo
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       {showCancelDialog ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/40 px-4">
-          <div
+          <form
             role="dialog"
             aria-modal="true"
             aria-labelledby="cancelar-torneo-title"
+            onSubmit={(event) => {
+              event.preventDefault()
+              void confirmCancel()
+            }}
             className="w-full max-w-md rounded-lg bg-white p-5 shadow-2xl"
           >
             <h3 id="cancelar-torneo-title" className="text-lg font-semibold text-stone-950">
               Cancelar torneo {torneoNombre}
             </h3>
-            <p className="mt-2 text-sm text-stone-600">Esta accion no se puede deshacer.</p>
+            <p className="mt-2 text-sm text-stone-600">
+              Esta accion no se puede deshacer. Escribi el nombre exacto del torneo para
+              confirmar.
+            </p>
+            <label className="mt-5 block text-sm font-semibold text-stone-900">
+              Nombre del torneo
+              <input
+                value={cancelConfirmation}
+                onChange={(event) => setCancelConfirmation(event.target.value)}
+                disabled={runningAction !== null}
+                autoFocus
+                className="mt-2 min-h-10 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm"
+                placeholder={torneoNombre}
+              />
+            </label>
             <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                onClick={() => setShowCancelDialog(false)}
+                onClick={closeCancelDialog}
                 disabled={runningAction !== null}
                 className="rounded-lg border border-stone-300 px-4 py-2 text-sm font-semibold text-stone-800"
               >
                 Mantener torneo
               </button>
               <button
-                type="button"
-                onClick={() => void confirmCancel()}
-                disabled={runningAction !== null}
+                type="submit"
+                disabled={runningAction !== null || !canConfirmCancel}
                 className="rounded-lg bg-red-700 px-4 py-2 text-sm font-semibold text-white disabled:bg-red-400"
               >
                 {runningAction === 'Cancelar torneo' ? 'Cancelando...' : 'Confirmar cancelacion'}
               </button>
             </div>
-          </div>
+          </form>
         </div>
       ) : null}
     </section>

--- a/quality/reports/codeguard/US-ADJ-8.3-quality.json
+++ b/quality/reports/codeguard/US-ADJ-8.3-quality.json
@@ -1,0 +1,20 @@
+{
+  "us_id": "US-ADJ-8.3",
+  "date": "2026-04-22",
+  "scope": "frontend organizador",
+  "checks": [
+    {
+      "command": "npm run lint",
+      "cwd": "frontend",
+      "result": "OK"
+    },
+    {
+      "command": "npm run build",
+      "cwd": "frontend",
+      "result": "OK"
+    }
+  ],
+  "notes": [
+    "No se ejecutaron tests UI automatizados por falta de harness React/browser."
+  ]
+}

--- a/tests/features/US-ADJ-8.3-cancelacion-fuerte-torneo.feature
+++ b/tests/features/US-ADJ-8.3-cancelacion-fuerte-torneo.feature
@@ -1,0 +1,28 @@
+Feature: US-ADJ-8.3 - Cancelacion fuerte de torneo
+
+  Background:
+    Given el organizador esta autenticado
+    And existe el torneo "BA 2026"
+
+  Scenario: Cancelar torneo esta en una zona de peligro
+    When el organizador abre el panel de acciones
+    Then la accion "Cancelar torneo" esta separada de las acciones normales de fase
+    And usa tratamiento visual de accion destructiva
+
+  Scenario: No se puede cancelar con un click accidental
+    When el organizador toca "Cancelar torneo"
+    Then se abre una confirmacion fuerte
+    And no se cancela el torneo todavia
+
+  Scenario: Confirmacion incorrecta mantiene accion bloqueada
+    When el organizador toca "Cancelar torneo"
+    And escribe "BA"
+    Then la accion final de cancelacion permanece deshabilitada
+    And el torneo sigue en su estado actual
+
+  Scenario: Confirmacion exacta permite cancelar
+    When el organizador toca "Cancelar torneo"
+    And escribe "BA 2026"
+    Then la accion final de cancelacion queda habilitada
+    When confirma la cancelacion
+    Then el frontend ejecuta la cancelacion del torneo


### PR DESCRIPTION
## Resumen
- Separa Cancelar torneo en zona de peligro.
- Exige escribir el nombre exacto del torneo antes de confirmar.
- Mantiene la API de cancelación existente.

## Validaciones
- npm run lint -> OK
- npm run build -> OK

## Notas
- Tests UI/BDD automatizados omitidos por falta de harness React/browser; queda feature BDD como especificación.