### PR TITLE
US-5.4.1: auto-registro de usuario

### DIFF
--- a/.claude/tracking/US-5.4.1-tracking.json
+++ b/.claude/tracking/US-5.4.1-tracking.json
@@ -1,0 +1,178 @@
+{
+  "metadata": {
+    "us_id": "US-5.4.1",
+    "us_title": "Auto-registro de usuario",
+    "us_points": 5,
+    "producto": "identidad",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-24T11:50:30.611801+00:00",
+    "completed_at": "2026-04-24T12:02:59.849871+00:00",
+    "total_elapsed_seconds": 749,
+    "effective_seconds": 749,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-24T11:50:35.286502+00:00",
+      "completed_at": "2026-04-24T11:51:41.904944+00:00",
+      "elapsed_seconds": 66,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-24T11:51:45.109516+00:00",
+      "completed_at": "2026-04-24T11:51:49.152679+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-24T11:51:52.091544+00:00",
+      "completed_at": "2026-04-24T11:51:56.338063+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada por Tareas",
+      "started_at": "2026-04-24T11:53:10.118244+00:00",
+      "completed_at": "2026-04-24T12:01:53.818989+00:00",
+      "elapsed_seconds": 523,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Backend auto-registro identidad",
+          "task_type": "backend",
+          "estimated_minutes": 120.0,
+          "started_at": "2026-04-24T11:53:13.799437+00:00",
+          "completed_at": "2026-04-24T12:01:32.044112+00:00",
+          "elapsed_seconds": 498,
+          "actual_minutes": 8.3,
+          "variance_minutes": -111.7,
+          "file_created": "src/identidad/api/router.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Frontend registro y usuarios",
+          "task_type": "frontend",
+          "estimated_minutes": 100.0,
+          "started_at": "2026-04-24T12:01:35.846165+00:00",
+          "completed_at": "2026-04-24T12:01:39.597678+00:00",
+          "elapsed_seconds": 3,
+          "actual_minutes": 0.05,
+          "variance_minutes": -99.95,
+          "file_created": "frontend/src/pages/RegistroPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Validacion automatizada y reporte",
+          "task_type": "test",
+          "estimated_minutes": 40.0,
+          "started_at": "2026-04-24T12:01:44.812792+00:00",
+          "completed_at": "2026-04-24T12:01:48.711463+00:00",
+          "elapsed_seconds": 3,
+          "actual_minutes": 0.05,
+          "variance_minutes": -39.95,
+          "file_created": "docs/reports/US-5.4.1-report.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-24T12:01:58.948845+00:00",
+      "completed_at": "2026-04-24T12:02:02.819495+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-24T12:02:07.142806+00:00",
+      "completed_at": "2026-04-24T12:02:11.843176+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-24T12:02:15.848216+00:00",
+      "completed_at": "2026-04-24T12:02:20.770241+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-24T12:02:28.658347+00:00",
+      "completed_at": "2026-04-24T12:02:33.100980+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Actualización de Documentación",
+      "started_at": "2026-04-24T12:02:38.850703+00:00",
+      "completed_at": "2026-04-24T12:02:45.216352+00:00",
+      "elapsed_seconds": 6,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-24T12:02:50.571724+00:00",
+      "completed_at": "2026-04-24T12:02:54.664827+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 10,
+    "estimated_total_minutes": 260.0,
+    "actual_total_minutes": 8.4,
+    "variance_minutes": -251.6,
+    "variance_percent": -96.77
+  }
+}

--- a/docs/plans/sp5/US-5.4.1-fase0.md
+++ b/docs/plans/sp5/US-5.4.1-fase0.md
@@ -1,0 +1,93 @@
+# US-5.4.1 — Fase 0: Validacion de Contexto
+
+**Fecha:** 2026-04-24
+**Branch:** `feature/US-5.4.1-auto-registro`
+**Producto:** `identidad` + `frontend`
+**Incremento:** INC-5.4 — Identidad Extendida
+
+---
+
+## Historia de Usuario
+
+**US:** US-5.4.1 — Auto-registro de usuario
+
+Como **persona sin cuenta**, quiero **registrarme con mi nombre, apellido, email, password y rol** para **acceder a la plataforma con el rol adecuado sin intervencion del organizador**.
+
+**Spec canonica:** `docs/specs/sp5/US-5.4.1.md`
+
+---
+
+## Contexto Validado
+
+### Arquitectura
+
+- Patron confirmado: Hexagonal DDD BC-first.
+- BC principal: `identidad`.
+- Producto UI afectado: `frontend`.
+- El flujo reutiliza el endpoint publico `POST /auth/registro` y extiende el aggregate `Usuario`.
+
+### Artefactos arquitectonicos encontrados
+
+- `docs/contexto/ATARAXIADIVE-CONTEXT.md`
+- `docs/adr/ADR-005-bounded-contexts-ddd-estrategico.md`
+- `docs/adr/ADR-006-estructura-bc-first.md`
+- `docs/design/architecture.md`
+- `docs/design/domain-model.md`
+
+### Estructura verificada
+
+- `src/identidad/domain/`
+- `src/identidad/application/`
+- `src/identidad/infrastructure/`
+- `src/identidad/api/`
+- `frontend/src/pages/`
+- `frontend/src/api/`
+- `tests/features/`
+
+---
+
+## Estado Actual Relevante
+
+### Backend identidad
+
+- `Usuario` hoy persiste `email`, `password_hash`, `rol` y `activo`; aun no tiene `nombre` ni `apellido`.
+- `RegistrarUsuarioCommand` y `RegistrarUsuarioHandler` aceptan solo `email`, `password` y `rol`.
+- `POST /auth/registro` ya existe y devuelve `201`, `409` o `422`, pero no bloquea `ADMIN`.
+- `GET /auth/usuarios` ya soporta listado completo para organizador, aunque la respuesta no incluye `nombre` ni `apellido`.
+- `SQLiteUsuarioRepository` crea la tabla `usuarios` sin columnas `nombre` y `apellido`, por lo que necesita migracion compatible con bases existentes.
+
+### Frontend
+
+- `LoginPage` no ofrece aun link publico a `/registro`.
+- `App.tsx` no expone ruta publica `/registro`.
+- `frontend/src/api/identidad.ts` soporta creacion/listado de usuarios, pero el payload de alta no incluye `nombre` ni `apellido`.
+- `UsuariosPage.tsx` muestra email, rol y estado; todavia no renderiza nombre/apellido.
+
+---
+
+## Quality Gates
+
+- `CLAUDE.md` encontrado.
+- `pyproject.toml` encontrado.
+- `[tool.codeguard]` configurado.
+- `[tool.designreviewer]` configurado.
+- Tests configurados en `tests/`.
+- Para esta US mixta, los gates esperables son:
+  - `pytest` sobre identidad
+  - `npm run build` en `frontend/`
+  - `npm run lint` en `frontend/` si el baseline local lo permite
+
+---
+
+## Riesgos Detectados
+
+- La migracion de SQLite debe ser idempotente: la tabla ya existe en entornos locales previos.
+- La regla `rol != ADMIN` tiene que aplicarse en backend, no solo en el selector del frontend.
+- Extender `UsuarioResponse` impacta la pagina existente `UsuariosPage`; esa pantalla no puede quedar desincronizada con la API.
+- El criterio de exito del registro combina UI publica y BC `identidad`; conviene implementar primero dominio/API y luego la pagina publica.
+
+---
+
+## Resultado
+
+Contexto validado. La US esta lista para Fase 1: escenarios BDD.

--- a/docs/plans/sp5/US-5.4.1-plan.md
+++ b/docs/plans/sp5/US-5.4.1-plan.md
@@ -1,0 +1,150 @@
+# Plan de Implementacion: US-5.4.1 - Auto-registro de usuario
+
+**Historia:** US-5.4.1 - Auto-registro de usuario
+**Incremento:** INC-5.4 - Identidad Extendida
+**Producto:** identidad + frontend
+**Patron:** Hexagonal DDD BC-first + React/Vite frontend
+**Estimacion:** 5 puntos
+**Estado:** EN PLANIFICACION
+
+---
+
+## Alcance
+
+Implementar auto-registro publico con extension del aggregate `Usuario`:
+
+- Extender `Usuario` con `nombre` y `apellido`.
+- Extender `POST /auth/registro` para aceptar esos campos.
+- Rechazar `rol=ADMIN` en backend con `403`.
+- Migrar SQLite para agregar columnas `nombre` y `apellido` sin romper DBs existentes.
+- Crear pagina publica `/registro` y link desde `LoginPage`.
+- Actualizar `UsuariosPage` y `GET /auth/usuarios` para mostrar `nombre` y `apellido`.
+
+Fuera de alcance: login automatico post-registro, recuperacion de password, cambio de password, edicion de perfil.
+
+---
+
+## Componentes a Modificar
+
+### Dominio identidad
+
+- [ ] `src/identidad/domain/aggregates/usuario.py` (20 min)
+  - Agregar `nombre` y `apellido` al aggregate.
+  - Validar que no sean vacios o solo espacios.
+
+- [ ] `src/identidad/domain/exceptions.py` (10 min)
+  - Agregar `RolNoPermitido`.
+  - Reutilizar mensaje especificado por la US.
+
+### Aplicacion identidad
+
+- [ ] `src/identidad/application/commands/registrar_usuario.py` (25 min)
+  - Extender `RegistrarUsuarioCommand` con `nombre` y `apellido`.
+  - Rechazar `Rol.ADMIN` antes de persistir.
+  - Construir `Usuario` con los nuevos campos.
+
+### Infraestructura identidad
+
+- [ ] `src/identidad/infrastructure/repositories/sqlite_usuario_repository.py` (40 min)
+  - Extender esquema `usuarios` con `nombre` y `apellido`.
+  - Hacer migracion idempotente en `_ensure_table`.
+  - Actualizar `save`, `find_by_id`, `find_by_email`, `list_by_rol` y `list_all`.
+
+### API identidad
+
+- [ ] `src/identidad/api/router.py` (35 min)
+  - Extender `RegistroRequest` con `nombre` y `apellido`.
+  - Validar password como hoy y mapear `RolNoPermitido` a `403`.
+  - Extender `UsuarioResponse` y el listado `/auth/usuarios`.
+
+### Frontend API
+
+- [ ] `frontend/src/api/identidad.ts` (25 min)
+  - Extender `CrearUsuarioRequest` con `nombre` y `apellido`.
+  - Extender `UsuarioDto` con `nombre` y `apellido`.
+  - Mantener compatibilidad con `listarTodosLosUsuarios()` y `crearUsuario()`.
+
+### Frontend paginas y routing
+
+- [ ] `frontend/src/pages/RegistroPage.tsx` (90 min)
+  - Crear pagina publica con campos nombre, apellido, email, password y rol.
+  - Validar nombre/apellido requeridos y password minima.
+  - Mostrar errores inline por `409`, `422` y `403`.
+  - Redirigir a `/login` tras alta exitosa con mensaje visible.
+
+- [ ] `frontend/src/pages/LoginPage.tsx` (15 min)
+  - Agregar CTA hacia `/registro`.
+  - Mantener redirect por sesion activa.
+
+- [ ] `frontend/src/App.tsx` (15 min)
+  - Registrar ruta publica `/registro`.
+
+- [ ] `frontend/src/pages/organizador/UsuariosPage.tsx` (30 min)
+  - Mostrar nombre y apellido junto al email en la lista.
+  - Ajustar formulario existente al nuevo payload.
+
+---
+
+## Tests
+
+### Unitarios backend
+
+- [ ] `tests/unit/identidad/application/test_registrar_usuario.py` (35 min)
+  - Cubrir nombre/apellido requeridos.
+  - Cubrir rechazo de `ADMIN`.
+  - Mantener email unico y password minima.
+
+- [ ] `tests/unit/identidad/api/test_registro_usuario.py` (35 min)
+  - Cubrir `201`, `403`, `409` y `422`.
+  - Verificar que el payload requiere `nombre` y `apellido`.
+
+### Integracion backend
+
+- [ ] `tests/integration/identidad/test_sqlite_usuario_repository.py` (30 min)
+  - Cubrir persistencia y lectura de `nombre`/`apellido`.
+  - Cubrir upgrade sobre DB existente con tabla sin columnas nuevas.
+
+### Frontend
+
+- [ ] Validacion TypeScript/build (20 min)
+  - Ejecutar `npm run build` en `frontend/`.
+  - Ejecutar `npm run lint` en `frontend/` si el baseline local lo permite.
+
+### BDD
+
+- [ ] `tests/features/US-5.4.1-auto-registro.feature` (15 min)
+  - Feature creada en Fase 1.
+  - Validacion UI/manual documentada si no hay harness browser automatizado.
+
+---
+
+## Quality Gates
+
+- [ ] `pytest` sobre tests unitarios de identidad afectados
+- [ ] `pytest` sobre tests de integracion de identidad afectados
+- [ ] `npm run build` en `frontend/`
+- [ ] `npm run lint` en `frontend/` si no falla por deuda previa ajena
+- [ ] `codeguard src/identidad/ --format json > quality/reports/codeguard/US-5.4.1-codeguard-raw.json`
+- [ ] Resumen `quality/reports/codeguard/US-5.4.1-quality.json`
+
+---
+
+## Riesgos y Decisiones
+
+- La decision de dejar `nombre` y `apellido` vacios para usuarios legacy queda acotada a la migracion; los nuevos registros no pueden crearse vacios.
+- El selector del frontend no expone `ADMIN`, pero la garantia real vive en el handler/backend.
+- La pantalla `UsuariosPage` ya existe y no puede romperse mientras entra la pagina publica.
+- El mensaje post-registro debe sobrevivir al redirect a `/login` sin requerir autenticacion previa.
+
+---
+
+## Criterios de Aceptacion Cubiertos
+
+- [ ] Auto-registro exitoso como atleta.
+- [ ] Nombre o apellido vacios se rechazan antes de enviar.
+- [ ] Email duplicado muestra error inline.
+- [ ] Rol `ADMIN` se rechaza en backend.
+- [ ] Rol `ADMIN` no aparece en selector.
+- [ ] Login muestra link publico a registro.
+
+**Estado:** 0/13 tareas completadas

--- a/docs/reports/US-5.4.1-report.md
+++ b/docs/reports/US-5.4.1-report.md
@@ -1,0 +1,66 @@
+# Reporte de Implementacion: US-5.4.1
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** US-5.4.1 - Auto-registro de usuario
+- **Puntos estimados:** 5
+- **Estado:** COMPLETADO
+- **Fecha completado:** 2026-04-24
+- **Branch de trabajo:** `feature/US-5.4.1-auto-registro`
+
+## Componentes Implementados
+
+- [x] Extension de `Usuario` con `nombre` y `apellido`.
+- [x] Nueva excepcion `RolNoPermitido` y validacion de campos requeridos.
+- [x] `RegistrarUsuarioCommand` y `RegistrarUsuarioHandler` extendidos para auto-registro publico.
+- [x] Migracion idempotente de `SQLiteUsuarioRepository` para columnas `nombre` y `apellido`.
+- [x] `POST /auth/registro` con payload extendido y rechazo de `ADMIN`.
+- [x] `GET /auth/usuarios` ahora expone `nombre` y `apellido`.
+- [x] Cliente frontend de identidad actualizado al nuevo contrato.
+- [x] Nueva pagina publica `frontend/src/pages/RegistroPage.tsx`.
+- [x] `LoginPage` con CTA a `/registro` y mensaje post-registro.
+- [x] `UsuariosPage` ajustada para nombre/apellido y nuevo payload.
+
+## Comportamiento Entregado
+
+- Una persona sin cuenta puede registrarse con nombre, apellido, email, password y rol.
+- El backend rechaza `rol=ADMIN` con `403` aunque el cliente no lo exponga.
+- La persistencia de identidad migra bases SQLite existentes sin recrear la tabla.
+- La pagina de login ahora permite navegar a `/registro`.
+- La lista de usuarios del organizador muestra nombre y apellido ademas de email, rol y estado.
+
+## Validacion Ejecutada
+
+| Gate | Resultado |
+|------|-----------|
+| `./.venv/bin/pytest tests/unit/identidad tests/integration/identidad` | OK |
+| `npm run build` | OK |
+| `npm run lint` | OK |
+| Validacion BDD/UI en navegador | Pendiente manual |
+
+## Riesgos y Observaciones
+
+- La advertencia de chunk >500 kB en Vite sigue presente, pero no bloquea el build de esta US.
+- Los tests de JWT siguen emitiendo `InsecureKeyLengthWarning` por el secret corto del fixture de prueba existente.
+- La migracion deja usuarios legacy con `nombre` y `apellido` vacios si ya existian en la base local; los nuevos registros no permiten ese estado.
+
+## Archivos Relevantes
+
+- `src/identidad/domain/aggregates/usuario.py`
+- `src/identidad/application/commands/registrar_usuario.py`
+- `src/identidad/infrastructure/repositories/sqlite_usuario_repository.py`
+- `src/identidad/api/router.py`
+- `frontend/src/pages/RegistroPage.tsx`
+- `frontend/src/pages/LoginPage.tsx`
+- `frontend/src/pages/organizador/UsuariosPage.tsx`
+- `tests/unit/identidad/api/test_registro_usuario.py`
+- `tests/integration/identidad/test_sqlite_usuario_repository.py`
+
+## Criterios de Aceptacion
+
+- [x] Auto-registro exitoso como atleta.
+- [x] Nombre o apellido vacios se rechazan antes de enviar.
+- [x] Email duplicado muestra error inline.
+- [x] Rol `ADMIN` se rechaza en backend.
+- [x] Rol `ADMIN` no aparece en selector.
+- [x] Login muestra link a registro.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useConnectionSync } from './stores/useConnectionStore'
 import { useSyncQueue } from './hooks/useSyncQueue'
 import useAuthStore from './stores/useAuthStore'
 import { LoginPage } from './pages/LoginPage'
+import { RegistroPage } from './pages/RegistroPage'
 import { RequireRole } from './components/RequireRole'
 import { DisciplinasPage } from './pages/juez/DisciplinasPage'
 import { GrillaPage } from './pages/juez/GrillaPage'
@@ -36,6 +37,7 @@ function App() {
       </div>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/registro" element={<RegistroPage />} />
         <Route path="/" element={<RootRedirect />} />
         <Route
           path="/juez/disciplinas"

--- a/frontend/src/api/identidad.ts
+++ b/frontend/src/api/identidad.ts
@@ -14,12 +14,16 @@ export type RolGestionUsuario = Exclude<RolIdentidad, 'ADMIN'>
 
 export interface UsuarioDto {
   usuario_id: string
+  nombre: string
+  apellido: string
   email: string
   rol: RolIdentidad
   activo: boolean
 }
 
 export interface CrearUsuarioRequest {
+  nombre: string
+  apellido: string
   email: string
   password: string
   rol: RolGestionUsuario

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Link, Navigate, useSearchParams } from 'react-router-dom'
 import { useMutation } from '@tanstack/react-query'
 import { loginApi } from '../api/auth'
 import useAuthStore from '../stores/useAuthStore'
 
 export function LoginPage() {
+  const [searchParams] = useSearchParams()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const login = useAuthStore((s) => s.login)
@@ -16,6 +17,7 @@ export function LoginPage() {
       login(data.access_token)
     },
   })
+  const registered = searchParams.get('registered') === '1'
 
   // Redirect si ya tiene sesión activa
   if (rol === 'juez') {
@@ -46,6 +48,11 @@ export function LoginPage() {
           <p className="mb-6 text-center text-sm text-slate-400">
             Portal del juez, organizador y atleta
           </p>
+          {registered ? (
+            <p className="mb-4 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-100">
+              Cuenta creada. Inicia sesion.
+            </p>
+          ) : null}
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div>
             <label className="mb-1 block text-sm font-medium text-slate-300">Email</label>
@@ -82,6 +89,12 @@ export function LoginPage() {
             {mutation.isPending ? 'Iniciando sesión...' : 'Iniciar sesión'}
           </button>
         </form>
+          <p className="mt-5 text-center text-sm text-slate-400">
+            No tenes cuenta?{' '}
+            <Link to="/registro" className="font-semibold text-sky-300 hover:text-sky-200">
+              Registrate
+            </Link>
+          </p>
       </div>
       </div>
     </div>

--- a/frontend/src/pages/RegistroPage.tsx
+++ b/frontend/src/pages/RegistroPage.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react'
+import type { FormEvent } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { useMutation } from '@tanstack/react-query'
+import {
+  ApiError,
+  crearUsuario,
+  type CrearUsuarioRequest,
+  type RolGestionUsuario,
+} from '../api/identidad'
+import useAuthStore from '../stores/useAuthStore'
+
+type FormState = CrearUsuarioRequest
+
+type FormErrors = Partial<Record<keyof FormState | 'general', string>>
+
+const INITIAL_FORM: FormState = {
+  nombre: '',
+  apellido: '',
+  email: '',
+  password: '',
+  rol: 'ATLETA',
+}
+
+const ROLES: Array<{ value: RolGestionUsuario; label: string }> = [
+  { value: 'ATLETA', label: 'Atleta' },
+  { value: 'JUEZ', label: 'Juez' },
+  { value: 'ORGANIZADOR', label: 'Organizador' },
+]
+
+function inputClass(hasError: boolean): string {
+  return [
+    'w-full rounded-2xl border px-4 py-3 text-sm text-slate-100 focus:outline-none focus:ring-2',
+    hasError
+      ? 'border-red-500 bg-red-950/30 focus:ring-red-500'
+      : 'border-slate-700 bg-slate-950 focus:ring-sky-500',
+  ].join(' ')
+}
+
+function resolveApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 409) return 'Este email ya esta registrado'
+    if (error.status === 422) return 'La contrasena debe tener al menos 8 caracteres'
+    if (error.status === 403) return 'El rol ADMIN no esta permitido en el auto-registro'
+    return error.message
+  }
+  if (error instanceof Error) return error.message
+  return 'No se pudo crear la cuenta'
+}
+
+export function RegistroPage() {
+  const navigate = useNavigate()
+  const rol = useAuthStore((s) => s.rol)
+  const [form, setForm] = useState<FormState>(INITIAL_FORM)
+  const [errors, setErrors] = useState<FormErrors>({})
+
+  const mutation = useMutation({
+    mutationFn: crearUsuario,
+    onSuccess: () => {
+      navigate('/login?registered=1', { replace: true })
+    },
+    onError: (error) => {
+      const message = resolveApiError(error)
+      if (error instanceof ApiError && error.status === 409) {
+        setErrors((current) => ({ ...current, email: message, general: undefined }))
+        return
+      }
+      if (error instanceof ApiError && error.status === 422) {
+        setErrors((current) => ({ ...current, password: message, general: undefined }))
+        return
+      }
+      setErrors((current) => ({ ...current, general: message }))
+    },
+  })
+
+  if (rol === 'juez') return <Navigate to="/juez/disciplinas" replace />
+  if (rol === 'organizador') return <Navigate to="/organizador/dashboard" replace />
+  if (rol === 'atleta') return <Navigate to="/atleta/dashboard" replace />
+
+  function updateField<T extends keyof FormState>(field: T, value: FormState[T]) {
+    setForm((current) => ({ ...current, [field]: value }))
+    setErrors((current) => ({ ...current, [field]: undefined, general: undefined }))
+  }
+
+  function validate(): FormErrors {
+    const nextErrors: FormErrors = {}
+    if (!form.nombre.trim()) nextErrors.nombre = 'El nombre es requerido'
+    if (!form.apellido.trim()) nextErrors.apellido = 'El apellido es requerido'
+    if (!form.email.trim()) nextErrors.email = 'El email es obligatorio'
+    if (!form.password) {
+      nextErrors.password = 'La contrasena es obligatoria'
+    } else if (form.password.length < 8) {
+      nextErrors.password = 'La contrasena debe tener al menos 8 caracteres'
+    }
+    return nextErrors
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const validationErrors = validate()
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) {
+      return
+    }
+
+    mutation.mutate({
+      nombre: form.nombre.trim(),
+      apellido: form.apellido.trim(),
+      email: form.email.trim(),
+      password: form.password,
+      rol: form.rol,
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex min-h-screen w-full max-w-md items-center px-4 py-8">
+        <div className="w-full rounded-[2rem] border border-slate-800 bg-slate-900/80 p-8 shadow-[0_24px_80px_-50px_rgba(34,211,238,0.7)]">
+          <p className="text-center text-xs font-semibold uppercase tracking-[0.24em] text-sky-400">
+            AtaraxiaDive
+          </p>
+          <h1 className="mb-2 mt-3 text-center text-3xl font-semibold text-slate-50">
+            Crear cuenta
+          </h1>
+          <p className="mb-6 text-center text-sm text-slate-400">
+            Registro publico para atletas, jueces y organizadores
+          </p>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="text-sm font-medium text-slate-300">
+                Nombre
+                <input
+                  type="text"
+                  value={form.nombre}
+                  onChange={(event) => updateField('nombre', event.target.value)}
+                  className={inputClass(Boolean(errors.nombre))}
+                />
+                {errors.nombre ? (
+                  <span className="mt-1 block text-sm text-red-300">{errors.nombre}</span>
+                ) : null}
+              </label>
+              <label className="text-sm font-medium text-slate-300">
+                Apellido
+                <input
+                  type="text"
+                  value={form.apellido}
+                  onChange={(event) => updateField('apellido', event.target.value)}
+                  className={inputClass(Boolean(errors.apellido))}
+                />
+                {errors.apellido ? (
+                  <span className="mt-1 block text-sm text-red-300">{errors.apellido}</span>
+                ) : null}
+              </label>
+            </div>
+
+            <label className="text-sm font-medium text-slate-300">
+              Email
+              <input
+                type="email"
+                value={form.email}
+                onChange={(event) => updateField('email', event.target.value)}
+                className={inputClass(Boolean(errors.email))}
+              />
+              {errors.email ? <span className="mt-1 block text-sm text-red-300">{errors.email}</span> : null}
+            </label>
+
+            <label className="text-sm font-medium text-slate-300">
+              Contraseña
+              <input
+                type="password"
+                value={form.password}
+                onChange={(event) => updateField('password', event.target.value)}
+                className={inputClass(Boolean(errors.password))}
+              />
+              {errors.password ? (
+                <span className="mt-1 block text-sm text-red-300">{errors.password}</span>
+              ) : null}
+            </label>
+
+            <label className="text-sm font-medium text-slate-300">
+              Rol
+              <select
+                value={form.rol}
+                onChange={(event) => updateField('rol', event.target.value as RolGestionUsuario)}
+                className={inputClass(false)}
+              >
+                {ROLES.map((rolOption) => (
+                  <option key={rolOption.value} value={rolOption.value}>
+                    {rolOption.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {errors.general ? (
+              <p className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-100">
+                {errors.general}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={mutation.isPending}
+              className="rounded-2xl bg-sky-500 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950 transition-colors hover:bg-sky-400 disabled:opacity-50"
+            >
+              {mutation.isPending ? 'Creando cuenta...' : 'Registrarme'}
+            </button>
+          </form>
+
+          <p className="mt-6 text-center text-sm text-slate-400">
+            ¿Ya tenes cuenta?{' '}
+            <Link to="/login" className="font-semibold text-sky-300 hover:text-sky-200">
+              Inicia sesion
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/organizador/UsuariosPage.tsx
+++ b/frontend/src/pages/organizador/UsuariosPage.tsx
@@ -12,6 +12,8 @@ import {
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 
 interface FormState {
+  nombre: string
+  apellido: string
   email: string
   password: string
   rol: RolGestionUsuario
@@ -20,6 +22,8 @@ interface FormState {
 type FormErrors = Partial<Record<keyof FormState | 'general', string>>
 
 const INITIAL_FORM: FormState = {
+  nombre: '',
+  apellido: '',
   email: '',
   password: '',
   rol: 'JUEZ',
@@ -106,6 +110,12 @@ export function UsuariosPage() {
     if (!form.email.trim()) {
       nextErrors.email = 'El email es obligatorio'
     }
+    if (!form.nombre.trim()) {
+      nextErrors.nombre = 'El nombre es obligatorio'
+    }
+    if (!form.apellido.trim()) {
+      nextErrors.apellido = 'El apellido es obligatorio'
+    }
     if (!form.password) {
       nextErrors.password = 'La contrasena es obligatoria'
     } else if (form.password.length < 8) {
@@ -123,6 +133,8 @@ export function UsuariosPage() {
     }
 
     crearUsuarioMutation.mutate({
+      nombre: form.nombre.trim(),
+      apellido: form.apellido.trim(),
       email: form.email.trim(),
       password: form.password,
       rol: form.rol,
@@ -175,6 +187,8 @@ export function UsuariosPage() {
               <table className="w-full border-collapse text-left text-sm">
                 <thead className="bg-stone-100 text-xs uppercase text-stone-500">
                   <tr>
+                    <th className="px-4 py-3 font-semibold">Nombre</th>
+                    <th className="px-4 py-3 font-semibold">Apellido</th>
                     <th className="px-4 py-3 font-semibold">Email</th>
                     <th className="px-4 py-3 font-semibold">Rol</th>
                     <th className="px-4 py-3 font-semibold">Estado</th>
@@ -183,6 +197,8 @@ export function UsuariosPage() {
                 <tbody className="divide-y divide-stone-200">
                   {usuarios.map((usuario) => (
                     <tr key={usuario.usuario_id} className="bg-white">
+                      <td className="px-4 py-3 text-stone-900">{usuario.nombre}</td>
+                      <td className="px-4 py-3 text-stone-900">{usuario.apellido}</td>
                       <td className="px-4 py-3 font-medium text-stone-900">{usuario.email}</td>
                       <td className="px-4 py-3 text-stone-700">
                         {ROL_LABELS[usuario.rol] ?? usuario.rol}
@@ -218,6 +234,34 @@ export function UsuariosPage() {
               {errors.general}
             </div>
           ) : null}
+
+          <label className="mt-5 block text-sm font-semibold text-stone-900">
+            Nombre
+            <input
+              type="text"
+              value={form.nombre}
+              onChange={(event) => updateField('nombre', event.target.value)}
+              className={inputClass(Boolean(errors.nombre))}
+              placeholder="Ana"
+            />
+            {errors.nombre ? (
+              <span className="mt-1 block text-sm text-red-700">{errors.nombre}</span>
+            ) : null}
+          </label>
+
+          <label className="mt-4 block text-sm font-semibold text-stone-900">
+            Apellido
+            <input
+              type="text"
+              value={form.apellido}
+              onChange={(event) => updateField('apellido', event.target.value)}
+              className={inputClass(Boolean(errors.apellido))}
+              placeholder="Garcia"
+            />
+            {errors.apellido ? (
+              <span className="mt-1 block text-sm text-red-700">{errors.apellido}</span>
+            ) : null}
+          </label>
 
           <label className="mt-5 block text-sm font-semibold text-stone-900">
             Email

--- a/src/identidad/api/router.py
+++ b/src/identidad/api/router.py
@@ -23,11 +23,15 @@ from identidad.application.commands.registrar_usuario import (
     RegistrarUsuarioHandler,
 )
 from identidad.domain.exceptions import (
+    CampoRequerido,
     CredencialesInvalidas,
     EmailYaRegistrado,
     PasswordDemasiadoCorto,
+    RolNoPermitido,
     UsuarioInactivo,
 )
+from identidad.domain.ports.password_hashing_port import PasswordHashingPort
+from identidad.domain.ports.token_service_port import TokenServicePort
 from identidad.domain.ports.usuario_repository_port import UsuarioRepositoryPort
 from identidad.domain.value_objects.rol import Rol
 
@@ -38,9 +42,19 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 class RegistroRequest(BaseModel):
+    nombre: str
+    apellido: str
     email: str
     password: str
     rol: Rol
+
+    @field_validator("nombre", "apellido")
+    @classmethod
+    def required_trimmed(cls, v: str, info) -> str:  # type: ignore[no-untyped-def]
+        normalizado = v.strip()
+        if not normalizado:
+            raise ValueError(f"El {info.field_name} es requerido")
+        return normalizado
 
     @field_validator("password")
     @classmethod
@@ -66,6 +80,8 @@ class LoginResponse(BaseModel):
 
 class UsuarioResponse(BaseModel):
     usuario_id: UUID
+    nombre: str
+    apellido: str
     email: str
     rol: Rol
     activo: bool
@@ -75,25 +91,39 @@ class UsuarioResponse(BaseModel):
 
 
 @router.post("/registro", status_code=201)
-async def registrar_usuario(body: RegistroRequest) -> JSONResponse:
-    repo = get_usuario_repository()
-    password_hasher = get_password_hasher()
+async def registrar_usuario(
+    body: RegistroRequest,
+    repo: Annotated[UsuarioRepositoryPort, Depends(get_usuario_repository)],
+    password_hasher: Annotated[PasswordHashingPort, Depends(get_password_hasher)],
+) -> JSONResponse:
     handler = RegistrarUsuarioHandler(repo, password_hasher)
-    cmd = RegistrarUsuarioCommand(email=body.email, password=body.password, rol=body.rol)
+    cmd = RegistrarUsuarioCommand(
+        nombre=body.nombre,
+        apellido=body.apellido,
+        email=body.email,
+        password=body.password,
+        rol=body.rol,
+    )
     try:
         usuario_id = await handler.handle(cmd)
+    except CampoRequerido as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
     except PasswordDemasiadoCorto as exc:
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except EmailYaRegistrado as exc:
         return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except RolNoPermitido as exc:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
     return JSONResponse(status_code=201, content={"usuario_id": str(usuario_id)})
 
 
 @router.post("/login", status_code=200)
-async def autenticar_usuario(body: LoginRequest) -> JSONResponse:
-    repo = get_usuario_repository()
-    token_service = get_token_service()
-    password_hasher = get_password_hasher()
+async def autenticar_usuario(
+    body: LoginRequest,
+    repo: Annotated[UsuarioRepositoryPort, Depends(get_usuario_repository)],
+    token_service: Annotated[TokenServicePort, Depends(get_token_service)],
+    password_hasher: Annotated[PasswordHashingPort, Depends(get_password_hasher)],
+) -> JSONResponse:
     handler = AutenticarUsuarioHandler(repo, token_service, password_hasher)
     cmd = AutenticarUsuarioCommand(email=body.email, password=body.password)
     try:
@@ -121,6 +151,8 @@ async def listar_usuarios(
         content=[
             {
                 "usuario_id": str(usuario.usuario_id),
+                "nombre": usuario.nombre,
+                "apellido": usuario.apellido,
                 "email": usuario.email,
                 "rol": usuario.rol.value,
                 "activo": usuario.activo,

--- a/src/identidad/application/commands/registrar_usuario.py
+++ b/src/identidad/application/commands/registrar_usuario.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from identidad.domain.aggregates.usuario import Usuario
-from identidad.domain.exceptions import EmailYaRegistrado, PasswordDemasiadoCorto
+from identidad.domain.exceptions import EmailYaRegistrado, PasswordDemasiadoCorto, RolNoPermitido
 from identidad.domain.ports.password_hashing_port import PasswordHashingPort
 from identidad.domain.ports.usuario_repository_port import UsuarioRepositoryPort
 from identidad.domain.value_objects.rol import Rol
@@ -15,6 +15,8 @@ _MIN_PASSWORD_LENGTH = 8
 
 @dataclass(frozen=True)
 class RegistrarUsuarioCommand:
+    nombre: str
+    apellido: str
     email: str
     password: str  # plain — el handler hashea con bcrypt
     rol: Rol
@@ -30,6 +32,9 @@ class RegistrarUsuarioHandler:
         if len(cmd.password) < _MIN_PASSWORD_LENGTH:
             raise PasswordDemasiadoCorto()
 
+        if cmd.rol == Rol.ADMIN:
+            raise RolNoPermitido()
+
         # INV-ID-01: email único
         existente = await self._repo.find_by_email(cmd.email)
         if existente is not None:
@@ -40,6 +45,8 @@ class RegistrarUsuarioHandler:
 
         usuario = Usuario(
             usuario_id=uuid.uuid4(),
+            nombre=cmd.nombre,
+            apellido=cmd.apellido,
             email=cmd.email,
             password_hash=password_hash,
             rol=cmd.rol,

--- a/src/identidad/domain/aggregates/usuario.py
+++ b/src/identidad/domain/aggregates/usuario.py
@@ -3,13 +3,27 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from uuid import UUID
 
+from identidad.domain.exceptions import CampoRequerido
 from identidad.domain.value_objects.rol import Rol
 
 
 @dataclass
 class Usuario:
     usuario_id: UUID
+    nombre: str
+    apellido: str
     email: str
     password_hash: str  # bcrypt — nunca plain text
     rol: Rol
     activo: bool = field(default=True)
+
+    def __post_init__(self) -> None:
+        self.nombre = self._validar_requerido(self.nombre, "nombre")
+        self.apellido = self._validar_requerido(self.apellido, "apellido")
+
+    @staticmethod
+    def _validar_requerido(valor: str, campo: str) -> str:
+        normalizado = valor.strip()
+        if not normalizado:
+            raise CampoRequerido(campo)
+        return normalizado

--- a/src/identidad/domain/exceptions.py
+++ b/src/identidad/domain/exceptions.py
@@ -26,6 +26,16 @@ class PasswordDemasiadoCorto(Exception):
         super().__init__("La contraseña debe tener al menos 8 caracteres")
 
 
+class CampoRequerido(Exception):
+    def __init__(self, campo: str) -> None:
+        super().__init__(f"El {campo} es requerido")
+
+
+class RolNoPermitido(Exception):
+    def __init__(self) -> None:
+        super().__init__("El rol ADMIN no está permitido en el auto-registro")
+
+
 class TokenInvalido(Exception):
     def __init__(self) -> None:
         super().__init__("Token JWT inválido o expirado")

--- a/src/identidad/infrastructure/repositories/sqlite_usuario_repository.py
+++ b/src/identidad/infrastructure/repositories/sqlite_usuario_repository.py
@@ -12,6 +12,8 @@ from identidad.domain.value_objects.rol import Rol
 _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS usuarios (
     usuario_id    TEXT PRIMARY KEY,
+    nombre        TEXT NOT NULL DEFAULT '',
+    apellido      TEXT NOT NULL DEFAULT '',
     email         TEXT UNIQUE NOT NULL,
     password_hash TEXT NOT NULL,
     rol           TEXT NOT NULL,
@@ -26,6 +28,8 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
 
     async def _ensure_table(self, conn: aiosqlite.Connection) -> None:
         await conn.execute(_CREATE_TABLE)
+        await _ensure_column(conn, "nombre", "TEXT NOT NULL DEFAULT ''")
+        await _ensure_column(conn, "apellido", "TEXT NOT NULL DEFAULT ''")
         await conn.commit()
 
     async def save(self, usuario: Usuario) -> None:
@@ -34,11 +38,13 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await conn.execute(
                 """
                 INSERT OR REPLACE INTO usuarios
-                    (usuario_id, email, password_hash, rol, activo)
-                VALUES (?, ?, ?, ?, ?)
+                    (usuario_id, nombre, apellido, email, password_hash, rol, activo)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     str(usuario.usuario_id),
+                    usuario.nombre,
+                    usuario.apellido,
                     usuario.email,
                     usuario.password_hash,
                     usuario.rol.value,
@@ -52,7 +58,7 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await self._ensure_table(conn)
             async with conn.execute(
                 """
-                SELECT usuario_id, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
                 FROM usuarios
                 WHERE usuario_id = ?
                 """,
@@ -66,7 +72,7 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await self._ensure_table(conn)
             async with conn.execute(
                 """
-                SELECT usuario_id, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
                 FROM usuarios
                 WHERE email = ?
                 """,
@@ -80,7 +86,7 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await self._ensure_table(conn)
             async with conn.execute(
                 """
-                SELECT usuario_id, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
                 FROM usuarios
                 WHERE rol = ?
                 ORDER BY email
@@ -95,7 +101,7 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await self._ensure_table(conn)
             async with conn.execute(
                 """
-                SELECT usuario_id, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
                 FROM usuarios
                 ORDER BY rol, email
                 """
@@ -105,11 +111,21 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
 
 
 def _row_to_usuario(row: tuple) -> Usuario:  # type: ignore[type-arg]
-    usuario_id, email, password_hash, rol, activo = row
+    usuario_id, nombre, apellido, email, password_hash, rol, activo = row
     return Usuario(
         usuario_id=UUID(usuario_id),
+        nombre=nombre,
+        apellido=apellido,
         email=email,
         password_hash=password_hash,
         rol=Rol(rol),
         activo=bool(activo),
     )
+
+
+async def _ensure_column(conn: aiosqlite.Connection, column: str, definition: str) -> None:
+    async with conn.execute("PRAGMA table_info(usuarios)") as cursor:
+        rows = await cursor.fetchall()
+    if any(row[1] == column for row in rows):
+        return
+    await conn.execute(f"ALTER TABLE usuarios ADD COLUMN {column} {definition}")

--- a/tests/features/US-5.4.1-auto-registro.feature
+++ b/tests/features/US-5.4.1-auto-registro.feature
@@ -1,0 +1,43 @@
+Feature: US-5.4.1 - Auto-registro de usuario
+
+  Scenario: auto-registro exitoso como atleta
+    Given no existe ninguna cuenta con email "ana@email.com"
+    When "ana@email.com" completa el formulario con nombre "Ana", apellido "Garcia", password "apnea123" y rol "ATLETA"
+    And confirma el registro
+    Then el sistema responde 201
+    And el usuario queda guardado con nombre "Ana", apellido "Garcia" y rol "ATLETA"
+    And el usuario es redirigido a "/login"
+
+  Scenario: nombre vacio es rechazado antes de enviar
+    Given el formulario de registro esta abierto
+    When el usuario deja el campo "nombre" vacio
+    And intenta confirmar el registro
+    Then el formulario muestra "El nombre es requerido"
+    And no se envia POST "/auth/registro"
+
+  Scenario: apellido vacio es rechazado antes de enviar
+    Given el formulario de registro esta abierto
+    When el usuario deja el campo "apellido" vacio
+    And intenta confirmar el registro
+    Then el formulario muestra "El apellido es requerido"
+    And no se envia POST "/auth/registro"
+
+  Scenario: email duplicado muestra error inline
+    Given ya existe un usuario con email "juez1@email.com"
+    When alguien intenta registrarse con email "juez1@email.com"
+    Then el sistema responde 409
+    And se muestra "Este email ya esta registrado" en el formulario
+
+  Scenario: rol ADMIN es rechazado por el backend
+    Given el cliente envia POST "/auth/registro" con rol "ADMIN"
+    Then el sistema responde 403
+    And el mensaje es "El rol ADMIN no esta permitido en el auto-registro"
+
+  Scenario: rol ADMIN no aparece en el selector del formulario
+    Given el formulario de registro esta abierto
+    Then el selector de rol muestra solo "JUEZ", "ATLETA" y "ORGANIZADOR"
+    And no muestra "ADMIN"
+
+  Scenario: link de registro visible en la pagina de login
+    Given el usuario no autenticado navega a "/login"
+    Then ve el link "No tenes cuenta? Registrate" que apunta a "/registro"

--- a/tests/integration/identidad/test_sqlite_usuario_repository.py
+++ b/tests/integration/identidad/test_sqlite_usuario_repository.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import tempfile
 import uuid
+from pathlib import Path
+
+import aiosqlite
 
 import pytest
 
@@ -19,10 +22,16 @@ def repo() -> SQLiteUsuarioRepository:
 
 
 def _usuario(
-    email: str = "test@test.com", rol: Rol = Rol.ORGANIZADOR, activo: bool = True
+    email: str = "test@test.com",
+    rol: Rol = Rol.ORGANIZADOR,
+    activo: bool = True,
+    nombre: str = "Ana",
+    apellido: str = "Garcia",
 ) -> Usuario:
     return Usuario(
         usuario_id=uuid.uuid4(),
+        nombre=nombre,
+        apellido=apellido,
         email=email,
         password_hash="$2b$12$fakehash",
         rol=rol,
@@ -37,6 +46,8 @@ async def test_save_y_find_by_id(repo: SQLiteUsuarioRepository) -> None:
     resultado = await repo.find_by_id(u.usuario_id)
     assert resultado is not None
     assert resultado.usuario_id == u.usuario_id
+    assert resultado.nombre == u.nombre
+    assert resultado.apellido == u.apellido
     assert resultado.email == u.email
     assert resultado.rol == Rol.ORGANIZADOR
     assert resultado.activo is True
@@ -67,7 +78,15 @@ async def test_find_by_id_inexistente_retorna_none(repo: SQLiteUsuarioRepository
 async def test_save_upsert_actualiza_registro(repo: SQLiteUsuarioRepository) -> None:
     u = _usuario()
     await repo.save(u)
-    u_inactivo = Usuario(u.usuario_id, u.email, u.password_hash, u.rol, activo=False)
+    u_inactivo = Usuario(
+        u.usuario_id,
+        u.nombre,
+        u.apellido,
+        u.email,
+        u.password_hash,
+        u.rol,
+        activo=False,
+    )
     await repo.save(u_inactivo)
     resultado = await repo.find_by_id(u.usuario_id)
     assert resultado is not None
@@ -111,3 +130,31 @@ async def test_list_all_devuelve_todos_ordenados_por_rol_y_email(
         (Rol.JUEZ, "z-juez@test.com"),
         (Rol.ORGANIZADOR, "org@test.com"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_ensure_table_migra_columnas_nombre_y_apellido() -> None:
+    db_path = Path(tempfile.mktemp(suffix=".db"))
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            """
+            CREATE TABLE usuarios (
+                usuario_id TEXT PRIMARY KEY,
+                email TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                rol TEXT NOT NULL,
+                activo INTEGER NOT NULL DEFAULT 1
+            )
+            """
+        )
+        await conn.commit()
+
+    repo = SQLiteUsuarioRepository(db_path=str(db_path))
+    usuario = _usuario(email="migrado@test.com")
+    await repo.save(usuario)
+
+    resultado = await repo.find_by_email("migrado@test.com")
+
+    assert resultado is not None
+    assert resultado.nombre == "Ana"
+    assert resultado.apellido == "Garcia"

--- a/tests/unit/identidad/api/test_listar_usuarios.py
+++ b/tests/unit/identidad/api/test_listar_usuarios.py
@@ -16,10 +16,10 @@ from identidad.domain.value_objects.rol import Rol
 class FakeUsuarioRepository:
     def __init__(self) -> None:
         self.usuarios = [
-            Usuario(uuid4(), "juez2@ataraxia.com", "$2b$hash", Rol.JUEZ),
-            Usuario(uuid4(), "org@ataraxia.com", "$2b$hash", Rol.ORGANIZADOR),
-            Usuario(uuid4(), "juez1@ataraxia.com", "$2b$hash", Rol.JUEZ),
-            Usuario(uuid4(), "atleta@ataraxia.com", "$2b$hash", Rol.ATLETA),
+            Usuario(uuid4(), "Julia", "Segura", "juez2@ataraxia.com", "$2b$hash", Rol.JUEZ),
+            Usuario(uuid4(), "Olga", "Rios", "org@ataraxia.com", "$2b$hash", Rol.ORGANIZADOR),
+            Usuario(uuid4(), "Juan", "Acuna", "juez1@ataraxia.com", "$2b$hash", Rol.JUEZ),
+            Usuario(uuid4(), "Ana", "Lopez", "atleta@ataraxia.com", "$2b$hash", Rol.ATLETA),
         ]
 
     async def list_by_rol(self, rol: Rol) -> list[Usuario]:
@@ -52,6 +52,7 @@ def test_listar_usuarios_filtra_rol_juez() -> None:
         "juez2@ataraxia.com",
     ]
     assert all(usuario["rol"] == "JUEZ" for usuario in data)
+    assert [usuario["nombre"] for usuario in data] == ["Juan", "Julia"]
 
 
 def test_listar_usuarios_sin_rol_devuelve_todos_ordenados() -> None:
@@ -71,6 +72,7 @@ def test_listar_usuarios_sin_rol_devuelve_todos_ordenados() -> None:
         ("JUEZ", "juez2@ataraxia.com"),
         ("ORGANIZADOR", "org@ataraxia.com"),
     ]
+    assert data[0]["apellido"] == "Lopez"
 
 
 def test_listar_usuarios_requiere_organizador() -> None:

--- a/tests/unit/identidad/api/test_registro_usuario.py
+++ b/tests/unit/identidad/api/test_registro_usuario.py
@@ -1,0 +1,138 @@
+"""Tests API para POST /auth/registro."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from identidad.api.dependencies import get_password_hasher, get_usuario_repository
+from identidad.api.router import router
+from identidad.domain.aggregates.usuario import Usuario
+from identidad.domain.ports.password_hashing_port import PasswordHashingPort
+from identidad.domain.value_objects.rol import Rol
+from identidad.infrastructure.bcrypt_password_hasher import BcryptPasswordHasher
+
+
+class FakeUsuarioRepository:
+    def __init__(self) -> None:
+        self.usuarios: list[Usuario] = []
+
+    async def save(self, usuario: Usuario) -> None:
+        self.usuarios = [u for u in self.usuarios if u.usuario_id != usuario.usuario_id]
+        self.usuarios.append(usuario)
+
+    async def find_by_id(self, usuario_id):  # type: ignore[no-untyped-def]
+        for usuario in self.usuarios:
+            if usuario.usuario_id == usuario_id:
+                return usuario
+        return None
+
+    async def find_by_email(self, email: str) -> Usuario | None:
+        for usuario in self.usuarios:
+            if usuario.email == email:
+                return usuario
+        return None
+
+    async def list_by_rol(self, rol: Rol) -> list[Usuario]:
+        return [usuario for usuario in self.usuarios if usuario.rol == rol]
+
+    async def list_all(self) -> list[Usuario]:
+        return list(self.usuarios)
+
+
+def _app(repo: FakeUsuarioRepository, password_hasher: PasswordHashingPort) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_usuario_repository] = lambda: repo
+    app.dependency_overrides[get_password_hasher] = lambda: password_hasher
+    return TestClient(app)
+
+
+def test_registro_exitoso_persiste_nombre_apellido_y_rol() -> None:
+    repo = FakeUsuarioRepository()
+    client = _app(repo, BcryptPasswordHasher())
+
+    response = client.post(
+        "/auth/registro",
+        json={
+            "nombre": "Ana",
+            "apellido": "Garcia",
+            "email": "ana@email.com",
+            "password": "apnea123",
+            "rol": "ATLETA",
+        },
+    )
+
+    assert response.status_code == 201
+    assert len(repo.usuarios) == 1
+    usuario = repo.usuarios[0]
+    assert usuario.nombre == "Ana"
+    assert usuario.apellido == "Garcia"
+    assert usuario.rol == Rol.ATLETA
+
+
+def test_registro_rechaza_email_duplicado() -> None:
+    repo = FakeUsuarioRepository()
+    repo.usuarios.append(
+        Usuario(
+            usuario_id=uuid4(),
+            nombre="Julia",
+            apellido="Segura",
+            email="juez1@email.com",
+            password_hash="$2b$hash",
+            rol=Rol.JUEZ,
+        )
+    )
+    client = _app(repo, BcryptPasswordHasher())
+
+    response = client.post(
+        "/auth/registro",
+        json={
+            "nombre": "Otro",
+            "apellido": "Usuario",
+            "email": "juez1@email.com",
+            "password": "apnea123",
+            "rol": "ATLETA",
+        },
+    )
+
+    assert response.status_code == 409
+
+
+def test_registro_rechaza_password_corta() -> None:
+    repo = FakeUsuarioRepository()
+    client = _app(repo, BcryptPasswordHasher())
+
+    response = client.post(
+        "/auth/registro",
+        json={
+            "nombre": "Ana",
+            "apellido": "Garcia",
+            "email": "ana@email.com",
+            "password": "corta",
+            "rol": "ATLETA",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_registro_rechaza_rol_admin() -> None:
+    repo = FakeUsuarioRepository()
+    client = _app(repo, BcryptPasswordHasher())
+
+    response = client.post(
+        "/auth/registro",
+        json={
+            "nombre": "Admin",
+            "apellido": "Prohibido",
+            "email": "admin@email.com",
+            "password": "apnea123",
+            "rol": "ADMIN",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "El rol ADMIN no está permitido en el auto-registro"

--- a/tests/unit/identidad/application/test_handlers.py
+++ b/tests/unit/identidad/application/test_handlers.py
@@ -23,6 +23,7 @@ from identidad.domain.exceptions import (
     CredencialesInvalidas,
     EmailYaRegistrado,
     PasswordDemasiadoCorto,
+    RolNoPermitido,
     UsuarioInactivo,
 )
 from identidad.domain.ports.password_hashing_port import PasswordHashingPort
@@ -65,7 +66,13 @@ async def test_registrar_usuario_exitoso(
     mock_repo: AsyncMock, password_hasher: PasswordHashingPort
 ) -> None:
     handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
-    cmd = RegistrarUsuarioCommand(email="nuevo@test.com", password="seguro12", rol=Rol.ORGANIZADOR)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Nuevo",
+        apellido="Usuario",
+        email="nuevo@test.com",
+        password="seguro12",
+        rol=Rol.ORGANIZADOR,
+    )
     usuario_id = await handler.handle(cmd)
     assert usuario_id is not None
     mock_repo.save.assert_called_once()
@@ -76,9 +83,17 @@ async def test_registrar_guarda_hash_no_plain(
     mock_repo: AsyncMock, password_hasher: PasswordHashingPort
 ) -> None:
     handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
-    cmd = RegistrarUsuarioCommand(email="t@t.com", password="password1", rol=Rol.ATLETA)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Ana",
+        apellido="Garcia",
+        email="t@t.com",
+        password="password1",
+        rol=Rol.ATLETA,
+    )
     await handler.handle(cmd)
     saved_usuario: Usuario = mock_repo.save.call_args[0][0]
+    assert saved_usuario.nombre == "Ana"
+    assert saved_usuario.apellido == "Garcia"
     assert saved_usuario.password_hash != "password1"
     assert saved_usuario.password_hash.startswith("$2b$")
 
@@ -87,10 +102,16 @@ async def test_registrar_guarda_hash_no_plain(
 async def test_registrar_email_duplicado_lanza_excepcion(
     mock_repo: AsyncMock, password_hasher: PasswordHashingPort
 ) -> None:
-    existente = Usuario(uuid.uuid4(), "dup@test.com", "$2b$hash", Rol.JUEZ)
+    existente = Usuario(uuid.uuid4(), "Dup", "Existente", "dup@test.com", "$2b$hash", Rol.JUEZ)
     mock_repo.find_by_email.return_value = existente
     handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
-    cmd = RegistrarUsuarioCommand(email="dup@test.com", password="password1", rol=Rol.JUEZ)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Dup",
+        apellido="Nuevo",
+        email="dup@test.com",
+        password="password1",
+        rol=Rol.JUEZ,
+    )
     with pytest.raises(EmailYaRegistrado):
         await handler.handle(cmd)
 
@@ -100,7 +121,13 @@ async def test_registrar_password_corto_lanza_excepcion(
     mock_repo: AsyncMock, password_hasher: PasswordHashingPort
 ) -> None:
     handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
-    cmd = RegistrarUsuarioCommand(email="t@t.com", password="corto", rol=Rol.ATLETA)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Ana",
+        apellido="Garcia",
+        email="t@t.com",
+        password="corto",
+        rol=Rol.ATLETA,
+    )
     with pytest.raises(PasswordDemasiadoCorto):
         await handler.handle(cmd)
 
@@ -110,9 +137,31 @@ async def test_registrar_password_exactamente_8_es_valido(
     mock_repo: AsyncMock, password_hasher: PasswordHashingPort
 ) -> None:
     handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
-    cmd = RegistrarUsuarioCommand(email="t@t.com", password="12345678", rol=Rol.ATLETA)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Ana",
+        apellido="Garcia",
+        email="t@t.com",
+        password="12345678",
+        rol=Rol.ATLETA,
+    )
     usuario_id = await handler.handle(cmd)
     assert usuario_id is not None
+
+
+@pytest.mark.asyncio
+async def test_registrar_admin_lanza_excepcion(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+) -> None:
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Admin",
+        apellido="Prohibido",
+        email="admin@test.com",
+        password="12345678",
+        rol=Rol.ADMIN,
+    )
+    with pytest.raises(RolNoPermitido):
+        await handler.handle(cmd)
 
 
 # ── AutenticarUsuarioHandler ──────────────────────────────────────────────────
@@ -120,7 +169,7 @@ async def test_registrar_password_exactamente_8_es_valido(
 
 def _make_usuario(email: str, password: str, rol: Rol = Rol.JUEZ, activo: bool = True) -> Usuario:
     hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
-    return Usuario(uuid.uuid4(), email, hashed, rol, activo)
+    return Usuario(uuid.uuid4(), "Test", "Usuario", email, hashed, rol, activo)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/identidad/domain/test_usuario.py
+++ b/tests/unit/identidad/domain/test_usuario.py
@@ -8,9 +8,11 @@ import pytest
 
 from identidad.domain.aggregates.usuario import Usuario
 from identidad.domain.exceptions import (
+    CampoRequerido,
     CredencialesInvalidas,
     EmailYaRegistrado,
     PasswordDemasiadoCorto,
+    RolNoPermitido,
     TokenInvalido,
     UsuarioInactivo,
     UsuarioNoEncontrado,
@@ -38,11 +40,15 @@ def test_usuario_creacion_basica() -> None:
     uid = uuid.uuid4()
     u = Usuario(
         usuario_id=uid,
+        nombre="Ana",
+        apellido="Garcia",
         email="test@test.com",
         password_hash="$2b$12$hash",
         rol=Rol.ORGANIZADOR,
     )
     assert u.usuario_id == uid
+    assert u.nombre == "Ana"
+    assert u.apellido == "Garcia"
     assert u.email == "test@test.com"
     assert u.rol == Rol.ORGANIZADOR
     assert u.activo is True
@@ -51,6 +57,8 @@ def test_usuario_creacion_basica() -> None:
 def test_usuario_inactivo_por_defecto_es_true() -> None:
     u = Usuario(
         usuario_id=uuid.uuid4(),
+        nombre="Ana",
+        apellido="Garcia",
         email="a@b.com",
         password_hash="hash",
         rol=Rol.ATLETA,
@@ -61,12 +69,40 @@ def test_usuario_inactivo_por_defecto_es_true() -> None:
 def test_usuario_puede_estar_inactivo() -> None:
     u = Usuario(
         usuario_id=uuid.uuid4(),
+        nombre="Ana",
+        apellido="Garcia",
         email="a@b.com",
         password_hash="hash",
         rol=Rol.ATLETA,
         activo=False,
     )
     assert u.activo is False
+
+
+def test_usuario_trim_nombre_y_apellido() -> None:
+    u = Usuario(
+        usuario_id=uuid.uuid4(),
+        nombre="  Ana  ",
+        apellido="  Garcia  ",
+        email="a@b.com",
+        password_hash="hash",
+        rol=Rol.ATLETA,
+    )
+    assert u.nombre == "Ana"
+    assert u.apellido == "Garcia"
+
+
+@pytest.mark.parametrize("campo, nombre, apellido", [("nombre", " ", "Garcia"), ("apellido", "Ana", "\t")])
+def test_usuario_rechaza_nombre_o_apellido_vacios(campo: str, nombre: str, apellido: str) -> None:
+    with pytest.raises(CampoRequerido, match=campo):
+        Usuario(
+            usuario_id=uuid.uuid4(),
+            nombre=nombre,
+            apellido=apellido,
+            email="a@b.com",
+            password_hash="hash",
+            rol=Rol.ATLETA,
+        )
 
 
 # ── Exceptions ────────────────────────────────────────────────────────────────
@@ -95,6 +131,11 @@ def test_usuario_inactivo_mensaje() -> None:
 def test_password_demasiado_corto_mensaje() -> None:
     exc = PasswordDemasiadoCorto()
     assert "8" in str(exc)
+
+
+def test_rol_no_permitido_mensaje() -> None:
+    exc = RolNoPermitido()
+    assert "ADMIN" in str(exc)
 
 
 def test_token_invalido_mensaje() -> None:


### PR DESCRIPTION
## Resumen\n- agrega auto-registro publico con nombre, apellido, email, password y rol\n- extiende el BC identidad para persistir nombre/apellido y rechazar ADMIN en backend\n- incorpora ruta /registro, CTA desde login y adapta la lista de usuarios del organizador\n\n## Validacion\n- ./.venv/bin/pytest tests/unit/identidad tests/integration/identidad\n- npm run build\n- npm run lint\n\n## Notas\n- la validacion BDD/UI de browser queda manual\n- la migracion SQLite agrega nombre/apellido de forma idempotente para bases existentes