### PR TITLE
US-5.3.2: agrega vista del atleta

### DIFF
--- a/docs/plans/sp5/US-5.3.2-plan.md
+++ b/docs/plans/sp5/US-5.3.2-plan.md
@@ -1,0 +1,120 @@
+# Plan de Implementacion: US-5.3.2 - Vista del atleta
+
+**Historia:** US-5.3.2 - Vista del atleta
+**Incremento:** INC-5.3 - Gestion de usuarios y roles
+**Producto:** frontend
+**Patron:** React/Vite frontend sobre arquitectura BC-first del repo
+**Estimacion operativa:** 2 puntos
+**Estado:** COMPLETADO
+**Fecha completado:** 2026-04-23
+
+---
+
+## Alcance
+
+Implementar la vista inicial del atleta:
+
+- Extender el tipo `RolUsuario` con `atleta`.
+- Redirigir al atleta autenticado desde `/` hacia `/atleta/dashboard`.
+- Proteger `/atleta/dashboard` con `RequireRole role="atleta"`.
+- Mostrar perfil del atleta usando `email` y `rol` del `authStore`.
+- Listar solo torneos con estado de inscripcion abierta.
+- Mostrar mensaje vacio si no hay torneos disponibles.
+
+Fuera de alcance:
+
+- Accion de inscripcion a torneo.
+- Formularios del atleta.
+- Cambios backend o endpoints nuevos.
+
+---
+
+## Contexto validado
+
+- `frontend/src/stores/useAuthStore.ts` ya convierte el claim JWT `rol` a minusculas, por lo que `ATLETA` pasa a `atleta`.
+- `frontend/src/components/RequireRole.tsx` solo necesita extender `RolUsuario` y `HOME_BY_ROL`.
+- `frontend/src/api/torneo.ts` ya expone `fetchTorneos()` y normaliza estados a `EstadoTorneo`.
+- El estado canonico actual del frontend para inscripcion abierta es `INSCRIPCION_ABIERTA`, no `INSCRIPCION`.
+
+Decision de plan:
+
+- La implementacion filtrara por `INSCRIPCION_ABIERTA`, alineada con el codigo real del frontend y con la normalizacion existente en `frontend/src/api/torneo.ts`.
+
+---
+
+## Componentes a Modificar
+
+### Routing y auth
+
+- [x] `frontend/src/types/auth.ts` (5 min)
+  - Agregar `'atleta'` a `RolUsuario`.
+
+- [x] `frontend/src/components/RequireRole.tsx` (10 min)
+  - Agregar home por rol para `atleta`.
+  - Mantener redireccion consistente para accesos cruzados.
+
+- [x] `frontend/src/App.tsx` (15 min)
+  - Importar `AtletaDashboardPage`.
+  - Extender `RootRedirect()` para atleta.
+  - Agregar ruta protegida `/atleta/dashboard`.
+
+### Vista atleta
+
+- [x] `frontend/src/pages/atleta/AtletaDashboardPage.tsx` (75 min)
+  - Crear pagina reutilizando el lenguaje visual actual del frontend.
+  - Leer `email`, `rol` y `logout` desde `useAuthStore`.
+  - Consultar torneos con React Query usando `fetchTorneos()`.
+  - Filtrar client-side por `estado === "INSCRIPCION_ABIERTA"`.
+  - Renderizar perfil y lista de torneos disponibles.
+  - Renderizar estado vacio y error de carga.
+
+### Tests y artefactos
+
+- [x] `tests/features/US-5.3.2-vista-atleta.feature` (15 min)
+  - Documentar redireccion, perfil, filtro de torneos y restricciones por rol.
+
+- [x] Validacion TypeScript/build (20 min)
+  - Ejecutar `npm run build` en `frontend/`.
+  - Ejecutar `npm run lint` solo si el estado base lo permite.
+
+---
+
+## Quality Gates
+
+- [x] `npm run build` en `frontend/`
+- [x] `npm run lint` en `frontend/`
+- [x] Validacion manual de la navegacion por roles:
+  - `/` redirige a `/atleta/dashboard` si el rol es `atleta`
+  - `/organizador/*` y `/juez/*` redirigen de vuelta al home del atleta
+
+---
+
+## Riesgos y Decisiones
+
+- La spec menciona `INSCRIPCION`, pero el frontend actual trabaja con `INSCRIPCION_ABIERTA`; usar `INSCRIPCION` romperia el filtro.
+- `OrganizadorLayout` muestra el encabezado fijo "Organizador"; si se reutiliza sin adaptacion, la vista del atleta quedaria semanticamente incorrecta.
+- No hay harness browser automatizado en el repo para esta vista; la validacion BDD/UI sera manual.
+
+---
+
+## Criterios de Aceptacion Cubiertos
+
+- [x] Atleta autenticado es redirigido a su dashboard.
+- [x] Dashboard muestra email y rol del atleta.
+- [x] Solo se muestran torneos con inscripcion abierta.
+- [x] Si no hay torneos disponibles, se muestra mensaje informativo.
+- [x] El atleta no puede acceder a rutas del organizador ni del juez.
+
+## Metricas de Tiempo
+
+- **Tiempo estimado:** 140 min
+- **Tiempo real registrado:** 162 s
+- **Observacion:** el tracking refleja solo esta sesion de implementacion y no tiempo de espera externo.
+
+## Lecciones Aprendidas
+
+- El guard de rol existente ya soportaba la logica necesaria; el cambio real fue extender el mapa de home por rol.
+- La spec debio aterrizarse al estado frontend real `INSCRIPCION_ABIERTA` para evitar un filtro inconsistente.
+- Reutilizar el layout del organizador sin cambios hubiese dejado una semantica incorrecta para el atleta.
+
+**Estado:** 9/9 tareas completadas

--- a/docs/reports/US-5.3.2-report.md
+++ b/docs/reports/US-5.3.2-report.md
@@ -1,0 +1,67 @@
+# Reporte de Implementacion: US-5.3.2
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** US-5.3.2 - Vista del atleta
+- **Puntos estimados:** 2
+- **Tiempo estimado:** 140 min
+- **Tiempo real registrado:** 162 s
+- **Estado:** COMPLETADO
+- **Fecha completado:** 2026-04-23
+
+## Componentes Implementados
+
+- [x] Extension de `RolUsuario` con `atleta` en `frontend/src/types/auth.ts`
+- [x] Redireccion por rol `atleta` en `frontend/src/components/RequireRole.tsx`
+- [x] Root redirect y ruta protegida `/atleta/dashboard` en `frontend/src/App.tsx`
+- [x] Redirect desde `frontend/src/pages/LoginPage.tsx` para sesion activa de atleta
+- [x] Nueva pagina `frontend/src/pages/atleta/AtletaDashboardPage.tsx`
+- [x] Escenarios BDD en `tests/features/US-5.3.2-vista-atleta.feature`
+- [x] Plan actualizado en `docs/plans/sp5/US-5.3.2-plan.md`
+
+## Comportamiento Entregado
+
+- El atleta autenticado entra a `/atleta/dashboard` desde `/` y desde `/login`.
+- La vista muestra perfil de solo lectura con email y rol.
+- La lista de torneos usa `fetchTorneos()` y filtra client-side por `INSCRIPCION_ABIERTA`.
+- Si no hay torneos disponibles, la pantalla informa el estado vacio.
+- Si un atleta intenta entrar a rutas de juez u organizador, `RequireRole` lo redirige a su home.
+
+## Metricas de Calidad
+
+| Gate | Resultado |
+|------|-----------|
+| `npm run build` | OK |
+| `npm run lint` | OK |
+| Validacion manual BDD/UI | Pendiente de ejecucion manual en navegador |
+
+## Archivos Creados o Modificados
+
+- `frontend/src/types/auth.ts`
+- `frontend/src/components/RequireRole.tsx`
+- `frontend/src/App.tsx`
+- `frontend/src/pages/LoginPage.tsx`
+- `frontend/src/pages/atleta/AtletaDashboardPage.tsx`
+- `tests/features/US-5.3.2-vista-atleta.feature`
+- `docs/plans/sp5/US-5.3.2-plan.md`
+- `docs/reports/US-5.3.2-report.md`
+
+## Criterios de Aceptacion
+
+- [x] Atleta autenticado es redirigido a su dashboard.
+- [x] Dashboard muestra perfil del atleta.
+- [x] Dashboard muestra solo torneos con inscripcion abierta.
+- [x] Sin torneos disponibles muestra mensaje informativo.
+- [x] El atleta no puede acceder a rutas del organizador.
+- [x] El atleta no puede acceder a rutas del juez.
+
+## Riesgos y Observaciones
+
+- La spec usa `INSCRIPCION`, pero el frontend real normaliza y usa `INSCRIPCION_ABIERTA`.
+- No se implemento accion de inscripcion; queda para `INC-5.4`.
+- La validacion BDD automatizada no existe para browser en este repo, por lo que esa parte sigue siendo manual.
+
+## Proximos Pasos
+
+- Ejecutar validacion manual del flujo atleta en navegador.
+- Continuar con `US-5.4.1` para habilitar la inscripcion efectiva.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { RequireRole } from './components/RequireRole'
 import { DisciplinasPage } from './pages/juez/DisciplinasPage'
 import { GrillaPage } from './pages/juez/GrillaPage'
 import { PerformanceFlowPage } from './pages/juez/PerformanceFlowPage'
+import { AtletaDashboardPage } from './pages/atleta/AtletaDashboardPage'
 import { DashboardPage } from './pages/organizador/DashboardPage'
 import { CrearTorneoPage } from './pages/organizador/CrearTorneoPage'
 import { DetalleTorneoPage } from './pages/organizador/DetalleTorneoPage'
@@ -20,6 +21,7 @@ function RootRedirect() {
   const rol = useAuthStore((s) => s.rol)
   if (rol === 'juez') return <Navigate to="/juez/disciplinas" replace />
   if (rol === 'organizador') return <Navigate to="/organizador/dashboard" replace />
+  if (rol === 'atleta') return <Navigate to="/atleta/dashboard" replace />
   return <Navigate to="/login" replace />
 }
 
@@ -56,6 +58,14 @@ function App() {
           element={
             <RequireRole role="juez">
               <PerformanceFlowPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/atleta/dashboard"
+          element={
+            <RequireRole role="atleta">
+              <AtletaDashboardPage />
             </RequireRole>
           }
         />

--- a/frontend/src/components/RequireRole.tsx
+++ b/frontend/src/components/RequireRole.tsx
@@ -11,6 +11,7 @@ interface RequireRoleProps {
 const HOME_BY_ROL: Record<RolUsuario, string> = {
   juez: '/juez/disciplinas',
   organizador: '/organizador/dashboard',
+  atleta: '/atleta/dashboard',
 }
 
 export function RequireRole({ role, children }: RequireRoleProps) {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -27,6 +27,10 @@ export function LoginPage() {
     void navigate('/organizador/dashboard', { replace: true })
     return null
   }
+  if (rol === 'atleta') {
+    void navigate('/atleta/dashboard', { replace: true })
+    return null
+  }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -44,7 +48,7 @@ export function LoginPage() {
             Iniciar sesión
           </h1>
           <p className="mb-6 text-center text-sm text-slate-400">
-            Portal del juez y organizador
+            Portal del juez, organizador y atleta
           </p>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div>

--- a/frontend/src/pages/atleta/AtletaDashboardPage.tsx
+++ b/frontend/src/pages/atleta/AtletaDashboardPage.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchTorneos } from '../../api/torneo'
+import useAuthStore from '../../stores/useAuthStore'
+
+function formatearFecha(fechaIso: string): string {
+  const fecha = new Date(fechaIso)
+  return new Intl.DateTimeFormat('es-AR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(fecha)
+}
+
+export function AtletaDashboardPage() {
+  const email = useAuthStore((s) => s.email)
+  const logout = useAuthStore((s) => s.logout)
+  const torneosQuery = useQuery({
+    queryKey: ['torneos-atleta'],
+    queryFn: fetchTorneos,
+  })
+  const torneosDisponibles = useMemo(
+    () =>
+      (torneosQuery.data ?? []).filter((torneo) => torneo.estado === 'INSCRIPCION_ABIERTA'),
+    [torneosQuery.data],
+  )
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,#daf1f7_0%,#d5eee4_22%,#f6f2e8_60%,#efe6d4_100%)] text-stone-900">
+      <div className="mx-auto max-w-6xl px-5 py-6 sm:px-8 lg:px-10">
+        <header className="rounded-[2rem] border border-teal-200/70 bg-white/80 p-6 shadow-[0_20px_60px_rgba(45,94,99,0.12)] backdrop-blur">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="max-w-3xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-700">
+                Atleta
+              </p>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-stone-900">
+                Mi portal
+              </h1>
+              <p className="mt-2 text-sm text-stone-600">
+                Perfil personal y torneos con inscripcion abierta para proximas competencias.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={logout}
+              className="rounded-lg bg-stone-900 px-4 py-2 text-sm font-semibold text-stone-50"
+            >
+              Cerrar sesion
+            </button>
+          </div>
+        </header>
+
+        <main className="mt-6 grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <section className="rounded-[2rem] border border-teal-200/70 bg-white/85 p-5 shadow-[0_20px_60px_rgba(45,94,99,0.08)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-700">
+              Mi perfil
+            </p>
+            <div className="mt-5 space-y-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                  Email
+                </p>
+                <p className="mt-1 text-base font-semibold text-stone-900">
+                  {email ?? 'Sin email disponible'}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                  Rol
+                </p>
+                <p className="mt-1 text-base font-semibold text-stone-900">Atleta</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-[2rem] border border-teal-200/70 bg-white/85 p-5 shadow-[0_20px_60px_rgba(45,94,99,0.08)]">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-700">
+                  Torneos disponibles
+                </p>
+                <h2 className="mt-1 text-xl font-semibold text-stone-900">
+                  Inscripcion abierta
+                </h2>
+              </div>
+              <p className="text-sm text-stone-600">
+                {torneosDisponibles.length} torneos habilitados
+              </p>
+            </div>
+
+            {torneosQuery.isLoading ? (
+              <div className="mt-5 rounded-xl border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+                Cargando torneos disponibles...
+              </div>
+            ) : null}
+
+            {torneosQuery.isError ? (
+              <div className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+                No se pudieron cargar los torneos.
+              </div>
+            ) : null}
+
+            {!torneosQuery.isLoading && !torneosQuery.isError && torneosDisponibles.length === 0 ? (
+              <div className="mt-5 rounded-xl border border-stone-200 bg-stone-50 p-4 text-sm text-stone-600">
+                No hay torneos disponibles en este momento
+              </div>
+            ) : null}
+
+            {!torneosQuery.isLoading && !torneosQuery.isError && torneosDisponibles.length > 0 ? (
+              <div className="mt-5 grid gap-4">
+                {torneosDisponibles.map((torneo) => (
+                  <article
+                    key={torneo.torneo_id}
+                    className="rounded-[1.5rem] border border-stone-200 bg-[linear-gradient(135deg,#ffffff_0%,#f3fbf7_100%)] p-5"
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                      Torneo
+                    </p>
+                    <h3 className="mt-2 text-lg font-semibold text-stone-900">{torneo.nombre}</h3>
+                    <p className="mt-3 text-sm text-stone-600">
+                      {torneo.sede.nombre}, {torneo.sede.ciudad}, {torneo.sede.pais}
+                    </p>
+                    <p className="mt-2 text-sm text-stone-600">
+                      {formatearFecha(torneo.fecha_inicio)} al {formatearFecha(torneo.fecha_fin)}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            ) : null}
+          </section>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,4 +1,4 @@
-export type RolUsuario = 'juez' | 'organizador'
+export type RolUsuario = 'juez' | 'organizador' | 'atleta'
 
 export type EstadoPerformance =
   | 'AnunciadaAP'

--- a/tests/features/US-5.3.2-vista-atleta.feature
+++ b/tests/features/US-5.3.2-vista-atleta.feature
@@ -1,0 +1,42 @@
+Feature: US-5.3.2 - Vista del atleta
+
+  Background:
+    Given el sistema tiene los torneos:
+      | nombre                 | estado               |
+      | Buenos Aires Open 2026 | INSCRIPCION_ABIERTA  |
+      | Campeonato Patagonia   | INSCRIPCION_ABIERTA  |
+      | Torneo BA 2025         | CERRADO              |
+
+  Scenario: atleta autenticado es redirigido a su dashboard
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When navega a "/"
+    Then es redirigido a "/atleta/dashboard"
+
+  Scenario: dashboard muestra perfil del atleta
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When accede a "/atleta/dashboard"
+    Then ve su email "atleta1@email.com"
+    And ve su rol como "Atleta"
+
+  Scenario: dashboard muestra solo torneos en inscripcion abierta
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When accede a "/atleta/dashboard"
+    Then ve "Buenos Aires Open 2026" en la lista de torneos disponibles
+    And ve "Campeonato Patagonia" en la lista de torneos disponibles
+    And no ve "Torneo BA 2025" en la lista
+
+  Scenario: sin torneos disponibles muestra mensaje informativo
+    Given no existen torneos en estado INSCRIPCION_ABIERTA
+    And "atleta1@email.com" esta autenticado con rol ATLETA
+    When accede a "/atleta/dashboard"
+    Then ve el mensaje "No hay torneos disponibles en este momento"
+
+  Scenario: atleta no puede acceder a rutas del organizador
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When intenta navegar a "/organizador/dashboard"
+    Then es redirigido a "/atleta/dashboard"
+
+  Scenario: atleta no puede acceder a rutas del juez
+    Given "atleta1@email.com" esta autenticado con rol ATLETA
+    When intenta navegar a "/juez/disciplinas"
+    Then es redirigido a "/atleta/dashboard"


### PR DESCRIPTION
## Resumen
- agrega soporte frontend para el rol `atleta`
- incorpora dashboard de atleta con perfil y torneos con inscripcion abierta
- ajusta redirecciones y guards para bloquear accesos cruzados por rol
- incluye artefactos del workflow: feature BDD, plan y reporte final

## Validacion
- `npm run build` en `frontend/` OK
- `npm run lint` en `frontend/` OK
- validacion BDD/UI automatizada: no aplica; queda manual por ausencia de harness browser en el repo