### PR TITLE
US-5.3.1: agrega gestion de usuarios

### DIFF
--- a/docs/specs/sp5/US-5.3.1.md
+++ b/docs/specs/sp5/US-5.3.1.md
@@ -1,0 +1,186 @@
+# US-5.3.1: UI de gestion de usuarios
+
+**Estado**: `To Do`
+**Sprint**: SP5 — La Puesta en Marcha
+**Incremento**: INC-5.3
+**Bounded Context**: `identidad` (API) + `frontend`
+**Capas afectadas**: `identidad/api/router.py`, `frontend/src/pages/organizador/`, `frontend/src/api/identidad.ts`
+
+---
+
+## Descripcion
+
+Como **organizador**,
+quiero **crear usuarios con su rol asignado y ver la lista de todos los usuarios registrados**
+para **configurar el equipo del torneo (jueces, atletas, otros organizadores) antes de iniciar la operacion**.
+
+---
+
+## Contexto del dominio
+
+### Modelo involucrado
+
+| Elemento | Nombre | Responsabilidad |
+|---|---|---|
+| Aggregate | `Usuario` | Identidad de un usuario: email, password_hash, rol, activo |
+| VO | `Rol` | `ORGANIZADOR` / `JUEZ` / `ATLETA` / `ADMIN` |
+| Command | `RegistrarUsuarioCommand` | Crea un usuario con email, password y rol asignado |
+| Query | `list_by_rol` | Devuelve usuarios filtrados por rol |
+| Endpoint nuevo | `GET /auth/usuarios` sin filtro | Devuelve todos los usuarios (rol opcional) |
+| Pagina nueva | `UsuariosPage` | Lista + formulario de creacion de usuarios del organizador |
+
+### Lenguaje ubicuo relevante
+
+- **Crear usuario:** el organizador registra un email + password + rol para que esa persona pueda ingresar al sistema.
+- **Rol asignado:** el rol determina que pantallas ve el usuario al iniciar sesion (organizador, juez, atleta).
+- **Usuario activo:** puede autenticarse; inactivo no puede (campo `activo` del aggregate).
+
+---
+
+## Especificacion del comportamiento
+
+### Invariantes
+
+- **INV-5.3.1-01:** Solo el organizador autenticado puede acceder a `/organizador/usuarios`.
+- **INV-5.3.1-02:** El selector de rol en el formulario expone solo `JUEZ`, `ATLETA` y `ORGANIZADOR`; nunca `ADMIN`.
+- **INV-5.3.1-03:** El email debe ser unico en el sistema; un intento de creacion con email duplicado muestra error inline sin cerrar el formulario.
+- **INV-5.3.1-04:** La password debe tener al menos 8 caracteres; validado en frontend antes de enviar.
+- **INV-5.3.1-05:** Al crear un usuario exitosamente, aparece en la lista sin recargar la pagina completa.
+
+### Operacion principal — listar usuarios
+
+| | Descripcion |
+|---|---|
+| **Precondicion** | Usuario autenticado con rol ORGANIZADOR. |
+| **Postcondicion** | Se muestra la lista completa de usuarios del sistema con su email, rol y estado activo/inactivo. |
+
+**Endpoint a extender:**
+
+El endpoint existente `GET /auth/usuarios?rol={rol}` requiere `rol` obligatorio.
+Esta US lo modifica para hacer `rol` opcional:
+
+```
+GET /auth/usuarios             -> devuelve todos los usuarios
+GET /auth/usuarios?rol=JUEZ    -> devuelve solo jueces (comportamiento actual conservado)
+```
+
+**Layout de la lista:**
+
+| Email | Rol | Estado |
+|-------|-----|--------|
+| juez1@email.com | JUEZ | Activo |
+| atleta1@email.com | ATLETA | Activo |
+
+### Operacion secundaria — crear usuario
+
+**Formulario:**
+
+| Campo | Tipo | Validacion |
+|---|---|---|
+| Email | text | Requerido, formato email |
+| Password | password | Minimo 8 caracteres |
+| Rol | selector | JUEZ / ATLETA / ORGANIZADOR |
+
+**Flujo:**
+
+```
+1. Organizador llena email, password y rol
+2. Submit -> POST /auth/registro { email, password, rol }
+3a. 201 Created -> nuevo usuario aparece en la lista; formulario se limpia
+3b. 409 Conflict -> "Este email ya esta registrado" (inline, formulario permanece abierto)
+3c. 422 -> "La contrasena debe tener al menos 8 caracteres" (inline)
+```
+
+**Ejemplo concreto:**
+
+```
+Organizador abre /organizador/usuarios.
+Lista muestra: [juez1@email.com — JUEZ — Activo]
+
+Organizador llena: email=juez2@email.com, password=pass1234, rol=JUEZ
+Submit -> POST /auth/registro 201
+Lista pasa a mostrar: [juez1@email.com, juez2@email.com]
+
+Organizador intenta: email=juez1@email.com, password=pass1234, rol=ATLETA
+Submit -> POST /auth/registro 409
+Mensaje inline: "Este email ya esta registrado"
+```
+
+---
+
+## Criterios de aceptacion (BDD)
+
+```gherkin
+Feature: US-5.3.1 — UI de gestion de usuarios
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And en el sistema existen los usuarios:
+      | email              | rol  | activo |
+      | juez1@email.com    | JUEZ | true   |
+
+  Scenario: listar todos los usuarios del sistema
+    When el organizador navega a la pagina de usuarios
+    Then ve una lista con "juez1@email.com" con rol "JUEZ"
+
+  Scenario: crear usuario juez exitosamente
+    When el organizador completa el formulario con email "juez2@email.com", password "pass1234" y rol "JUEZ"
+    And confirma la creacion
+    Then el sistema responde 201
+    And "juez2@email.com" aparece en la lista con rol "JUEZ"
+    And el formulario queda limpio para una nueva entrada
+
+  Scenario: crear usuario con email duplicado muestra error inline
+    When el organizador intenta crear un usuario con email "juez1@email.com"
+    And confirma la creacion
+    Then el sistema responde 409
+    And se muestra "Este email ya esta registrado" en el formulario
+    And el formulario permanece abierto con los datos ingresados
+
+  Scenario: password de menos de 8 caracteres es rechazada antes de enviar
+    When el organizador ingresa password "abc"
+    And intenta confirmar la creacion
+    Then el formulario muestra "La contrasena debe tener al menos 8 caracteres"
+    And no se envia POST /auth/registro
+
+  Scenario: rol ADMIN no esta disponible en el selector
+    When el organizador abre el formulario de creacion
+    Then el selector de rol muestra solo "JUEZ", "ATLETA" y "ORGANIZADOR"
+    And no muestra "ADMIN"
+```
+
+---
+
+## Impacto arquitectonico
+
+- [x] Si — modifica `identidad/api/router.py` para hacer `rol` opcional en `GET /auth/usuarios`.
+
+**Capa(s) afectadas:**
+- [x] `identidad/api/router.py` — hacer parametro `rol` opcional; sin filtro devuelve todos.
+- [x] `frontend/src/api/identidad.ts` — agregar `listarTodosLosUsuarios()` (sin filtro) y conservar `listarUsuariosPorRol()`.
+- [x] `frontend/src/pages/organizador/UsuariosPage.tsx` — nueva pagina con lista y formulario de creacion.
+- [x] `frontend/src/App.tsx` — agregar ruta `/organizador/usuarios` con `RequireRole role="organizador"`.
+
+---
+
+## Referencias
+
+- Plan SP5: `docs/plans/sp5/PLAN-SP5.md §INC-5.3`
+- Endpoint actual: `src/identidad/api/router.py` — `GET /auth/usuarios`
+- Command existente: `src/identidad/application/commands/registrar_usuario.py`
+- Aggregate: `src/identidad/domain/aggregates/usuario.py`
+- VO Rol: `src/identidad/domain/value_objects/rol.py`
+- Frontend auth: `frontend/src/api/identidad.ts`
+
+---
+
+## Notas de implementacion
+
+- El endpoint `GET /auth/usuarios` debe seguir requiriendo autenticacion con rol ORGANIZADOR. Solo el parametro `rol` pasa a ser opcional.
+- La lista se ordena por rol y luego por email para facilitar la lectura al configurar el equipo.
+- No se implementa desactivacion/edicion de usuarios en esta US — solo creacion y listado.
+- La pagina se accede desde el panel del organizador como una nueva seccion de configuracion.
+
+---
+
+*Redactado: 2026-04-23 — INC-5.3 Gestion de usuarios y roles*

--- a/docs/specs/sp5/US-5.3.2.md
+++ b/docs/specs/sp5/US-5.3.2.md
@@ -1,0 +1,196 @@
+# US-5.3.2: Vista del atleta
+
+**Estado**: `To Do`
+**Sprint**: SP5 — La Puesta en Marcha
+**Incremento**: INC-5.3
+**Bounded Context**: `frontend` (consume `torneo/api/` y `registro/api/`)
+**Capas afectadas**: `frontend/src/App.tsx`, `frontend/src/types/auth.ts`, `frontend/src/pages/atleta/`
+
+---
+
+## Descripcion
+
+Como **atleta**,
+quiero **ver mi perfil y los torneos disponibles para inscripcion**
+para **saber donde puedo participar y acceder a mi informacion personal en la plataforma**.
+
+---
+
+## Contexto del dominio
+
+### Modelo involucrado
+
+| Elemento | Nombre | Responsabilidad |
+|---|---|---|
+| Tipo | `RolUsuario` | Extiende con `'atleta'` ademas de `'juez'` y `'organizador'` |
+| Guard | `RequireRole` | Protege las rutas `/atleta/*` — redirige si el rol no es `atleta` |
+| Query | `GET /torneos` | Lista torneos; el atleta filtra los que estan en estado `INSCRIPCION` |
+| Pagina nueva | `AtletaDashboardPage` | Perfil del atleta + torneos disponibles para inscripcion |
+
+### Lenguaje ubicuo relevante
+
+- **Atleta:** usuario con rol ATLETA; accede a su propio perfil e inscripcion.
+- **Torneo disponible:** torneo en estado `INSCRIPCION` — puede recibir nuevas inscripciones.
+- **Perfil del atleta:** email y rol leidos del JWT en memoria (sin llamada adicional al backend).
+
+---
+
+## Especificacion del comportamiento
+
+### Invariantes
+
+- **INV-5.3.2-01:** Solo usuarios con rol `ATLETA` pueden acceder a `/atleta/*`; cualquier otro rol es redirigido a su ruta correspondiente por `RequireRole`.
+- **INV-5.3.2-02:** Un atleta autenticado no puede navegar a `/organizador/*` ni `/juez/*`; `RequireRole` bloquea el acceso y redirige a `/`.
+- **INV-5.3.2-03:** La seccion "Torneos disponibles" muestra solo torneos con estado `INSCRIPCION`; los torneos en otros estados no se muestran.
+- **INV-5.3.2-04:** El perfil se construye con los claims del JWT en memoria (email, rol); no requiere llamada adicional al backend.
+- **INV-5.3.2-05:** Esta vista es de solo lectura — la inscripcion efectiva se implementa en INC-5.4.
+
+### Operacion principal — cargar dashboard del atleta
+
+| | Descripcion |
+|---|---|
+| **Precondicion** | Usuario autenticado con rol ATLETA. |
+| **Postcondicion** | Se muestra perfil (email + rol) y lista de torneos en estado INSCRIPCION con nombre, sede y fechas. |
+
+**Flujo de datos:**
+
+```
+1. Perfil: leer email y rol del authStore (JWT en memoria)
+2. Torneos disponibles:
+   GET /torneos -> filtrar client-side por estado == "INSCRIPCION"
+3. Renderizar:
+   - Seccion "Mi perfil": email, rol "Atleta"
+   - Seccion "Torneos disponibles": lista con nombre, sede, fecha_inicio
+   - Si no hay torneos en INSCRIPCION: mensaje "No hay torneos disponibles en este momento"
+```
+
+### Routing y tipos
+
+**Cambios en `frontend/src/types/auth.ts`:**
+
+```typescript
+// Antes
+export type RolUsuario = 'juez' | 'organizador'
+
+// Despues
+export type RolUsuario = 'juez' | 'organizador' | 'atleta'
+```
+
+**Cambios en `frontend/src/App.tsx`:**
+
+```typescript
+// RootRedirect agrega rama atleta
+if (rol === 'atleta') return <Navigate to="/atleta/dashboard" replace />
+
+// Nueva ruta protegida
+<Route
+  path="/atleta/dashboard"
+  element={
+    <RequireRole role="atleta">
+      <AtletaDashboardPage />
+    </RequireRole>
+  }
+/>
+```
+
+**Ejemplo concreto:**
+
+```
+Atleta "atleta1@email.com" inicia sesion.
+JWT contiene: { sub: "atleta1@email.com", rol: "ATLETA" }.
+RootRedirect -> /atleta/dashboard
+
+Dashboard muestra:
+  Mi perfil: atleta1@email.com — Atleta
+  Torneos disponibles:
+    "Buenos Aires Open 2026" — Piscina Municipal — 10 jun 2026
+    "Campeonato Patagonia" — Mar del Plata — 15 jul 2026
+
+Atleta navega manualmente a /organizador/dashboard.
+RequireRole role="organizador" -> redirige a / -> RootRedirect -> /atleta/dashboard
+```
+
+---
+
+## Criterios de aceptacion (BDD)
+
+```gherkin
+Feature: US-5.3.2 — Vista del atleta
+
+  Background:
+    Given el sistema tiene los torneos:
+      | nombre                  | estado       |
+      | Buenos Aires Open 2026  | INSCRIPCION  |
+      | Campeonato Patagonia    | INSCRIPCION  |
+      | Torneo BA 2025          | FINALIZADO   |
+
+  Scenario: atleta autenticado es redirigido a su dashboard
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When navega a "/"
+    Then es redirigido a "/atleta/dashboard"
+
+  Scenario: dashboard muestra perfil del atleta
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When accede a "/atleta/dashboard"
+    Then ve su email "atleta1@email.com"
+    And ve su rol como "Atleta"
+
+  Scenario: dashboard muestra solo torneos en INSCRIPCION
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When accede a "/atleta/dashboard"
+    Then ve "Buenos Aires Open 2026" en la lista de torneos disponibles
+    And ve "Campeonato Patagonia" en la lista de torneos disponibles
+    And no ve "Torneo BA 2025" en la lista
+
+  Scenario: sin torneos disponibles muestra mensaje informativo
+    Given no existen torneos en estado INSCRIPCION
+    And "atleta1@email.com" esta autenticado con rol ATLETA
+    When accede a "/atleta/dashboard"
+    Then ve el mensaje "No hay torneos disponibles en este momento"
+
+  Scenario: atleta no puede acceder a rutas del organizador
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When intenta navegar a "/organizador/dashboard"
+    Then es redirigido a "/atleta/dashboard"
+
+  Scenario: atleta no puede acceder a rutas del juez
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When intenta navegar a "/juez/disciplinas"
+    Then es redirigido a "/atleta/dashboard"
+```
+
+---
+
+## Impacto arquitectonico
+
+- [x] No — solo frontend; reutiliza `GET /torneos` existente.
+
+**Capa(s) afectadas:**
+- [x] `frontend/src/types/auth.ts` — agregar `'atleta'` a `RolUsuario`.
+- [x] `frontend/src/App.tsx` — `RootRedirect` para atleta + ruta `/atleta/dashboard`.
+- [x] `frontend/src/pages/atleta/AtletaDashboardPage.tsx` — nueva pagina (perfil + torneos disponibles).
+- [x] `frontend/src/api/torneo.ts` — reutilizar `listarTorneos()`; filtrado client-side por estado.
+
+---
+
+## Referencias
+
+- Plan SP5: `docs/plans/sp5/PLAN-SP5.md §INC-5.3`
+- Tipos de auth: `frontend/src/types/auth.ts`
+- Routing actual: `frontend/src/App.tsx`
+- Guard de rol: `frontend/src/components/RequireRole.tsx`
+- API torneos: `frontend/src/api/torneo.ts`
+- INC-5.4 (inscripcion completa): especificara la accion de inscribirse desde esta vista
+
+---
+
+## Notas de implementacion
+
+- El `RequireRole` existente ya funciona con strings; agregar `'atleta'` al tipo es suficiente para que el guard funcione sin modificarlo.
+- La vista es intencionalmente minima — un placeholder con alcance claro para INC-5.4. No implementar botones de inscripcion ni flujos que correspondan a INC-5.4.
+- Usar el mismo patron de layout que el organizador (sidebar o header con logout) para coherencia visual.
+- El filtrado por estado `INSCRIPCION` es client-side sobre la respuesta de `GET /torneos`; no requiere nuevo endpoint.
+
+---
+
+*Redactado: 2026-04-23 — INC-5.3 Gestion de usuarios y roles*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { DashboardPage } from './pages/organizador/DashboardPage'
 import { CrearTorneoPage } from './pages/organizador/CrearTorneoPage'
 import { DetalleTorneoPage } from './pages/organizador/DetalleTorneoPage'
 import { TorneoCompetenciasPage } from './pages/organizador/TorneoCompetenciasPage'
+import { UsuariosPage } from './pages/organizador/UsuariosPage'
 import { AuditoriaCompetenciaPage } from './pages/organizador/AuditoriaCompetenciaPage'
 import { AuditoriaPerformancePage } from './pages/organizador/AuditoriaPerformancePage'
 import { HealthCheck } from './components/HealthCheck'
@@ -71,6 +72,14 @@ function App() {
           element={
             <RequireRole role="organizador">
               <CrearTorneoPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/organizador/usuarios"
+          element={
+            <RequireRole role="organizador">
+              <UsuariosPage />
             </RequireRole>
           }
         />

--- a/frontend/src/api/identidad.ts
+++ b/frontend/src/api/identidad.ts
@@ -10,12 +10,23 @@ export class ApiError extends Error {
 }
 
 export type RolIdentidad = 'JUEZ' | 'ORGANIZADOR' | 'ATLETA' | 'ADMIN'
+export type RolGestionUsuario = Exclude<RolIdentidad, 'ADMIN'>
 
 export interface UsuarioDto {
   usuario_id: string
   email: string
   rol: RolIdentidad
   activo: boolean
+}
+
+export interface CrearUsuarioRequest {
+  email: string
+  password: string
+  rol: RolGestionUsuario
+}
+
+export interface CrearUsuarioResponse {
+  usuario_id: string
 }
 
 function buildHeaders(): Record<string, string> {
@@ -60,4 +71,20 @@ export async function listarUsuariosPorRol(rol: RolIdentidad): Promise<UsuarioDt
     headers: buildHeaders(),
   })
   return parseResponse<UsuarioDto[]>(response)
+}
+
+export async function listarTodosLosUsuarios(): Promise<UsuarioDto[]> {
+  const response = await fetch('/auth/usuarios', {
+    headers: buildHeaders(),
+  })
+  return parseResponse<UsuarioDto[]>(response)
+}
+
+export async function crearUsuario(body: CrearUsuarioRequest): Promise<CrearUsuarioResponse> {
+  const response = await fetch('/auth/registro', {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify(body),
+  })
+  return parseResponse<CrearUsuarioResponse>(response)
 }

--- a/frontend/src/pages/organizador/DashboardPage.tsx
+++ b/frontend/src/pages/organizador/DashboardPage.tsx
@@ -66,6 +66,12 @@ export function DashboardPage() {
       actions={
         <>
           <Link
+            to="/organizador/usuarios"
+            className="rounded-lg border border-stone-900 px-4 py-2 text-sm font-semibold text-stone-900"
+          >
+            Usuarios
+          </Link>
+          <Link
             to="/organizador/torneos/nuevo"
             className="rounded-lg bg-emerald-800 px-4 py-2 text-sm font-semibold text-white"
           >

--- a/frontend/src/pages/organizador/UsuariosPage.tsx
+++ b/frontend/src/pages/organizador/UsuariosPage.tsx
@@ -1,0 +1,274 @@
+import { useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  ApiError,
+  crearUsuario,
+  listarTodosLosUsuarios,
+  type RolGestionUsuario,
+  type UsuarioDto,
+} from '../../api/identidad'
+import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
+
+interface FormState {
+  email: string
+  password: string
+  rol: RolGestionUsuario
+}
+
+type FormErrors = Partial<Record<keyof FormState | 'general', string>>
+
+const INITIAL_FORM: FormState = {
+  email: '',
+  password: '',
+  rol: 'JUEZ',
+}
+
+const ROLES_GESTIONABLES: Array<{ value: RolGestionUsuario; label: string }> = [
+  { value: 'JUEZ', label: 'Juez' },
+  { value: 'ATLETA', label: 'Atleta' },
+  { value: 'ORGANIZADOR', label: 'Organizador' },
+]
+
+const ROL_LABELS: Record<string, string> = {
+  JUEZ: 'Juez',
+  ATLETA: 'Atleta',
+  ORGANIZADOR: 'Organizador',
+  ADMIN: 'Admin',
+}
+
+function inputClass(hasError: boolean): string {
+  return [
+    'mt-2 w-full rounded-lg border bg-white px-3 py-2 text-sm text-stone-900 outline-none transition',
+    hasError ? 'border-red-400 focus:border-red-600' : 'border-stone-300 focus:border-emerald-700',
+  ].join(' ')
+}
+
+function getUsuarioError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 409) return 'Este email ya esta registrado'
+    if (error.status === 422) return 'La contrasena debe tener al menos 8 caracteres'
+    return error.message
+  }
+  if (error instanceof Error) return error.message
+  return 'No se pudo crear el usuario'
+}
+
+function ordenarUsuarios(usuarios: UsuarioDto[]): UsuarioDto[] {
+  return [...usuarios].sort((a, b) => {
+    const rolCompare = a.rol.localeCompare(b.rol)
+    if (rolCompare !== 0) return rolCompare
+    return a.email.localeCompare(b.email)
+  })
+}
+
+export function UsuariosPage() {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState<FormState>(INITIAL_FORM)
+  const [errors, setErrors] = useState<FormErrors>({})
+  const usuariosQuery = useQuery({
+    queryKey: ['usuarios'],
+    queryFn: listarTodosLosUsuarios,
+  })
+  const usuarios = useMemo(
+    () => ordenarUsuarios(usuariosQuery.data ?? []),
+    [usuariosQuery.data],
+  )
+  const crearUsuarioMutation = useMutation({
+    mutationFn: crearUsuario,
+    onSuccess: async () => {
+      setForm(INITIAL_FORM)
+      setErrors({})
+      await queryClient.invalidateQueries({ queryKey: ['usuarios'] })
+    },
+    onError: (error) => {
+      const message = getUsuarioError(error)
+      if (error instanceof ApiError && error.status === 409) {
+        setErrors((current) => ({ ...current, email: message, general: undefined }))
+        return
+      }
+      if (error instanceof ApiError && error.status === 422) {
+        setErrors((current) => ({ ...current, password: message, general: undefined }))
+        return
+      }
+      setErrors((current) => ({ ...current, general: message }))
+    },
+  })
+
+  function updateField<T extends keyof FormState>(field: T, value: FormState[T]) {
+    setForm((current) => ({ ...current, [field]: value }))
+    setErrors((current) => ({ ...current, [field]: undefined, general: undefined }))
+  }
+
+  function validate(): FormErrors {
+    const nextErrors: FormErrors = {}
+    if (!form.email.trim()) {
+      nextErrors.email = 'El email es obligatorio'
+    }
+    if (!form.password) {
+      nextErrors.password = 'La contrasena es obligatoria'
+    } else if (form.password.length < 8) {
+      nextErrors.password = 'La contrasena debe tener al menos 8 caracteres'
+    }
+    return nextErrors
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const validationErrors = validate()
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) {
+      return
+    }
+
+    crearUsuarioMutation.mutate({
+      email: form.email.trim(),
+      password: form.password,
+      rol: form.rol,
+    })
+  }
+
+  return (
+    <OrganizadorLayout
+      title="Gestion de usuarios"
+      subtitle="Alta de jueces, atletas y organizadores para operar el torneo"
+      actions={
+        <Link
+          to="/organizador/dashboard"
+          className="rounded-lg border border-stone-900 px-4 py-2 text-sm font-semibold text-stone-900"
+        >
+          Volver
+        </Link>
+      }
+    >
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_380px]">
+        <div className="rounded-lg border border-stone-300 bg-white p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase text-stone-500">Usuarios</p>
+              <h2 className="mt-1 text-xl font-semibold text-stone-900">Registrados</h2>
+            </div>
+            <p className="text-sm text-stone-600">{usuarios.length} usuarios</p>
+          </div>
+
+          {usuariosQuery.isLoading ? (
+            <div className="mt-5 rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+              Cargando usuarios...
+            </div>
+          ) : null}
+
+          {usuariosQuery.isError ? (
+            <div className="mt-5 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+              No se pudieron cargar los usuarios.
+            </div>
+          ) : null}
+
+          {!usuariosQuery.isLoading && !usuariosQuery.isError && usuarios.length === 0 ? (
+            <div className="mt-5 rounded-lg border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+              No hay usuarios registrados.
+            </div>
+          ) : null}
+
+          {!usuariosQuery.isLoading && !usuariosQuery.isError && usuarios.length > 0 ? (
+            <div className="mt-5 overflow-hidden rounded-lg border border-stone-200">
+              <table className="w-full border-collapse text-left text-sm">
+                <thead className="bg-stone-100 text-xs uppercase text-stone-500">
+                  <tr>
+                    <th className="px-4 py-3 font-semibold">Email</th>
+                    <th className="px-4 py-3 font-semibold">Rol</th>
+                    <th className="px-4 py-3 font-semibold">Estado</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-stone-200">
+                  {usuarios.map((usuario) => (
+                    <tr key={usuario.usuario_id} className="bg-white">
+                      <td className="px-4 py-3 font-medium text-stone-900">{usuario.email}</td>
+                      <td className="px-4 py-3 text-stone-700">
+                        {ROL_LABELS[usuario.rol] ?? usuario.rol}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={
+                            usuario.activo
+                              ? 'inline-flex rounded-lg bg-emerald-50 px-2 py-1 text-xs font-semibold text-emerald-800'
+                              : 'inline-flex rounded-lg bg-stone-100 px-2 py-1 text-xs font-semibold text-stone-600'
+                          }
+                        >
+                          {usuario.activo ? 'Activo' : 'Inactivo'}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-lg border border-stone-300 bg-white p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]"
+        >
+          <p className="text-xs font-semibold uppercase text-stone-500">Nuevo usuario</p>
+          <h2 className="mt-1 text-xl font-semibold text-stone-900">Crear acceso</h2>
+
+          {errors.general ? (
+            <div className="mt-4 rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-900">
+              {errors.general}
+            </div>
+          ) : null}
+
+          <label className="mt-5 block text-sm font-semibold text-stone-900">
+            Email
+            <input
+              type="email"
+              value={form.email}
+              onChange={(event) => updateField('email', event.target.value)}
+              className={inputClass(Boolean(errors.email))}
+              placeholder="juez@email.com"
+            />
+            {errors.email ? <span className="mt-1 block text-sm text-red-700">{errors.email}</span> : null}
+          </label>
+
+          <label className="mt-4 block text-sm font-semibold text-stone-900">
+            Password
+            <input
+              type="password"
+              value={form.password}
+              onChange={(event) => updateField('password', event.target.value)}
+              className={inputClass(Boolean(errors.password))}
+              placeholder="Minimo 8 caracteres"
+            />
+            {errors.password ? (
+              <span className="mt-1 block text-sm text-red-700">{errors.password}</span>
+            ) : null}
+          </label>
+
+          <label className="mt-4 block text-sm font-semibold text-stone-900">
+            Rol
+            <select
+              value={form.rol}
+              onChange={(event) => updateField('rol', event.target.value as RolGestionUsuario)}
+              className={inputClass(Boolean(errors.rol))}
+            >
+              {ROLES_GESTIONABLES.map((rol) => (
+                <option key={rol.value} value={rol.value}>
+                  {rol.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <button
+            type="submit"
+            disabled={crearUsuarioMutation.isPending}
+            className="mt-6 w-full rounded-lg bg-emerald-800 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-stone-400"
+          >
+            {crearUsuarioMutation.isPending ? 'Creando...' : 'Crear usuario'}
+          </button>
+        </form>
+      </section>
+    </OrganizadorLayout>
+  )
+}

--- a/src/identidad/api/router.py
+++ b/src/identidad/api/router.py
@@ -111,11 +111,11 @@ async def autenticar_usuario(body: LoginRequest) -> JSONResponse:
 
 @router.get("/usuarios", status_code=200)
 async def listar_usuarios(
-    rol: Rol,
     _: OrganizadorDep,
     repo: Annotated[UsuarioRepositoryPort, Depends(get_usuario_repository)],
+    rol: Rol | None = None,
 ) -> JSONResponse:
-    usuarios = await repo.list_by_rol(rol)
+    usuarios = await repo.list_by_rol(rol) if rol else await repo.list_all()
     return JSONResponse(
         status_code=200,
         content=[

--- a/src/identidad/domain/ports/usuario_repository_port.py
+++ b/src/identidad/domain/ports/usuario_repository_port.py
@@ -19,3 +19,6 @@ class UsuarioRepositoryPort(ABC):
 
     @abstractmethod
     async def list_by_rol(self, rol: Rol) -> list[Usuario]: ...
+
+    @abstractmethod
+    async def list_all(self) -> list[Usuario]: ...

--- a/src/identidad/infrastructure/repositories/sqlite_usuario_repository.py
+++ b/src/identidad/infrastructure/repositories/sqlite_usuario_repository.py
@@ -90,6 +90,19 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
                 rows = await cursor.fetchall()
         return [_row_to_usuario(row) for row in rows]
 
+    async def list_all(self) -> list[Usuario]:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._ensure_table(conn)
+            async with conn.execute(
+                """
+                SELECT usuario_id, email, password_hash, rol, activo
+                FROM usuarios
+                ORDER BY rol, email
+                """
+            ) as cursor:
+                rows = await cursor.fetchall()
+        return [_row_to_usuario(row) for row in rows]
+
 
 def _row_to_usuario(row: tuple) -> Usuario:  # type: ignore[type-arg]
     usuario_id, email, password_hash, rol, activo = row

--- a/tests/features/US-5.3.1-gestion-usuarios.feature
+++ b/tests/features/US-5.3.1-gestion-usuarios.feature
@@ -1,0 +1,37 @@
+Feature: US-5.3.1 - UI de gestion de usuarios
+
+  Background:
+    Given el organizador "org@ataraxia.com" esta autenticado con rol ORGANIZADOR
+    And en el sistema existen los usuarios:
+      | email           | rol  | activo |
+      | juez1@email.com | JUEZ | true   |
+
+  Scenario: listar todos los usuarios del sistema
+    When el organizador navega a la pagina de gestion de usuarios
+    Then ve una lista con "juez1@email.com" con rol "JUEZ"
+    And ve el estado "Activo" para "juez1@email.com"
+
+  Scenario: crear usuario juez exitosamente
+    When el organizador completa el formulario de usuario con email "juez2@email.com", password "pass1234" y rol "JUEZ"
+    And confirma la creacion del usuario
+    Then el sistema responde 201
+    And "juez2@email.com" aparece en la lista con rol "JUEZ"
+    And el formulario de usuario queda limpio para una nueva entrada
+
+  Scenario: crear usuario con email duplicado muestra error inline
+    When el organizador intenta crear un usuario con email "juez1@email.com", password "pass1234" y rol "ATLETA"
+    And confirma la creacion del usuario
+    Then el sistema responde 409
+    And se muestra "Este email ya esta registrado" en el formulario de usuario
+    And el formulario de usuario permanece abierto con los datos ingresados
+
+  Scenario: password de menos de 8 caracteres es rechazada antes de enviar
+    When el organizador ingresa password "abc" en el formulario de usuario
+    And intenta confirmar la creacion del usuario
+    Then el formulario de usuario muestra "La contrasena debe tener al menos 8 caracteres"
+    And no se envia POST a "/auth/registro"
+
+  Scenario: rol ADMIN no esta disponible en el selector
+    When el organizador abre el formulario de creacion de usuario
+    Then el selector de rol muestra solo "JUEZ", "ATLETA" y "ORGANIZADOR"
+    And no muestra "ADMIN"

--- a/tests/integration/identidad/test_sqlite_usuario_repository.py
+++ b/tests/integration/identidad/test_sqlite_usuario_repository.py
@@ -92,3 +92,22 @@ async def test_list_by_rol_filtra_y_ordena_por_email(repo: SQLiteUsuarioReposito
     jueces = await repo.list_by_rol(Rol.JUEZ)
 
     assert [usuario.email for usuario in jueces] == ["a-juez@test.com", "z-juez@test.com"]
+
+
+@pytest.mark.asyncio
+async def test_list_all_devuelve_todos_ordenados_por_rol_y_email(
+    repo: SQLiteUsuarioRepository,
+) -> None:
+    await repo.save(_usuario(email="z-juez@test.com", rol=Rol.JUEZ))
+    await repo.save(_usuario(email="org@test.com", rol=Rol.ORGANIZADOR))
+    await repo.save(_usuario(email="atleta@test.com", rol=Rol.ATLETA))
+    await repo.save(_usuario(email="a-juez@test.com", rol=Rol.JUEZ))
+
+    usuarios = await repo.list_all()
+
+    assert [(usuario.rol, usuario.email) for usuario in usuarios] == [
+        (Rol.ATLETA, "atleta@test.com"),
+        (Rol.JUEZ, "a-juez@test.com"),
+        (Rol.JUEZ, "z-juez@test.com"),
+        (Rol.ORGANIZADOR, "org@test.com"),
+    ]

--- a/tests/unit/identidad/api/test_listar_usuarios.py
+++ b/tests/unit/identidad/api/test_listar_usuarios.py
@@ -14,16 +14,22 @@ from identidad.domain.value_objects.rol import Rol
 
 
 class FakeUsuarioRepository:
-    async def list_by_rol(self, rol: Rol) -> list[Usuario]:
-        usuarios = [
+    def __init__(self) -> None:
+        self.usuarios = [
             Usuario(uuid4(), "juez2@ataraxia.com", "$2b$hash", Rol.JUEZ),
             Usuario(uuid4(), "org@ataraxia.com", "$2b$hash", Rol.ORGANIZADOR),
             Usuario(uuid4(), "juez1@ataraxia.com", "$2b$hash", Rol.JUEZ),
+            Usuario(uuid4(), "atleta@ataraxia.com", "$2b$hash", Rol.ATLETA),
         ]
+
+    async def list_by_rol(self, rol: Rol) -> list[Usuario]:
         return sorted(
-            [usuario for usuario in usuarios if usuario.rol == rol],
+            [usuario for usuario in self.usuarios if usuario.rol == rol],
             key=lambda usuario: usuario.email,
         )
+
+    async def list_all(self) -> list[Usuario]:
+        return sorted(self.usuarios, key=lambda usuario: (usuario.rol.value, usuario.email))
 
 
 def _mock_user(rol: str) -> dict:  # type: ignore[type-arg]
@@ -46,6 +52,25 @@ def test_listar_usuarios_filtra_rol_juez() -> None:
         "juez2@ataraxia.com",
     ]
     assert all(usuario["rol"] == "JUEZ" for usuario in data)
+
+
+def test_listar_usuarios_sin_rol_devuelve_todos_ordenados() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: _mock_user("ORGANIZADOR")
+    app.dependency_overrides[get_usuario_repository] = lambda: FakeUsuarioRepository()
+    client = TestClient(app)
+
+    response = client.get("/auth/usuarios")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [(usuario["rol"], usuario["email"]) for usuario in data] == [
+        ("ATLETA", "atleta@ataraxia.com"),
+        ("JUEZ", "juez1@ataraxia.com"),
+        ("JUEZ", "juez2@ataraxia.com"),
+        ("ORGANIZADOR", "org@ataraxia.com"),
+    ]
 
 
 def test_listar_usuarios_requiere_organizador() -> None:


### PR DESCRIPTION
## Resumen
- agrega la pantalla de gestion de usuarios para organizador
- permite listar todos los usuarios y crear jueces, atletas y organizadores
- mantiene el filtro por rol en backend y suma cobertura de tests backend y feature BDD

## Validacion
- `npm run build` en `frontend/` OK
- `pytest tests/unit/identidad/api/test_listar_usuarios.py` no ejecuta en este entorno por falta de `aiosqlite`
- `pytest tests/integration/identidad/test_sqlite_usuario_repository.py` no ejecuta en este entorno por falta de `aiosqlite`