### PR TITLE
US-5.5.1: portal atleta y AP

### DIFF
--- a/.claude/tracking/US-5.5.1-tracking.json
+++ b/.claude/tracking/US-5.5.1-tracking.json
@@ -1,0 +1,178 @@
+{
+  "metadata": {
+    "us_id": "US-5.5.1",
+    "us_title": "Inscripción completa del atleta + Declarar/Modificar AP",
+    "us_points": 5,
+    "producto": "frontend + identidad + registro + competencia",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-26T12:12:13+00:00",
+    "completed_at": "2026-04-26T13:35:00+00:00",
+    "total_elapsed_seconds": 4967,
+    "effective_seconds": 4967,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-26T12:12:13+00:00",
+      "completed_at": "2026-04-26T12:28:00+00:00",
+      "elapsed_seconds": 947,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-26T13:28:00+00:00",
+      "completed_at": "2026-04-26T13:29:00+00:00",
+      "elapsed_seconds": 60,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-26T13:29:00+00:00",
+      "completed_at": "2026-04-26T13:30:00+00:00",
+      "elapsed_seconds": 60,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación Guiada por Tareas",
+      "started_at": "2026-04-26T12:28:00+00:00",
+      "completed_at": "2026-04-26T13:10:00+00:00",
+      "elapsed_seconds": 2520,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Extender JWT y store del atleta",
+          "task_type": "backend+frontend",
+          "estimated_minutes": 30.0,
+          "started_at": "2026-04-26T12:30:00+00:00",
+          "completed_at": "2026-04-26T12:38:00+00:00",
+          "elapsed_seconds": 480,
+          "actual_minutes": 8.0,
+          "variance_minutes": -22.0,
+          "file_created": "src/identidad/infrastructure/jwt_service.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Exponer inscripciones del atleta y registrar AP",
+          "task_type": "backend",
+          "estimated_minutes": 45.0,
+          "started_at": "2026-04-26T12:38:00+00:00",
+          "completed_at": "2026-04-26T12:52:00+00:00",
+          "elapsed_seconds": 840,
+          "actual_minutes": 14.0,
+          "variance_minutes": -31.0,
+          "file_created": "src/competencia/api/router.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Rehacer portal atleta S-01..S-06",
+          "task_type": "frontend",
+          "estimated_minutes": 120.0,
+          "started_at": "2026-04-26T12:52:00+00:00",
+          "completed_at": "2026-04-26T13:10:00+00:00",
+          "elapsed_seconds": 1080,
+          "actual_minutes": 18.0,
+          "variance_minutes": -102.0,
+          "file_created": "frontend/src/pages/atleta/AtletaHomePage.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-26T13:10:00+00:00",
+      "completed_at": "2026-04-26T13:14:00+00:00",
+      "elapsed_seconds": 240,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-26T13:14:00+00:00",
+      "completed_at": "2026-04-26T13:14:00+00:00",
+      "elapsed_seconds": 0,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-26T13:30:00+00:00",
+      "completed_at": "2026-04-26T13:31:00+00:00",
+      "elapsed_seconds": 60,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-26T13:31:00+00:00",
+      "completed_at": "2026-04-26T13:35:00+00:00",
+      "elapsed_seconds": 240,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Actualización de Documentación",
+      "started_at": "2026-04-26T13:32:00+00:00",
+      "completed_at": "2026-04-26T13:34:00+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-26T13:34:00+00:00",
+      "completed_at": "2026-04-26T13:35:00+00:00",
+      "elapsed_seconds": 60,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 10,
+    "estimated_total_minutes": 195.0,
+    "actual_total_minutes": 40.0,
+    "variance_minutes": -155.0,
+    "variance_percent": -79.49
+  }
+}

--- a/docs/contexto/HITO-29-SPEC-VALIDATORIA-UX-ANTI-PATRON.md
+++ b/docs/contexto/HITO-29-SPEC-VALIDATORIA-UX-ANTI-PATRON.md
@@ -1,0 +1,101 @@
+# HITO-29 — Spec-validatoria: el anti-patrón de especificar desde el código existente
+
+| Campo | Valor |
+|-------|-------|
+| **Documento** | HITO-29 — Hallazgo metodológico en INC-5.5 (SP5) |
+| **Fecha** | 2026-04-26 |
+| **Sprint** | SP5 — La Puesta en Marcha |
+| **Relacionado** | HITO-18 · `docs/design/ux/wireframes-atleta.md` · `docs/design/ux/prototipos/prototipo-atleta.html` |
+
+---
+
+## Contexto
+
+En SP5, INC-5.5 fue implementado completamente (US-5.5.1 + US-5.5.2, 2 PRs mergeados) y luego revertido íntegramente porque la implementación no respetaba la UX aprobada en INC-4.0.
+
+Las specs originales de US-5.5.1 y US-5.5.2 fueron escritas mirando el código existente:
+- US-5.5.1 tomó `AtletaDashboardPage.tsx` como base y agregó una sección inline de APs
+- US-5.5.2 tomó `InscriptosPanel.tsx` como base y lo optimizó (N+1 → 1 call)
+
+Ninguno de los artefactos UX aprobados en INC-4.0 fue consultado antes de escribir las specs. Esos documentos existían en el repositorio:
+
+- `docs/design/ux/wireframes-atleta.md` — define 8 pantallas (S-01..S-08)
+- `docs/design/ux/flujos-por-rol.md` — define el flujo completo del atleta
+- `docs/design/ux/prototipos/prototipo-atleta.html` — prototipo navegable validado
+
+El código en `AtletaDashboardPage.tsx` era un MVP de integración (single-page, desktop-first, tema claro) que nunca implementó el prototipo. Al usarlo como referencia para las specs, la distancia entre diseño aprobado y código quedó invisible hasta el UAT — cuando el hallazgo `UAT-5.5-01` (portal sin nombre/apellido) disparó la revisión UX que reveló 14 gaps críticos.
+
+---
+
+## El anti-patrón identificado
+
+**Spec-validatoria:** la spec se escribe mirando la implementación existente y la valida en lugar de prescribir lo que debería ser.
+
+```
+Anti-patrón (lo que ocurrió):
+  Código existente (MVP sin UX) → Spec → Implementar lo mismo → "Done"
+
+Cadena correcta (IEDD Capa 3 → Capa 5):
+  UX aprobada (wireframes + prototipo) → Spec → Implementación
+```
+
+El resultado es un bucle cerrado que nunca consulta los artefactos de diseño. La spec pierde su función de contrato y se convierte en descripción del estado actual, que puede estar incorrecto. La US puede pasar todos sus criterios de aceptación y aun así violar la UX aprobada, porque los criterios fueron escritos mirando el código equivocado.
+
+---
+
+## Causa raíz
+
+Tres factores concurrentes:
+
+**1. INC-4.0 cerrado con deuda oculta.**
+El incremento de UX Design fue marcado como Done cuando el prototipo navegable fue aprobado, sin verificar que la implementación React lo siguiera. La distancia entre el prototipo aprobado y el código real quedó invisible en la baseline BL-004.
+
+**2. Sin gate de UX antes de la spec.**
+El proceso de elaboración de USs (WORKFLOW §3) no exigía consultar `docs/design/ux/` antes de escribir specs de frontend. El specifier usó lo más accesible: el código existente.
+
+**3. Framing de optimización, no de diseño.**
+US-5.5.1 fue encuadrada como "exponer un handler existente y agregar una sección". Ese framing asume que la estructura actual es correcta y excluye la pregunta de si debería ser diferente. Cuando el framing ya impone la arquitectura como dada, nadie pregunta si esa arquitectura es la correcta.
+
+---
+
+## Relación con HITO-18
+
+HITO-18 estableció que, para pantallas con restricciones físicas, se necesita un prototipo navegable validado **antes** de escribir la spec (problema de validación táctil).
+
+HITO-29 identifica el problema simétrico: aunque el prototipo ya exista y esté validado, la spec puede ignorarlo si el proceso no exige consultarlo. La existencia del artefacto no garantiza su uso.
+
+| HITO | Problema | Regla |
+|------|----------|-------|
+| HITO-18 | La spec existe, pero no fue precedida por un prototipo | Prototipo → Spec → Implementación (no saltear el prototipo) |
+| HITO-29 | El prototipo existe, pero la spec lo ignoró | Consultar el prototipo aprobado antes de escribir cualquier spec de frontend |
+
+Son problemas distintos con el mismo origen: la Capa 3 (Spec) desconectada de la Capa 4 (Arquitectura/UX).
+
+---
+
+## Aprendizaje central
+
+> Cuando una US-IEDD toca `frontend/`, la fuente de verdad es la UX aprobada en `docs/design/ux/`, no la implementación existente. El código actual puede ser un MVP que no implementa el diseño. La spec debe derivarse de los artefactos UX, comparar con el código actual, e incorporar los gaps al scope antes de especificar comportamiento nuevo.
+
+---
+
+## Implicancia para IEDD como metodología
+
+La Capa 3 (Especificación) debe derivarse de las Capas 1–4, no de la Capa 5. Para USs de frontend, esto requiere un paso explícito de consulta UX antes de escribir la spec.
+
+Si ese paso no existe en el proceso, la cadena IEDD puede invertirse de forma invisible: el specifier mira el código más que el diseño, y la spec termina siendo un documento que justifica el estado actual en lugar de prescribir el estado correcto.
+
+La regla práctica: la spec de una US de frontend es incorrecta si no menciona los artefactos UX de los que fue derivada. Ese campo vacío es una señal de proceso roto, no de spec completa.
+
+---
+
+## Acción tomada
+
+- [x] HITO-29 registrado
+- [x] WORKFLOW-DESARROLLO.md v1.8: §3 — gate de consulta UX obligatorio antes de specs de frontend; campo `Fuente de verdad UX` obligatorio
+- [x] WORKFLOW-DESARROLLO.md v1.8: §6 — verificación de prototipo al cerrar INCs que produjeron artefactos UX
+- [x] INC-5.5 revertido y redefinido desde la UX aprobada (specs US-5.5.1 y US-5.5.2 refactorizadas)
+
+---
+
+*Registrado al inicio de SP5 INC-5.5 reiniciado — la primera reversión completa de un INC por incompatibilidad con la UX aprobada*

--- a/docs/contexto/HITO-29-SPEC-VALIDATORIA-UX-ANTI-PATRON.md
+++ b/docs/contexto/HITO-29-SPEC-VALIDATORIA-UX-ANTI-PATRON.md
@@ -98,4 +98,22 @@ La regla práctica: la spec de una US de frontend es incorrecta si no menciona l
 
 ---
 
+## Pregunta abierta — a conceptualizar al cierre del proyecto
+
+El análisis de este hito abrió una pregunta sobre la posición del UX Design en IEDD:
+el modelo actual trata el UX como un bloque global (INC-4.0), pero en proyectos reales
+aparecen al menos tres modos de temporalización:
+
+- **UX Discovery** — antes de cualquier backend (valida hipótesis con usuarios rápido)
+- **UX Post-Backend** — después de tener el dominio consolidado (lo que hizo AtaraxiaDive)
+- **UX Incremental** — por entrega, sincronizado con cada incremento de valor
+
+La hipótesis es que el tercer modo es el más sostenible y debería formalizarse como
+un mini-ciclo por incremento: UX Design del INC → aprobación → Specs US-IEDD → Implementación.
+
+**Decisión:** diferido al cierre de SP5. El experimento producirá evidencia empírica de
+los tres modos antes de terminar; mejor conceptualizar con datos que con hipótesis.
+
+---
+
 *Registrado al inicio de SP5 INC-5.5 reiniciado — la primera reversión completa de un INC por incompatibilidad con la UX aprobada*

--- a/docs/plans/WORKFLOW-DESARROLLO.md
+++ b/docs/plans/WORKFLOW-DESARROLLO.md
@@ -1,7 +1,7 @@
 # Workflow de Desarrollo — AtaraxiaDive
 
-**Versión:** 1.7
-**Fecha:** 2026-04-23
+**Versión:** 1.8
+**Fecha:** 2026-04-26
 **Alcance:** Convenciones de branching, PRs, quality gates y gestión administrativa para SP1 en adelante
 
 ---
@@ -67,7 +67,17 @@ Como <rol>, quiero <acción> para <valor>.
 2. Victor revisa y aprueba (con ajustes si corresponde)
 3. Por cada US aprobada:
    a. Crear GitHub Issue con template US-IEDD → asignar Milestone + Labels
-   b. Crear docs/specs/spN/US-X.Y.Z.md con la especificación US-IEDD completa
+   b. **[CONDICIONAL — si la US toca `frontend/`]:** consultar `docs/design/ux/` ANTES de escribir la spec
+      → Leer el wireframe y prototipo del rol afectado (`wireframes-atleta.md`, `wireframes-organizador.md`, etc.)
+      → Comparar con la implementación React actual (`frontend/src/pages/`, `frontend/src/components/`)
+      → Si hay gaps entre la UX aprobada y el código: incorporarlos al scope de esta US
+        o abrir una US previa de corrección. No especificar comportamiento nuevo sobre código
+        que ya diverge del diseño aprobado.
+      → La spec DEBE incluir un campo explícito `## Fuente de verdad UX` con referencias
+        a los artefactos consultados (`wireframes-X.md`, `prototipos/prototipo-X.html`).
+      Una spec de frontend sin ese campo no está completa — el campo es evidencia de que
+      la consulta se realizó. Ver HITO-29.
+   c. Crear docs/specs/spN/US-X.Y.Z.md con la especificación US-IEDD completa
 4. Las US quedan en estado "backlog" hasta iniciar su Incremento
 ```
 
@@ -173,6 +183,13 @@ max_god_object_lines = N
 ```
 1. Todas las US del Incremento mergeadas a develop (PR individual por US)
 2. Verificar DoD de integración (test end-to-end observable)
+2b. **[CONDICIONAL — si el INC incluyó artefactos UX en `docs/design/ux/prototipos/`]:**
+    verificar que la implementación React sigue el prototipo aprobado.
+    → El prototipo existir no es suficiente — la implementación debe implementarlo.
+    → Comparar pantalla a pantalla: shell, navegación, flujos críticos.
+    → Si hay divergencia: clasificar como gap (ver paso 7) y resolverlo antes de cerrar el INC.
+    → Un INC con prototipo UX no está Done hasta que el código implementa el diseño.
+    Ver HITO-29.
 3. [MANUAL] Correr DesignReviewer sobre el estado consolidado del incremento:
    designreviewer src/ --config pyproject.toml
    → Complementa el DesignReviewer automático (pre-push por US) — aquí se verifica
@@ -308,6 +325,7 @@ feature/US-1.2.3-registrar-resultado → /implement-us → /pr → merge develop
 
 ---
 
+*v1.8 — 2026-04-26. §3: gate de consulta UX obligatorio antes de specs de frontend; campo "Fuente de verdad UX" obligatorio en toda spec que toca frontend/. §6: verificación de prototipo al cerrar INCs con artefactos UX aprobados. Ver HITO-29.*
 *v1.7 — 2026-04-23. §6: clasificación de hallazgos UAT por track (frontend/ vs src/). §7: paso de clasificación en UAT post-SP. §8: nota de clasificación UAT. Ver HITO-28.*
 *v1.6 — 2026-04-23. §6: gate condicional de consistencia documental si hay ADRs nuevos. §7: SP-ADJ incluye barrido documental obligatorio (Gate 2). §8: dos nuevas filas de quality gate documental. Ver HITO-27.*
 *v1.5 — 2026-03-29. §5: orden de arranque, artefactos por fase, aprobaciones, bug tracker prefijo non-US-.*

--- a/docs/plans/sp5/US-5.5.1-fase0.md
+++ b/docs/plans/sp5/US-5.5.1-fase0.md
@@ -1,0 +1,79 @@
+# US-5.5.1 — Fase 0: Validacion de Contexto
+
+**Fecha:** 2026-04-26
+**Producto:** `frontend` + `identidad` + `registro` + `competencia`
+**Incremento:** INC-5.5 — Portal atleta e inscriptos
+**Spec canonica:** `docs/specs/sp5/US-5.5.1.md`
+
+---
+
+## Historia
+
+**US:** US-5.5.1 — Inscripcion completa del atleta + Declarar/Modificar AP
+
+Como **atleta**, quiero **inscribirme a un torneo mediante el flujo UX aprobado y luego declarar o modificar mi AP por disciplina antes del cierre**, para **gestionar mi participacion completa desde el portal del atleta, con navegacion movil y estados claros por torneo y disciplina**.
+
+---
+
+## Fuentes de Verdad Validadas
+
+- `docs/specs/sp5/US-5.5.1.md`
+- `docs/design/ux/wireframes-atleta.md`
+- `docs/design/ux/flujos-por-rol.md`
+- `docs/design/ux/prototipos/prototipo-atleta.html`
+- `.work/revision-sp5/04-hallazgos-ux-portal-atleta.md`
+- `.work/revision-sp5/03-hallazgos-uat-inc-5.5.md`
+
+---
+
+## Contexto Relevante
+
+### Frontend atleta
+
+- El estado previo estaba concentrado en `frontend/src/pages/atleta/AtletaDashboardPage.tsx`.
+- La UX aprobada exige shell movil dark, tab bar persistente y navegacion por pantallas dedicadas.
+- El gap critico identificado en revision UX fue `UX-ATL-08`: wizard de inscripcion de 3 pasos.
+
+### Identidad
+
+- El JWT solo exponia `sub`, `email` y `rol`.
+- El hallazgo UAT `UAT-5.5-01` pedia nombre/apellido visibles en el portal atleta.
+
+### Registro
+
+- El BC Registro ya exponia `POST /registro/inscripciones` y `GET /registro/atletas/{id}`.
+- No existia consulta publica del atleta a sus propias inscripciones.
+
+### Competencia
+
+- El BC Competencia ya tenia `RegistrarAPHandler`.
+- El comando no estaba expuesto en `src/competencia/api/router.py`.
+- La logica previa rechazaba un segundo AP, pero la spec actualizada exige **declarar o modificar** mientras el plazo siga abierto.
+
+---
+
+## Riesgos Detectados
+
+- El wizard UX pide adjuntos obligatorios, pero el contrato backend actual de Registro no persiste archivos.
+- La nocion visible de “deadline de anuncios” no tiene aun un artefacto de dominio explicito en frontend; el estado actual se infiere desde `torneo.estado`.
+- Cambiar el comportamiento de `RegistrarAPHandler` puede impactar tests historicos que asumian alta unica.
+- El portal atleta nuevo convive con el archivo legacy `AtletaDashboardPage.tsx`, que no debe romper la build.
+
+---
+
+## Quality Gates Esperables
+
+- `npm run build` en `frontend/`
+- tests focalizados de `RegistrarAPHandler`
+- tests focalizados de JWT payload para nombre/apellido
+- validacion BDD documental (waiver de automatizacion UI si no hay harness browser)
+
+---
+
+## Resultado
+
+Contexto validado. La US queda lista para:
+
+1. Fase 1 — Escenarios BDD
+2. Fase 2 — Plan de implementacion
+3. Fase 3 — Implementacion formal

--- a/docs/plans/sp5/US-5.5.1-implementation-notes.md
+++ b/docs/plans/sp5/US-5.5.1-implementation-notes.md
@@ -1,0 +1,50 @@
+# US-5.5.1 — Notas de Implementacion
+
+**Fecha:** 2026-04-26
+**Fase:** 3 — Implementacion
+
+---
+
+## Enfoque
+
+La prioridad fue alinear la experiencia del atleta con la UX aprobada sin romper
+los contratos existentes del sistema. El trabajo se dividio en tres capas:
+
+1. **Identidad visible**
+   - nombre/apellido en JWT para evitar una segunda consulta obligatoria solo para render inicial.
+
+2. **Backend minimo faltante**
+   - consulta de inscripciones del atleta;
+   - endpoint de `registrar-ap` consumible desde frontend;
+   - ajuste semantico para permitir modificacion de AP mientras la performance siga anunciada.
+
+3. **Shell y navegacion atleta**
+   - rutas dedicadas y composicion movil dark;
+   - wizard de inscripcion;
+   - pantalla dedicada de AP;
+   - vista de `Mis inscripciones`.
+
+---
+
+## Decisiones Tomadas
+
+- Se mantuvo `AtletaDashboardPage.tsx` solo como archivo legacy para no mezclar una remocion amplia en esta regularizacion.
+- Se dejo redirect de `/atleta/dashboard` hacia `/atleta` para compatibilidad con rutas previas.
+- El estado visible `AP cerrado` se infiere hoy desde `torneo.estado != INSCRIPCION_ABIERTA`.
+- La modificacion de AP reutiliza el mismo evento `APRegistrado`; no se agrego un evento nuevo de correccion en esta iteracion.
+
+---
+
+## Desvios Conscientes Respecto de la Spec
+
+- Los adjuntos de `Certificado medico` y `Comprobante de pago` se validan en frontend, pero no se persisten en el backend.
+- El `deadline` de anuncios se muestra como regla de negocio visible, no como timestamp real proveniente de API.
+- `Mis resultados` queda como placeholder navegable dentro del shell, no como implementacion completa del ranking de la spec.
+
+---
+
+## Verificacion Ejecutada
+
+- `npm run build` en `frontend/` — OK
+- `./.venv/bin/pytest tests/unit/competencia/application/test_registrar_ap_handler.py -q` — OK
+- `./.venv/bin/pytest tests/unit/identidad/application/test_handlers.py -q -k jwt_generate_y_verify_payload` — OK

--- a/docs/plans/sp5/US-5.5.1-plan.md
+++ b/docs/plans/sp5/US-5.5.1-plan.md
@@ -1,0 +1,112 @@
+# Plan de Implementacion: US-5.5.1 — Inscripcion completa del atleta + Declarar/Modificar AP
+
+**Historia:** US-5.5.1
+**Incremento:** INC-5.5
+**Producto:** `frontend` + `identidad` + `registro` + `competencia`
+**Estado:** REGULARIZADO POST-IMPLEMENTACION
+
+---
+
+## Alcance
+
+Implementar la UX redefinida del atleta para:
+
+- reemplazar el dashboard unico por shell movil dark con rutas dedicadas;
+- permitir inscripcion via wizard de 3 pasos;
+- mostrar `Mis inscripciones` por torneo/disciplina;
+- permitir declarar o modificar AP desde pantalla dedicada;
+- identificar al atleta por nombre y apellido en el portal.
+
+Fuera de alcance de esta iteracion:
+
+- persistencia real de adjuntos del wizard;
+- pantalla completa S-07 Mi grilla;
+- pantalla completa S-08 Resultados con ranking real;
+- deadline de anuncios modelado explicitamente como entidad/evento separado del estado del torneo.
+
+---
+
+## Componentes a Modificar
+
+### Identidad
+
+- [x] `src/identidad/infrastructure/jwt_service.py`
+  - agregar `nombre` y `apellido` al payload JWT.
+
+- [x] `frontend/src/api/auth.ts`
+- [x] `frontend/src/stores/useAuthStore.ts`
+- [x] `frontend/src/types/auth.ts`
+  - persistir `nombre` y `apellido` en el store del frontend.
+
+### Registro
+
+- [x] `src/registro/domain/ports/inscripcion_repository_port.py`
+- [x] `src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py`
+  - agregar consulta `find_by_atleta`.
+
+- [x] `src/registro/api/router.py`
+  - exponer `GET /registro/atletas/{id}/inscripciones`.
+
+- [x] `frontend/src/api/registro.ts`
+  - consumir la consulta de inscripciones del atleta.
+
+### Competencia
+
+- [x] `src/competencia/api/router.py`
+  - exponer `POST /competencia/{id}/registrar-ap`.
+
+- [x] `src/competencia/application/commands/registrar_ap.py`
+  - permitir actualizacion de AP si la performance sigue en `AnunciadaAP`.
+  - rechazar modificacion si la performance ya avanzo.
+
+### Frontend atleta
+
+- [x] `frontend/src/App.tsx`
+  - registrar rutas nuevas del portal atleta y redirect legacy.
+
+- [x] `frontend/src/utils/auth.ts`
+- [x] `frontend/src/pages/LoginPage.tsx`
+- [x] `frontend/src/pages/RegistroPage.tsx`
+- [x] `frontend/src/pages/ResetPasswordPage.tsx`
+  - alinear redirects al nuevo home `/atleta`.
+
+- [x] `frontend/src/components/atleta/AtletaShell.tsx`
+  - shell dark, header sticky y tab bar persistente.
+
+- [x] `frontend/src/pages/atleta/AtletaHomePage.tsx`
+- [x] `frontend/src/pages/atleta/AtletaTorneosPage.tsx`
+- [x] `frontend/src/pages/atleta/AtletaTorneoDetallePage.tsx`
+- [x] `frontend/src/pages/atleta/AtletaInscripcionPage.tsx`
+- [x] `frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx`
+- [x] `frontend/src/pages/atleta/AtletaDeclararAPPage.tsx`
+- [x] `frontend/src/pages/atleta/AtletaResultadosPage.tsx`
+- [x] `frontend/src/pages/atleta/portalData.ts`
+  - componer el flujo S-01..S-06 y placeholders navegables para S-08.
+
+---
+
+## Estrategia
+
+1. Resolver identidad visible para destrabar el header del atleta.
+2. Exponer consultas/operaciones backend faltantes para que la UX no quede mockeada.
+3. Reemplazar la ruta `/atleta/dashboard` por un shell real con pantallas dedicadas.
+4. Materializar wizard y AP con el mejor contrato disponible.
+5. Validar build y tests focalizados del cambio semantico de AP.
+
+---
+
+## Riesgos / Waivers
+
+- **Waiver UX/documentos:** el wizard exige adjuntos obligatorios, pero en esta iteracion se validan solo a nivel UI; no hay persistencia backend de archivos.
+- **Waiver BDD UI:** el repo no tiene harness browser automatizado para montar el portal React end-to-end.
+- **Waiver resultados/grilla:** S-07 y S-08 no quedaron completas en esta US; se priorizo alcance minimo navegable y S-04/S-05/S-06.
+
+---
+
+## Quality Gates
+
+- [x] `npm run build` en `frontend/`
+- [x] `./.venv/bin/pytest tests/unit/competencia/application/test_registrar_ap_handler.py -q`
+- [x] `./.venv/bin/pytest tests/unit/identidad/application/test_handlers.py -q -k jwt_generate_y_verify_payload`
+- [ ] automatizacion BDD UI completa
+- [ ] evidencia de upload/persistencia documental en backend

--- a/docs/reports/US-5.5.1-bdd-validation.md
+++ b/docs/reports/US-5.5.1-bdd-validation.md
@@ -1,0 +1,32 @@
+# Validacion BDD - US-5.5.1
+
+## Feature
+
+`tests/features/US-5.5.1-inscripcion-atleta-ap.feature`
+
+## Resultado
+
+Cobertura BDD materializada en archivo feature, con **waiver de automatizacion UI**.
+
+La historia redefine un flujo React multipantalla (`S-01..S-06`) y el repositorio no
+cuenta hoy con harness browser para ejecutar estos escenarios end-to-end con Router,
+React Query y mocks HTTP integrados.
+
+## Escenarios cubiertos
+
+- wizard de inscripcion de 3 pasos;
+- bloqueo de envio sin adjuntos obligatorios;
+- declaracion de AP desde pantalla dedicada;
+- modificacion de AP mientras el periodo sigue abierto;
+- estado de solo lectura `AP cerrado` tras cierre del periodo.
+
+## Validacion aplicada
+
+- revision manual contra la spec `docs/specs/sp5/US-5.5.1.md`;
+- verificacion de rutas y build TypeScript/Vite;
+- test unitario focalizado del cambio semantico en `RegistrarAPHandler`.
+
+## Riesgo residual
+
+Sin browser automation, los escenarios UI quedan validados por inspeccion de codigo
+y build, no por simulacion automatizada de clicks/navegacion.

--- a/docs/reports/US-5.5.1-report.md
+++ b/docs/reports/US-5.5.1-report.md
@@ -1,0 +1,79 @@
+# Reporte de Implementacion: US-5.5.1
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** US-5.5.1 — Inscripcion completa del atleta + Declarar/Modificar AP
+- **Incremento:** INC-5.5
+- **Fecha:** 2026-04-26
+- **Estado:** IMPLEMENTADO CON DESVIACIONES DECLARADAS
+
+## Componentes Entregados
+
+- [x] JWT extendido con `nombre` y `apellido`.
+- [x] Store frontend de autenticacion actualizado al nuevo payload.
+- [x] Endpoint de Registro para listar inscripciones del atleta.
+- [x] Endpoint de Competencia para registrar AP desde el portal atleta.
+- [x] `RegistrarAPHandler` ajustado para permitir modificacion mientras la performance siga `AnunciadaAP`.
+- [x] Shell movil dark del atleta con tab bar persistente.
+- [x] Nuevas pantallas:
+  - Inicio
+  - Torneos
+  - Detalle del torneo
+  - Inscribirme (wizard)
+  - Mis inscripciones
+  - Declarar AP
+  - Resultados (placeholder navegable)
+
+## Comportamiento Entregado
+
+- El atleta ahora ingresa a `/atleta` y no a un dashboard monolitico.
+- El portal muestra nombre/apellido/categoria/club en la experiencia principal.
+- El flujo de inscripcion sigue la UX aprobada con wizard de 3 pasos.
+- `Mis inscripciones` refleja estados `AP pendiente`, `AP declarado` y `AP cerrado`.
+- El AP puede declararse o modificarse desde una pantalla dedicada mientras la performance no haya avanzado.
+
+## Validacion Ejecutada
+
+| Gate | Resultado |
+|------|-----------|
+| `npm run build` en `frontend/` | OK |
+| `npm run lint` en `frontend/` | OK |
+| `./.venv/bin/pytest tests/unit/competencia/application/test_registrar_ap_handler.py -q` | OK |
+| `./.venv/bin/pytest tests/unit/identidad/application/test_handlers.py -q -k jwt_generate_y_verify_payload` | OK |
+| `./.venv/bin/codeguard src/identidad src/registro src/competencia --config pyproject.toml --format json --analysis-type pre-commit` | Pendiente / no concluido en este entorno |
+| BDD automatizado UI | Waiver |
+
+## Desviaciones / Gaps Residuales
+
+- Los adjuntos del wizard (`certificado medico` y `comprobante de pago`) se validan solo en UI; no se persisten aun en backend.
+- La pantalla `Mis resultados` todavia no implementa ranking real ni resultado publicado completo.
+- El cierre de AP se infiere desde `torneo.estado`, no desde un deadline explicito provisto por API.
+- No se agrego evidencia automatizada browser-level del flujo UI.
+- `codeguard` no devolvio salida utilizable dentro de un tiempo razonable durante esta corrida, por lo que no se marca como gate aprobado.
+
+## Archivos Relevantes
+
+- `frontend/src/App.tsx`
+- `frontend/src/components/atleta/AtletaShell.tsx`
+- `frontend/src/pages/atleta/AtletaHomePage.tsx`
+- `frontend/src/pages/atleta/AtletaInscripcionPage.tsx`
+- `frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx`
+- `frontend/src/pages/atleta/AtletaDeclararAPPage.tsx`
+- `frontend/src/pages/atleta/portalData.ts`
+- `src/identidad/infrastructure/jwt_service.py`
+- `src/registro/api/router.py`
+- `src/competencia/api/router.py`
+- `src/competencia/application/commands/registrar_ap.py`
+
+## Criterios de Aceptacion
+
+- [x] El atleta puede navegar por shell movil dark con tabs persistentes.
+- [x] Existe detalle de torneo antes del CTA de inscripcion.
+- [x] La inscripcion se realiza desde wizard de 3 pasos.
+- [x] La UI bloquea el envio si faltan adjuntos.
+- [x] Existe pantalla dedicada para declarar/modificar AP.
+- [x] El AP puede modificarse antes del cierre visible.
+- [x] `Mis inscripciones` muestra estado por disciplina.
+- [ ] Persistencia backend de adjuntos obligatorios.
+- [ ] Deadline de anuncios modelado explicitamente.
+- [ ] Implementacion completa de resultados del atleta.

--- a/docs/reports/US-5.5.1-test-strategy.md
+++ b/docs/reports/US-5.5.1-test-strategy.md
@@ -1,0 +1,51 @@
+# Estrategia de Tests - US-5.5.1
+
+## Alcance
+
+US-5.5.1 toca cuatro frentes:
+
+- payload JWT de identidad;
+- consulta de inscripciones del atleta;
+- comando/API de registrar AP;
+- shell y pantallas del portal atleta en frontend.
+
+## Estrategia aplicada
+
+### Backend
+
+- test focalizado de JWT:
+  - verificar que el payload incluya `nombre` y `apellido`.
+
+- test focalizado de `RegistrarAPHandler`:
+  - mantener camino feliz;
+  - permitir modificar AP mientras la performance siga en `AnunciadaAP`;
+  - rechazar modificacion cuando la performance ya avanzo.
+
+### Frontend
+
+- `npm run build` como gate principal:
+  - tipado de rutas nuevas;
+  - integracion de stores y clientes API;
+  - consistencia de imports y componentes del portal atleta.
+
+- `npm run lint`:
+  - enforcement de reglas React/TS del repo;
+  - correccion de inicializacion de estado para evitar `set-state-in-effect`.
+
+- `codeguard`:
+  - gate deseable sobre BCs tocados;
+  - en esta corrida quedo pendiente/no concluido por falta de salida utilizable del comando.
+
+## Waivers
+
+- No hay suite automatizada React/DOM para montar el portal atleta.
+- No se agrego prueba automatizada de uploads porque el backend no persiste archivos en esta iteracion.
+- No se agrego prueba end-to-end del endpoint `GET /registro/atletas/{id}/inscripciones` en esta regularizacion.
+
+## Riesgo residual
+
+La mayor parte del riesgo remanente queda en integracion UI/manual:
+
+- navegacion real entre pantallas en browser;
+- compatibilidad de la inferencia `AP cerrado` basada en `torneo.estado`;
+- ausencia de persistencia real de adjuntos del wizard.

--- a/docs/specs/sp5/US-5.5.1.md
+++ b/docs/specs/sp5/US-5.5.1.md
@@ -1,0 +1,230 @@
+# US-5.5.1: Inscripción completa del atleta + Declarar/Modificar AP
+
+**Estado**: `To Do`
+**Sprint**: SP5 — La Puesta en Marcha
+**Incremento**: INC-5.5
+**Bounded Context**: `registro` + `competencia` + `frontend`
+**Capas afectadas**: `frontend/src/pages/atleta/`, `frontend/src/components/atleta/`, `registro/api/`, `competencia/api/`, `identidad/`
+
+---
+
+## Descripcion
+
+Como **atleta**,
+quiero **inscribirme a un torneo mediante el flujo UX aprobado y luego declarar o modificar mi AP por disciplina antes del cierre**,
+para **gestionar mi participación completa desde el portal del atleta, con navegación móvil y estados claros por torneo y disciplina**.
+
+---
+
+## Fuente de verdad UX
+
+Esta US se redefine tomando como contrato primario:
+
+- `docs/design/ux/flujos-por-rol.md`
+- `docs/design/ux/wireframes-atleta.md`
+- `docs/design/ux/prototipos/prototipo-atleta.html`
+- `.work/revision-sp5/04-hallazgos-ux-portal-atleta.md`
+
+En particular corrige los gaps `UX-ATL-01..03`, `UX-ATL-08..12`.
+
+---
+
+## Contexto de diseño
+
+El flujo aprobado para el atleta no es un dashboard único con paneles inline. La UX define:
+
+1. shell móvil dark (`max-width: 430 px`) con `header` sticky y `tabbar` inferior persistente
+2. navegación entre pantallas `S-01..S-08`
+3. wizard de inscripción `S-04` con 3 pasos
+4. pantalla dedicada `S-05 Mis inscripciones`
+5. pantalla dedicada `S-06 Declarar / Modificar AP`
+
+Esta US debe respetar esa estructura. Cualquier decisión técnica debe adaptarse al flujo UX, no reemplazarlo.
+
+---
+
+## Alcance funcional
+
+### A. Shell base del portal del atleta
+
+El portal del atleta debe usar el shell definido en UX:
+
+- tema dark con tokens de `wireframes-atleta.md`
+- header sticky
+- tab bar persistente con tabs `Inicio`, `Torneos`, `Mis inscr.`, `Resultados`
+- navegación por pantallas/rutas, no composición single-page obligatoria
+
+### B. S-03 / S-04 — Inscripción completa
+
+El atleta debe poder abrir el detalle del torneo y ejecutar el wizard `Inscribirme` de 3 pasos:
+
+- **Paso 1 — Personales**: correo readonly, nombre y apellido, fecha de nacimiento, género, documento, teléfono
+- **Paso 2 — Competencia**: selección de disciplinas, categoría calculada/revisable, nº brevet opcional
+- **Paso 3 — Requisitos**: certificado médico y comprobante de pago obligatorios
+
+El envío genera una inscripción en estado de verificación.
+
+### C. S-05 — Mis inscripciones
+
+La pantalla debe concentrar el estado de participación por torneo y disciplina:
+
+- sección `En ejecución`
+- sección `Inscripciones abiertas`
+- estado visible por disciplina
+- `deadline` de cierre de anuncios visible cuando corresponda
+
+### D. S-06 — Declarar / Modificar AP
+
+El AP se declara o modifica desde una pantalla dedicada, no inline:
+
+- card de contexto con torneo, disciplina y horario
+- input principal de AP
+- deadline visible
+- acción `Guardar AP`
+
+La UX aprobada exige **ingresar / modificar AP** antes del cierre. No se permite redefinir esta historia como “alta única” si el período de anuncios sigue abierto.
+
+---
+
+## Invariantes
+
+- **INV-5.5.1-01:** El portal del atleta usa shell móvil dark y tab bar persistente según `wireframes-atleta.md`.
+- **INV-5.5.1-02:** La inscripción al torneo se realiza mediante wizard de 3 pasos; no puede reducirse a un panel inline de disciplinas.
+- **INV-5.5.1-03:** Certificado médico y comprobante de pago son obligatorios para completar la inscripción (`INV-ATL-08`).
+- **INV-5.5.1-04:** La categoría competitiva debe poder revisarse antes del envío y deriva de la fecha de nacimiento (`INV-ATL-07`).
+- **INV-5.5.1-05:** El atleta puede declarar **o modificar** su AP mientras el período de anuncios siga abierto (`INV-ATL-01`).
+- **INV-5.5.1-06:** Una vez cerrado el período de anuncios, la UI pasa a estado de solo lectura y muestra `AP cerrado`.
+- **INV-5.5.1-07:** Durante la ejecución de la performance, la experiencia del atleta es solo lectura.
+
+---
+
+## Especificacion del comportamiento
+
+### Operacion principal 1 — inscribirse a un torneo
+
+**Flujo UX:**
+
+```text
+S-02 Torneos
+  -> S-03 Detalle del torneo
+      -> CTA "Inscribirme en este torneo"
+          -> S-04 Inscribirme (wizard 3 pasos)
+              -> Enviar inscripción
+                  -> S-05 Mis inscripciones
+```
+
+**Comportamiento esperado:**
+
+- el paso 1 precarga la información conocida del atleta y permite completarla/corregirla
+- el paso 2 selecciona disciplinas y muestra categoría calculada
+- el paso 3 exige ambos adjuntos antes de habilitar `Enviar inscripción`
+- al enviar, la inscripción queda visible en `S-05`
+
+### Operacion principal 2 — declarar o modificar AP
+
+**Flujo UX:**
+
+```text
+S-05 Mis inscripciones
+  -> fila de disciplina con estado "AP pendiente"
+      -> CTA "Declarar AP"
+          -> S-06 Declarar / Modificar AP
+              -> Guardar AP
+                  -> vuelve a S-05
+```
+
+**Comportamiento esperado:**
+
+- si no existe AP previo, `S-06` opera como alta
+- si ya existe AP y el período sigue abierto, `S-06` opera como modificación
+- al guardar, `S-05` refleja el nuevo valor y actualiza el estado visual
+- cuando el organizador cierra el período de anuncios, el CTA desaparece y la disciplina muestra `AP cerrado`
+
+### Unidades y disciplina
+
+La pantalla `S-06` debe adaptarse al tipo de disciplina:
+
+- dinámicas (`DNF`, `DYN`, `DYNB`, `DBF`) -> input de distancia
+- estáticas (`STA`) -> input de tiempo
+
+La UX de referencia explicita que la estática requiere un comportamiento distinto al mock base de metros.
+
+---
+
+## Criterios de aceptacion (BDD)
+
+```gherkin
+Feature: US-5.5.1 — Inscripción completa del atleta y declaración de AP
+
+  Background:
+    Given existe el torneo "BA Open 2026" publicado con inscripciones abiertas
+    And el atleta "ana@email.com" accede al portal del atleta
+
+  Scenario: atleta completa la inscripción con wizard de 3 pasos
+    When navega a "Torneos"
+    And abre el detalle del torneo "BA Open 2026"
+    And presiona "Inscribirme en este torneo"
+    And completa Personales, Competencia y Requisitos
+    Then el sistema registra la inscripción
+    And la inscripción queda visible en "Mis inscripciones"
+    And el estado queda "pendiente de verificación"
+
+  Scenario: no se puede enviar inscripción sin ambos adjuntos obligatorios
+    Given el atleta está en el paso 3 "Requisitos"
+    When intenta enviar la inscripción sin certificado médico
+    Then la UI bloquea el envío
+    And informa que el certificado médico es obligatorio
+
+  Scenario: atleta declara AP desde pantalla dedicada
+    Given el atleta ya está inscripto en DNF
+    And el período de anuncios sigue abierto
+    When desde "Mis inscripciones" presiona "Declarar AP"
+    And guarda AP=70 metros
+    Then vuelve a "Mis inscripciones"
+    And la disciplina DNF muestra el AP guardado
+
+  Scenario: atleta modifica AP antes del cierre
+    Given el atleta ya declaró AP=70 para DNF
+    And el período de anuncios sigue abierto
+    When vuelve a "Declarar AP"
+    And cambia el valor a 72 metros
+    Then la disciplina DNF muestra AP=72
+
+  Scenario: AP queda solo lectura después del cierre
+    Given el atleta ya declaró AP para DNF
+    And el organizador cerró el período de anuncios
+    When el atleta abre "Mis inscripciones"
+    Then la disciplina muestra chip "AP cerrado"
+    And no existe CTA "Declarar AP"
+```
+
+---
+
+## Impacto arquitectonico
+
+- [x] Sí — corrige una desviación de UX e impacta navegación, composición de pantallas y contratos de backend.
+
+### Capas afectadas
+
+- `frontend/src/pages/atleta/` — pantallas `S-02` a `S-06`
+- `frontend/src/components/atleta/` — shell, tab bar, stepper, upload areas, filas de inscripción
+- `registro/api/` — soporte para inscripción completa con datos y requisitos
+- `competencia/api/` — alta/modificación de AP dentro del período habilitado
+- `identidad/` — perfil del atleta visible en portal si faltan datos civiles básicos
+
+### Nota de modelado
+
+La decisión de permitir modificar AP mientras el período siga abierto proviene de la UX aprobada y de `flujos-por-rol.md`. Si el dominio actual solo soporta alta única, deberá ajustarse backend o agregarse operación explícita de actualización compatible con el cierre de anuncios.
+
+---
+
+## Referencias
+
+- `docs/design/ux/flujos-por-rol.md §3 Rol: Atleta`
+- `docs/design/ux/wireframes-atleta.md §S-03..S-06`
+- `docs/design/ux/prototipos/prototipo-atleta.html`
+- `.work/revision-sp5/04-hallazgos-ux-portal-atleta.md`
+
+---
+
+*Redefinido: 2026-04-25 — INC-5.5 reiniciado desde UX aprobada*

--- a/docs/specs/sp5/US-5.5.2.md
+++ b/docs/specs/sp5/US-5.5.2.md
@@ -1,0 +1,198 @@
+# US-5.5.2: Vista del organizador de inscriptos con estado AP
+
+**Estado**: `To Do`
+**Sprint**: SP5 — La Puesta en Marcha
+**Incremento**: INC-5.5
+**Bounded Context**: `registro` + `competencia` + `frontend`
+**Capas afectadas**: `frontend/src/pages/organizador/`, `frontend/src/components/organizador/`, `registro/api/`, `competencia/api/`
+
+---
+
+## Descripcion
+
+Como **organizador**,
+quiero **ver a los inscriptos con sus datos completos, disciplinas y estado de AP dentro de la navegación UX aprobada del panel organizador**,
+para **controlar quién terminó su inscripción y quién está listo para pasar a grilla antes de cerrar el período de anuncios**.
+
+---
+
+## Fuente de verdad UX
+
+Esta US se redefine tomando como contrato primario:
+
+- `docs/design/ux/flujos-por-rol.md`
+- `docs/design/ux/wireframes-organizador.md`
+- `docs/design/ux/prototipos/prototipo-organizador.html`
+- `docs/design/ux/wireframes-atleta.md` y `.work/revision-sp5/04-hallazgos-ux-portal-atleta.md` como fuente complementaria para el significado visible de los estados `AP pendiente` / `AP cerrado`
+
+---
+
+## Contexto de diseño
+
+El panel del organizador es desktop-first con navbar superior persistente y navegación por secciones. Esta US no debe introducir una experiencia aislada o ajena a ese patrón.
+
+El diseño UX no define una pantalla independiente llamada "Inscriptos" como primario; por lo tanto, esta historia debe integrarse dentro del área de gestión del torneo conservando:
+
+- navbar superior sticky
+- layout desktop-first
+- cards/tablas consistentes con `wireframes-organizador.md`
+
+**Inferencia desde la UX aprobada:** la vista de inscriptos pertenece al área `Torneo` o a una subvista de gestión del torneo, no a una UI separada que rompa la navegación principal.
+
+---
+
+## Alcance funcional
+
+### A. Vista de inscriptos dentro del panel organizador
+
+El organizador debe contar con una vista de consulta de inscriptos del torneo donde cada fila muestre:
+
+- apellido y nombre
+- categoría
+- club
+- disciplinas inscriptas
+- estado de AP por disciplina
+- estado general de la inscripción cuando corresponda
+
+### B. Estados visibles por disciplina
+
+La vista debe reflejar, al menos, estos estados UX:
+
+- `AP pendiente`
+- `AP declarado`
+- `AP cerrado`
+
+Cuando aplique, el estado visible debe ser consistente con lo que ve el atleta en `S-05 Mis inscripciones`.
+
+### C. Uso operativo
+
+La vista debe permitir al organizador responder preguntas operativas previas a la grilla:
+
+- quién completó la inscripción
+- quién todavía no cargó AP
+- qué disciplinas ya tienen AP listo
+- cuándo el período está cerrado y ya no se aceptan anuncios
+
+---
+
+## Invariantes
+
+- **INV-5.5.2-01:** la vista respeta la navegación desktop del organizador con navbar superior persistente.
+- **INV-5.5.2-02:** solo el organizador autenticado puede acceder.
+- **INV-5.5.2-03:** la información visible del atleta usa nombre y apellido, no solo email.
+- **INV-5.5.2-04:** el estado de AP mostrado al organizador debe ser consistente con el flujo del atleta en `S-05/S-06`.
+- **INV-5.5.2-05:** una inscripción cancelada no aparece como participante operativo para generar grilla.
+- **INV-5.5.2-06:** al cerrar el período de anuncios, la vista cambia a estado de solo lectura respecto de AP y muestra `AP cerrado` donde corresponda.
+
+---
+
+## Especificacion del comportamiento
+
+### Operacion principal — listar inscriptos del torneo con estado AP
+
+**Flujo UX esperado:**
+
+```text
+Panel organizador
+  -> sección Torneo / gestión
+      -> vista de inscriptos del torneo
+```
+
+**Comportamiento esperado:**
+
+- el organizador selecciona un torneo
+- la vista lista inscripciones activas del torneo
+- por cada atleta se muestran sus disciplinas y el estado AP correspondiente
+- la vista prioriza legibilidad operativa sobre detalles técnicos internos
+
+### Construccion del estado AP
+
+El estado AP es un dato de producto visible para el organizador. La implementación puede resolverlo con el backend, el frontend o una combinación, pero la spec no fija una solución interna como contrato.
+
+Lo obligatorio es el resultado visible:
+
+- si la disciplina no tiene AP y el período sigue abierto -> `AP pendiente`
+- si la disciplina tiene AP cargado y el período sigue abierto -> `AP declarado`
+- si el período de anuncios cerró -> `AP cerrado`
+
+### Presentacion
+
+La vista debe seguir el lenguaje visual del organizador:
+
+- tabla o lista desktop-first
+- uso de chips/badges para estado
+- consistencia de color con tokens del panel organizador
+
+No debe degradarse a una simple respuesta técnica de endpoint ni a una experiencia separada de la navbar principal.
+
+---
+
+## Criterios de aceptacion (BDD)
+
+```gherkin
+Feature: US-5.5.2 — Vista del organizador de inscriptos con estado AP
+
+  Background:
+    Given existe el torneo "BA Open 2026"
+    And el organizador está autenticado
+    And hay inscripciones activas de Ana García y Carlos López
+
+  Scenario: organizador ve inscriptos con datos completos
+    When abre la vista de inscriptos del torneo
+    Then ve apellido y nombre de cada atleta
+    And ve categoría y club
+    And ve las disciplinas inscriptas por atleta
+
+  Scenario: organizador distingue AP pendiente y AP declarado
+    Given Ana declaró AP para DNF
+    And Carlos todavía no declaró AP para DYN
+    When el organizador consulta la vista
+    Then Ana aparece con estado "AP declarado" en DNF
+    And Carlos aparece con estado "AP pendiente" en DYN
+
+  Scenario: cierre del período bloquea nuevos anuncios y cambia el estado visible
+    Given el organizador cerró el período de anuncios del torneo
+    When consulta la vista de inscriptos
+    Then las disciplinas muestran estado "AP cerrado" donde corresponda
+    And la vista queda en solo lectura respecto del AP
+
+  Scenario: inscripciones canceladas no aparecen como operativas
+    Given existe una inscripción cancelada para "pepe@email.com"
+    When el organizador consulta la vista
+    Then Pepe no aparece en la lista operativa de inscriptos
+
+  Scenario: acceso con rol atleta es rechazado
+    Given un usuario autenticado con rol ATLETA
+    When intenta abrir la vista de inscriptos del organizador
+    Then el sistema rechaza el acceso
+```
+
+---
+
+## Impacto arquitectonico
+
+- [x] Sí — la historia define comportamiento visible del panel organizador y puede requerir composición de datos entre BC Registro y BC Competencia.
+
+### Capas afectadas
+
+- `frontend/src/pages/organizador/` — integración de la vista en la navegación del organizador
+- `frontend/src/components/organizador/` — tabla/lista de inscriptos y badges de AP
+- `registro/api/` — datos enriquecidos de inscripción y perfil del atleta
+- `competencia/api/` — estado operativo de AP o cierre del período de anuncios
+
+### Nota de especificacion
+
+La spec no fija que el contrato sea un endpoint específico tipo `inscriptos-detalle` ni obliga a una solución N+1/anti-N+1. Eso pertenece al diseño técnico posterior. La fuente de verdad acá es la UX visible y el dato de negocio que el organizador necesita.
+
+---
+
+## Referencias
+
+- `docs/design/ux/flujos-por-rol.md §2 Rol: Organizador`
+- `docs/design/ux/wireframes-organizador.md §Navegación principal y S-06 Gestión del Torneo`
+- `docs/design/ux/wireframes-atleta.md §S-05 Mis inscripciones`
+- `.work/revision-sp5/04-hallazgos-ux-portal-atleta.md`
+
+---
+
+*Redefinido: 2026-04-25 — INC-5.5 reiniciado desde UX aprobada*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,13 @@ import { RequireRole } from './components/RequireRole'
 import { DisciplinasPage } from './pages/juez/DisciplinasPage'
 import { GrillaPage } from './pages/juez/GrillaPage'
 import { PerformanceFlowPage } from './pages/juez/PerformanceFlowPage'
-import { AtletaDashboardPage } from './pages/atleta/AtletaDashboardPage'
+import { AtletaHomePage } from './pages/atleta/AtletaHomePage'
+import { AtletaTorneosPage } from './pages/atleta/AtletaTorneosPage'
+import { AtletaTorneoDetallePage } from './pages/atleta/AtletaTorneoDetallePage'
+import { AtletaInscripcionPage } from './pages/atleta/AtletaInscripcionPage'
+import { AtletaMisInscripcionesPage } from './pages/atleta/AtletaMisInscripcionesPage'
+import { AtletaDeclararAPPage } from './pages/atleta/AtletaDeclararAPPage'
+import { AtletaResultadosPage } from './pages/atleta/AtletaResultadosPage'
 import { DashboardPage } from './pages/organizador/DashboardPage'
 import { CrearTorneoPage } from './pages/organizador/CrearTorneoPage'
 import { DetalleTorneoPage } from './pages/organizador/DetalleTorneoPage'
@@ -26,7 +32,7 @@ function RootRedirect() {
   const rol = useAuthStore((s) => s.rol)
   if (rol === 'juez') return <Navigate to="/juez/disciplinas" replace />
   if (rol === 'organizador') return <Navigate to="/organizador/dashboard" replace />
-  if (rol === 'atleta') return <Navigate to="/atleta/dashboard" replace />
+  if (rol === 'atleta') return <Navigate to="/atleta" replace />
   return <Navigate to="/login" replace />
 }
 
@@ -78,10 +84,62 @@ function App() {
           }
         />
         <Route
-          path="/atleta/dashboard"
+          path="/atleta"
           element={
             <RequireRole role="atleta">
-              <AtletaDashboardPage />
+              <AtletaHomePage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/atleta/dashboard"
+          element={<Navigate to="/atleta" replace />}
+        />
+        <Route
+          path="/atleta/torneos"
+          element={
+            <RequireRole role="atleta">
+              <AtletaTorneosPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/atleta/torneos/:torneoId"
+          element={
+            <RequireRole role="atleta">
+              <AtletaTorneoDetallePage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/atleta/torneos/:torneoId/inscripcion"
+          element={
+            <RequireRole role="atleta">
+              <AtletaInscripcionPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/atleta/mis-inscripciones"
+          element={
+            <RequireRole role="atleta">
+              <AtletaMisInscripcionesPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/atleta/ap/:torneoId/:disciplina"
+          element={
+            <RequireRole role="atleta">
+              <AtletaDeclararAPPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/atleta/resultados"
+          element={
+            <RequireRole role="atleta">
+              <AtletaResultadosPage />
             </RequireRole>
           }
         />

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -8,6 +8,8 @@ interface LoginResponse {
 interface JwtPayload {
   sub: string
   email: string
+  nombre: string
+  apellido: string
   rol: RolUsuario
   [key: string]: unknown
 }

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -80,6 +80,14 @@ export interface ProximoAtletaDto {
   posicion: number
 }
 
+export interface RegistrarAPPayload {
+  competenciaId: string
+  participanteId: string
+  disciplina: string
+  valorAp: string
+  unidad: 'METROS' | 'SEGUNDOS'
+}
+
 export interface PenalizacionPayload {
   tipo: string
   deduccion: string
@@ -321,6 +329,21 @@ export async function llamarAtleta(payload: {
       ot_programado: payload.otProgramado,
       posicion_grilla: payload.posicionGrilla,
       andarivel: payload.andarivel,
+    }),
+  })
+
+  await parseResponse<void>(response)
+}
+
+export async function registrarAP(payload: RegistrarAPPayload): Promise<void> {
+  const response = await fetch(`/competencia/${payload.competenciaId}/registrar-ap`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      participante_id: payload.participanteId,
+      disciplina: payload.disciplina,
+      valor_ap: payload.valorAp,
+      unidad: payload.unidad,
     }),
   })
 

--- a/frontend/src/api/registro.ts
+++ b/frontend/src/api/registro.ts
@@ -40,6 +40,21 @@ export interface InscribirAtletaResponse {
   inscripcion_id: string
 }
 
+export interface RegistroPasoUnoPayload {
+  nombre_completo: string
+  fecha_nacimiento: string
+  genero: string
+  documento_tipo: string
+  documento_numero: string
+  telefono: string
+}
+
+export interface RegistroPasoDosPayload {
+  disciplinas: DisciplinaCodigo[]
+  categoria: string
+  brevet: string
+}
+
 function buildHeaders(): Record<string, string> {
   const token = getToken()
   const headers: Record<string, string> = {
@@ -89,6 +104,13 @@ export async function fetchAtleta(atletaId: string): Promise<AtletaDto> {
     headers: buildHeaders(),
   })
   return parseResponse<AtletaDto>(response)
+}
+
+export async function listarInscripcionesDeAtleta(atletaId: string): Promise<InscriptoDto[]> {
+  const response = await fetch(`/registro/atletas/${atletaId}/inscripciones`, {
+    headers: buildHeaders(),
+  })
+  return parseResponse<InscriptoDto[]>(response)
 }
 
 export async function inscribirAtleta(

--- a/frontend/src/api/torneo.ts
+++ b/frontend/src/api/torneo.ts
@@ -56,6 +56,7 @@ export type DisciplinaCodigo =
   | 'STA'
   | 'DNF'
   | 'DYN'
+  | 'DYNB'
   | 'DBF'
   | 'SPE_2X50'
   | 'SPE_4X50'

--- a/frontend/src/components/atleta/AtletaShell.tsx
+++ b/frontend/src/components/atleta/AtletaShell.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
+interface AtletaShellProps {
+  title: string
+  subtitle?: string
+  showBack?: boolean
+  actions?: ReactNode
+  children: ReactNode
+}
+
+const TABS = [
+  { label: 'Inicio', to: '/atleta' },
+  { label: 'Torneos', to: '/atleta/torneos' },
+  { label: 'Mis inscr.', to: '/atleta/mis-inscripciones' },
+  { label: 'Resultados', to: '/atleta/resultados' },
+]
+
+function isTabActive(pathname: string, to: string): boolean {
+  if (to === '/atleta') {
+    return pathname === '/atleta' || pathname === '/atleta/dashboard'
+  }
+  return pathname === to || pathname.startsWith(`${to}/`)
+}
+
+export function AtletaShell({
+  title,
+  subtitle,
+  showBack = false,
+  actions,
+  children,
+}: AtletaShellProps) {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex min-h-screen w-full max-w-[430px] flex-col border-x border-slate-800 bg-slate-950">
+        <header className="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/95 px-4 py-3 backdrop-blur">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                {showBack ? (
+                  <button
+                    type="button"
+                    onClick={() => navigate(-1)}
+                    className="rounded-full border border-slate-700 px-2 py-1 text-sm font-semibold text-slate-200"
+                  >
+                    ←
+                  </button>
+                ) : null}
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-400">
+                  AtaraxiaDive
+                </p>
+              </div>
+              <h1 className="mt-2 text-xl font-semibold text-white">{title}</h1>
+              {subtitle ? <p className="mt-1 text-sm text-slate-400">{subtitle}</p> : null}
+            </div>
+            {actions ? <div className="shrink-0">{actions}</div> : null}
+          </div>
+        </header>
+
+        <main className="flex-1 px-4 py-4 pb-24">{children}</main>
+
+        <nav className="sticky bottom-0 z-20 grid h-14 grid-cols-4 border-t border-slate-800 bg-slate-900/95 backdrop-blur">
+          {TABS.map((tab) => {
+            const active = isTabActive(location.pathname, tab.to)
+            return (
+              <Link
+                key={tab.to}
+                to={tab.to}
+                className={[
+                  'flex items-center justify-center text-center text-xs font-semibold transition-colors',
+                  active ? 'text-sky-300' : 'text-slate-400',
+                ].join(' ')}
+              >
+                {tab.label}
+              </Link>
+            )
+          })}
+        </nav>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -28,7 +28,7 @@ export function LoginPage() {
     return <Navigate to="/organizador/dashboard" replace />
   }
   if (rol === 'atleta') {
-    return <Navigate to="/atleta/dashboard" replace />
+    return <Navigate to="/atleta" replace />
   }
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/frontend/src/pages/RegistroPage.tsx
+++ b/frontend/src/pages/RegistroPage.tsx
@@ -77,7 +77,7 @@ export function RegistroPage() {
 
   if (rol === 'juez') return <Navigate to="/juez/disciplinas" replace />
   if (rol === 'organizador') return <Navigate to="/organizador/dashboard" replace />
-  if (rol === 'atleta') return <Navigate to="/atleta/dashboard" replace />
+  if (rol === 'atleta') return <Navigate to="/atleta" replace />
 
   function updateField<T extends keyof FormState>(field: T, value: FormState[T]) {
     setForm((current) => ({ ...current, [field]: value }))

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -31,7 +31,7 @@ export function ResetPasswordPage() {
 
   if (rol === 'juez') return <Navigate to="/juez/disciplinas" replace />
   if (rol === 'organizador') return <Navigate to="/organizador/dashboard" replace />
-  if (rol === 'atleta') return <Navigate to="/atleta/dashboard" replace />
+  if (rol === 'atleta') return <Navigate to="/atleta" replace />
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/frontend/src/pages/atleta/AtletaDashboardPage.tsx
+++ b/frontend/src/pages/atleta/AtletaDashboardPage.tsx
@@ -23,6 +23,7 @@ const DISCIPLINA_LABELS: Record<DisciplinaCodigo, string> = {
   STA: 'STA',
   DNF: 'DNF',
   DYN: 'DYN',
+  DYNB: 'DYNB',
   DBF: 'DBF',
   SPE_2X50: 'SPE 2x50',
   SPE_4X50: 'SPE 4x50',

--- a/frontend/src/pages/atleta/AtletaDeclararAPPage.tsx
+++ b/frontend/src/pages/atleta/AtletaDeclararAPPage.tsx
@@ -1,0 +1,151 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { fetchCompetenciasPorTorneo, fetchGrillaCompetencia, registrarAP } from '../../api/competencia'
+import { fetchTorneo } from '../../api/torneo'
+import useAuthStore from '../../stores/useAuthStore'
+import { AtletaShell } from '../../components/atleta/AtletaShell'
+import { ApiError } from '../../api/competencia'
+import { formatDisciplina, formatFecha, getUnidadEsperada, getUnidadLabel } from './portalData'
+
+async function loadApContext(torneoId: string, disciplina: string, atletaId: string) {
+  const [torneo, competencias] = await Promise.all([
+    fetchTorneo(torneoId),
+    fetchCompetenciasPorTorneo(torneoId),
+  ])
+  const competencia = competencias.find((item) => item.disciplina === disciplina) ?? null
+  const grilla = competencia
+    ? await fetchGrillaCompetencia(competencia.competencia_id, competencia.disciplina).catch(() => [])
+    : []
+  const athleteEntry = grilla.find((entry) => entry.atleta_id === atletaId) ?? null
+
+  return { torneo, competencia, athleteEntry }
+}
+
+function getApError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 409) return 'No se pudo guardar el AP en el estado actual de la disciplina.'
+    return error.message
+  }
+  if (error instanceof Error) return error.message
+  return 'No se pudo guardar el AP.'
+}
+
+export function AtletaDeclararAPPage() {
+  const { torneoId, disciplina } = useParams<{ torneoId: string; disciplina: string }>()
+  const atletaId = useAuthStore((state) => state.userId)
+  const navigate = useNavigate()
+  const [valorAp, setValorAp] = useState('')
+  const query = useQuery({
+    queryKey: ['atleta-ap-context', torneoId, disciplina, atletaId],
+    queryFn: () => loadApContext(torneoId ?? '', disciplina ?? '', atletaId ?? ''),
+    enabled: Boolean(torneoId && disciplina && atletaId),
+  })
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!query.data?.competencia || !atletaId || !disciplina) {
+        throw new Error('La disciplina todavía no está preparada para anunciar AP.')
+      }
+      return registrarAP({
+        competenciaId: query.data.competencia.competencia_id,
+        participanteId: atletaId,
+        disciplina,
+        valorAp: valorApValue,
+        unidad: getUnidadEsperada(disciplina),
+      })
+    },
+    onSuccess: () => {
+      navigate('/atleta/mis-inscripciones')
+    },
+  })
+
+  const unidadEsperada = getUnidadEsperada(disciplina ?? '')
+  const unidadLabel = getUnidadLabel(unidadEsperada)
+  const currentAp = query.data?.athleteEntry?.ap_declarado ?? ''
+  const valorApValue = valorAp || currentAp
+
+  return (
+    <AtletaShell title="Declarar AP" subtitle="Cargá o corregí tu announced performance antes del cierre." showBack>
+      {query.isLoading ? (
+        <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+          Cargando contexto de AP...
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          No se pudo cargar el contexto para declarar AP.
+        </div>
+      ) : null}
+
+      {query.data ? (
+        <div className="space-y-4">
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+            El AP es tu marca anunciada previa. Podés declararla o actualizarla mientras el período siga abierto.
+          </section>
+
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4">
+            <p className="text-sm font-semibold text-white">{query.data.torneo.nombre}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.18em] text-sky-300">
+              {formatDisciplina(disciplina ?? '')}
+            </p>
+            <p className="mt-2 text-sm text-slate-400">
+              Fecha del torneo: {formatFecha(query.data.torneo.fecha_inicio)}
+            </p>
+            <p className="mt-2 text-sm text-slate-400">
+              Deadline visible: hasta el cierre del período de anuncios del torneo.
+            </p>
+          </section>
+
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+            <label className="block text-sm text-slate-300">
+              AP — {unidadEsperada === 'SEGUNDOS' ? 'Tiempo anunciado' : 'Distancia anunciada'} *
+              <div className="mt-3 flex items-center gap-3 rounded-3xl border border-sky-500/40 bg-sky-500/10 px-4 py-4">
+                <input
+                  value={valorApValue}
+                  onChange={(event) => setValorAp(event.target.value)}
+                  inputMode="decimal"
+                  placeholder={unidadEsperada === 'SEGUNDOS' ? '03:30 o 210' : '70'}
+                  className="w-full bg-transparent text-3xl font-semibold text-white outline-none"
+                />
+                <span className="text-sm font-semibold uppercase tracking-[0.18em] text-sky-300">
+                  {unidadLabel}
+                </span>
+              </div>
+            </label>
+            {currentAp ? (
+              <p className="mt-3 text-sm text-slate-400">
+                AP actual guardado: {currentAp} {getUnidadLabel(query.data.athleteEntry?.unidad ?? unidadEsperada)}
+              </p>
+            ) : null}
+          </section>
+
+          {mutation.isError ? (
+            <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+              {getApError(mutation.error)}
+            </div>
+          ) : null}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => navigate('/atleta/mis-inscripciones')}
+              className="flex-1 rounded-2xl border border-slate-700 px-4 py-3 text-sm font-semibold text-slate-200"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={() => mutation.mutate()}
+              disabled={mutation.isPending || !valorApValue || !query.data.competencia}
+              className="flex-1 rounded-2xl bg-sky-500 px-4 py-3 text-sm font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:opacity-60"
+            >
+              {mutation.isPending ? 'Guardando...' : 'Guardar AP'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </AtletaShell>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaHomePage.tsx
+++ b/frontend/src/pages/atleta/AtletaHomePage.tsx
@@ -1,0 +1,183 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import useAuthStore from '../../stores/useAuthStore'
+import { AtletaShell } from '../../components/atleta/AtletaShell'
+import {
+  buildNombreCorto,
+  formatDisciplina,
+  formatFecha,
+  formatHora,
+  getEstadoTorneoLabel,
+  getUnidadLabel,
+  loadAtletaPortalSnapshot,
+} from './portalData'
+
+export function AtletaHomePage() {
+  const atletaId = useAuthStore((state) => state.userId)
+  const logout = useAuthStore((state) => state.logout)
+  const query = useQuery({
+    queryKey: ['atleta-portal-home', atletaId],
+    queryFn: () => loadAtletaPortalSnapshot(atletaId ?? ''),
+    enabled: Boolean(atletaId),
+  })
+
+  const nextOt = query.data?.entries
+    .filter((entry) => entry.ot)
+    .sort((left, right) => new Date(left.ot ?? 0).getTime() - new Date(right.ot ?? 0).getTime())[0]
+  const torneosActivos = Array.from(
+    new Map(
+      (query.data?.entries ?? []).map((entry) => [
+        entry.torneo.torneo_id,
+        {
+          torneo: entry.torneo,
+          disciplinas: (query.data?.entries ?? []).filter(
+            (candidate) => candidate.torneo.torneo_id === entry.torneo.torneo_id,
+          ),
+        },
+      ]),
+    ).values(),
+  )
+
+  return (
+    <AtletaShell
+      title="Portal del atleta"
+      subtitle="Tus próximos torneos, anuncios y estado de participación."
+      actions={
+        <button
+          type="button"
+          onClick={logout}
+          className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-200"
+        >
+          Salir
+        </button>
+      }
+    >
+      {query.isLoading ? (
+        <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+          Cargando portal del atleta...
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          No se pudo cargar el portal del atleta.
+        </div>
+      ) : null}
+
+      {query.data ? (
+        <div className="space-y-4">
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5 shadow-[0_30px_60px_-40px_rgba(56,189,248,0.5)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+              Hola
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">
+              {buildNombreCorto(query.data.atleta)}
+            </h2>
+            <dl className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
+              <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">Categoría</dt>
+                <dd className="mt-1 font-semibold text-white">{query.data.atleta.categoria}</dd>
+              </div>
+              <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">Club</dt>
+                <dd className="mt-1 font-semibold text-white">{query.data.atleta.club}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+                  Tu próximo OT
+                </p>
+                <h3 className="mt-1 text-lg font-semibold text-white">Próxima salida</h3>
+              </div>
+              {nextOt?.torneo ? (
+                <Link
+                  to="/atleta/mis-inscripciones"
+                  className="text-sm font-semibold text-sky-300"
+                >
+                  Ver grilla
+                </Link>
+              ) : null}
+            </div>
+
+            {nextOt ? (
+              <div className="mt-4 rounded-3xl border border-sky-500/30 bg-sky-500/10 p-4">
+                <p className="text-sm font-semibold text-white">{nextOt.torneo.nombre}</p>
+                <p className="mt-1 text-xs uppercase tracking-[0.18em] text-sky-300">
+                  {formatDisciplina(nextOt.disciplina)}
+                </p>
+                <p className="mt-3 text-3xl font-semibold text-white">{formatHora(nextOt.ot ?? '')}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  Andarivel {nextOt.andarivel ?? '—'} · Posición {nextOt.posicion ?? '—'}
+                </p>
+                <p className="mt-1 text-sm text-slate-300">
+                  AP {nextOt.ap ?? 'sin declarar'} {getUnidadLabel(nextOt.unidad)}
+                </p>
+              </div>
+            ) : (
+              <div className="mt-4 rounded-3xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-400">
+                Todavía no tenés OT asignado. Tus horarios aparecerán acá cuando la grilla esté publicada.
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+                  Mis inscripciones activas
+                </p>
+                <h3 className="mt-1 text-lg font-semibold text-white">Torneos vinculados</h3>
+              </div>
+              <Link to="/atleta/torneos" className="text-sm font-semibold text-sky-300">
+                Explorar
+              </Link>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {torneosActivos.length === 0 ? (
+                <div className="rounded-3xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-400">
+                  Todavía no tenés inscripciones activas.
+                </div>
+              ) : null}
+
+              {torneosActivos.map(({ torneo, disciplinas }) => (
+                <Link
+                  key={torneo.torneo_id}
+                  to="/atleta/mis-inscripciones"
+                  className="block rounded-3xl border border-slate-800 bg-slate-950/70 p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h4 className="text-base font-semibold text-white">{torneo.nombre}</h4>
+                      <p className="mt-1 text-sm text-slate-400">
+                        {formatFecha(torneo.fecha_inicio)} · {torneo.sede.ciudad}
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold text-slate-200">
+                      {getEstadoTorneoLabel(torneo.estado)}
+                    </span>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {disciplinas.map((entry) => (
+                      <span
+                        key={`${torneo.torneo_id}-${entry.disciplina}`}
+                        className="rounded-full border border-slate-700 bg-slate-900 px-3 py-1 text-xs font-semibold text-slate-200"
+                      >
+                        {formatDisciplina(entry.disciplina)}
+                        {entry.apEstado === 'declarado' ? ' ✓ AP' : entry.apEstado === 'cerrado' ? ' AP cerrado' : ' Sin AP'}
+                      </span>
+                    ))}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </AtletaShell>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaInscripcionPage.tsx
+++ b/frontend/src/pages/atleta/AtletaInscripcionPage.tsx
@@ -1,0 +1,348 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { fetchTorneo, listarDisciplinasTorneo } from '../../api/torneo'
+import { fetchAtleta, inscribirAtleta } from '../../api/registro'
+import useAuthStore from '../../stores/useAuthStore'
+import { AtletaShell } from '../../components/atleta/AtletaShell'
+import { ApiError } from '../../api/registro'
+import { formatDisciplina, formatFecha } from './portalData'
+import type { DisciplinaCodigo } from '../../api/torneo'
+
+type WizardStep = 1 | 2 | 3
+
+function getInscripcionError(error: unknown): string {
+  if (error instanceof ApiError) return error.message
+  if (error instanceof Error) return error.message
+  return 'No se pudo completar la inscripción.'
+}
+
+export function AtletaInscripcionPage() {
+  const { torneoId } = useParams<{ torneoId: string }>()
+  const atletaId = useAuthStore((state) => state.userId)
+  const email = useAuthStore((state) => state.email)
+  const navigate = useNavigate()
+  const [step, setStep] = useState<WizardStep>(1)
+  const [nombreCompleto, setNombreCompleto] = useState('')
+  const [fechaNacimiento, setFechaNacimiento] = useState('')
+  const [genero, setGenero] = useState('F')
+  const [documentoTipo, setDocumentoTipo] = useState('DNI')
+  const [documentoNumero, setDocumentoNumero] = useState('')
+  const [telefono, setTelefono] = useState('')
+  const [categoria, setCategoria] = useState('')
+  const [brevet, setBrevet] = useState('')
+  const [disciplinasSeleccionadas, setDisciplinasSeleccionadas] = useState<string[]>([])
+  const [certificado, setCertificado] = useState<File | null>(null)
+  const [comprobante, setComprobante] = useState<File | null>(null)
+  const [validationError, setValidationError] = useState('')
+
+  const query = useQuery({
+    queryKey: ['atleta-inscripcion-form', torneoId, atletaId],
+    queryFn: async () => {
+      const [torneo, disciplinas, atleta] = await Promise.all([
+        fetchTorneo(torneoId ?? ''),
+        listarDisciplinasTorneo(torneoId ?? ''),
+        fetchAtleta(atletaId ?? ''),
+      ])
+      return { torneo, disciplinas, atleta }
+    },
+    enabled: Boolean(torneoId && atletaId),
+  })
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!atletaId || !torneoId) {
+        throw new Error('No se pudo identificar al atleta o torneo para inscribirse.')
+      }
+      return inscribirAtleta({
+        atletaId,
+        torneoId,
+        disciplinas: disciplinasSeleccionadas as DisciplinaCodigo[],
+      })
+    },
+    onSuccess: () => {
+      navigate('/atleta/mis-inscripciones')
+    },
+  })
+
+  const atleta = query.data?.atleta
+  const nombreCompletoValue = nombreCompleto || (atleta ? `${atleta.nombre} ${atleta.apellido}`.trim() : '')
+  const fechaNacimientoValue = fechaNacimiento || atleta?.fecha_nacimiento || ''
+  const categoriaValue = categoria || atleta?.categoria || ''
+  const brevetValue = brevet || atleta?.brevet || ''
+
+  function toggleDisciplina(disciplina: string) {
+    setDisciplinasSeleccionadas((current) =>
+      current.includes(disciplina)
+        ? current.filter((item) => item !== disciplina)
+        : [...current, disciplina],
+    )
+  }
+
+  function nextStep() {
+    if (step === 1) {
+      if (!nombreCompletoValue || !fechaNacimientoValue || !documentoNumero || !telefono) {
+        setValidationError('Completá todos los datos personales obligatorios.')
+        return
+      }
+    }
+    if (step === 2) {
+      if (disciplinasSeleccionadas.length === 0 || !categoriaValue) {
+        setValidationError('Seleccioná al menos una disciplina y confirmá la categoría.')
+        return
+      }
+    }
+    setValidationError('')
+    setStep((current) => Math.min(3, current + 1) as WizardStep)
+  }
+
+  function prevStep() {
+    setValidationError('')
+    setStep((current) => Math.max(1, current - 1) as WizardStep)
+  }
+
+  async function submit() {
+    if (!certificado || !comprobante) {
+      setValidationError('El certificado médico y el comprobante de pago son obligatorios.')
+      return
+    }
+    setValidationError('')
+    await mutation.mutateAsync()
+  }
+
+  return (
+    <AtletaShell title="Inscribirme" subtitle="Completá el wizard de 3 pasos para enviar tu inscripción." showBack>
+      {query.isLoading ? (
+        <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+          Cargando formulario de inscripción...
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          No se pudo preparar el formulario de inscripción.
+        </div>
+      ) : null}
+
+      {query.data ? (
+        <div className="space-y-4">
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-400">
+              Paso {step} de 3
+            </p>
+            <h2 className="mt-1 text-lg font-semibold text-white">{query.data.torneo.nombre}</h2>
+            <p className="mt-1 text-sm text-slate-400">
+              {formatFecha(query.data.torneo.fecha_inicio)} al {formatFecha(query.data.torneo.fecha_fin)}
+            </p>
+            <div className="mt-4 grid grid-cols-3 gap-2">
+              {[1, 2, 3].map((item) => (
+                <div
+                  key={item}
+                  className={[
+                    'h-2 rounded-full',
+                    item <= step ? 'bg-sky-400' : 'bg-slate-800',
+                  ].join(' ')}
+                />
+              ))}
+            </div>
+          </section>
+
+          {step === 1 ? (
+            <section className="space-y-3 rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4">
+              <p className="text-sm font-semibold text-white">1. Datos personales</p>
+              <label className="block text-sm text-slate-300">
+                Correo
+                <input
+                  value={email ?? ''}
+                  readOnly
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-400"
+                />
+              </label>
+              <label className="block text-sm text-slate-300">
+                Nombre y apellido *
+                <input
+                  value={nombreCompletoValue}
+                  onChange={(event) => setNombreCompleto(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                />
+              </label>
+              <label className="block text-sm text-slate-300">
+                Fecha de nacimiento *
+                <input
+                  type="date"
+                  value={fechaNacimientoValue}
+                  onChange={(event) => setFechaNacimiento(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                />
+              </label>
+              <label className="block text-sm text-slate-300">
+                Género *
+                <select
+                  value={genero}
+                  onChange={(event) => setGenero(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                >
+                  <option value="F">Femenino</option>
+                  <option value="M">Masculino</option>
+                  <option value="X">Otro</option>
+                </select>
+              </label>
+              <div className="grid grid-cols-[110px_minmax(0,1fr)] gap-3">
+                <label className="block text-sm text-slate-300">
+                  Tipo
+                  <select
+                    value={documentoTipo}
+                    onChange={(event) => setDocumentoTipo(event.target.value)}
+                    className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                  >
+                    <option value="DNI">DNI</option>
+                    <option value="PAS">Pasaporte</option>
+                  </select>
+                </label>
+                <label className="block text-sm text-slate-300">
+                  Documento *
+                  <input
+                    value={documentoNumero}
+                    onChange={(event) => setDocumentoNumero(event.target.value)}
+                    className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                  />
+                </label>
+              </div>
+              <label className="block text-sm text-slate-300">
+                Teléfono *
+                <input
+                  value={telefono}
+                  onChange={(event) => setTelefono(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                />
+              </label>
+            </section>
+          ) : null}
+
+          {step === 2 ? (
+            <section className="space-y-3 rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4">
+              <p className="text-sm font-semibold text-white">2. Datos de competencia</p>
+              <p className="text-sm text-slate-400">
+                Seleccioná disciplinas y revisá tu categoría antes de enviar.
+              </p>
+              <div className="grid gap-3">
+                {query.data.disciplinas.map((disciplina) => {
+                  const selected = disciplinasSeleccionadas.includes(disciplina.disciplina)
+                  return (
+                    <button
+                      key={disciplina.disciplina}
+                      type="button"
+                      onClick={() => toggleDisciplina(disciplina.disciplina)}
+                      className={[
+                        'rounded-3xl border px-4 py-4 text-left text-sm font-semibold transition-colors',
+                        selected
+                          ? 'border-sky-400 bg-sky-500/10 text-sky-200'
+                          : 'border-slate-800 bg-slate-950/70 text-slate-200',
+                      ].join(' ')}
+                    >
+                      {formatDisciplina(disciplina.disciplina)}
+                    </button>
+                  )
+                })}
+              </div>
+              <label className="block text-sm text-slate-300">
+                Categoría *
+                <input
+                  value={categoriaValue}
+                  onChange={(event) => setCategoria(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                />
+              </label>
+              <label className="block text-sm text-slate-300">
+                Nº Brevet FAAS
+                <input
+                  value={brevetValue}
+                  onChange={(event) => setBrevet(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                />
+              </label>
+            </section>
+          ) : null}
+
+          {step === 3 ? (
+            <section className="space-y-3 rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4">
+              <p className="text-sm font-semibold text-white">3. Requisitos</p>
+              <div className="rounded-3xl border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">
+                La inscripción quedará pendiente de verificación hasta revisar la documentación obligatoria.
+              </div>
+              <label className="block rounded-3xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-300">
+                Certificado médico *
+                <input
+                  type="file"
+                  onChange={(event) => setCertificado(event.target.files?.[0] ?? null)}
+                  className="mt-3 block w-full text-sm text-slate-300"
+                />
+                <p className="mt-2 text-xs text-slate-500">PDF o imagen. Máximo 10 MB.</p>
+              </label>
+              <label className="block rounded-3xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-300">
+                Comprobante de pago *
+                <input
+                  type="file"
+                  onChange={(event) => setComprobante(event.target.files?.[0] ?? null)}
+                  className="mt-3 block w-full text-sm text-slate-300"
+                />
+                <p className="mt-2 text-xs text-slate-500">PDF o imagen. Máximo 10 MB.</p>
+              </label>
+            </section>
+          ) : null}
+
+          {validationError ? (
+            <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+              {validationError}
+            </div>
+          ) : null}
+
+          {mutation.isError ? (
+            <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+              {getInscripcionError(mutation.error)}
+            </div>
+          ) : null}
+
+          <div className="flex gap-3">
+            {step > 1 ? (
+              <button
+                type="button"
+                onClick={prevStep}
+                className="flex-1 rounded-2xl border border-slate-700 px-4 py-3 text-sm font-semibold text-slate-200"
+              >
+                ← Anterior
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => navigate(-1)}
+                className="flex-1 rounded-2xl border border-slate-700 px-4 py-3 text-sm font-semibold text-slate-200"
+              >
+                Cancelar
+              </button>
+            )}
+
+            {step < 3 ? (
+              <button
+                type="button"
+                onClick={nextStep}
+                className="flex-1 rounded-2xl bg-sky-500 px-4 py-3 text-sm font-semibold uppercase tracking-[0.16em] text-slate-950"
+              >
+                Siguiente →
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={submit}
+                disabled={mutation.isPending}
+                className="flex-1 rounded-2xl bg-sky-500 px-4 py-3 text-sm font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:opacity-60"
+              >
+                {mutation.isPending ? 'Enviando...' : 'Enviar inscripción'}
+              </button>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </AtletaShell>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx
+++ b/frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx
@@ -1,0 +1,152 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import useAuthStore from '../../stores/useAuthStore'
+import { AtletaShell } from '../../components/atleta/AtletaShell'
+import {
+  formatDisciplina,
+  formatFecha,
+  formatHora,
+  getUnidadLabel,
+  loadAtletaPortalSnapshot,
+} from './portalData'
+
+export function AtletaMisInscripcionesPage() {
+  const atletaId = useAuthStore((state) => state.userId)
+  const query = useQuery({
+    queryKey: ['atleta-mis-inscripciones', atletaId],
+    queryFn: () => loadAtletaPortalSnapshot(atletaId ?? ''),
+    enabled: Boolean(atletaId),
+  })
+
+  const enEjecucion = (query.data?.entries ?? []).filter(
+    (entry) => entry.torneo.estado !== 'INSCRIPCION_ABIERTA',
+  )
+  const abiertas = (query.data?.entries ?? []).filter(
+    (entry) => entry.torneo.estado === 'INSCRIPCION_ABIERTA',
+  )
+
+  return (
+    <AtletaShell title="Mis inscripciones" subtitle="Estado visible por torneo y disciplina, con acceso al anuncio de AP.">
+      {query.isLoading ? (
+        <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+          Cargando inscripciones...
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          No se pudieron cargar tus inscripciones.
+        </div>
+      ) : null}
+
+      {query.data ? (
+        <div className="space-y-5">
+          <section>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+              En ejecución
+            </p>
+            <div className="mt-3 space-y-3">
+              {enEjecucion.length === 0 ? (
+                <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-400">
+                  No hay disciplinas en ejecución para tus inscripciones activas.
+                </div>
+              ) : null}
+
+              {enEjecucion.map((entry) => (
+                <div
+                  key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
+                  className="rounded-3xl border border-slate-800 bg-slate-900 p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{entry.torneo.nombre}</p>
+                      <p className="mt-1 text-xs uppercase tracking-[0.18em] text-sky-300">
+                        {formatDisciplina(entry.disciplina)}
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold text-slate-200">
+                      AP cerrado
+                    </span>
+                  </div>
+                  <dl className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
+                    <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+                      <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">AP</dt>
+                      <dd className="mt-1 font-semibold text-white">
+                        {entry.ap ? `${entry.ap} ${getUnidadLabel(entry.unidad)}` : 'Sin dato'}
+                      </dd>
+                    </div>
+                    <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+                      <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">OT</dt>
+                      <dd className="mt-1 font-semibold text-white">
+                        {entry.ot ? formatHora(entry.ot) : 'Pendiente'}
+                      </dd>
+                    </div>
+                  </dl>
+                  <p className="mt-3 text-sm text-slate-400">
+                    Andarivel {entry.andarivel ?? '—'} · Posición {entry.posicion ?? '—'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+              Inscripciones abiertas
+            </p>
+            <div className="mt-3 space-y-3">
+              {abiertas.length === 0 ? (
+                <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-400">
+                  No tenés inscripciones abiertas para declarar AP.
+                </div>
+              ) : null}
+
+              {abiertas.map((entry) => (
+                <div
+                  key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
+                  className="rounded-3xl border border-slate-800 bg-slate-900 p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{entry.torneo.nombre}</p>
+                      <p className="mt-1 text-xs uppercase tracking-[0.18em] text-sky-300">
+                        {formatDisciplina(entry.disciplina)}
+                      </p>
+                    </div>
+                    <span
+                      className={[
+                        'rounded-full px-3 py-1 text-xs font-semibold',
+                        entry.apEstado === 'declarado'
+                          ? 'border border-emerald-500/30 bg-emerald-500/10 text-emerald-200'
+                          : 'border border-amber-500/30 bg-amber-500/10 text-amber-100',
+                      ].join(' ')}
+                    >
+                      {entry.apEstado === 'declarado' ? 'AP declarado' : 'AP pendiente'}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm text-slate-400">
+                    Deadline visible: el anuncio permanece abierto mientras el torneo siga en inscripción.
+                  </p>
+                  <p className="mt-2 text-sm text-slate-400">
+                    Inicio del torneo: {formatFecha(entry.torneo.fecha_inicio)}
+                  </p>
+                  <div className="mt-4 flex items-center justify-between gap-3">
+                    <p className="text-sm text-slate-300">
+                      {entry.ap ? `AP actual ${entry.ap} ${getUnidadLabel(entry.unidad)}` : '⚠ Sin AP declarado'}
+                    </p>
+                    <Link
+                      to={`/atleta/ap/${entry.torneo.torneo_id}/${entry.disciplina}`}
+                      className="rounded-2xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950"
+                    >
+                      {entry.ap ? 'Modificar AP' : 'Declarar AP'}
+                    </Link>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </AtletaShell>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaResultadosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaResultadosPage.tsx
@@ -1,0 +1,14 @@
+import { AtletaShell } from '../../components/atleta/AtletaShell'
+
+export function AtletaResultadosPage() {
+  return (
+    <AtletaShell title="Mis resultados" subtitle="Resultados publicados y ranking por disciplina.">
+      <div className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+        <p className="text-sm font-semibold text-white">Resultados aún no publicados</p>
+        <p className="mt-2 text-sm text-slate-400">
+          Esta vista queda preparada dentro del shell UX del atleta. Los resultados aparecerán cuando la organización los publique.
+        </p>
+      </div>
+    </AtletaShell>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaTorneoDetallePage.tsx
+++ b/frontend/src/pages/atleta/AtletaTorneoDetallePage.tsx
@@ -1,0 +1,94 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router-dom'
+import { fetchTorneo, listarDisciplinasTorneo } from '../../api/torneo'
+import { AtletaShell } from '../../components/atleta/AtletaShell'
+import { formatDisciplina, formatFecha, getEstadoTorneoLabel } from './portalData'
+
+async function loadTorneoDetalle(torneoId: string) {
+  const [torneo, disciplinas] = await Promise.all([
+    fetchTorneo(torneoId),
+    listarDisciplinasTorneo(torneoId),
+  ])
+  return { torneo, disciplinas }
+}
+
+export function AtletaTorneoDetallePage() {
+  const { torneoId } = useParams<{ torneoId: string }>()
+  const query = useQuery({
+    queryKey: ['atleta-torneo-detalle', torneoId],
+    queryFn: () => loadTorneoDetalle(torneoId ?? ''),
+    enabled: Boolean(torneoId),
+  })
+
+  return (
+    <AtletaShell title="Detalle del torneo" subtitle="Revisá condiciones, sede y disciplinas antes de inscribirte." showBack>
+      {query.isLoading ? (
+        <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+          Cargando torneo...
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          No se pudo cargar el detalle del torneo.
+        </div>
+      ) : null}
+
+      {query.data ? (
+        <div className="space-y-4">
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-xl font-semibold text-white">{query.data.torneo.nombre}</h2>
+                <p className="mt-2 text-sm text-slate-400">
+                  {formatFecha(query.data.torneo.fecha_inicio)} al {formatFecha(query.data.torneo.fecha_fin)}
+                </p>
+              </div>
+              <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-300">
+                {getEstadoTorneoLabel(query.data.torneo.estado)}
+              </span>
+            </div>
+            <dl className="mt-4 space-y-3 text-sm text-slate-300">
+              <div>
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">Sede</dt>
+                <dd className="mt-1">
+                  {query.data.torneo.sede.nombre}, {query.data.torneo.sede.ciudad}, {query.data.torneo.sede.pais}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">Descripción</dt>
+                <dd className="mt-1">{query.data.torneo.descripcion || 'Sin descripción pública.'}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+              Disciplinas disponibles
+            </p>
+            <div className="mt-4 space-y-3">
+              {query.data.disciplinas.map((disciplina) => (
+                <div
+                  key={disciplina.disciplina}
+                  className="rounded-3xl border border-slate-800 bg-slate-950/70 p-4"
+                >
+                  <p className="text-sm font-semibold text-white">{formatDisciplina(disciplina.disciplina)}</p>
+                  <p className="mt-1 text-sm text-slate-400">
+                    Juez asignado: {disciplina.juez_id ? 'Sí' : 'Pendiente'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <Link
+            to={`/atleta/torneos/${query.data.torneo.torneo_id}/inscripcion`}
+            className="flex min-h-11 items-center justify-center rounded-2xl bg-sky-500 px-4 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950"
+          >
+            Inscribirme en este torneo
+          </Link>
+        </div>
+      ) : null}
+    </AtletaShell>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaTorneosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaTorneosPage.tsx
@@ -1,0 +1,128 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { fetchTorneos } from '../../api/torneo'
+import { AtletaShell } from '../../components/atleta/AtletaShell'
+import {
+  formatDisciplina,
+  formatFecha,
+  getEstadoTorneoLabel,
+  isTorneoAbierto,
+  isTorneoProximo,
+} from './portalData'
+import { listarDisciplinasTorneo } from '../../api/torneo'
+
+function sortDetalleByFecha<T extends { torneo: { fecha_inicio: string } }>(items: T[]): T[] {
+  return [...items].sort(
+    (left, right) =>
+      new Date(left.torneo.fecha_inicio).getTime() - new Date(right.torneo.fecha_inicio).getTime(),
+  )
+}
+
+async function loadTorneos() {
+  const torneos = await fetchTorneos()
+  const detalle = await Promise.all(
+    torneos.map(async (torneo) => {
+      try {
+        const disciplinas = await listarDisciplinasTorneo(torneo.torneo_id)
+        return { torneo, disciplinas }
+      } catch {
+        return { torneo, disciplinas: [] }
+      }
+    }),
+  )
+
+  return {
+    abiertos: sortDetalleByFecha(detalle.filter((item) => isTorneoAbierto(item.torneo.estado))),
+    proximos: sortDetalleByFecha(detalle.filter((item) => isTorneoProximo(item.torneo.estado))),
+  }
+}
+
+export function AtletaTorneosPage() {
+  const query = useQuery({
+    queryKey: ['atleta-torneos'],
+    queryFn: loadTorneos,
+  })
+
+  return (
+    <AtletaShell title="Torneos" subtitle="Explorá torneos publicados y revisá si la inscripción está abierta.">
+      {query.isLoading ? (
+        <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+          Cargando torneos...
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          No se pudieron cargar los torneos.
+        </div>
+      ) : null}
+
+      {query.data ? (
+        <div className="space-y-5">
+          <section>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+              Inscripciones abiertas
+            </p>
+            <div className="mt-3 space-y-3">
+              {query.data.abiertos.length === 0 ? (
+                <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-400">
+                  No hay torneos con inscripción abierta.
+                </div>
+              ) : null}
+
+              {query.data.abiertos.map(({ torneo, disciplinas }) => (
+                <Link
+                  key={torneo.torneo_id}
+                  to={`/atleta/torneos/${torneo.torneo_id}`}
+                  className="block rounded-3xl border border-slate-800 bg-slate-900 p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h2 className="text-base font-semibold text-white">{torneo.nombre}</h2>
+                      <p className="mt-1 text-sm text-slate-400">
+                        {formatFecha(torneo.fecha_inicio)} · {torneo.sede.nombre}, {torneo.sede.ciudad}
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-300">
+                      {getEstadoTorneoLabel(torneo.estado)}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm text-slate-300">
+                    Disciplinas: {disciplinas.map((item) => formatDisciplina(item.disciplina)).join(' · ') || 'Por definir'}
+                  </p>
+                  <p className="mt-2 text-sm font-semibold text-sky-300">Ver detalle →</p>
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Próximos
+            </p>
+            <div className="mt-3 space-y-3">
+              {query.data.proximos.length === 0 ? (
+                <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-400">
+                  No hay torneos próximos publicados.
+                </div>
+              ) : null}
+
+              {query.data.proximos.map(({ torneo }) => (
+                <div
+                  key={torneo.torneo_id}
+                  className="rounded-3xl border border-slate-800 bg-slate-900/70 p-4 opacity-80"
+                >
+                  <h2 className="text-base font-semibold text-white">{torneo.nombre}</h2>
+                  <p className="mt-1 text-sm text-slate-400">
+                    {formatFecha(torneo.fecha_inicio)} · {torneo.sede.ciudad}
+                  </p>
+                  <p className="mt-2 text-sm text-slate-500">Aún sin inscripción habilitada.</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </AtletaShell>
+  )
+}

--- a/frontend/src/pages/atleta/portalData.ts
+++ b/frontend/src/pages/atleta/portalData.ts
@@ -1,0 +1,195 @@
+import {
+  fetchCompetenciasPorTorneo,
+  fetchGrillaCompetencia,
+  type CompetenciaResumenDto,
+  type GrillaAtletaDto,
+} from '../../api/competencia'
+import {
+  fetchAtleta,
+  listarInscripcionesDeAtleta,
+  type AtletaDto,
+  type InscriptoDto,
+} from '../../api/registro'
+import { fetchTorneos, type EstadoTorneo, type TorneoDto } from '../../api/torneo'
+
+export interface AtletaPortalEntry {
+  torneo: TorneoDto
+  inscripcion: InscriptoDto
+  disciplina: string
+  competenciaId: string | null
+  ap: string | null
+  unidad: string | null
+  apEstado: 'pendiente' | 'declarado' | 'cerrado'
+  ot: string | null
+  andarivel: number | null
+  posicion: number | null
+}
+
+export interface AtletaPortalSnapshot {
+  atleta: AtletaDto
+  inscripciones: InscriptoDto[]
+  torneos: TorneoDto[]
+  entries: AtletaPortalEntry[]
+}
+
+export const DISCIPLINA_LABELS: Record<string, string> = {
+  STA: 'STA',
+  DNF: 'DNF',
+  DYN: 'DYN',
+  DBF: 'DBF',
+  DYNB: 'DYNB',
+  SPE_2X50: 'SPE 2x50',
+  SPE_4X50: 'SPE 4x50',
+  SPE_8X50: 'SPE 8x50',
+  SPE_16X50: 'SPE 16x50',
+}
+
+export function formatDisciplina(disciplina: string): string {
+  return DISCIPLINA_LABELS[disciplina] ?? disciplina
+}
+
+export function formatFecha(fechaIso: string): string {
+  const fecha = new Date(fechaIso)
+  return new Intl.DateTimeFormat('es-AR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(fecha)
+}
+
+export function formatHora(fechaIso: string): string {
+  const fecha = new Date(fechaIso)
+  return new Intl.DateTimeFormat('es-AR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(fecha)
+}
+
+export function getEstadoTorneoLabel(estado: EstadoTorneo): string {
+  switch (estado) {
+    case 'INSCRIPCION_ABIERTA':
+      return 'Inscripciones abiertas'
+    case 'PREPARACION':
+      return 'Preparación'
+    case 'EJECUCION':
+      return 'En ejecución'
+    case 'PREMIACION':
+      return 'Premiación'
+    case 'CERRADO':
+      return 'Cerrado'
+    case 'CANCELADO':
+      return 'Cancelado'
+    default:
+      return 'Creado'
+  }
+}
+
+export function getUnidadEsperada(disciplina: string): 'METROS' | 'SEGUNDOS' {
+  return disciplina === 'STA' ? 'SEGUNDOS' : 'METROS'
+}
+
+export function getUnidadLabel(unidad: string | null): string {
+  if (unidad === 'SEGUNDOS') return 'seg'
+  return 'm'
+}
+
+function buildApEstado(
+  torneoEstado: EstadoTorneo,
+  grilla: GrillaAtletaDto | null,
+): 'pendiente' | 'declarado' | 'cerrado' {
+  if (torneoEstado !== 'INSCRIPCION_ABIERTA') {
+    return 'cerrado'
+  }
+  return grilla?.ap_declarado?.trim() ? 'declarado' : 'pendiente'
+}
+
+export async function loadAtletaPortalSnapshot(atletaId: string): Promise<AtletaPortalSnapshot> {
+  const [atleta, inscripciones, torneos] = await Promise.all([
+    fetchAtleta(atletaId),
+    listarInscripcionesDeAtleta(atletaId),
+    fetchTorneos(),
+  ])
+
+  const torneosById = new Map(torneos.map((torneo) => [torneo.torneo_id, torneo]))
+  const torneosInscriptos = inscripciones
+    .map((inscripcion) => inscripcion.torneo_id)
+    .filter((torneoId, index, array) => array.indexOf(torneoId) === index)
+
+  const competenciasPorTorneo = new Map<string, CompetenciaResumenDto[]>()
+  await Promise.all(
+    torneosInscriptos.map(async (torneoId) => {
+      try {
+        const competencias = await fetchCompetenciasPorTorneo(torneoId)
+        competenciasPorTorneo.set(torneoId, competencias)
+      } catch {
+        competenciasPorTorneo.set(torneoId, [])
+      }
+    }),
+  )
+
+  const grillasPorCompetencia = new Map<string, GrillaAtletaDto[]>()
+  await Promise.all(
+    Array.from(competenciasPorTorneo.values())
+      .flat()
+      .map(async (competencia) => {
+        try {
+          const grilla = await fetchGrillaCompetencia(
+            competencia.competencia_id,
+            competencia.disciplina,
+          )
+          grillasPorCompetencia.set(competencia.competencia_id, grilla)
+        } catch {
+          grillasPorCompetencia.set(competencia.competencia_id, [])
+        }
+      }),
+  )
+
+  const entries: AtletaPortalEntry[] = inscripciones.flatMap((inscripcion) => {
+    const torneo = torneosById.get(inscripcion.torneo_id)
+    if (!torneo) return []
+
+    return inscripcion.disciplinas.map((disciplina) => {
+      const competencia = (competenciasPorTorneo.get(inscripcion.torneo_id) ?? []).find(
+        (item) => item.disciplina === disciplina,
+      )
+      const grilla = competencia
+        ? (grillasPorCompetencia.get(competencia.competencia_id) ?? []).find(
+            (entry) => entry.atleta_id === atletaId,
+          ) ?? null
+        : null
+
+      return {
+        torneo,
+        inscripcion,
+        disciplina,
+        competenciaId: competencia?.competencia_id ?? null,
+        ap: grilla?.ap_declarado ?? null,
+        unidad: grilla?.unidad ?? null,
+        apEstado: buildApEstado(torneo.estado, grilla),
+        ot: grilla?.ot_programado ?? null,
+        andarivel: grilla?.andarivel ?? null,
+        posicion: grilla?.posicion ?? null,
+      }
+    })
+  })
+
+  return { atleta, inscripciones, torneos, entries }
+}
+
+export function buildNombreCorto(atleta: AtletaDto): string {
+  return `${atleta.nombre} ${atleta.apellido}`.trim()
+}
+
+export function isTorneoProximo(estado: EstadoTorneo): boolean {
+  return estado === 'CREADO'
+}
+
+export function isTorneoAbierto(estado: EstadoTorneo): boolean {
+  return estado === 'INSCRIPCION_ABIERTA'
+}
+
+export function sortByDateAsc<T extends { fecha_inicio: string }>(items: T[]): T[] {
+  return [...items].sort(
+    (left, right) => new Date(left.fecha_inicio).getTime() - new Date(right.fecha_inicio).getTime(),
+  )
+}

--- a/frontend/src/stores/useAuthStore.ts
+++ b/frontend/src/stores/useAuthStore.ts
@@ -9,6 +9,8 @@ const useAuthStore = create<AuthState>()(
       token: null,
       userId: null,
       email: null,
+      nombre: null,
+      apellido: null,
       rol: null,
 
       login: (token: string) => {
@@ -17,12 +19,21 @@ const useAuthStore = create<AuthState>()(
           token,
           userId: payload.sub,
           email: payload.email,
+          nombre: payload.nombre,
+          apellido: payload.apellido,
           rol: payload.rol.toLowerCase() as RolUsuario,
         })
       },
 
       logout: () => {
-        set({ token: null, userId: null, email: null, rol: null })
+        set({
+          token: null,
+          userId: null,
+          email: null,
+          nombre: null,
+          apellido: null,
+          rol: null,
+        })
       },
     }),
     {
@@ -32,6 +43,8 @@ const useAuthStore = create<AuthState>()(
         token: state.token,
         userId: state.userId,
         email: state.email,
+        nombre: state.nombre,
+        apellido: state.apellido,
         rol: state.rol,
       }),
     },

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -12,6 +12,8 @@ export interface AuthState {
   token: string | null
   userId: string | null
   email: string | null
+  nombre: string | null
+  apellido: string | null
   rol: RolUsuario | null
   login: (token: string) => void
   logout: () => void

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -3,5 +3,5 @@ import type { RolUsuario } from '../types/auth'
 export const HOME_BY_ROL: Record<RolUsuario, string> = {
   juez: '/juez/disciplinas',
   organizador: '/organizador/dashboard',
-  atleta: '/atleta/dashboard',
+  atleta: '/atleta',
 }

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -60,6 +60,13 @@ from competencia.application.commands.registrar_dns import (
     RegistrarDNSHandler,
     PerformanceNoEncontrada as PerformanceNoEncontradaRegistrarDns,
 )
+from competencia.application.commands.registrar_ap import (
+    APYaRegistrado,
+    GrillaYaConfirmadaError,
+    PlazoAPVencidoError,
+    RegistrarAPCommand,
+    RegistrarAPHandler,
+)
 from competencia.application.commands.resolver_revision import (
     ResolverRevisionCommand,
     ResolverRevisionHandler,
@@ -137,7 +144,7 @@ from competencia.infrastructure.repositories.sqlite_competencias_por_torneo impo
 )
 from competencia.infrastructure.repositories.atleta_nombre_adapter import AtletaNombreAdapter
 from competencia.domain.exceptions import DomainError
-from shared.api.dependencies import JuezDep, OrganizadorDep
+from shared.api.dependencies import AtletaDep, JuezDep, OrganizadorDep
 
 router = APIRouter(prefix="/competencia", tags=["competencia"])
 
@@ -221,6 +228,15 @@ class RegistrarDNSBody(BaseModel):
 
     participante_id: UUID
     disciplina: Disciplina
+
+
+class RegistrarAPBody(BaseModel):
+    """Body del endpoint POST /competencia/{id}/registrar-ap."""
+
+    participante_id: UUID
+    disciplina: Disciplina
+    valor_ap: Decimal
+    unidad: UnidadMedida
 
 
 class CorregirResultadoTrasDNSBody(BaseModel):
@@ -349,6 +365,18 @@ def get_registrar_resultado_handler(
     return RegistrarResultadoHandler(event_store, disciplina_descriptor)
 
 
+def get_registrar_ap_handler(
+    event_store: EventStoreDep,
+    disciplina_descriptor: DisciplinaDescriptorDep,
+) -> RegistrarAPHandler:
+    """Dependency: handler para registrar AP."""
+    return RegistrarAPHandler(
+        event_store,
+        CompetenciaEstadoAdapter(event_store),
+        disciplina_descriptor,
+    )
+
+
 def get_asignar_tarjeta_handler(
     event_store: EventStoreDep,
     performances_estado: PerformancesEstadoAdapterDep,
@@ -395,6 +423,7 @@ PerformancesEstadoAdapterDep = Annotated[
     PerformancesEstadoAdapter, Depends(get_performances_estado_adapter)
 ]
 LlamarAtletaHandlerDep = Annotated[LlamarAtletaHandler, Depends(get_llamar_atleta_handler)]
+RegistrarAPHandlerDep = Annotated[RegistrarAPHandler, Depends(get_registrar_ap_handler)]
 RegistrarResultadoHandlerDep = Annotated[
     RegistrarResultadoHandler, Depends(get_registrar_resultado_handler)
 ]
@@ -812,6 +841,35 @@ async def post_llamar_atleta(
         return JSONResponse(status_code=404, content={"detail": str(exc)})
     except DomainError as exc:
         return JSONResponse(status_code=409, content={"detail": str(exc)})
+    return Response(status_code=204)
+
+
+@router.post("/{competencia_id}/registrar-ap", response_class=JSONResponse)
+async def post_registrar_ap(
+    competencia_id: UUID,
+    body: RegistrarAPBody,
+    handler: RegistrarAPHandlerDep,
+    _: AtletaDep,
+) -> JSONResponse:
+    """Registra AP para la disciplina del atleta antes del cierre del plazo."""
+    try:
+        await handler.handle(
+            RegistrarAPCommand(
+                competencia_id=competencia_id,
+                participante_id=body.participante_id,
+                disciplina=body.disciplina,
+                valor_ap=body.valor_ap,
+                unidad=body.unidad,
+            )
+        )
+    except UnidadIncompatible as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    except APYaRegistrado as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except (PlazoAPVencidoError, GrillaYaConfirmadaError) as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except DomainError as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
     return Response(status_code=204)
 
 

--- a/src/competencia/application/commands/registrar_ap.py
+++ b/src/competencia/application/commands/registrar_ap.py
@@ -12,15 +12,23 @@ from competencia.application.commands._handler_utils import (
 )
 from competencia.application.commands.registrar_resultado import UnidadIncompatible
 from competencia.domain.aggregates.performance import Performance
+from competencia.domain.exceptions import DomainError
 from competencia.domain.ports.competencia_estado_port import CompetenciaEstadoPort
 from competencia.domain.ports.disciplina_descriptor_port import DisciplinaDescriptorPort
 from competencia.domain.ports.event_store_port import EventStorePort
 from competencia.domain.value_objects.disciplina import Disciplina
+from competencia.domain.value_objects.estado_performance import EstadoPerformance
 from competencia.domain.value_objects.unidad_medida import UnidadMedida
 
 # ── Re-export para uso externo ─────────────────────────────────────────────────
 
-__all__ = ["UnidadIncompatible", "APYaRegistrado", "PlazoAPVencidoError", "GrillaYaConfirmadaError"]
+__all__ = [
+    "UnidadIncompatible",
+    "APYaRegistrado",
+    "PlazoAPVencidoError",
+    "GrillaYaConfirmadaError",
+    "APNoModificableError",
+]
 
 
 # ── Excepciones de aplicación ─────────────────────────────────────────────────
@@ -36,6 +44,10 @@ class PlazoAPVencidoError(Exception):
 
 class GrillaYaConfirmadaError(Exception):
     """INV-P-04: la grilla fue confirmada — no se permiten nuevos APs."""
+
+
+class APNoModificableError(DomainError):
+    """La performance ya avanzó y el AP no puede modificarse."""
 
 
 # ── Command ───────────────────────────────────────────────────────────────────
@@ -106,14 +118,7 @@ class RegistrarAPHandler:
         stream_id = build_performance_stream_id(
             command.competencia_id, command.participante_id, command.disciplina
         )
-        await self._validar_ap_duplicado(command, stream_id)
-        performance_id = uuid4()
-        performance = Performance(
-            performance_id=performance_id,
-            competencia_id=command.competencia_id,
-            participante_id=command.participante_id,
-            disciplina=command.disciplina,
-        )
+        performance = await self._cargar_o_crear_performance(command, stream_id)
         performance.registrar_ap(command.valor_ap, command.unidad)
         await persistir_eventos_pendientes(
             event_store=self._event_store,
@@ -121,7 +126,7 @@ class RegistrarAPHandler:
             aggregate=performance,
         )
 
-        return performance_id
+        return performance.performance_id
 
     def _validar_unidad(self, command: RegistrarAPCommand) -> None:
         descriptor = self._disciplina_descriptor.describe(command.disciplina)
@@ -146,14 +151,26 @@ class RegistrarAPHandler:
                 f"INV-P-04: grilla confirmada para competencia={command.competencia_id}"
             )
 
-    async def _validar_ap_duplicado(self, command: RegistrarAPCommand, stream_id: str) -> None:
+    async def _cargar_o_crear_performance(
+        self, command: RegistrarAPCommand, stream_id: str
+    ) -> Performance:
         existing_events = await self._event_store.load(stream_id)
-        if existing_events:
-            raise APYaRegistrado(
-                f"INV-P-02: ya existe un AP para participante={command.participante_id} "
-                f"disciplina={command.disciplina.value} "
-                f"competencia={command.competencia_id}"
+        if not existing_events:
+            return Performance(
+                performance_id=uuid4(),
+                competencia_id=command.competencia_id,
+                participante_id=command.participante_id,
+                disciplina=command.disciplina,
             )
+
+        performance = Performance.reconstitute(existing_events)
+        if performance.estado != EstadoPerformance.AnunciadaAP:
+            raise APNoModificableError(
+                f"El AP de participante={command.participante_id} para "
+                f"{command.disciplina.value} ya no puede modificarse"
+            )
+
+        return performance
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/identidad/infrastructure/jwt_service.py
+++ b/src/identidad/infrastructure/jwt_service.py
@@ -29,6 +29,8 @@ class JWTService(TokenServicePort):
         payload = {
             "sub": str(usuario.usuario_id),
             "email": usuario.email,
+            "nombre": usuario.nombre,
+            "apellido": usuario.apellido,
             "rol": usuario.rol.value,
             "exp": datetime.now(tz=timezone.utc) + timedelta(hours=self._expiry_hours),
         }

--- a/src/registro/api/router.py
+++ b/src/registro/api/router.py
@@ -231,3 +231,22 @@ async def listar_inscriptos(torneo_id: UUID, _: OrganizadorDep) -> JSONResponse:
             for i in inscripciones
         ],
     )
+
+
+@router.get("/atletas/{atleta_id}/inscripciones", status_code=200)
+async def listar_inscripciones_de_atleta(atleta_id: UUID, _: AtletaDep) -> JSONResponse:
+    inscripciones = await _inscripcion_repo().find_by_atleta(atleta_id)
+    return JSONResponse(
+        status_code=200,
+        content=[
+            InscripcionResponse(
+                inscripcion_id=i.inscripcion_id,
+                atleta_id=i.atleta_id,
+                torneo_id=i.torneo_id,
+                disciplinas=[d.value for d in i.disciplinas],
+                estado=i.estado,
+                fecha_inscripcion=i.fecha_inscripcion,
+            ).model_dump(mode="json")
+            for i in inscripciones
+        ],
+    )

--- a/src/registro/domain/ports/inscripcion_repository_port.py
+++ b/src/registro/domain/ports/inscripcion_repository_port.py
@@ -20,3 +20,6 @@ class InscripcionRepositoryPort(ABC):
 
     @abstractmethod
     async def find_by_torneo(self, torneo_id: UUID) -> list[Inscripcion]: ...
+
+    @abstractmethod
+    async def find_by_atleta(self, atleta_id: UUID) -> list[Inscripcion]: ...

--- a/src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py
+++ b/src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py
@@ -84,6 +84,21 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
                 rows = await cursor.fetchall()
                 return [self._row_to_inscripcion(row) for row in rows]
 
+    async def find_by_atleta(self, atleta_id: UUID) -> list[Inscripcion]:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._ensure_table(conn)
+            conn.row_factory = aiosqlite.Row
+            async with conn.execute(
+                """
+                SELECT * FROM inscripciones
+                WHERE atleta_id = ?
+                ORDER BY fecha_inscripcion DESC
+                """,
+                (str(atleta_id),),
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [self._row_to_inscripcion(row) for row in rows]
+
     def _row_to_inscripcion(self, row: aiosqlite.Row) -> Inscripcion:
         return Inscripcion(
             inscripcion_id=UUID(row["inscripcion_id"]),

--- a/tests/features/US-5.5.1-inscripcion-atleta-ap.feature
+++ b/tests/features/US-5.5.1-inscripcion-atleta-ap.feature
@@ -1,0 +1,42 @@
+Feature: US-5.5.1 - Inscripcion completa del atleta y declaracion/modificacion de AP
+
+  Background:
+    Given existe el torneo "BA Open 2026" publicado con inscripciones abiertas
+    And el atleta "ana@email.com" accede al portal del atleta
+
+  Scenario: atleta completa la inscripcion con wizard de 3 pasos
+    When navega a "Torneos"
+    And abre el detalle del torneo "BA Open 2026"
+    And presiona "Inscribirme en este torneo"
+    And completa Personales, Competencia y Requisitos
+    Then el sistema registra la inscripcion
+    And la inscripcion queda visible en "Mis inscripciones"
+    And el estado queda "pendiente de verificacion"
+
+  Scenario: no se puede enviar inscripcion sin ambos adjuntos obligatorios
+    Given el atleta esta en el paso 3 "Requisitos"
+    When intenta enviar la inscripcion sin certificado medico
+    Then la UI bloquea el envio
+    And informa que el certificado medico es obligatorio
+
+  Scenario: atleta declara AP desde pantalla dedicada
+    Given el atleta ya esta inscripto en DNF
+    And el periodo de anuncios sigue abierto
+    When desde "Mis inscripciones" presiona "Declarar AP"
+    And guarda AP=70 metros
+    Then vuelve a "Mis inscripciones"
+    And la disciplina DNF muestra el AP guardado
+
+  Scenario: atleta modifica AP antes del cierre
+    Given el atleta ya declaro AP=70 para DNF
+    And el periodo de anuncios sigue abierto
+    When vuelve a "Declarar AP"
+    And cambia el valor a 72 metros
+    Then la disciplina DNF muestra AP=72
+
+  Scenario: AP queda solo lectura despues del cierre
+    Given el atleta ya declaro AP para DNF
+    And el organizador cerro el periodo de anuncios
+    When el atleta abre "Mis inscripciones"
+    Then la disciplina muestra chip "AP cerrado"
+    And no existe CTA "Declarar AP"

--- a/tests/unit/competencia/application/test_registrar_ap_handler.py
+++ b/tests/unit/competencia/application/test_registrar_ap_handler.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 
 from competencia.application.commands.registrar_ap import (
-    APYaRegistrado,
+    APNoModificableError,
     GrillaYaConfirmadaError,
     PlazoAPVencidoError,
     RegistrarAPCommand,
@@ -129,23 +129,78 @@ async def test_handle_stream_id_contiene_natural_key(
     assert "DNF" in stream_id
 
 
-# ── INV-P-02: AP ya registrado ────────────────────────────────────────────────
+# ── INV-P-02 actualizado: AP modificable mientras siga Anunciada ─────────────
 
 
-async def test_handle_ap_ya_registrado_lanza_excepcion(
+async def test_handle_ap_existente_actualiza_valor_mientras_sigue_anunciada(
     handler: RegistrarAPHandler,
     mock_event_store: AsyncMock,
     competencia_id: Any,
     participante_id: Any,
 ) -> None:
-    """INV-P-02: stream no vacío lanza APYaRegistrado."""
-    mock_event_store.load.return_value = [{"event_type": "APRegistrado", "payload": {}}]
+    """La spec de US-5.5.1 permite modificar AP si la performance sigue AnunciadaAP."""
+    performance_id = str(uuid4())
+    mock_event_store.load.return_value = [
+        {
+            "event_type": "APRegistrado",
+            "payload": {
+                "performance_id": performance_id,
+                "competencia_id": str(competencia_id),
+                "participante_id": str(participante_id),
+                "disciplina": Disciplina.STA.value,
+                "valor_ap": "330",
+                "unidad": UnidadMedida.Segundos.value,
+                "occurred_at": "2026-04-26T12:00:00+00:00",
+            },
+        }
+    ]
 
-    cmd = make_command(competencia_id, participante_id)
-    with pytest.raises(APYaRegistrado):
+    cmd = make_command(competencia_id, participante_id, valor="345")
+    result = await handler.handle(cmd)
+
+    assert str(result) == performance_id
+    assert mock_event_store.append.call_count == 1
+    assert mock_event_store.append.call_args.kwargs["event_type"] == "APRegistrado"
+
+
+async def test_handle_ap_no_modificable_si_la_performance_ya_avanzo(
+    handler: RegistrarAPHandler,
+    mock_event_store: AsyncMock,
+    competencia_id: Any,
+    participante_id: Any,
+) -> None:
+    """Si la performance ya fue llamada, el AP deja de ser editable."""
+    performance_id = str(uuid4())
+    mock_event_store.load.return_value = [
+        {
+            "event_type": "APRegistrado",
+            "payload": {
+                "performance_id": performance_id,
+                "competencia_id": str(competencia_id),
+                "participante_id": str(participante_id),
+                "disciplina": Disciplina.STA.value,
+                "valor_ap": "330",
+                "unidad": UnidadMedida.Segundos.value,
+                "occurred_at": "2026-04-26T12:00:00+00:00",
+            },
+        },
+        {
+            "event_type": "AtletaLlamado",
+            "payload": {
+                "performance_id": performance_id,
+                "participante_id": str(participante_id),
+                "disciplina": Disciplina.STA.value,
+                "ot_programado": "2026-04-26T12:05:00+00:00",
+                "posicion_grilla": 1,
+                "andarivel": 1,
+                "occurred_at": "2026-04-26T12:01:00+00:00",
+            },
+        },
+    ]
+
+    cmd = make_command(competencia_id, participante_id, valor="345")
+    with pytest.raises(APNoModificableError):
         await handler.handle(cmd)
-
-    mock_event_store.append.assert_not_called()
 
 
 # ── INV-P-03: plazo vencido ───────────────────────────────────────────────────

--- a/tests/unit/identidad/application/test_handlers.py
+++ b/tests/unit/identidad/application/test_handlers.py
@@ -413,6 +413,8 @@ def test_jwt_generate_y_verify_payload(jwt_service: JWTService) -> None:
     payload = jwt_service.verify(token)
     assert payload["sub"] == str(u.usuario_id)
     assert payload["email"] == "admin@test.com"
+    assert payload["nombre"] == "Test"
+    assert payload["apellido"] == "Usuario"
     assert payload["rol"] == "ADMIN"
 
 


### PR DESCRIPTION
## Resumen
- rehace el portal atleta con shell móvil dark y rutas dedicadas
- agrega wizard de inscripción y pantalla dedicada para declarar/modificar AP
- expone inscripciones del atleta y endpoint para registrar AP
- regulariza artefactos de implement-us y tracking JSON de la US

## Validación
- npm run build
- npm run lint
- ./.venv/bin/pytest tests/unit/competencia/application/test_registrar_ap_handler.py -q
- ./.venv/bin/pytest tests/unit/identidad/application/test_handlers.py -q -k jwt_generate_y_verify_payload

## Notas
- codeguard quedó pendiente/no concluido en este entorno
- los adjuntos del wizard se validan en UI pero todavía no se persisten en backend