### PR TITLE
feat(registro): vista del organizador — inscriptos con estado AP [US-5.5.2]

### DIFF
--- a/docs/plans/sp5/US-5.5.2-plan.md
+++ b/docs/plans/sp5/US-5.5.2-plan.md
@@ -1,0 +1,70 @@
+# Plan de Implementación: US-5.5.2 — Vista del organizador con inscriptos y estado AP
+
+**Patrón:** hexagonal-ddd-bc
+**BC principal:** `registro` (backend) + `frontend`
+**Estimación Total:** 1h 50min
+
+---
+
+## Componentes a Implementar
+
+### 1. Query handler (Application Layer — BC Registro)
+
+- [ ] `src/registro/application/queries/listar_inscriptos_detalle.py` (20 min)
+  - `InscriptoDetalleDto`: dataclass con `inscripcion_id`, `atleta_id`, `nombre`, `apellido`, `categoria`, `club`, `disciplinas`, `estado`
+  - `ListarInscriptosDetalleHandler`: recibe `InscripcionRepositoryPort` + `AtletaRepositoryPort`
+  - Carga todas las inscripciones del torneo, filtra `estado == ACTIVA` en memoria
+  - Para cada inscripción, busca el atleta por `atleta_id` — atleta no encontrado → skip con log
+
+### 2. Endpoint REST (API Layer — BC Registro)
+
+- [ ] Agregar schema `InscriptoDetalleResponse` en `src/registro/api/router.py` (10 min)
+  - Pydantic BaseModel: `inscripcion_id`, `atleta_id`, `nombre`, `apellido`, `categoria`, `club`, `disciplinas`, `estado`
+- [ ] Agregar endpoint `GET /torneos/{torneo_id}/inscriptos-detalle` en `src/registro/api/router.py` (10 min)
+  - Auth: `OrganizadorDep` — responde 403 si rol != organizador
+  - Instancia `ListarInscriptosDetalleHandler(_inscripcion_repo(), _repo())`
+  - Serializa con `InscriptoDetalleResponse`
+
+### 3. API client frontend
+
+- [ ] `frontend/src/api/registro.ts` — agregar `InscriptoDetalleDto` + `listarInscriptosDetalle` (10 min)
+  - Interface `InscriptoDetalleDto`: `inscripcion_id`, `atleta_id`, `nombre`, `apellido`, `categoria`, `club`, `disciplinas`, `estado`
+  - Función `listarInscriptosDetalle(torneoId: string): Promise<InscriptoDetalleDto[]>`
+
+### 4. Actualizar InscriptosPanel (Frontend)
+
+- [ ] `frontend/src/components/organizador/InscriptosPanel.tsx` (20 min)
+  - Reemplazar `listarInscriptos` + N×`fetchAtleta` por `listarInscriptosDetalle` (1 llamada)
+  - Eliminar import de `fetchAtleta` si ya no se usa
+  - Mantener lógica de cruce con grillas para estado AP (sin cambios)
+  - `rows` se construye directamente desde `InscriptoDetalleDto` (nombre, apellido, categoria, club ya vienen del backend)
+
+### 5. Tests unitarios
+
+- [ ] `tests/unit/registro/test_listar_inscriptos_detalle.py` (20 min)
+  - Handler devuelve solo inscripciones ACTIVAS
+  - Handler enriquece con datos del atleta
+  - Atleta no encontrado → inscripción skipeada (o error de integridad — decidir en impl.)
+  - Torneo sin inscripciones activas → lista vacía
+
+### 6. Tests de integración
+
+- [ ] `tests/integration/registro/test_inscriptos_detalle_endpoint.py` (15 min)
+  - 200 con inscripciones ACTIVAS enriquecidas
+  - 200 con lista vacía si no hay inscripciones activas
+  - CANCELADA no aparece en la respuesta
+  - 403 con rol ATLETA
+
+### 7. BDD Steps
+
+- [ ] `tests/features/steps/US-5.5.2-vista-organizador-inscriptos-steps.py` (10 min)
+  - Steps para los 4 escenarios del `.feature`
+
+### 8. Validación
+
+- [ ] Ejecutar tests + BDD (5 min)
+- [ ] Quality gates: CodeGuard (5 min)
+
+---
+
+**Estado:** 0/12 tareas completadas

--- a/docs/specs/sp5/US-5.5.2.md
+++ b/docs/specs/sp5/US-5.5.2.md
@@ -1,6 +1,6 @@
 # US-5.5.2: Vista del organizador — inscriptos con estado AP
 
-**Estado**: `To Do`
+**Estado**: `Done`
 **Sprint**: SP5 — La Puesta en Marcha
 **Incremento**: INC-5.5
 **Bounded Context**: `registro` (endpoint) + `frontend`

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -6,7 +6,7 @@
 | **Capa IEDD** | Capa 3 — Especificación (puente con Implementación) |
 | **Fecha** | 2026-04-24 |
 | **Fuentes** | `05-requerimientos_funcionales.md` · Context Map v1.1 · `estrategia-desarrollo-bc.md` · ES Competencia |
-| **Estado** | ✅ v1.25 — INC-5.4 cerrado (US-5.4.1..5.4.3 · DesignReviewer 0 CRITICAL · 222 WARNING) |
+| **Estado** | ✅ v1.26 — INC-5.5 parcial: US-5.5.1 (PR #115) + US-5.5.2 Done · DesignReviewer pendiente |
 
 ---
 
@@ -572,6 +572,8 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 | US-5.4.1 | unit/identidad/application (`registrar_usuario`) · integration/identidad · `tests/features/US-5.4.1` · frontend (build + eslint) | ✅ Done (PR #112) |
 | US-5.4.2 | unit/identidad/application (`test_handlers.py` CambiarPassword) · integration/identidad · `tests/features/US-5.4.2` | ✅ Done (PR #113) |
 | US-5.4.3 | unit/identidad/api (`test_reset_password.py`) · unit/identidad/application (`test_handlers.py` Reset) · `tests/features/US-5.4.3-recuperar-password.feature` · frontend (build + eslint) | ✅ Done (PR #114) |
+| US-5.5.1 | unit/competencia/application (`test_registrar_ap_handler.py`) · integration/competencia (`test_registrar_ap_endpoint.py`) · `tests/features/US-5.5.1-registro-aps.feature` · frontend (build) | ✅ Done (PR #115) |
+| US-5.5.2 | unit/registro/application (`test_listar_inscriptos_detalle_handler.py`) · integration/registro (`test_inscriptos_detalle_endpoint.py`) · `tests/features/US-5.5.2-vista-organizador-inscriptos.feature` · frontend (build) | ✅ Done |
 
 ---
 
@@ -604,6 +606,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 *v1.19 — 2026-04-20: US-5.1.2 implementada · trazabilidad frontend de gestion de fases agregada*
 *v1.20 — 2026-04-20: US-5.1.3 implementada · trazabilidad frontend de inscriptos/AP agregada*
 *v1.22 — 2026-04-22: INC-5.2 cerrado (§21 nuevo · DesignReviewer 0 CRITICAL · 215 WARNING) · SP-ADJ-08 §22 · §§ renumerados 23..26 · US→Tests US-5.2.1..5.2.2 · US-ADJ-8.1..8.3*
+*v1.26 — 2026-04-25: INC-5.5 parcial: US-5.5.1 (PR #115) + US-5.5.2 Done · §27 US→Tests actualizado*
 *v1.25 — 2026-04-24: INC-5.4 cerrado (§24 nuevo · DesignReviewer 0 CRITICAL · 222 WARNING) · §§ renumerados 25..28 · US→Tests US-5.4.1..5.4.3 · PRs #112..#114*
 *v1.24 — 2026-04-23: INC-5.3 cerrado (§23 nuevo · DesignReviewer 0 CRITICAL · 215 WARNING) · §§ renumerados 24..27 · US→Tests US-5.3.1..5.3.2 · nota scope adelantado INC-5.4 en US-5.3.2*
 *v1.23 — 2026-04-23: matriz reconciliada contra PLAN-SP5 vigente · RF-IG/RF-IN-07 movidos a futuro fuera de scope SP5 · RF-PM y RF-IN-05/06 marcados como parciales con exposición final en INC-5.4/5.5*

--- a/frontend/src/api/registro.ts
+++ b/frontend/src/api/registro.ts
@@ -30,6 +30,17 @@ export interface AtletaDto {
   brevet: string | null
 }
 
+export interface InscriptoDetalleDto {
+  inscripcion_id: string
+  atleta_id: string
+  nombre: string
+  apellido: string
+  categoria: string
+  club: string
+  disciplinas: string[]
+  estado: string
+}
+
 export interface InscribirAtletaPayload {
   atletaId: string
   torneoId: string
@@ -82,6 +93,13 @@ export async function listarInscriptos(torneoId: string): Promise<InscriptoDto[]
     headers: buildHeaders(),
   })
   return parseResponse<InscriptoDto[]>(response)
+}
+
+export async function listarInscriptosDetalle(torneoId: string): Promise<InscriptoDetalleDto[]> {
+  const response = await fetch(`/registro/torneos/${torneoId}/inscriptos-detalle`, {
+    headers: buildHeaders(),
+  })
+  return parseResponse<InscriptoDetalleDto[]>(response)
 }
 
 export async function fetchAtleta(atletaId: string): Promise<AtletaDto> {

--- a/frontend/src/components/organizador/InscriptosPanel.tsx
+++ b/frontend/src/components/organizador/InscriptosPanel.tsx
@@ -4,7 +4,7 @@ import {
   fetchGrillaCompetencia,
   type GrillaAtletaDto,
 } from '../../api/competencia'
-import { fetchAtleta, listarInscriptos } from '../../api/registro'
+import { listarInscriptosDetalle } from '../../api/registro'
 import { TablaInscriptos, type InscriptoRow } from './TablaInscriptos'
 
 interface InscriptosPanelProps {
@@ -26,11 +26,9 @@ function buildApMap(grillas: Array<{ disciplina: string; entradas: GrillaAtletaD
 
 async function loadInscriptos(torneoId: string) {
   const [inscriptos, competencias] = await Promise.all([
-    listarInscriptos(torneoId),
+    listarInscriptosDetalle(torneoId),
     fetchCompetenciasPorTorneo(torneoId),
   ])
-  const atletas = await Promise.all(inscriptos.map((inscripto) => fetchAtleta(inscripto.atleta_id)))
-  const atletaPorId = new Map(atletas.map((atleta) => [atleta.atleta_id, atleta]))
   const disciplinas = Array.from(
     new Set(inscriptos.flatMap((inscripto) => inscripto.disciplinas)),
   ).sort()
@@ -53,7 +51,6 @@ async function loadInscriptos(torneoId: string) {
   )
   const apMap = buildApMap(grillas)
   const rows: InscriptoRow[] = inscriptos.map((inscripto) => {
-    const atleta = atletaPorId.get(inscripto.atleta_id)
     const estadoApPorDisciplina = Object.fromEntries(
       inscripto.disciplinas.map((disciplina) => [
         disciplina,
@@ -64,9 +61,9 @@ async function loadInscriptos(torneoId: string) {
     return {
       inscripcionId: inscripto.inscripcion_id,
       atletaId: inscripto.atleta_id,
-      nombre: atleta ? `${atleta.apellido}, ${atleta.nombre}` : 'Atleta sin datos',
-      club: atleta?.club ?? 'Sin dato',
-      categoria: atleta?.categoria ?? 'Sin dato',
+      nombre: `${inscripto.apellido}, ${inscripto.nombre}`,
+      club: inscripto.club,
+      categoria: inscripto.categoria,
       genero: 'Sin dato',
       disciplinas: inscripto.disciplinas,
       estadoApPorDisciplina,

--- a/quality/reports/codeguard/US-5.5.2-codeguard-raw.json
+++ b/quality/reports/codeguard/US-5.5.2-codeguard-raw.json
@@ -1,0 +1,46 @@
+CodeGuard v0.2.0 (Arquitectura Modular)
+Analizando: /Users/victor/PycharmProjects/ataraxiadive/src/registro/application/queries/listar_inscriptos_detalle.py, /Users/victor/PycharmProjects/ataraxiadive/src/registro/api/router.py
+Archivos Python encontrados: 2
+Tipo de análisis: pre-commit
+
+Checks disponibles: 6
+---
+╭──────────────────────────────────────────────────────────────────────────────╮
+│  🛡️  CodeGuard - Control de Calidad Automatizado                             │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+Archivos analizados:  2    
+Checks ejecutados:    6    
+Tiempo de ejecución:  1.47s
+Resultados totales:   6    
+
+───────────────────────────── 📦  api  (3 issues) ──────────────────────────────
+
+                                Informativos (3)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                  ┃ Mensaje                            ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/registro/api/router.py │ ✓ No security issues detected      │
+│ PEP8       │ src/registro/api/router.py │ ✓ PEP8 compliant                   │
+│ Complexity │ src/registro/api/router.py │ ✓ All functions below complexity   │
+│            │                            │ threshold (≤10)                    │
+└────────────┴────────────────────────────┴────────────────────────────────────┘
+
+─────────────────────────── 📦  queries  (3 issues) ────────────────────────────
+
+                                Informativos (3)                                
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check      ┃ Ubicación                      ┃ Mensaje                        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Security   │ src/registro/application/quer… │ ✓ No security issues detected  │
+│ PEP8       │ src/registro/application/quer… │ ✓ PEP8 compliant               │
+│ Complexity │ src/registro/application/quer… │ ✓ All functions below          │
+│            │                                │ complexity threshold (≤10)     │
+└────────────┴────────────────────────────────┴────────────────────────────────┘
+
+╭─────────────────────────────── Resumen Final ────────────────────────────────╮
+│  Resumen:                                                                    │
+│            0 errores                                                         │
+│            0 advertencias                                                    │
+│            6 informativos                                                    │
+╰──────────────────────────────────────────────────────────────────────────────╯

--- a/src/registro/api/router.py
+++ b/src/registro/api/router.py
@@ -22,6 +22,7 @@ from registro.application.commands.registrar_atleta import (
     RegistrarAtletaHandler,
 )
 from registro.application.queries.listar_inscriptos import ListarInscriptosHandler
+from registro.application.queries.listar_inscriptos_detalle import ListarInscriptosDetalleHandler
 from registro.application.queries.obtener_atleta import ObtenerAtletaHandler
 from registro.domain.aggregates.inscripcion import Inscripcion
 from registro.domain.exceptions import (
@@ -103,6 +104,17 @@ class InscripcionResponse(BaseModel):
     disciplinas: list[str]
     estado: EstadoInscripcion
     fecha_inscripcion: datetime
+
+
+class InscriptoDetalleResponse(BaseModel):
+    inscripcion_id: UUID
+    atleta_id: UUID
+    nombre: str
+    apellido: str
+    categoria: str
+    club: str
+    disciplinas: list[str]
+    estado: str
 
 
 # ── Helpers de dependencias ───────────────────────────────────────────────────
@@ -211,6 +223,28 @@ async def cancelar_inscripcion(inscripcion_id: UUID, _: AtletaDep) -> JSONRespon
     except PlazoCancelacionVencido as exc:
         return JSONResponse(status_code=409, content={"detail": str(exc)})
     return JSONResponse(status_code=200, content={"ok": True})
+
+
+@router.get("/torneos/{torneo_id}/inscriptos-detalle", status_code=200)
+async def listar_inscriptos_detalle(torneo_id: UUID, _: OrganizadorDep) -> JSONResponse:
+    handler = ListarInscriptosDetalleHandler(_inscripcion_repo(), _repo())
+    inscriptos = await handler.handle(torneo_id)
+    return JSONResponse(
+        status_code=200,
+        content=[
+            InscriptoDetalleResponse(
+                inscripcion_id=i.inscripcion_id,
+                atleta_id=i.atleta_id,
+                nombre=i.nombre,
+                apellido=i.apellido,
+                categoria=i.categoria,
+                club=i.club,
+                disciplinas=i.disciplinas,
+                estado=i.estado,
+            ).model_dump(mode="json")
+            for i in inscriptos
+        ],
+    )
 
 
 @router.get("/torneos/{torneo_id}/inscriptos", status_code=200)

--- a/src/registro/application/queries/listar_inscriptos_detalle.py
+++ b/src/registro/application/queries/listar_inscriptos_detalle.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from registro.domain.ports.atleta_repository_port import AtletaRepositoryPort
+from registro.domain.ports.inscripcion_repository_port import InscripcionRepositoryPort
+from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
+
+
+@dataclass
+class InscriptoDetalleDto:
+    inscripcion_id: UUID
+    atleta_id: UUID
+    nombre: str
+    apellido: str
+    categoria: str
+    club: str
+    disciplinas: list[str]
+    estado: str
+
+
+class ListarInscriptosDetalleHandler:
+    def __init__(
+        self,
+        inscripcion_repo: InscripcionRepositoryPort,
+        atleta_repo: AtletaRepositoryPort,
+    ) -> None:
+        self._inscripcion_repo = inscripcion_repo
+        self._atleta_repo = atleta_repo
+
+    async def handle(self, torneo_id: UUID) -> list[InscriptoDetalleDto]:
+        inscripciones = await self._inscripcion_repo.find_by_torneo(torneo_id)
+        activas = [i for i in inscripciones if i.estado == EstadoInscripcion.ACTIVA]
+
+        resultado: list[InscriptoDetalleDto] = []
+        for inscripcion in activas:
+            atleta = await self._atleta_repo.find_by_id(inscripcion.atleta_id)
+            if atleta is None:
+                continue
+            resultado.append(
+                InscriptoDetalleDto(
+                    inscripcion_id=inscripcion.inscripcion_id,
+                    atleta_id=inscripcion.atleta_id,
+                    nombre=atleta.nombre,
+                    apellido=atleta.apellido,
+                    categoria=atleta.categoria.value,
+                    club=atleta.club,
+                    disciplinas=[d.value for d in inscripcion.disciplinas],
+                    estado=inscripcion.estado.value,
+                )
+            )
+        return resultado

--- a/tests/features/US-5.5.2-vista-organizador-inscriptos.feature
+++ b/tests/features/US-5.5.2-vista-organizador-inscriptos.feature
@@ -1,0 +1,32 @@
+Feature: US-5.5.2 — Vista del organizador con inscriptos y estado AP
+
+  Background:
+    Given el torneo "BA Open 2026" tiene inscriptos activos con datos completos
+    And la atleta "ana@email.com" esta inscripta en DNF y STA con nombre "Garcia, Ana"
+    And el atleta "carlos@email.com" esta inscripto en DYN con nombre "Lopez, Carlos"
+    And existe una inscripcion CANCELADA de "pepe@email.com"
+
+  Scenario: organizador obtiene lista enriquecida de inscriptos
+    Given el organizador esta autenticado
+    When realiza GET /registro/torneos/{id}/inscriptos-detalle
+    Then el sistema responde 200
+    And la respuesta contiene a "Garcia" con disciplinas DNF y STA
+    And la respuesta contiene a "Lopez" con disciplinas DYN
+    And la respuesta no contiene la inscripcion CANCELADA
+
+  Scenario: inscripcion cancelada no aparece en la lista
+    Given el organizador esta autenticado
+    When realiza GET /registro/torneos/{id}/inscriptos-detalle
+    Then la respuesta no incluye inscripciones con estado CANCELADA
+
+  Scenario: acceso sin rol organizador es rechazado
+    Given el usuario esta autenticado con rol ATLETA
+    When realiza GET /registro/torneos/{id}/inscriptos-detalle
+    Then el sistema responde 403
+
+  Scenario: torneo sin inscriptos devuelve lista vacia
+    Given existe el torneo "Torneo Vacio" sin inscriptos activos
+    And el organizador esta autenticado
+    When el organizador realiza GET /registro/torneos/{id-vacio}/inscriptos-detalle
+    Then el sistema responde 200
+    And la respuesta es una lista vacia

--- a/tests/features/steps/US_5_5_2_vista_organizador_inscriptos_steps.py
+++ b/tests/features/steps/US_5_5_2_vista_organizador_inscriptos_steps.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from app import app
+from identidad.api.dependencies import get_current_user
+from registro.domain.aggregates.atleta import Atleta
+from registro.domain.aggregates.inscripcion import Inscripcion
+from registro.domain.value_objects.categoria import Categoria
+from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
+from registro.infrastructure.repositories.sqlite_atleta_repository import SQLiteAtletaRepository
+from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
+    SQLiteInscripcionRepository,
+)
+from shared.domain.value_objects.disciplina import Disciplina
+from torneo.domain.aggregates.torneo import Torneo
+from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
+from torneo.domain.value_objects.sede import Sede
+from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
+
+scenarios("../US-5.5.2-vista-organizador-inscriptos.feature")
+
+
+@pytest.fixture
+def context(tmp_path: Any, monkeypatch: Any) -> dict[str, Any]:
+    registro_db = str(tmp_path / "registro.db")
+    torneo_db = str(tmp_path / "torneo.db")
+    monkeypatch.setenv("REGISTRO_DB_PATH", registro_db)
+    monkeypatch.setenv("TORNEO_DB_PATH", torneo_db)
+
+    organizador_id = uuid4()
+    torneo_id = uuid4()
+
+    return {
+        "registro_db": registro_db,
+        "torneo_db": torneo_db,
+        "torneo_id": torneo_id,
+        "torneo_vacio_id": None,
+        "organizador_id": organizador_id,
+        "atleta1_id": uuid4(),
+        "atleta2_id": uuid4(),
+        "atleta_cancelado_id": uuid4(),
+        "response": None,
+    }
+
+
+@pytest.fixture
+def client() -> TestClient:
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# ── Background ────────────────────────────────────────────────────────────────
+
+
+@given('el torneo "BA Open 2026" tiene inscriptos activos con datos completos')
+def torneo_con_inscriptos(context: dict[str, Any]) -> None:
+    atleta_repo = SQLiteAtletaRepository(context["registro_db"])
+    torneo_repo = SQLiteTorneoRepository(context["torneo_db"])
+    torneo_id = context["torneo_id"]
+
+    async def _seed() -> None:
+        torneo = Torneo(
+            torneo_id=torneo_id,
+            nombre="BA Open 2026",
+            descripcion="Torneo test",
+            fecha_inicio=date(2026, 5, 15),
+            fecha_fin=date(2026, 5, 16),
+            sede=Sede(nombre="Club Nautico", ciudad="Buenos Aires", pais="Argentina"),
+            entidad_organizadora=EntidadOrganizadora(nombre="ADA", tipo="FEDERACION"),
+        )
+        torneo.abrir_inscripcion()
+        await torneo_repo.save(torneo)
+
+    asyncio.run(_seed())
+
+
+@given('la atleta "ana@email.com" esta inscripta en DNF y STA con nombre "Garcia, Ana"')
+def atleta_ana_inscripta(context: dict[str, Any]) -> None:
+    atleta_repo = SQLiteAtletaRepository(context["registro_db"])
+    inscripcion_repo = SQLiteInscripcionRepository(context["registro_db"])
+    atleta1_id = context["atleta1_id"]
+
+    async def _seed() -> None:
+        await atleta_repo.save(
+            Atleta(
+                atleta_id=atleta1_id,
+                nombre="Ana",
+                apellido="Garcia",
+                email="ana@email.com",
+                fecha_nacimiento=date(1990, 5, 15),
+                categoria=Categoria.SENIOR_FEMENINO,
+                club="Club Aqua",
+            )
+        )
+        await inscripcion_repo.save(
+            Inscripcion(
+                atleta_id=atleta1_id,
+                torneo_id=context["torneo_id"],
+                disciplinas=frozenset([Disciplina.DNF, Disciplina.STA]),
+            )
+        )
+
+    asyncio.run(_seed())
+
+
+@given('el atleta "carlos@email.com" esta inscripto en DYN con nombre "Lopez, Carlos"')
+def atleta_carlos_inscripto(context: dict[str, Any]) -> None:
+    atleta_repo = SQLiteAtletaRepository(context["registro_db"])
+    inscripcion_repo = SQLiteInscripcionRepository(context["registro_db"])
+    atleta2_id = context["atleta2_id"]
+
+    async def _seed() -> None:
+        await atleta_repo.save(
+            Atleta(
+                atleta_id=atleta2_id,
+                nombre="Carlos",
+                apellido="Lopez",
+                email="carlos@email.com",
+                fecha_nacimiento=date(1985, 3, 10),
+                categoria=Categoria.MASTER_MASCULINO,
+                club="Club Mar",
+            )
+        )
+        await inscripcion_repo.save(
+            Inscripcion(
+                atleta_id=atleta2_id,
+                torneo_id=context["torneo_id"],
+                disciplinas=frozenset([Disciplina.DYN]),
+            )
+        )
+
+    asyncio.run(_seed())
+
+
+@given('existe una inscripcion CANCELADA de "pepe@email.com"')
+def inscripcion_cancelada(context: dict[str, Any]) -> None:
+    atleta_repo = SQLiteAtletaRepository(context["registro_db"])
+    inscripcion_repo = SQLiteInscripcionRepository(context["registro_db"])
+    cancelado_id = context["atleta_cancelado_id"]
+
+    async def _seed() -> None:
+        await atleta_repo.save(
+            Atleta(
+                atleta_id=cancelado_id,
+                nombre="Pepe",
+                apellido="Gomez",
+                email="pepe@email.com",
+                fecha_nacimiento=date(1988, 1, 1),
+                categoria=Categoria.SENIOR_MASCULINO,
+                club="Club X",
+            )
+        )
+        insc = Inscripcion(
+            atleta_id=cancelado_id,
+            torneo_id=context["torneo_id"],
+            disciplinas=frozenset([Disciplina.DNF]),
+        )
+        insc.estado = EstadoInscripcion.CANCELADA
+        await inscripcion_repo.save(insc)
+
+    asyncio.run(_seed())
+
+
+# ── Scenario: torneo vacío ─────────────────────────────────────────────────────
+
+
+@given('existe el torneo "Torneo Vacio" sin inscriptos activos')
+def torneo_vacio(context: dict[str, Any]) -> None:
+    torneo_repo = SQLiteTorneoRepository(context["torneo_db"])
+    torneo_vacio_id = uuid4()
+    context["torneo_vacio_id"] = torneo_vacio_id
+
+    async def _seed() -> None:
+        torneo = Torneo(
+            torneo_id=torneo_vacio_id,
+            nombre="Torneo Vacio",
+            descripcion="Sin inscriptos",
+            fecha_inicio=date(2026, 6, 1),
+            fecha_fin=date(2026, 6, 2),
+            sede=Sede(nombre="Club", ciudad="BA", pais="Argentina"),
+            entidad_organizadora=EntidadOrganizadora(nombre="ADA", tipo="FEDERACION"),
+        )
+        torneo.abrir_inscripcion()
+        await torneo_repo.save(torneo)
+
+    asyncio.run(_seed())
+
+
+# ── Auth steps ────────────────────────────────────────────────────────────────
+
+
+@given("el organizador esta autenticado")
+def organizador_autenticado(client: TestClient, context: dict[str, Any]) -> None:
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": str(context["organizador_id"]),
+        "email": "org@ataraxiadive.io",
+        "rol": "ORGANIZADOR",
+    }
+
+
+@given("el usuario esta autenticado con rol ATLETA")
+def usuario_rol_atleta(client: TestClient) -> None:
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": str(uuid4()),
+        "email": "atleta@example.com",
+        "rol": "ATLETA",
+    }
+
+
+# ── When steps ────────────────────────────────────────────────────────────────
+
+
+@when("realiza GET /registro/torneos/{id}/inscriptos-detalle")
+def get_inscriptos_detalle(client: TestClient, context: dict[str, Any]) -> None:
+    context["response"] = client.get(f"/registro/torneos/{context['torneo_id']}/inscriptos-detalle")
+
+
+@when("el organizador realiza GET /registro/torneos/{id-vacio}/inscriptos-detalle")
+def get_inscriptos_detalle_vacio(client: TestClient, context: dict[str, Any]) -> None:
+    context["response"] = client.get(
+        f"/registro/torneos/{context['torneo_vacio_id']}/inscriptos-detalle"
+    )
+
+
+# ── Then steps ────────────────────────────────────────────────────────────────
+
+
+@then(parsers.parse("el sistema responde {codigo:d}"))
+def sistema_responde(context: dict[str, Any], codigo: int) -> None:
+    assert context["response"].status_code == codigo
+
+
+@then('la respuesta contiene a "Garcia" con disciplinas DNF y STA')
+def contiene_garcia(context: dict[str, Any]) -> None:
+    data = context["response"].json()
+    garcia = next((d for d in data if d["apellido"] == "Garcia"), None)
+    assert garcia is not None
+    assert set(garcia["disciplinas"]) == {"DNF", "STA"}
+
+
+@then('la respuesta contiene a "Lopez" con disciplinas DYN')
+def contiene_lopez(context: dict[str, Any]) -> None:
+    data = context["response"].json()
+    lopez = next((d for d in data if d["apellido"] == "Lopez"), None)
+    assert lopez is not None
+    assert set(lopez["disciplinas"]) == {"DYN"}
+
+
+@then("la respuesta no contiene la inscripcion CANCELADA")
+def no_contiene_cancelada(context: dict[str, Any]) -> None:
+    data = context["response"].json()
+    ids = [d["atleta_id"] for d in data]
+    assert str(context["atleta_cancelado_id"]) not in ids
+
+
+@then("la respuesta no incluye inscripciones con estado CANCELADA")
+def no_incluye_canceladas(context: dict[str, Any]) -> None:
+    data = context["response"].json()
+    estados = [d["estado"] for d in data]
+    assert "CANCELADA" not in estados
+
+
+@then("la respuesta es una lista vacia")
+def lista_vacia(context: dict[str, Any]) -> None:
+    assert context["response"].json() == []

--- a/tests/integration/registro/test_inscriptos_detalle_endpoint.py
+++ b/tests/integration/registro/test_inscriptos_detalle_endpoint.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app
+from identidad.api.dependencies import get_current_user
+from registro.domain.aggregates.atleta import Atleta
+from registro.domain.value_objects.categoria import Categoria
+from registro.infrastructure.repositories.sqlite_atleta_repository import SQLiteAtletaRepository
+from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
+    SQLiteInscripcionRepository,
+)
+from registro.domain.aggregates.inscripcion import Inscripcion
+from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
+from shared.domain.value_objects.disciplina import Disciplina
+from torneo.domain.aggregates.torneo import Torneo
+from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
+from torneo.domain.value_objects.sede import Sede
+from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
+
+
+def _atleta(atleta_id=None, apellido="García", nombre="Ana", email=None) -> Atleta:
+    return Atleta(
+        atleta_id=atleta_id or uuid4(),
+        nombre=nombre,
+        apellido=apellido,
+        email=email or f"{apellido.lower()}@example.com",
+        fecha_nacimiento=date(1990, 5, 15),
+        categoria=Categoria.SENIOR_FEMENINO,
+        club="Club Aqua",
+    )
+
+
+@pytest.fixture
+def inscriptos_context(tmp_path, monkeypatch):
+    registro_db = str(tmp_path / "registro.db")
+    torneo_db = str(tmp_path / "torneo.db")
+    monkeypatch.setenv("REGISTRO_DB_PATH", registro_db)
+    monkeypatch.setenv("TORNEO_DB_PATH", torneo_db)
+
+    organizador_id = uuid4()
+    atleta1_id = uuid4()
+    atleta2_id = uuid4()
+    atleta_cancelado_id = uuid4()
+    torneo_id = uuid4()
+    torneo_vacio_id = uuid4()
+
+    atleta_repo = SQLiteAtletaRepository(registro_db)
+    inscripcion_repo = SQLiteInscripcionRepository(registro_db)
+    torneo_repo = SQLiteTorneoRepository(torneo_db)
+
+    async def _seed() -> None:
+        # Atletas
+        await atleta_repo.save(
+            _atleta(atleta_id=atleta1_id, apellido="Garcia", nombre="Ana", email="ana@example.com")
+        )
+        await atleta_repo.save(
+            _atleta(
+                atleta_id=atleta2_id, apellido="Lopez", nombre="Carlos", email="carlos@example.com"
+            )
+        )
+        await atleta_repo.save(
+            _atleta(
+                atleta_id=atleta_cancelado_id,
+                apellido="Pepe",
+                nombre="Pepe",
+                email="pepe@example.com",
+            )
+        )
+
+        # Torneo principal
+        torneo = Torneo(
+            torneo_id=torneo_id,
+            nombre="BA Open 2026",
+            descripcion="Torneo test",
+            fecha_inicio=date(2026, 5, 15),
+            fecha_fin=date(2026, 5, 16),
+            sede=Sede(nombre="Club Nautico", ciudad="Buenos Aires", pais="Argentina"),
+            entidad_organizadora=EntidadOrganizadora(nombre="ADA", tipo="FEDERACION"),
+        )
+        torneo.abrir_inscripcion()
+        await torneo_repo.save(torneo)
+
+        # Torneo vacío
+        torneo_vacio = Torneo(
+            torneo_id=torneo_vacio_id,
+            nombre="Torneo Vacío",
+            descripcion="Sin inscriptos",
+            fecha_inicio=date(2026, 6, 1),
+            fecha_fin=date(2026, 6, 2),
+            sede=Sede(nombre="Club", ciudad="BA", pais="Argentina"),
+            entidad_organizadora=EntidadOrganizadora(nombre="ADA", tipo="FEDERACION"),
+        )
+        torneo_vacio.abrir_inscripcion()
+        await torneo_repo.save(torneo_vacio)
+
+        # Inscripciones ACTIVAS
+        await inscripcion_repo.save(
+            Inscripcion(
+                atleta_id=atleta1_id,
+                torneo_id=torneo_id,
+                disciplinas=frozenset([Disciplina.DNF, Disciplina.STA]),
+            )
+        )
+        await inscripcion_repo.save(
+            Inscripcion(
+                atleta_id=atleta2_id, torneo_id=torneo_id, disciplinas=frozenset([Disciplina.DYN])
+            )
+        )
+
+        # Inscripción CANCELADA
+        insc_cancelada = Inscripcion(
+            atleta_id=atleta_cancelado_id,
+            torneo_id=torneo_id,
+            disciplinas=frozenset([Disciplina.DNF]),
+        )
+        insc_cancelada.estado = EstadoInscripcion.CANCELADA
+        await inscripcion_repo.save(insc_cancelada)
+
+    asyncio.run(_seed())
+
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": str(organizador_id),
+        "email": "org@ataraxiadive.io",
+        "rol": "ORGANIZADOR",
+    }
+
+    yield {
+        "torneo_id": torneo_id,
+        "torneo_vacio_id": torneo_vacio_id,
+        "atleta1_id": atleta1_id,
+        "atleta2_id": atleta2_id,
+        "atleta_cancelado_id": atleta_cancelado_id,
+        "organizador_id": organizador_id,
+    }
+
+    app.dependency_overrides.clear()
+
+
+def test_organizador_obtiene_inscriptos_detalle(inscriptos_context):
+    client = TestClient(app)
+    torneo_id = inscriptos_context["torneo_id"]
+
+    response = client.get(f"/registro/torneos/{torneo_id}/inscriptos-detalle")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    apellidos = {d["apellido"] for d in data}
+    assert "Garcia" in apellidos
+    assert "Lopez" in apellidos
+    # Pepe (CANCELADA) no aparece
+    assert "Pepe" not in apellidos
+
+
+def test_respuesta_contiene_datos_atleta_completos(inscriptos_context):
+    client = TestClient(app)
+    torneo_id = inscriptos_context["torneo_id"]
+
+    response = client.get(f"/registro/torneos/{torneo_id}/inscriptos-detalle")
+
+    assert response.status_code == 200
+    garcia = next(d for d in response.json() if d["apellido"] == "Garcia")
+    assert garcia["nombre"] == "Ana"
+    assert garcia["club"] == "Club Aqua"
+    assert garcia["categoria"] == Categoria.SENIOR_FEMENINO.value
+    assert set(garcia["disciplinas"]) == {"DNF", "STA"}
+    assert garcia["estado"] == "ACTIVA"
+
+
+def test_inscripciones_canceladas_no_aparecen(inscriptos_context):
+    client = TestClient(app)
+    torneo_id = inscriptos_context["torneo_id"]
+
+    response = client.get(f"/registro/torneos/{torneo_id}/inscriptos-detalle")
+
+    assert response.status_code == 200
+    atleta_cancelado_id = str(inscriptos_context["atleta_cancelado_id"])
+    ids = [d["atleta_id"] for d in response.json()]
+    assert atleta_cancelado_id not in ids
+
+
+def test_torneo_sin_inscriptos_devuelve_lista_vacia(inscriptos_context):
+    client = TestClient(app)
+    torneo_vacio_id = inscriptos_context["torneo_vacio_id"]
+
+    response = client.get(f"/registro/torneos/{torneo_vacio_id}/inscriptos-detalle")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_acceso_con_rol_atleta_es_rechazado(inscriptos_context):
+    client = TestClient(app)
+    torneo_id = inscriptos_context["torneo_id"]
+
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": str(uuid4()),
+        "email": "atleta@example.com",
+        "rol": "ATLETA",
+    }
+
+    response = client.get(f"/registro/torneos/{torneo_id}/inscriptos-detalle")
+
+    assert response.status_code == 403
+
+    # Restaurar override de organizador
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": str(inscriptos_context["organizador_id"]),
+        "email": "org@ataraxiadive.io",
+        "rol": "ORGANIZADOR",
+    }

--- a/tests/unit/registro/test_listar_inscriptos_detalle_handler.py
+++ b/tests/unit/registro/test_listar_inscriptos_detalle_handler.py
@@ -1,0 +1,131 @@
+from datetime import date, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from registro.application.queries.listar_inscriptos_detalle import (
+    InscriptoDetalleDto,
+    ListarInscriptosDetalleHandler,
+)
+from registro.domain.aggregates.atleta import Atleta
+from registro.domain.aggregates.inscripcion import Inscripcion
+from registro.domain.value_objects.categoria import Categoria
+from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
+from shared.domain.value_objects.disciplina import Disciplina
+
+
+def _atleta(atleta_id=None) -> Atleta:
+    return Atleta(
+        atleta_id=atleta_id or uuid4(),
+        nombre="Ana",
+        apellido="García",
+        email="ana@example.com",
+        fecha_nacimiento=date(1990, 5, 15),
+        categoria=Categoria.SENIOR_FEMENINO,
+        club="Club Aqua",
+    )
+
+
+def _inscripcion(
+    atleta_id, torneo_id, disciplinas=None, estado=EstadoInscripcion.ACTIVA
+) -> Inscripcion:
+    insc = Inscripcion(
+        atleta_id=atleta_id,
+        torneo_id=torneo_id,
+        disciplinas=frozenset(disciplinas or [Disciplina.DNF]),
+        fecha_inscripcion=datetime(2026, 1, 1),
+    )
+    insc.estado = estado
+    return insc
+
+
+class TestListarInscriptosDetalleHandler:
+    async def test_retorna_inscripciones_activas_con_datos_atleta(self):
+        torneo_id = uuid4()
+        atleta = _atleta()
+        insc = _inscripcion(atleta.atleta_id, torneo_id, [Disciplina.DNF, Disciplina.STA])
+
+        inscripcion_repo = AsyncMock()
+        inscripcion_repo.find_by_torneo.return_value = [insc]
+        atleta_repo = AsyncMock()
+        atleta_repo.find_by_id.return_value = atleta
+
+        handler = ListarInscriptosDetalleHandler(inscripcion_repo, atleta_repo)
+        result = await handler.handle(torneo_id)
+
+        assert len(result) == 1
+        dto = result[0]
+        assert isinstance(dto, InscriptoDetalleDto)
+        assert dto.atleta_id == atleta.atleta_id
+        assert dto.nombre == "Ana"
+        assert dto.apellido == "García"
+        assert dto.categoria == Categoria.SENIOR_FEMENINO.value
+        assert dto.club == "Club Aqua"
+        assert set(dto.disciplinas) == {"DNF", "STA"}
+        assert dto.estado == "ACTIVA"
+
+    async def test_excluye_inscripciones_canceladas(self):
+        torneo_id = uuid4()
+        atleta = _atleta()
+        insc_activa = _inscripcion(atleta.atleta_id, torneo_id)
+        insc_cancelada = _inscripcion(uuid4(), torneo_id, estado=EstadoInscripcion.CANCELADA)
+
+        inscripcion_repo = AsyncMock()
+        inscripcion_repo.find_by_torneo.return_value = [insc_activa, insc_cancelada]
+        atleta_repo = AsyncMock()
+        atleta_repo.find_by_id.return_value = atleta
+
+        handler = ListarInscriptosDetalleHandler(inscripcion_repo, atleta_repo)
+        result = await handler.handle(torneo_id)
+
+        assert len(result) == 1
+        assert result[0].atleta_id == atleta.atleta_id
+
+    async def test_torneo_sin_inscripciones_activas_devuelve_lista_vacia(self):
+        torneo_id = uuid4()
+        inscripcion_repo = AsyncMock()
+        inscripcion_repo.find_by_torneo.return_value = []
+        atleta_repo = AsyncMock()
+
+        handler = ListarInscriptosDetalleHandler(inscripcion_repo, atleta_repo)
+        result = await handler.handle(torneo_id)
+
+        assert result == []
+        atleta_repo.find_by_id.assert_not_awaited()
+
+    async def test_atleta_no_encontrado_es_omitido(self):
+        torneo_id = uuid4()
+        insc = _inscripcion(uuid4(), torneo_id)
+
+        inscripcion_repo = AsyncMock()
+        inscripcion_repo.find_by_torneo.return_value = [insc]
+        atleta_repo = AsyncMock()
+        atleta_repo.find_by_id.return_value = None
+
+        handler = ListarInscriptosDetalleHandler(inscripcion_repo, atleta_repo)
+        result = await handler.handle(torneo_id)
+
+        assert result == []
+
+    async def test_multiples_inscripciones_activas(self):
+        torneo_id = uuid4()
+        atleta1 = _atleta()
+        atleta2 = _atleta()
+        insc1 = _inscripcion(atleta1.atleta_id, torneo_id, [Disciplina.DNF])
+        insc2 = _inscripcion(atleta2.atleta_id, torneo_id, [Disciplina.DYN])
+
+        inscripcion_repo = AsyncMock()
+        inscripcion_repo.find_by_torneo.return_value = [insc1, insc2]
+        atleta_repo = AsyncMock()
+        atleta_repo.find_by_id.side_effect = lambda aid: (
+            atleta1 if aid == atleta1.atleta_id else atleta2
+        )
+
+        handler = ListarInscriptosDetalleHandler(inscripcion_repo, atleta_repo)
+        result = await handler.handle(torneo_id)
+
+        assert len(result) == 2
+        ids = {r.atleta_id for r in result}
+        assert atleta1.atleta_id in ids
+        assert atleta2.atleta_id in ids


### PR DESCRIPTION
## Resumen

Consolida el endpoint N+1 del `InscriptosPanel` en una única llamada enriquecida. El organizador ahora obtiene nombre, apellido, categoría, club y disciplinas de cada inscripto en un solo `GET`, eliminando las N llamadas a `/registro/atletas/{id}` que existían por cada inscripto.

## Cambios Principales

- `registro/application/queries/listar_inscriptos_detalle.py` — nuevo handler que une `InscripcionRepository` + `AtletaRepository`, filtra solo ACTIVAS (INV-5.5.2-02)
- `registro/api/router.py` — endpoint `GET /torneos/{id}/inscriptos-detalle` (OrganizadorDep, 403 si rol != ORGANIZADOR)
- `frontend/src/api/registro.ts` — `InscriptoDetalleDto` + `listarInscriptosDetalle()`
- `frontend/src/components/organizador/InscriptosPanel.tsx` — reemplaza N+1 por 1 llamada; lógica de cruce con grilla para estado AP sin cambios

## Test Plan

- [x] 5 tests unitarios (`test_listar_inscriptos_detalle_handler.py`) — handler filtra ACTIVAS, enriquece datos, omite atleta no encontrado
- [x] 5 tests de integración (`test_inscriptos_detalle_endpoint.py`) — endpoint 200/403, CANCELADA ausente, lista vacía
- [x] 4 escenarios BDD (`US-5.5.2-vista-organizador-inscriptos.feature`) — todos pasando
- [x] Build frontend sin errores de tipos
- [x] CodeGuard: 0 errores · 0 advertencias
- [x] matrix.md v1.26 · spec US-5.5.2 → Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)