### PR TITLE
US-5.4.2: cambiar contraseña

### DIFF
--- a/.claude/tracking/US-5.4.2-tracking.json
+++ b/.claude/tracking/US-5.4.2-tracking.json
@@ -1,0 +1,178 @@
+{
+  "metadata": {
+    "us_id": "US-5.4.2",
+    "us_title": "Cambiar contraseña",
+    "us_points": 3,
+    "producto": "identidad",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-24T12:15:40.721280+00:00",
+    "completed_at": "2026-04-24T12:28:50.198216+00:00",
+    "total_elapsed_seconds": 789,
+    "effective_seconds": 789,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-24T12:15:46.583032+00:00",
+      "completed_at": "2026-04-24T12:16:42.087529+00:00",
+      "elapsed_seconds": 55,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-24T12:16:46.850331+00:00",
+      "completed_at": "2026-04-24T12:16:51.876676+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-24T12:16:56.570935+00:00",
+      "completed_at": "2026-04-24T12:17:00.991800+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada por Tareas",
+      "started_at": "2026-04-24T12:20:35.619531+00:00",
+      "completed_at": "2026-04-24T12:27:46.372364+00:00",
+      "elapsed_seconds": 430,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Backend cambio de password",
+          "task_type": "backend",
+          "estimated_minutes": 90.0,
+          "started_at": "2026-04-24T12:20:43.760390+00:00",
+          "completed_at": "2026-04-24T12:21:48.462256+00:00",
+          "elapsed_seconds": 64,
+          "actual_minutes": 1.07,
+          "variance_minutes": -88.93,
+          "file_created": "src/identidad/application/commands/cambiar_password.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Frontend cambio de password",
+          "task_type": "frontend",
+          "estimated_minutes": 90.0,
+          "started_at": "2026-04-24T12:21:51.890043+00:00",
+          "completed_at": "2026-04-24T12:26:46.878121+00:00",
+          "elapsed_seconds": 294,
+          "actual_minutes": 4.9,
+          "variance_minutes": -85.1,
+          "file_created": "frontend/src/pages/CambiarPasswordPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Validacion automatizada",
+          "task_type": "test",
+          "estimated_minutes": 40.0,
+          "started_at": "2026-04-24T12:26:50.789090+00:00",
+          "completed_at": "2026-04-24T12:27:40.946925+00:00",
+          "elapsed_seconds": 50,
+          "actual_minutes": 0.83,
+          "variance_minutes": -39.17,
+          "file_created": "docs/reports/US-5.4.2-report.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-24T12:27:53.735916+00:00",
+      "completed_at": "2026-04-24T12:27:59.704195+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-24T12:28:06.056773+00:00",
+      "completed_at": "2026-04-24T12:28:09.940246+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-24T12:28:16.012718+00:00",
+      "completed_at": "2026-04-24T12:28:20.399684+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-24T12:28:26.093645+00:00",
+      "completed_at": "2026-04-24T12:28:29.678010+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Actualización de Documentación",
+      "started_at": "2026-04-24T12:28:33.507558+00:00",
+      "completed_at": "2026-04-24T12:28:37.382485+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-24T12:28:43.210650+00:00",
+      "completed_at": "2026-04-24T12:28:46.771124+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 10,
+    "estimated_total_minutes": 220.0,
+    "actual_total_minutes": 6.8,
+    "variance_minutes": -213.2,
+    "variance_percent": -96.91
+  }
+}

--- a/docs/plans/sp5/US-5.4.2-fase0.md
+++ b/docs/plans/sp5/US-5.4.2-fase0.md
@@ -1,0 +1,91 @@
+# US-5.4.2 — Fase 0: Validacion de Contexto
+
+**Fecha:** 2026-04-24
+**Branch:** `feature/US-5.4.2-cambiar-password`
+**Producto:** `identidad` + `frontend`
+**Incremento:** INC-5.4 — Identidad Extendida
+
+---
+
+## Historia de Usuario
+
+**US:** US-5.4.2 — Cambiar contraseña
+
+Como **usuario autenticado**, quiero **cambiar mi contraseña ingresando la contraseña actual y la nueva** para **mantener el control de la seguridad de mi cuenta**.
+
+**Spec canonica:** `docs/specs/sp5/US-5.4.2.md`
+
+---
+
+## Contexto Validado
+
+### Arquitectura
+
+- Patron confirmado: Hexagonal DDD BC-first.
+- BC principal: `identidad`.
+- Producto UI afectado: `frontend`.
+- La autenticacion ya emite JWT con `sub`, `email` y `rol`; el cambio de password debe reutilizar el `userId` persistido en `useAuthStore`.
+
+### Artefactos arquitectonicos encontrados
+
+- `docs/contexto/ATARAXIADIVE-CONTEXT.md`
+- `docs/adr/ADR-005-bounded-contexts-ddd-estrategico.md`
+- `docs/adr/ADR-006-estructura-bc-first.md`
+- `docs/design/architecture.md`
+- `docs/design/domain-model.md`
+
+### Estructura verificada
+
+- `src/identidad/domain/`
+- `src/identidad/application/`
+- `src/identidad/infrastructure/`
+- `src/identidad/api/`
+- `frontend/src/pages/`
+- `frontend/src/api/`
+- `tests/features/`
+
+---
+
+## Estado Actual Relevante
+
+### Backend identidad
+
+- `PasswordHashingPort` ya expone `hash()` y `verify()`, y `BcryptPasswordHasher` implementa ambas operaciones.
+- `UsuarioRepositoryPort` ya permite `find_by_id()` y `save()`, suficientes para un command de cambio de password sin tocar el aggregate.
+- `router.py` ya usa `get_current_user` indirectamente en dependencias de rol, pero no tiene aun un endpoint autenticado transversal para cambio de contraseña.
+- Las excepciones actuales cubren password corta, email duplicado y roles; falta una excepcion especifica para password actual incorrecta.
+
+### Frontend
+
+- `useAuthStore` persiste `userId`, `email`, `rol` y `token`, por lo que la UI puede redirigir al home correcto luego del cambio.
+- Existe `RequireRole`, pero hoy las rutas estan segmentadas por rol; no hay una pantalla comun de cambio de password para todos los usuarios autenticados.
+- `LoginPage` y `RegistroPage` ya existen, pero no hay navegacion a una pantalla de cambio de password.
+
+---
+
+## Quality Gates
+
+- `CLAUDE.md` encontrado.
+- `pyproject.toml` encontrado.
+- `[tool.codeguard]` configurado.
+- `[tool.designreviewer]` configurado.
+- Tests configurados en `tests/`.
+- Para esta US mixta, los gates esperables son:
+  - `pytest` sobre identidad
+  - `npm run build` en `frontend/`
+  - `npm run lint` en `frontend/`
+
+---
+
+## Riesgos Detectados
+
+- La ruta frontend debe ser transversal a los tres roles sin abrir acceso a usuarios anonimos.
+- El endpoint debe usar el `sub` del JWT como fuente de verdad del usuario y no aceptar `usuario_id` en el body.
+- El token actual sigue siendo valido tras el cambio; la UI no puede asumir logout automatico.
+- Si el acceso a la pantalla queda escondido en la navegacion, la funcionalidad puede estar implementada pero no ser alcanzable en UAT.
+
+---
+
+## Resultado
+
+Contexto validado. La US esta lista para Fase 1: escenarios BDD.

--- a/docs/plans/sp5/US-5.4.2-plan.md
+++ b/docs/plans/sp5/US-5.4.2-plan.md
@@ -1,0 +1,125 @@
+# Plan de Implementacion: US-5.4.2 - Cambiar contrasena
+
+**Historia:** US-5.4.2 - Cambiar contraseña
+**Incremento:** INC-5.4 - Identidad Extendida
+**Producto:** identidad + frontend
+**Patron:** Hexagonal DDD BC-first + React/Vite frontend
+**Estimacion:** 3 puntos
+**Estado:** EN PLANIFICACION
+
+---
+
+## Alcance
+
+Implementar cambio de contraseña para usuarios autenticados:
+
+- Agregar command y handler para verificar password actual y persistir el nuevo hash.
+- Exponer `POST /auth/cambiar-password` autenticado por JWT.
+- Crear pantalla frontend con password actual, nueva y confirmacion.
+- Redirigir al home correcto segun rol tras cambio exitoso.
+
+Fuera de alcance: invalidacion de JWT vigente, politicas de password compleja, recuperacion de password.
+
+---
+
+## Componentes a Modificar
+
+### Dominio identidad
+
+- [ ] `src/identidad/domain/exceptions.py` (10 min)
+  - Agregar `PasswordActualIncorrecto`.
+
+### Aplicacion identidad
+
+- [ ] `src/identidad/application/commands/cambiar_password.py` (35 min)
+  - Crear `CambiarPasswordCommand`.
+  - Crear `CambiarPasswordHandler`.
+  - Buscar usuario por `usuario_id`, verificar bcrypt actual y persistir hash nuevo.
+  - Rechazar password nueva menor a 8 caracteres.
+
+### API identidad
+
+- [ ] `src/identidad/api/router.py` (35 min)
+  - Crear schema `CambiarPasswordRequest`.
+  - Agregar endpoint `POST /auth/cambiar-password`.
+  - Obtener `usuario_id` desde `get_current_user`.
+  - Mapear `PasswordActualIncorrecto` a `401` y password corta a `422`.
+
+### Frontend API
+
+- [ ] `frontend/src/api/identidad.ts` (20 min)
+  - Agregar `cambiarPassword(passwordActual, passwordNueva)`.
+  - Reusar `ApiError`.
+
+### Frontend paginas y routing
+
+- [ ] `frontend/src/pages/CambiarPasswordPage.tsx` (75 min)
+  - Crear formulario con password actual, nueva y confirmacion.
+  - Validar longitud minima y coincidencia de confirmacion.
+  - Mostrar errores inline y redirigir al home del rol al exito.
+
+- [ ] `frontend/src/App.tsx` (20 min)
+  - Agregar ruta protegida para usuarios autenticados.
+  - Resolver acceso transversal a los tres roles sin duplicar pantallas.
+
+- [ ] `frontend/src/pages/atleta/AtletaDashboardPage.tsx` y/o layouts existentes (25 min)
+  - Exponer un acceso navegable a la pantalla de cambio de password desde una vista ya accesible para cada rol.
+
+---
+
+## Tests
+
+### Unitarios backend
+
+- [ ] `tests/unit/identidad/application/test_cambiar_password.py` o ampliar `test_handlers.py` (35 min)
+  - Cubrir exito, password actual incorrecta y password nueva corta.
+
+- [ ] `tests/unit/identidad/api/test_cambiar_password.py` (30 min)
+  - Cubrir `204`, `401` y `422`.
+  - Cubrir requisito de autenticacion JWT.
+
+### Integracion backend
+
+- [ ] `tests/integration/identidad/test_sqlite_usuario_repository.py` o nuevo test de flujo (20 min)
+  - Verificar que luego del cambio el hash persistido ya no valida la password anterior y si la nueva.
+
+### Frontend
+
+- [ ] Validacion TypeScript/build (20 min)
+  - Ejecutar `npm run build` en `frontend/`.
+  - Ejecutar `npm run lint` en `frontend/`.
+
+### BDD
+
+- [ ] `tests/features/US-5.4.2-cambiar-password.feature` (10 min)
+  - Feature creada en Fase 1.
+  - Validacion UI/manual documentada si no hay harness browser automatizado.
+
+---
+
+## Quality Gates
+
+- [ ] `./.venv/bin/pytest tests/unit/identidad tests/integration/identidad`
+- [ ] `npm run build` en `frontend/`
+- [ ] `npm run lint` en `frontend/`
+- [ ] `codeguard src/identidad/ --format json > quality/reports/codeguard/US-5.4.2-codeguard-raw.json`
+
+---
+
+## Riesgos y Decisiones
+
+- El body del endpoint no debe aceptar `usuario_id`; el origen de verdad es el JWT.
+- La pantalla debe ser alcanzable por organizador, juez y atleta sin crear tres implementaciones paralelas.
+- El cambio de password no invalida el JWT actual; ese comportamiento debe quedar documentado.
+- El repositorio ya persiste `Usuario` completo, por lo que el update puede resolverse como re-save del aggregate modificado.
+
+---
+
+## Criterios de Aceptacion Cubiertos
+
+- [ ] Cambio de password exitoso.
+- [ ] Password actual incorrecta se rechaza.
+- [ ] Password nueva corta se rechaza antes de enviar.
+- [ ] Confirmacion distinta se rechaza en frontend.
+
+**Estado:** 0/9 tareas completadas

--- a/docs/reports/US-5.4.2-report.md
+++ b/docs/reports/US-5.4.2-report.md
@@ -1,0 +1,64 @@
+# Reporte de Implementacion: US-5.4.2
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** US-5.4.2 - Cambiar contraseña
+- **Puntos estimados:** 3
+- **Estado:** COMPLETADO
+- **Fecha completado:** 2026-04-24
+- **Branch de trabajo:** `feature/US-5.4.2-cambiar-password`
+
+## Componentes Implementados
+
+- [x] Nueva excepcion `PasswordActualIncorrecto`.
+- [x] Nuevo command/handler `CambiarPasswordCommand` + `CambiarPasswordHandler`.
+- [x] Nuevo endpoint autenticado `POST /auth/cambiar-password`.
+- [x] Cliente frontend `cambiarPassword()` sin redireccion automatica en `401` de negocio.
+- [x] Nueva pagina `frontend/src/pages/CambiarPasswordPage.tsx`.
+- [x] Nueva proteccion transversal `RequireAuth`.
+- [x] Navegacion a cambio de password desde juez, organizador y atleta.
+- [x] Mensaje de exito al volver al home del rol.
+
+## Comportamiento Entregado
+
+- Un usuario autenticado puede cambiar su contraseña con password actual y nueva.
+- El backend verifica la password actual con bcrypt antes de persistir el nuevo hash.
+- La nueva password debe tener al menos 8 caracteres.
+- La confirmacion de password se valida en frontend y no se envía al backend.
+- El usuario vuelve al home de su rol luego del cambio exitoso.
+
+## Validacion Ejecutada
+
+| Gate | Resultado |
+|------|-----------|
+| `./.venv/bin/pytest tests/unit/identidad tests/integration/identidad` | OK |
+| `npm run build` | OK |
+| `npm run lint` | OK |
+| Validacion BDD/UI en navegador | Pendiente manual |
+
+## Riesgos y Observaciones
+
+- `401` en `/auth/cambiar-password` es un error de negocio y ya no expulsa al usuario al login.
+- La advertencia de chunk >500 kB en Vite sigue presente, pero no bloquea el build.
+- Los tests JWT siguen emitiendo `InsecureKeyLengthWarning` por el fixture existente de secret corto.
+- El JWT vigente no se invalida tras el cambio de password; queda documentado como comportamiento actual.
+
+## Archivos Relevantes
+
+- `src/identidad/application/commands/cambiar_password.py`
+- `src/identidad/api/router.py`
+- `src/identidad/domain/exceptions.py`
+- `frontend/src/api/identidad.ts`
+- `frontend/src/components/RequireAuth.tsx`
+- `frontend/src/pages/CambiarPasswordPage.tsx`
+- `frontend/src/pages/juez/DisciplinasPage.tsx`
+- `frontend/src/pages/organizador/DashboardPage.tsx`
+- `frontend/src/pages/atleta/AtletaDashboardPage.tsx`
+- `tests/unit/identidad/api/test_cambiar_password.py`
+
+## Criterios de Aceptacion
+
+- [x] Cambio de password exitoso.
+- [x] Password actual incorrecta se rechaza.
+- [x] Password nueva corta se rechaza antes de enviar.
+- [x] Confirmacion distinta se rechaza en frontend.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import { useSyncQueue } from './hooks/useSyncQueue'
 import useAuthStore from './stores/useAuthStore'
 import { LoginPage } from './pages/LoginPage'
 import { RegistroPage } from './pages/RegistroPage'
+import { CambiarPasswordPage } from './pages/CambiarPasswordPage'
+import { RequireAuth } from './components/RequireAuth'
 import { RequireRole } from './components/RequireRole'
 import { DisciplinasPage } from './pages/juez/DisciplinasPage'
 import { GrillaPage } from './pages/juez/GrillaPage'
@@ -38,6 +40,14 @@ function App() {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/registro" element={<RegistroPage />} />
+        <Route
+          path="/cambiar-password"
+          element={
+            <RequireAuth>
+              <CambiarPasswordPage />
+            </RequireAuth>
+          }
+        />
         <Route path="/" element={<RootRedirect />} />
         <Route
           path="/juez/disciplinas"

--- a/frontend/src/api/identidad.ts
+++ b/frontend/src/api/identidad.ts
@@ -33,6 +33,11 @@ export interface CrearUsuarioResponse {
   usuario_id: string
 }
 
+export interface CambiarPasswordRequest {
+  password_actual: string
+  password_nueva: string
+}
+
 function buildHeaders(): Record<string, string> {
   const token = getToken()
   const headers: Record<string, string> = {
@@ -46,7 +51,11 @@ function buildHeaders(): Record<string, string> {
   return headers
 }
 
-async function parseResponse<T>(response: Response): Promise<T> {
+async function parseResponse<T>(
+  response: Response,
+  options: { redirectOn401?: boolean } = {},
+): Promise<T> {
+  const { redirectOn401 = true } = options
   if (response.ok) {
     if (response.status === 204) {
       return undefined as T
@@ -54,7 +63,7 @@ async function parseResponse<T>(response: Response): Promise<T> {
     return response.json() as Promise<T>
   }
 
-  if (response.status === 401) {
+  if (response.status === 401 && redirectOn401) {
     handleUnauthorized()
   }
 
@@ -91,4 +100,13 @@ export async function crearUsuario(body: CrearUsuarioRequest): Promise<CrearUsua
     body: JSON.stringify(body),
   })
   return parseResponse<CrearUsuarioResponse>(response)
+}
+
+export async function cambiarPassword(body: CambiarPasswordRequest): Promise<void> {
+  const response = await fetch('/auth/cambiar-password', {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify(body),
+  })
+  return parseResponse<void>(response, { redirectOn401: false })
 }

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,24 +1,17 @@
 import type { ReactNode } from 'react'
 import { Navigate } from 'react-router-dom'
 import useAuthStore from '../stores/useAuthStore'
-import type { RolUsuario } from '../types/auth'
-import { HOME_BY_ROL } from '../utils/auth'
 
-interface RequireRoleProps {
-  role: RolUsuario
+interface RequireAuthProps {
   children: ReactNode
 }
 
-export function RequireRole({ role, children }: RequireRoleProps) {
+export function RequireAuth({ children }: RequireAuthProps) {
   const token = useAuthStore((s) => s.token)
   const rol = useAuthStore((s) => s.rol)
 
   if (!token || !rol) {
     return <Navigate to="/login" replace />
-  }
-
-  if (rol !== role) {
-    return <Navigate to={HOME_BY_ROL[rol]} replace />
   }
 
   return <>{children}</>

--- a/frontend/src/pages/CambiarPasswordPage.tsx
+++ b/frontend/src/pages/CambiarPasswordPage.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react'
+import type { FormEvent } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Link, useNavigate } from 'react-router-dom'
+import { ApiError, cambiarPassword } from '../api/identidad'
+import useAuthStore from '../stores/useAuthStore'
+import { HOME_BY_ROL } from '../utils/auth'
+
+interface FormState {
+  passwordActual: string
+  passwordNueva: string
+  confirmacion: string
+}
+
+type FormErrors = Partial<Record<keyof FormState | 'general', string>>
+
+const INITIAL_FORM: FormState = {
+  passwordActual: '',
+  passwordNueva: '',
+  confirmacion: '',
+}
+
+function inputClass(hasError: boolean): string {
+  return [
+    'w-full rounded-2xl border px-4 py-3 text-sm text-slate-100 focus:outline-none focus:ring-2',
+    hasError
+      ? 'border-red-500 bg-red-950/30 focus:ring-red-500'
+      : 'border-slate-700 bg-slate-950 focus:ring-sky-500',
+  ].join(' ')
+}
+
+function resolveApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return 'La contrasena actual es incorrecta'
+    if (error.status === 422) return 'La contrasena debe tener al menos 8 caracteres'
+    return error.message
+  }
+  if (error instanceof Error) return error.message
+  return 'No se pudo actualizar la contrasena'
+}
+
+export function CambiarPasswordPage() {
+  const navigate = useNavigate()
+  const rol = useAuthStore((s) => s.rol)
+  const [form, setForm] = useState<FormState>(INITIAL_FORM)
+  const [errors, setErrors] = useState<FormErrors>({})
+
+  const mutation = useMutation({
+    mutationFn: cambiarPassword,
+    onSuccess: () => {
+      if (rol) {
+        navigate(HOME_BY_ROL[rol], {
+          replace: true,
+          state: { passwordUpdated: true },
+        })
+      }
+    },
+    onError: (error) => {
+      const message = resolveApiError(error)
+      if (error instanceof ApiError && error.status === 401) {
+        setErrors((current) => ({ ...current, passwordActual: message, general: undefined }))
+        return
+      }
+      if (error instanceof ApiError && error.status === 422) {
+        setErrors((current) => ({ ...current, passwordNueva: message, general: undefined }))
+        return
+      }
+      setErrors((current) => ({ ...current, general: message }))
+    },
+  })
+
+  function updateField<T extends keyof FormState>(field: T, value: FormState[T]) {
+    setForm((current) => ({ ...current, [field]: value }))
+    setErrors((current) => ({ ...current, [field]: undefined, general: undefined }))
+  }
+
+  function validate(): FormErrors {
+    const nextErrors: FormErrors = {}
+    if (!form.passwordActual) nextErrors.passwordActual = 'La contrasena actual es obligatoria'
+    if (!form.passwordNueva) {
+      nextErrors.passwordNueva = 'La contrasena nueva es obligatoria'
+    } else if (form.passwordNueva.length < 8) {
+      nextErrors.passwordNueva = 'La contrasena debe tener al menos 8 caracteres'
+    }
+    if (!form.confirmacion) {
+      nextErrors.confirmacion = 'Debes confirmar la contrasena nueva'
+    } else if (form.confirmacion !== form.passwordNueva) {
+      nextErrors.confirmacion = 'Las contrasenas no coinciden'
+    }
+    return nextErrors
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const validationErrors = validate()
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) {
+      return
+    }
+
+    mutation.mutate({
+      password_actual: form.passwordActual,
+      password_nueva: form.passwordNueva,
+    })
+  }
+
+  const backHref = rol ? HOME_BY_ROL[rol] : '/'
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex min-h-screen w-full max-w-md items-center px-4 py-8">
+        <div className="w-full rounded-[2rem] border border-slate-800 bg-slate-900/80 p-8 shadow-[0_24px_80px_-50px_rgba(34,211,238,0.7)]">
+          <p className="text-center text-xs font-semibold uppercase tracking-[0.24em] text-sky-400">
+            Seguridad
+          </p>
+          <h1 className="mb-2 mt-3 text-center text-3xl font-semibold text-slate-50">
+            Cambiar contrasena
+          </h1>
+          <p className="mb-6 text-center text-sm text-slate-400">
+            Actualiza tu acceso ingresando primero la contrasena actual.
+          </p>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <label className="text-sm font-medium text-slate-300">
+              Contrasena actual
+              <input
+                type="password"
+                value={form.passwordActual}
+                onChange={(event) => updateField('passwordActual', event.target.value)}
+                className={inputClass(Boolean(errors.passwordActual))}
+              />
+              {errors.passwordActual ? (
+                <span className="mt-1 block text-sm text-red-300">{errors.passwordActual}</span>
+              ) : null}
+            </label>
+
+            <label className="text-sm font-medium text-slate-300">
+              Nueva contrasena
+              <input
+                type="password"
+                value={form.passwordNueva}
+                onChange={(event) => updateField('passwordNueva', event.target.value)}
+                className={inputClass(Boolean(errors.passwordNueva))}
+              />
+              {errors.passwordNueva ? (
+                <span className="mt-1 block text-sm text-red-300">{errors.passwordNueva}</span>
+              ) : null}
+            </label>
+
+            <label className="text-sm font-medium text-slate-300">
+              Confirmar nueva contrasena
+              <input
+                type="password"
+                value={form.confirmacion}
+                onChange={(event) => updateField('confirmacion', event.target.value)}
+                className={inputClass(Boolean(errors.confirmacion))}
+              />
+              {errors.confirmacion ? (
+                <span className="mt-1 block text-sm text-red-300">{errors.confirmacion}</span>
+              ) : null}
+            </label>
+
+            {errors.general ? (
+              <p className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-100">
+                {errors.general}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={mutation.isPending}
+              className="rounded-2xl bg-sky-500 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950 transition-colors hover:bg-sky-400 disabled:opacity-50"
+            >
+              {mutation.isPending ? 'Actualizando...' : 'Actualizar contrasena'}
+            </button>
+          </form>
+
+          <p className="mt-6 text-center text-sm text-slate-400">
+            <Link to={backHref} className="font-semibold text-sky-300 hover:text-sky-200">
+              Volver
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaDashboardPage.tsx
+++ b/frontend/src/pages/atleta/AtletaDashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
+import { Link, useLocation } from 'react-router-dom'
 import { ApiError, inscribirAtleta } from '../../api/registro'
 import {
   fetchTorneos,
@@ -179,6 +180,7 @@ function InscripcionPanel({ torneo, atletaId }: InscripcionPanelProps) {
 }
 
 export function AtletaDashboardPage() {
+  const location = useLocation()
   const email = useAuthStore((s) => s.email)
   const atletaId = useAuthStore((s) => s.userId)
   const logout = useAuthStore((s) => s.logout)
@@ -218,6 +220,12 @@ export function AtletaDashboardPage() {
           </div>
         </header>
 
+        {location.state && (location.state as { passwordUpdated?: boolean }).passwordUpdated ? (
+          <div className="mt-4 rounded-[1.5rem] border border-emerald-300 bg-emerald-50 px-5 py-4 text-sm text-emerald-900">
+            Contrasena actualizada correctamente.
+          </div>
+        ) : null}
+
         <main className="mt-6 grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
           <section className="rounded-[2rem] border border-teal-200/70 bg-white/85 p-5 shadow-[0_20px_60px_rgba(45,94,99,0.08)]">
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-700">
@@ -238,6 +246,12 @@ export function AtletaDashboardPage() {
                 </p>
                 <p className="mt-1 text-base font-semibold text-stone-900">Atleta</p>
               </div>
+              <Link
+                to="/cambiar-password"
+                className="inline-flex rounded-lg border border-teal-700 px-4 py-2 text-sm font-semibold text-teal-900"
+              >
+                Cambiar contrasena
+              </Link>
             </div>
           </section>
 

--- a/frontend/src/pages/juez/DisciplinasPage.tsx
+++ b/frontend/src/pages/juez/DisciplinasPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { DisciplinaCard } from '../../components/juez/DisciplinaCard'
 import { JuezLayout } from '../../components/juez/JuezLayout'
 import { useDisciplinasJuez } from '../../hooks/useDisciplinasJuez'
@@ -6,6 +6,7 @@ import useAuthStore from '../../stores/useAuthStore'
 import useCompetenciaStore from '../../stores/useCompetenciaStore'
 
 export function DisciplinasPage() {
+  const location = useLocation()
   const navigate = useNavigate()
   const logout = useAuthStore((s) => s.logout)
   const seleccionarCompetencia = useCompetenciaStore((s) => s.seleccionarCompetencia)
@@ -16,15 +17,30 @@ export function DisciplinasPage() {
       title="Mis disciplinas"
       subtitle={subtitle}
       actions={
-        <button
-          type="button"
-          onClick={logout}
-          className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-200"
-        >
-          Salir
-        </button>
+        <div className="flex flex-col gap-2 sm:items-end">
+          <button
+            type="button"
+            onClick={() => void navigate('/cambiar-password')}
+            className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-200"
+          >
+            Password
+          </button>
+          <button
+            type="button"
+            onClick={logout}
+            className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-200"
+          >
+            Salir
+          </button>
+        </div>
       }
     >
+      {location.state && (location.state as { passwordUpdated?: boolean }).passwordUpdated ? (
+        <section className="rounded-3xl border border-emerald-500/30 bg-emerald-500/10 p-5 text-sm text-emerald-100">
+          Contrasena actualizada correctamente.
+        </section>
+      ) : null}
+
       {isLoading ? (
         <section className="rounded-3xl border border-slate-800 bg-slate-900/70 p-5 text-sm text-slate-300">
           Cargando disciplinas asignadas...

--- a/frontend/src/pages/organizador/DashboardPage.tsx
+++ b/frontend/src/pages/organizador/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { fetchTorneos, type EstadoTorneo, type TorneoDto } from '../../api/torneo'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 import useAuthStore from '../../stores/useAuthStore'
@@ -47,6 +47,7 @@ function emptyMessage(filtro: FiltroTorneos): string {
 }
 
 export function DashboardPage() {
+  const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
   const email = useAuthStore((s) => s.email)
   const [filtro, setFiltro] = useState<FiltroTorneos>('abiertos')
@@ -65,6 +66,12 @@ export function DashboardPage() {
       subtitle={email ? `Sesion activa: ${email}` : 'Gestion de auditoria y seguimiento'}
       actions={
         <>
+          <Link
+            to="/cambiar-password"
+            className="rounded-lg border border-stone-900 px-4 py-2 text-sm font-semibold text-stone-900"
+          >
+            Password
+          </Link>
           <Link
             to="/organizador/usuarios"
             className="rounded-lg border border-stone-900 px-4 py-2 text-sm font-semibold text-stone-900"
@@ -87,6 +94,12 @@ export function DashboardPage() {
         </>
       }
     >
+      {location.state && (location.state as { passwordUpdated?: boolean }).passwordUpdated ? (
+        <section className="rounded-[2rem] border border-emerald-300 bg-emerald-50 p-5 text-sm text-emerald-900">
+          Contrasena actualizada correctamente.
+        </section>
+      ) : null}
+
       {torneosQuery.isLoading ? (
         <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
           Cargando torneos...

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,0 +1,7 @@
+import type { RolUsuario } from '../types/auth'
+
+export const HOME_BY_ROL: Record<RolUsuario, string> = {
+  juez: '/juez/disciplinas',
+  organizador: '/organizador/dashboard',
+  atleta: '/atleta/dashboard',
+}

--- a/src/identidad/api/router.py
+++ b/src/identidad/api/router.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, field_validator
 
 from identidad.api.dependencies import (
     OrganizadorDep,
+    get_current_user,
     get_password_hasher,
     get_token_service,
     get_usuario_repository,
@@ -18,6 +19,10 @@ from identidad.application.commands.autenticar_usuario import (
     AutenticarUsuarioHandler,
     TokenResponse,
 )
+from identidad.application.commands.cambiar_password import (
+    CambiarPasswordCommand,
+    CambiarPasswordHandler,
+)
 from identidad.application.commands.registrar_usuario import (
     RegistrarUsuarioCommand,
     RegistrarUsuarioHandler,
@@ -26,9 +31,11 @@ from identidad.domain.exceptions import (
     CampoRequerido,
     CredencialesInvalidas,
     EmailYaRegistrado,
+    PasswordActualIncorrecto,
     PasswordDemasiadoCorto,
     RolNoPermitido,
     UsuarioInactivo,
+    UsuarioNoEncontrado,
 )
 from identidad.domain.ports.password_hashing_port import PasswordHashingPort
 from identidad.domain.ports.token_service_port import TokenServicePort
@@ -76,6 +83,18 @@ class LoginRequest(BaseModel):
 class LoginResponse(BaseModel):
     access_token: str
     token_type: str
+
+
+class CambiarPasswordRequest(BaseModel):
+    password_actual: str
+    password_nueva: str
+
+    @field_validator("password_nueva")
+    @classmethod
+    def password_min_length(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("La contraseña debe tener al menos 8 caracteres")
+        return v
 
 
 class UsuarioResponse(BaseModel):
@@ -137,6 +156,30 @@ async def autenticar_usuario(
             "token_type": token_response.token_type,
         },
     )
+
+
+@router.post("/cambiar-password", status_code=204)
+async def cambiar_password(
+    body: CambiarPasswordRequest,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    repo: Annotated[UsuarioRepositoryPort, Depends(get_usuario_repository)],
+    password_hasher: Annotated[PasswordHashingPort, Depends(get_password_hasher)],
+) -> JSONResponse:
+    handler = CambiarPasswordHandler(repo, password_hasher)
+    cmd = CambiarPasswordCommand(
+        usuario_id=UUID(current_user["sub"]),
+        password_actual=body.password_actual,
+        password_nueva=body.password_nueva,
+    )
+    try:
+        await handler.handle(cmd)
+    except PasswordActualIncorrecto as exc:
+        return JSONResponse(status_code=401, content={"detail": str(exc)})
+    except PasswordDemasiadoCorto as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except UsuarioNoEncontrado:
+        return JSONResponse(status_code=401, content={"detail": "Token inválido o expirado"})
+    return JSONResponse(status_code=204, content=None)
 
 
 @router.get("/usuarios", status_code=200)

--- a/src/identidad/application/commands/cambiar_password.py
+++ b/src/identidad/application/commands/cambiar_password.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from identidad.domain.exceptions import PasswordActualIncorrecto, PasswordDemasiadoCorto, UsuarioNoEncontrado
+from identidad.domain.ports.password_hashing_port import PasswordHashingPort
+from identidad.domain.ports.usuario_repository_port import UsuarioRepositoryPort
+
+_MIN_PASSWORD_LENGTH = 8
+
+
+@dataclass(frozen=True)
+class CambiarPasswordCommand:
+    usuario_id: UUID
+    password_actual: str
+    password_nueva: str
+
+
+class CambiarPasswordHandler:
+    def __init__(self, repo: UsuarioRepositoryPort, password_hasher: PasswordHashingPort) -> None:
+        self._repo = repo
+        self._password_hasher = password_hasher
+
+    async def handle(self, cmd: CambiarPasswordCommand) -> None:
+        usuario = await self._repo.find_by_id(cmd.usuario_id)
+        if usuario is None:
+            raise UsuarioNoEncontrado(str(cmd.usuario_id))
+
+        if not self._password_hasher.verify(cmd.password_actual, usuario.password_hash):
+            raise PasswordActualIncorrecto()
+
+        if len(cmd.password_nueva) < _MIN_PASSWORD_LENGTH:
+            raise PasswordDemasiadoCorto()
+
+        usuario.password_hash = self._password_hasher.hash(cmd.password_nueva)
+        await self._repo.save(usuario)

--- a/src/identidad/domain/exceptions.py
+++ b/src/identidad/domain/exceptions.py
@@ -36,6 +36,11 @@ class RolNoPermitido(Exception):
         super().__init__("El rol ADMIN no está permitido en el auto-registro")
 
 
+class PasswordActualIncorrecto(Exception):
+    def __init__(self) -> None:
+        super().__init__("La contraseña actual es incorrecta")
+
+
 class TokenInvalido(Exception):
     def __init__(self) -> None:
         super().__init__("Token JWT inválido o expirado")

--- a/tests/features/US-5.4.2-cambiar-password.feature
+++ b/tests/features/US-5.4.2-cambiar-password.feature
@@ -1,0 +1,28 @@
+Feature: US-5.4.2 - Cambiar contrasena
+
+  Background:
+    Given el usuario "juez1@email.com" esta autenticado con password actual "apnea123"
+
+  Scenario: cambiar password exitosamente
+    When el usuario ingresa password actual "apnea123" y nueva password "nuevapass456"
+    And confirma el cambio
+    Then el sistema responde 204
+    And el usuario puede autenticarse con "nuevapass456" en adelante
+
+  Scenario: password actual incorrecta es rechazada
+    When el usuario ingresa password actual "wrongpass" y nueva password "nuevapass456"
+    And confirma el cambio
+    Then el sistema responde 401
+    And se muestra "La contrasena actual es incorrecta"
+
+  Scenario: nueva password menor a 8 caracteres es rechazada antes de enviar
+    When el usuario ingresa nueva password "abc"
+    And intenta confirmar el cambio
+    Then el formulario muestra "La contrasena debe tener al menos 8 caracteres"
+    And no se envia POST "/auth/cambiar-password"
+
+  Scenario: confirmacion de nueva password no coincide es rechazada en frontend
+    When el usuario ingresa nueva password "nuevapass456" y confirmacion "otrapass789"
+    And intenta confirmar el cambio
+    Then el formulario muestra "Las contrasenas no coinciden"
+    And no se envia POST "/auth/cambiar-password"

--- a/tests/unit/identidad/api/test_cambiar_password.py
+++ b/tests/unit/identidad/api/test_cambiar_password.py
@@ -1,0 +1,117 @@
+"""Tests API para POST /auth/cambiar-password."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from identidad.api.dependencies import get_current_user, get_password_hasher, get_usuario_repository
+from identidad.api.router import router
+from identidad.domain.aggregates.usuario import Usuario
+from identidad.domain.ports.password_hashing_port import PasswordHashingPort
+from identidad.domain.value_objects.rol import Rol
+from identidad.infrastructure.bcrypt_password_hasher import BcryptPasswordHasher
+
+
+class FakeUsuarioRepository:
+    def __init__(self, password_hasher: PasswordHashingPort) -> None:
+        self.usuario = Usuario(
+            usuario_id=uuid4(),
+            nombre="Julia",
+            apellido="Segura",
+            email="juez1@email.com",
+            password_hash=password_hasher.hash("apnea123"),
+            rol=Rol.JUEZ,
+        )
+
+    async def save(self, usuario: Usuario) -> None:
+        self.usuario = usuario
+
+    async def find_by_id(self, usuario_id):  # type: ignore[no-untyped-def]
+        if usuario_id == self.usuario.usuario_id:
+            return self.usuario
+        return None
+
+    async def find_by_email(self, email: str) -> Usuario | None:
+        if email == self.usuario.email:
+            return self.usuario
+        return None
+
+    async def list_by_rol(self, rol: Rol) -> list[Usuario]:
+        return [self.usuario] if self.usuario.rol == rol else []
+
+    async def list_all(self) -> list[Usuario]:
+        return [self.usuario]
+
+
+def _client(repo: FakeUsuarioRepository, password_hasher: PasswordHashingPort) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_usuario_repository] = lambda: repo
+    app.dependency_overrides[get_password_hasher] = lambda: password_hasher
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": str(repo.usuario.usuario_id),
+        "email": repo.usuario.email,
+        "rol": "JUEZ",
+    }
+    return TestClient(app)
+
+
+def test_cambiar_password_exitoso() -> None:
+    password_hasher = BcryptPasswordHasher()
+    repo = FakeUsuarioRepository(password_hasher)
+    client = _client(repo, password_hasher)
+
+    response = client.post(
+        "/auth/cambiar-password",
+        json={"password_actual": "apnea123", "password_nueva": "nuevapass456"},
+    )
+
+    assert response.status_code == 204
+    assert password_hasher.verify("nuevapass456", repo.usuario.password_hash)
+
+
+def test_cambiar_password_rechaza_password_actual_incorrecta() -> None:
+    password_hasher = BcryptPasswordHasher()
+    repo = FakeUsuarioRepository(password_hasher)
+    client = _client(repo, password_hasher)
+
+    response = client.post(
+        "/auth/cambiar-password",
+        json={"password_actual": "wrongpass", "password_nueva": "nuevapass456"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "La contraseña actual es incorrecta"
+
+
+def test_cambiar_password_rechaza_password_nueva_corta() -> None:
+    password_hasher = BcryptPasswordHasher()
+    repo = FakeUsuarioRepository(password_hasher)
+    client = _client(repo, password_hasher)
+
+    response = client.post(
+        "/auth/cambiar-password",
+        json={"password_actual": "apnea123", "password_nueva": "abc"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_cambiar_password_requiere_autenticacion() -> None:
+    password_hasher = BcryptPasswordHasher()
+    repo = FakeUsuarioRepository(password_hasher)
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_usuario_repository] = lambda: repo
+    app.dependency_overrides[get_password_hasher] = lambda: password_hasher
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post(
+        "/auth/cambiar-password",
+        json={"password_actual": "apnea123", "password_nueva": "nuevapass456"},
+    )
+
+    assert response.status_code == 401

--- a/tests/unit/identidad/application/test_handlers.py
+++ b/tests/unit/identidad/application/test_handlers.py
@@ -14,6 +14,10 @@ from identidad.application.commands.autenticar_usuario import (
     AutenticarUsuarioHandler,
     TokenResponse,
 )
+from identidad.application.commands.cambiar_password import (
+    CambiarPasswordCommand,
+    CambiarPasswordHandler,
+)
 from identidad.application.commands.registrar_usuario import (
     RegistrarUsuarioCommand,
     RegistrarUsuarioHandler,
@@ -22,8 +26,10 @@ from identidad.domain.aggregates.usuario import Usuario
 from identidad.domain.exceptions import (
     CredencialesInvalidas,
     EmailYaRegistrado,
+    PasswordActualIncorrecto,
     PasswordDemasiadoCorto,
     RolNoPermitido,
+    UsuarioNoEncontrado,
     UsuarioInactivo,
 )
 from identidad.domain.ports.password_hashing_port import PasswordHashingPort
@@ -162,6 +168,82 @@ async def test_registrar_admin_lanza_excepcion(
     )
     with pytest.raises(RolNoPermitido):
         await handler.handle(cmd)
+
+
+# ── CambiarPasswordHandler ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cambiar_password_exitoso(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+) -> None:
+    usuario = _make_usuario("juez@test.com", "clave1234")
+    mock_repo.find_by_id.return_value = usuario
+    handler = CambiarPasswordHandler(mock_repo, password_hasher)
+
+    await handler.handle(
+        CambiarPasswordCommand(
+            usuario_id=usuario.usuario_id,
+            password_actual="clave1234",
+            password_nueva="nuevapass456",
+        )
+    )
+
+    assert password_hasher.verify("nuevapass456", usuario.password_hash)
+    mock_repo.save.assert_called_once_with(usuario)
+
+
+@pytest.mark.asyncio
+async def test_cambiar_password_rechaza_password_actual_incorrecta(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+) -> None:
+    usuario = _make_usuario("juez@test.com", "clave1234")
+    mock_repo.find_by_id.return_value = usuario
+    handler = CambiarPasswordHandler(mock_repo, password_hasher)
+
+    with pytest.raises(PasswordActualIncorrecto):
+        await handler.handle(
+            CambiarPasswordCommand(
+                usuario_id=usuario.usuario_id,
+                password_actual="wrongpass",
+                password_nueva="nuevapass456",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_cambiar_password_rechaza_password_nueva_corta(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+) -> None:
+    usuario = _make_usuario("juez@test.com", "clave1234")
+    mock_repo.find_by_id.return_value = usuario
+    handler = CambiarPasswordHandler(mock_repo, password_hasher)
+
+    with pytest.raises(PasswordDemasiadoCorto):
+        await handler.handle(
+            CambiarPasswordCommand(
+                usuario_id=usuario.usuario_id,
+                password_actual="clave1234",
+                password_nueva="abc",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_cambiar_password_rechaza_usuario_inexistente(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+) -> None:
+    mock_repo.find_by_id.return_value = None
+    handler = CambiarPasswordHandler(mock_repo, password_hasher)
+
+    with pytest.raises(UsuarioNoEncontrado):
+        await handler.handle(
+            CambiarPasswordCommand(
+                usuario_id=uuid.uuid4(),
+                password_actual="clave1234",
+                password_nueva="nuevapass456",
+            )
+        )
 
 
 # ── AutenticarUsuarioHandler ──────────────────────────────────────────────────


### PR DESCRIPTION
## Resumen\n- agrega command y endpoint autenticado para cambio de password\n- incorpora pantalla transversal de cambio de contraseña para juez, organizador y atleta\n- ajusta el cliente frontend para tratar el 401 de password incorrecta como error de negocio\n\n## Validacion\n- ./.venv/bin/pytest tests/unit/identidad tests/integration/identidad\n- npm run build\n- npm run lint\n\n## Notas\n- la validacion BDD/UI de browser queda manual\n- el JWT vigente no se invalida tras el cambio de password