### PR TITLE
feat(resultados): RankingCompetencia con puntos FAAS por categoría [US-5.6.3]

### DIFF
--- a/.claude/tracking/US-5.6.3-tracking.json
+++ b/.claude/tracking/US-5.6.3-tracking.json
@@ -1,0 +1,204 @@
+{
+  "metadata": {
+    "us_id": "US-5.6.3",
+    "us_title": "RankingCompetencia con puntaje FAAS por categoria",
+    "us_points": 5,
+    "producto": "resultados",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-26T21:37:26.133158+00:00",
+    "completed_at": "2026-04-26T23:21:12.709985+00:00",
+    "total_elapsed_seconds": 6226,
+    "effective_seconds": 6226,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-26T21:37:30.629028+00:00",
+      "completed_at": "2026-04-26T21:38:41.784064+00:00",
+      "elapsed_seconds": 71,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-26T21:42:48.786643+00:00",
+      "completed_at": "2026-04-26T21:44:38.888160+00:00",
+      "elapsed_seconds": 110,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementación",
+      "started_at": "2026-04-26T21:44:44.232885+00:00",
+      "completed_at": "2026-04-26T21:46:08.252940+00:00",
+      "elapsed_seconds": 84,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-26T21:46:09.056319+00:00",
+      "completed_at": "2026-04-26T22:55:48.436404+00:00",
+      "elapsed_seconds": 4179,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "T1",
+          "task_name": "EntradaRanking puntos",
+          "task_type": "domain",
+          "estimated_minutes": 10.0,
+          "started_at": "2026-04-26T21:46:18.533089+00:00",
+          "completed_at": "2026-04-26T21:46:41.464587+00:00",
+          "elapsed_seconds": 22,
+          "actual_minutes": 0.37,
+          "variance_minutes": -9.63,
+          "file_created": null,
+          "status": "completed"
+        },
+        {
+          "task_id": "T2",
+          "task_name": "RankingCompetencia calcular con puntos",
+          "task_type": "domain",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-04-26T21:46:42.097526+00:00",
+          "completed_at": "2026-04-26T22:52:09.895585+00:00",
+          "elapsed_seconds": 3927,
+          "actual_minutes": 65.45,
+          "variance_minutes": 40.45,
+          "file_created": null,
+          "status": "completed"
+        },
+        {
+          "task_id": "T3",
+          "task_name": "CalcularRankingHandler pasar algoritmo",
+          "task_type": "application",
+          "estimated_minutes": 10.0,
+          "started_at": "2026-04-26T22:52:12.932402+00:00",
+          "completed_at": "2026-04-26T22:52:46.757099+00:00",
+          "elapsed_seconds": 33,
+          "actual_minutes": 0.55,
+          "variance_minutes": -9.45,
+          "file_created": null,
+          "status": "completed"
+        },
+        {
+          "task_id": "T4",
+          "task_name": "ObtenerRankingHandler DTO puntos",
+          "task_type": "application",
+          "estimated_minutes": 10.0,
+          "started_at": "2026-04-26T22:53:02.840255+00:00",
+          "completed_at": "2026-04-26T22:54:46.170091+00:00",
+          "elapsed_seconds": 103,
+          "actual_minutes": 1.72,
+          "variance_minutes": -8.28,
+          "file_created": null,
+          "status": "completed"
+        },
+        {
+          "task_id": "T5",
+          "task_name": "API router puntos en respuesta",
+          "task_type": "api",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-04-26T22:54:49.819442+00:00",
+          "completed_at": "2026-04-26T22:55:19.686971+00:00",
+          "elapsed_seconds": 29,
+          "actual_minutes": 0.48,
+          "variance_minutes": -4.52,
+          "file_created": null,
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-26T22:56:03.202001+00:00",
+      "completed_at": "2026-04-26T22:58:26.470257+00:00",
+      "elapsed_seconds": 143,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-26T22:58:37.250062+00:00",
+      "completed_at": "2026-04-26T23:00:47.747806+00:00",
+      "elapsed_seconds": 130,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-26T23:00:55.853773+00:00",
+      "completed_at": "2026-04-26T23:03:27.827560+00:00",
+      "elapsed_seconds": 151,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-26T23:03:37.375660+00:00",
+      "completed_at": "2026-04-26T23:18:29.955885+00:00",
+      "elapsed_seconds": 892,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-26T23:20:05.518288+00:00",
+      "completed_at": "2026-04-26T23:20:54.665798+00:00",
+      "elapsed_seconds": 49,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-26T23:21:02.164780+00:00",
+      "completed_at": null,
+      "elapsed_seconds": 0,
+      "status": "in_progress",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 5,
+    "completed_tasks": 5,
+    "total_phases": 10,
+    "estimated_total_minutes": 60.0,
+    "actual_total_minutes": 68.57,
+    "variance_minutes": 8.57,
+    "variance_percent": 14.28
+  }
+}

--- a/docs/plans/sp5/US-5.6.3-plan.md
+++ b/docs/plans/sp5/US-5.6.3-plan.md
@@ -1,0 +1,84 @@
+# Plan de Implementación — US-5.6.3
+# RankingCompetencia con puntaje FAAS por categoría
+
+**BC:** `resultados`
+**Estimación:** 5 puntos
+**Fecha:** 2026-04-26
+
+---
+
+## Componentes a modificar (en orden de dependencia)
+
+### 1. Value Object — `EntradaRanking`
+**Archivo:** `src/resultados/domain/value_objects/entrada_ranking.py`
+- Agregar campo `puntos: Decimal` con default `Decimal("0.00")` (INV-5.6.3-04)
+- El campo tiene default para no romper construcciones legacy
+
+### 2. Aggregate — `RankingCompetencia`
+**Archivo:** `src/resultados/domain/aggregates/ranking_competencia.py`
+
+**Cambio de firma de `calcular()`:**
+```python
+# ANTES
+def calcular(self, resultados, descriptor: DisciplinaDescriptor) -> None:
+# DESPUÉS
+def calcular(self, resultados, algoritmo: AlgoritmoPuntaje | None = None) -> None:
+```
+
+**Nueva lógica `_calcular_entries`:**
+- Cuando `algoritmo is None` → path legacy (sort by RP, puntos=0.00)
+- Cuando `algoritmo` provisto → computar `puntos_map = algoritmo.calcular(resultados, disciplina)`, sort by puntos desc dentro de cada categoría, tie-break por RP (INV-5.6.3-02)
+
+**Serialización/deserialización:**
+- `_entrada_a_dict`: agregar `"puntos": str(e.puntos)`
+- `_dict_a_entrada`: leer `d.get("puntos", "0.00")` con fallback (INV-5.6.3-05)
+
+### 3. Command Handler — `CalcularRankingHandler`
+**Archivo:** `src/resultados/application/commands/calcular_ranking.py`
+- Eliminar `descriptor = self._descriptor.describe(command.disciplina)`
+- Cambiar `ranking.calcular(resultados, descriptor)` → `ranking.calcular(resultados, self._algoritmo)`
+- Mantener `descriptor` en `__init__` por compat con tests de integración legacy
+
+### 4. Query Handler — `ObtenerRankingHandler` + DTO
+**Archivo:** `src/resultados/application/queries/obtener_ranking.py`
+- Agregar `puntos: str` a `RankingEntradaDTO`
+- Mapear `puntos=str(entry.puntos)` en `handle()`
+
+### 5. API Router
+**Archivo:** `src/resultados/api/router.py`
+- Agregar `"puntos": e.puntos` al dict de cada entrada en `get_ranking()`
+
+---
+
+## Tests a crear
+
+### Unitarios (nuevos) — `tests/unit/resultados/domain/test_ranking_competencia.py`
+- `test_calcular_con_faas_incluye_puntos_en_entradas`
+- `test_calcular_con_faas_ordena_por_puntos_desc`
+- `test_calcular_dns_puntos_cero_con_algoritmo`
+- `test_calcular_sin_algoritmo_mantiene_behavior_legacy`
+- `test_reconstitute_incluye_puntos_del_evento`
+- `test_serialización_incluye_puntos`
+- `test_deserializacion_legacy_puntos_fallback_cero`
+
+### Integración (nuevos) — `tests/integration/resultados/test_calcular_ranking_integration.py`
+- `test_calcular_ranking_con_algoritmo_faas_incluye_puntos`
+
+### BDD — `tests/features/steps/`
+- Implementar step definitions para `US-5.6.3-ranking-puntos-faas.feature`
+
+---
+
+## Invariantes a respetar
+- INV-5.6.3-01: posición por `puntos` desc (cuando algoritmo provisto)
+- INV-5.6.3-02: empate por RP como desempate secundario
+- INV-5.6.3-03: DNS/Roja → `puntos=0`, al final, `en_podio=False`
+- INV-5.6.3-04: `puntos` con 2 decimales
+- INV-5.6.3-05: serialización incluye `puntos`; fallback `"0.00"` en reconstitución legacy
+
+---
+
+## Estrategia de compatibilidad
+Todos los tests existentes que llaman `ranking.calcular(resultados, None)` seguirán funcionando
+porque el path legacy (algoritmo=None) preserva el ordenamiento por RP.
+Los tests de integración que instancian `CalcularRankingHandler` sin `algoritmo=` tampoco se rompen.

--- a/docs/reports/US-5.6.3-report.md
+++ b/docs/reports/US-5.6.3-report.md
@@ -1,0 +1,70 @@
+# Reporte de Implementación — US-5.6.3
+# RankingCompetencia con puntaje FAAS por categoría
+
+**Fecha:** 2026-04-26
+**BC:** `resultados`
+**Tiempo total:** ~103 min
+**Estado:** ✅ Completa
+
+---
+
+## Resumen ejecutivo
+
+US-5.6.3 extiende `RankingCompetencia` para calcular y almacenar puntos FAAS por atleta
+(`puntos: Decimal`) y ordenar el ranking por puntos dentro de cada `Categoría`.
+
+---
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `domain/value_objects/entrada_ranking.py` | Campo `puntos: Decimal` con default `0.00` |
+| `domain/aggregates/ranking_competencia.py` | Firma `calcular()` cambiada; dos paths (FAAS / legacy); serde actualizado |
+| `application/commands/calcular_ranking.py` | Pasa `self._algoritmo` en lugar de `descriptor` |
+| `application/queries/exportar_resultados.py` | Limpieza: elimina paso de `descriptor` a `calcular()` |
+| `application/queries/obtener_ranking.py` | `RankingEntradaDTO` + `puntos: str` |
+| `api/router.py` | Respuesta `GET /ranking` incluye `puntos` |
+
+## Tests creados / actualizados
+
+| Archivo | Tests nuevos | Tests actualizados |
+|---------|:------------:|:------------------:|
+| `test_ranking_competencia.py` | 9 (FAAS) | 0 (legacy sin cambios) |
+| `test_calcular_ranking_integration.py` | 1 | 0 |
+| `test_US_5_6_3_steps.py` | 4 (BDD) | — |
+| `test_router_ranking.py` | 0 | 1 (agregado `"puntos"` al expected) |
+
+**Total tests BC resultados:** 80 unit+integration · 4 BDD · todos verdes
+
+---
+
+## Invariantes verificados
+
+| INV | Descripción | Test |
+|-----|-------------|------|
+| INV-5.6.3-01 | Posición por `puntos` desc | `test_calcular_con_faas_ordena_por_puntos_desc_dentro_de_categoria` |
+| INV-5.6.3-02 | Empate por RP como desempate | `test_calcular_con_faas_empate_puntos_comparte_posicion` |
+| INV-5.6.3-03 | DNS/Roja → `puntos=0`, `en_podio=False` | `test_calcular_con_faas_dns_puntos_cero_sin_podio` |
+| INV-5.6.3-04 | 2 decimales | `test_calcular_con_faas_incluye_puntos_en_entradas` |
+| INV-5.6.3-05 | Serde incluye `puntos`; fallback legacy `"0.00"` | `test_deserializacion_legacy_sin_puntos_usa_fallback_cero` |
+
+---
+
+## Decisión de diseño: compatibilidad legacy
+
+`calcular(algoritmo: AlgoritmoPuntaje | None = None)` mantiene el path legacy
+cuando `algoritmo=None`, preservando todos los tests existentes (ordenamiento por RP,
+`puntos=0.00` en todas las entradas). El path FAAS activa cuando se inyecta
+un algoritmo concreto. Esta separación garantiza cero regresiones en 16 tests legacy.
+
+---
+
+## Quality gates
+
+| Gate | Resultado |
+|------|-----------|
+| Pylint | 9.65/10 (≥ 8.0) ✅ |
+| Cobertura `domain/` + `application/` | 96% (≥ 90%) ✅ |
+| DesignReviewer (pre-push) | Ver PR |
+| Black | ✅ |

--- a/docs/specs/sp5/US-5.6.3.md
+++ b/docs/specs/sp5/US-5.6.3.md
@@ -1,6 +1,6 @@
 # US-5.6.3: RankingCompetencia con puntaje FAAS por categoría
 
-**Estado**: `To Do`
+**Estado**: `Done`
 **Sprint**: SP5 — La Puesta en Marcha
 **Incremento**: INC-5.6
 **Bounded Context**: `resultados`

--- a/quality/reports/codeguard/US-5.6.3-quality.json
+++ b/quality/reports/codeguard/US-5.6.3-quality.json
@@ -1,0 +1,19 @@
+************* Module src.resultados.domain.aggregates.ranking_competencia
+src/resultados/domain/aggregates/ranking_competencia.py:85:12: C0415: Import outside toplevel (resultados.domain.exceptions.ResultadosIncompletos) (import-outside-toplevel)
+************* Module src.resultados.domain.value_objects.entrada_ranking
+src/resultados/domain/value_objects/entrada_ranking.py:13:0: R0902: Too many instance attributes (9/7) (too-many-instance-attributes)
+************* Module src.resultados.application.commands.calcular_ranking
+src/resultados/application/commands/calcular_ranking.py:57:4: R0913: Too many arguments (6/5) (too-many-arguments)
+src/resultados/application/commands/calcular_ranking.py:57:4: R0917: Too many positional arguments (6/5) (too-many-positional-arguments)
+src/resultados/application/commands/calcular_ranking.py:43:0: R0903: Too few public methods (1/2) (too-few-public-methods)
+src/resultados/application/commands/calcular_ranking.py:114:0: R0903: Too few public methods (1/2) (too-few-public-methods)
+************* Module src.resultados.application.queries.obtener_ranking
+src/resultados/application/queries/obtener_ranking.py:33:0: R0902: Too many instance attributes (8/7) (too-many-instance-attributes)
+src/resultados/application/queries/obtener_ranking.py:68:0: R0903: Too few public methods (1/2) (too-few-public-methods)
+************* Module src.resultados.api.router
+src/resultados/api/router.py:199:4: W0622: Redefining built-in 'format' (redefined-builtin)
+src/resultados/api/router.py:26:0: C0412: Imports from package resultados are not grouped (ungrouped-imports)
+
+-----------------------------------
+Your code has been rated at 9.65/10
+

--- a/src/resultados/api/router.py
+++ b/src/resultados/api/router.py
@@ -146,6 +146,7 @@ async def get_ranking(
                             "tarjeta": e.tarjeta,
                             "es_dns": e.es_dns,
                             "en_podio": e.en_podio,
+                            "puntos": e.puntos,
                         }
                         for e in grupo.entradas
                     ],
@@ -211,7 +212,7 @@ async def get_export_resultados(
     except TorneoNoEncontrado as exc:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
 
-    filename = f'resultados-{torneo_id}.{format}'
+    filename = f"resultados-{torneo_id}.{format}"
     headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
 
     if format == "json":

--- a/src/resultados/application/commands/calcular_ranking.py
+++ b/src/resultados/application/commands/calcular_ranking.py
@@ -91,8 +91,7 @@ class CalcularRankingHandler:
             events=existing,
         )
 
-        descriptor = self._descriptor.describe(command.disciplina)
-        ranking.calcular(resultados, descriptor)
+        ranking.calcular(resultados, self._algoritmo)
 
         for event in ranking.pull_events():
             await self._ranking_store.append(

--- a/src/resultados/application/queries/exportar_resultados.py
+++ b/src/resultados/application/queries/exportar_resultados.py
@@ -224,7 +224,7 @@ class ExportarResultadosHandler:
 
         ranking = RankingCompetencia.reconstitute(competencia_id, disciplina, events=[])
         try:
-            ranking.calcular(resultados, self._descriptor.describe(disciplina))
+            ranking.calcular(resultados)
         except ResultadosIncompletos:
             return []
 

--- a/src/resultados/application/queries/obtener_ranking.py
+++ b/src/resultados/application/queries/obtener_ranking.py
@@ -41,6 +41,7 @@ class RankingEntradaDTO:
         tarjeta: Tipo de tarjeta, o None.
         es_dns: True si el atleta no se presentó.
         en_podio: True si está en el podio (posición 1, 2 o 3).
+        puntos: Puntaje FAAS del atleta (2 decimales). "0.00" sin algoritmo.
     """
 
     posicion: int
@@ -50,6 +51,7 @@ class RankingEntradaDTO:
     tarjeta: str | None
     es_dns: bool
     en_podio: bool
+    puntos: str = "0.00"
 
 
 @dataclass(frozen=True)
@@ -106,6 +108,7 @@ class ObtenerRankingHandler:
                     tarjeta=entry.tarjeta,
                     es_dns=entry.es_dns,
                     en_podio=entry.en_podio,
+                    puntos=str(entry.puntos),
                 )
             )
         return [

--- a/src/resultados/domain/aggregates/ranking_competencia.py
+++ b/src/resultados/domain/aggregates/ranking_competencia.py
@@ -9,12 +9,12 @@ from typing import Any
 from uuid import UUID
 
 from registro.domain.value_objects.categoria import Categoria
-from shared.domain.base.aggregate_root import AggregateRoot
 from resultados.domain.events.resultados_calculados import ResultadosCalculados
+from resultados.domain.ports.algoritmo_puntaje import AlgoritmoPuntaje
 from resultados.domain.ports.resultados_competencia_port import ResultadoFinal
 from resultados.domain.value_objects.entrada_ranking import EntradaRanking
+from shared.domain.base.aggregate_root import AggregateRoot
 from shared.domain.value_objects.disciplina import Disciplina
-from shared.domain.value_objects.disciplina_descriptor import DisciplinaDescriptor
 
 # Tarjetas que producen un resultado válido (se posicionan antes de DNS/Roja)
 _TARJETAS_VALIDAS = {"Blanca", "BlancaConPenalizaciones", "Amarilla"}
@@ -29,11 +29,16 @@ class RankingCompetencia(AggregateRoot):
 
     Stream ID: "ranking-{competencia_id}-{disciplina}"
 
-    Reglas de ordenamiento (RF-PM-03):
-        1. Performances válidas (Blanca/BlancaConPenalizaciones/Amarilla): RP mayor → menor.
-        2. Empates: comparten posición; la siguiente posición se omite.
-        3. DNS y tarjeta roja: al final, sin marca numérica.
-        4. Podio: posiciones 1, 2 y 3 (incluyendo empates en esas posiciones).
+    Reglas de ordenamiento:
+        Con algoritmo (FAAS, INV-5.6.3-01/02):
+            1. Performances válidas: puntos desc dentro de cada Categoría.
+            2. Empate de puntos: desempate por RP desc.
+            3. DNS y tarjeta roja: puntos=0.00, al final, sin posición de podio.
+        Sin algoritmo (path legacy):
+            1. Performances válidas: RP desc (mayor es mejor).
+            2. Empates de RP: comparten posición; la siguiente se omite.
+            3. DNS y tarjeta roja: al final, sin marca numérica.
+        Podio: posiciones 1, 2 y 3 (incluyendo empates en esas posiciones).
     """
 
     def __init__(self, competencia_id: UUID, disciplina: Disciplina) -> None:
@@ -70,13 +75,13 @@ class RankingCompetencia(AggregateRoot):
     def calcular(
         self,
         resultados: list[ResultadoFinal],
-        descriptor: DisciplinaDescriptor,
+        algoritmo: AlgoritmoPuntaje | None = None,
     ) -> None:
         """Calcula el ranking y emite ResultadosCalculados.
 
         Args:
             resultados: Lista completa de resultados finales (Ejecutada + DNS).
-            descriptor: Descriptor de la disciplina (para ordenamiento).
+            algoritmo: AlgoritmoPuntaje para calcular puntos. None → path legacy (sort por RP).
 
         Raises:
             ResultadosIncompletos: Si la lista está vacía.
@@ -88,7 +93,7 @@ class RankingCompetencia(AggregateRoot):
                 f"RankingCompetencia {self._competencia_id}: sin resultados para calcular"
             )
 
-        entries = _calcular_entries(resultados)
+        entries = _calcular_entries(resultados, algoritmo, self._disciplina)
 
         now = ResultadosCalculados.now()
         entries_payload = [_entrada_a_dict(e) for e in entries]
@@ -142,19 +147,23 @@ class RankingCompetencia(AggregateRoot):
 # ── Helpers de dominio ────────────────────────────────────────────────────────
 
 
-def _calcular_entries(resultados: list[ResultadoFinal]) -> list[EntradaRanking]:
-    """Aplica reglas de ordenamiento y asignación de posiciones.
-
-    Válidas (Blanca/BlancaConPenalizaciones/Amarilla): ordenadas por RP desc (mayor es mejor).
-    Inválidas (DNS/Roja): al final, en orden de aparición.
-    Empates: comparten posición; la siguiente se omite.
-    Podio: posiciones 1, 2 y 3.
-    """
+def _calcular_entries(
+    resultados: list[ResultadoFinal],
+    algoritmo: AlgoritmoPuntaje | None,
+    disciplina: Disciplina,
+) -> list[EntradaRanking]:
+    """Despacha al path con puntos FAAS o al path legacy según el algoritmo."""
     grupos = _agrupar_por_categoria(resultados)
     entries: list[EntradaRanking] = []
-    for categoria in sorted(grupos, key=lambda cat: cat.value):
-        entries.extend(_calcular_entries_categoria(categoria, grupos[categoria]))
-
+    if algoritmo is not None:
+        puntos_map = algoritmo.calcular(resultados, disciplina)
+        for categoria in sorted(grupos, key=lambda cat: cat.value):
+            entries.extend(
+                _calcular_entries_categoria_con_puntos(categoria, grupos[categoria], puntos_map)
+            )
+    else:
+        for categoria in sorted(grupos, key=lambda cat: cat.value):
+            entries.extend(_calcular_entries_categoria_legacy(categoria, grupos[categoria]))
     return entries
 
 
@@ -171,18 +180,63 @@ def _agrupar_por_categoria(
     return dict(grupos)
 
 
-def _calcular_entries_categoria(
+def _calcular_entries_categoria_con_puntos(
     categoria: Categoria,
     resultados: list[ResultadoFinal],
+    puntos_map: dict[UUID, Decimal],
 ) -> list[EntradaRanking]:
+    """Path FAAS: ordena por puntos desc; tie-break por RP desc (INV-5.6.3-01/02)."""
     validas = [r for r in resultados if r.tarjeta in _TARJETAS_VALIDAS]
     invalidas = [r for r in resultados if r.tarjeta not in _TARJETAS_VALIDAS]
-    validas_ordenadas = _ordenar_validas(validas)
+
+    validas_ordenadas = sorted(
+        validas,
+        key=lambda r: (
+            puntos_map.get(r.atleta_id, Decimal("0")),
+            r.rp if r.rp is not None else Decimal(0),
+        ),
+        reverse=True,
+    )
 
     entries: list[EntradaRanking] = []
     posicion_actual = 1
     for i, resultado in enumerate(validas_ordenadas):
-        pos = _resolver_posicion_valida(entries, validas_ordenadas, resultado, i, posicion_actual)
+        puntos = puntos_map.get(resultado.atleta_id, Decimal("0.00"))
+        if i > 0:
+            prev_puntos = puntos_map.get(validas_ordenadas[i - 1].atleta_id, Decimal("0.00"))
+            pos = entries[-1].posicion if puntos == prev_puntos else posicion_actual
+        else:
+            pos = posicion_actual
+        entries.append(_crear_entry_valida(categoria, resultado, pos, puntos))
+        posicion_actual = len(entries) + 1
+
+    for resultado in invalidas:
+        entries.append(_crear_entry_invalida(categoria, resultado, posicion_actual))
+        posicion_actual += 1
+
+    return entries
+
+
+def _calcular_entries_categoria_legacy(
+    categoria: Categoria,
+    resultados: list[ResultadoFinal],
+) -> list[EntradaRanking]:
+    """Path legacy (sin algoritmo): ordena por RP desc; puntos=0.00."""
+    validas = [r for r in resultados if r.tarjeta in _TARJETAS_VALIDAS]
+    invalidas = [r for r in resultados if r.tarjeta not in _TARJETAS_VALIDAS]
+    validas_ordenadas = sorted(
+        validas,
+        key=lambda r: r.rp if r.rp is not None else Decimal(0),
+        reverse=True,
+    )
+
+    entries: list[EntradaRanking] = []
+    posicion_actual = 1
+    for i, resultado in enumerate(validas_ordenadas):
+        if i > 0 and resultado.rp == validas_ordenadas[i - 1].rp:
+            pos = entries[-1].posicion
+        else:
+            pos = posicion_actual
         entries.append(_crear_entry_valida(categoria, resultado, pos))
         posicion_actual = len(entries) + 1
 
@@ -193,30 +247,11 @@ def _calcular_entries_categoria(
     return entries
 
 
-def _ordenar_validas(validas: list[ResultadoFinal]) -> list[ResultadoFinal]:
-    return sorted(
-        validas,
-        key=lambda r: r.rp if r.rp is not None else Decimal(0),
-        reverse=True,
-    )
-
-
-def _resolver_posicion_valida(
-    entries: list[EntradaRanking],
-    validas_ordenadas: list[ResultadoFinal],
-    resultado: ResultadoFinal,
-    index: int,
-    posicion_actual: int,
-) -> int:
-    if index > 0 and resultado.rp == validas_ordenadas[index - 1].rp:
-        return entries[-1].posicion
-    return posicion_actual
-
-
 def _crear_entry_valida(
     categoria: Categoria,
     resultado: ResultadoFinal,
     posicion: int,
+    puntos: Decimal = Decimal("0.00"),
 ) -> EntradaRanking:
     return EntradaRanking(
         posicion=posicion,
@@ -227,6 +262,7 @@ def _crear_entry_valida(
         tarjeta=resultado.tarjeta,
         es_dns=False,
         en_podio=posicion <= 3,
+        puntos=puntos,
     )
 
 
@@ -244,6 +280,7 @@ def _crear_entry_invalida(
         tarjeta=resultado.tarjeta,
         es_dns=resultado.es_dns,
         en_podio=False,
+        puntos=Decimal("0.00"),
     )
 
 
@@ -258,11 +295,12 @@ def _entrada_a_dict(e: EntradaRanking) -> dict[str, Any]:
         "tarjeta": e.tarjeta,
         "es_dns": e.es_dns,
         "en_podio": e.en_podio,
+        "puntos": str(e.puntos),
     }
 
 
 def _dict_a_entrada(d: dict[str, Any]) -> EntradaRanking:
-    """Deserializa un dict a EntradaRanking."""
+    """Deserializa un dict a EntradaRanking. Fallback puntos="0.00" para eventos legacy."""
     return EntradaRanking(
         posicion=d["posicion"],
         atleta_id=UUID(d["atleta_id"]),
@@ -272,4 +310,5 @@ def _dict_a_entrada(d: dict[str, Any]) -> EntradaRanking:
         tarjeta=d["tarjeta"],
         es_dns=d["es_dns"],
         en_podio=d["en_podio"],
+        puntos=Decimal(d.get("puntos", "0.00")),
     )

--- a/src/resultados/domain/aggregates/ranking_overall.py
+++ b/src/resultados/domain/aggregates/ranking_overall.py
@@ -120,9 +120,7 @@ def _filtrar_rankings_validos(
 def _categorias_presentes(
     rankings_validos: dict[Disciplina, list[EntradaRanking]],
 ) -> set[Categoria]:
-    return {
-        entry.categoria for entries in rankings_validos.values() for entry in entries
-    }
+    return {entry.categoria for entries in rankings_validos.values() for entry in entries}
 
 
 def _acumular_puntajes_categoria(
@@ -189,10 +187,7 @@ def _ordenar_puntuados(
     acumulado: dict[UUID, dict[str, int]],
 ) -> list[tuple[UUID, dict[str, int], int]]:
     return sorted(
-        (
-            (atleta_id, detalle, sum(detalle.values()))
-            for atleta_id, detalle in acumulado.items()
-        ),
+        ((atleta_id, detalle, sum(detalle.values())) for atleta_id, detalle in acumulado.items()),
         key=lambda item: (item[2], str(item[0])),
     )
 

--- a/src/resultados/domain/value_objects/entrada_ranking.py
+++ b/src/resultados/domain/value_objects/entrada_ranking.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from uuid import UUID
 
@@ -22,6 +22,7 @@ class EntradaRanking:
         tarjeta: Tipo de tarjeta asignada ("Blanca", "Amarilla", "Roja"). None para DNS.
         es_dns: True si el atleta no se presentó (Did Not Start).
         en_podio: True si la posición está en el podio (pos 1, 2 o 3).
+        puntos: Puntaje FAAS del atleta (INV-5.6.3-04). 0.00 para DNS/Roja o sin algoritmo.
     """
 
     posicion: int
@@ -32,3 +33,4 @@ class EntradaRanking:
     tarjeta: str | None
     es_dns: bool
     en_podio: bool
+    puntos: Decimal = field(default=Decimal("0.00"))

--- a/tests/features/US-5.6.3-ranking-puntos-faas.feature
+++ b/tests/features/US-5.6.3-ranking-puntos-faas.feature
@@ -1,0 +1,33 @@
+Feature: US-5.6.3 — RankingCompetencia con puntos FAAS por categoria
+
+  Background:
+    Given un algoritmo FAAS inyectado en el aggregate
+
+  Scenario: ranking incluye puntos FAAS por atleta en DNF
+    Given una disciplina DNF con Ana (70m Blanca, SENIOR_FEMENINO) y Luis (56m Blanca, SENIOR_MASCULINO)
+    When se calcula el ranking con algoritmo FAAS
+    Then Ana tiene puntos = 100.00 en su EntradaRanking
+    And Luis tiene puntos = 80.00 en su EntradaRanking
+
+  Scenario: ranking agrupa y ordena por puntos dentro de cada categoria
+    Given atletas en tres categorias con resultados DNF
+      | atleta | categoria         | rp | tarjeta |
+      | A      | SENIOR_MASCULINO  | 80 | Blanca  |
+      | B      | SENIOR_MASCULINO  | 60 | Blanca  |
+      | C      | SENIOR_FEMENINO   | 70 | Blanca  |
+    When se calcula el ranking con algoritmo FAAS
+    Then la posicion 1 en SENIOR_MASCULINO corresponde al atleta con mas puntos
+    And la posicion 1 en SENIOR_FEMENINO corresponde al atleta con mas puntos
+
+  Scenario: DNS tiene puntos 0.00 y no tiene posicion de podio
+    Given Pedro con DNS en DNF categoria SENIOR_MASCULINO
+    And Luis con RP 60m Blanca en DNF categoria SENIOR_MASCULINO
+    When se calcula el ranking con algoritmo FAAS
+    Then Pedro tiene puntos = 0.00
+    And Pedro no tiene posicion de podio
+
+  Scenario: evento ResultadosCalculados serializa y reconstituye puntos
+    Given un ranking DNF calculado con algoritmo FAAS para Ana (70m) y Luis (56m)
+    When se serializa y reconstituye el aggregate desde el event store
+    Then el aggregate reconstituido tiene los mismos puntos que el original
+    And la reconstitucion no require recalcular

--- a/tests/features/steps/test_US_5_6_3_steps.py
+++ b/tests/features/steps/test_US_5_6_3_steps.py
@@ -1,0 +1,254 @@
+"""Step definitions BDD — US-5.6.3: RankingCompetencia con puntos FAAS por categoría."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from registro.domain.value_objects.categoria import Categoria
+from resultados.domain.aggregates.ranking_competencia import RankingCompetencia
+from resultados.domain.ports.resultados_competencia_port import ResultadoFinal
+from resultados.domain.services.algoritmo_faas import AlgoritmoPuntajeFAAS
+from shared.domain.value_objects.disciplina import Disciplina
+
+scenarios("../US-5.6.3-ranking-puntos-faas.feature")
+
+
+# ── Fixture de contexto ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ctx() -> dict:
+    return {
+        "algoritmo": None,
+        "ranking": None,
+        "resultados": [],
+        "atleta_ids": {},
+    }
+
+
+# ── Background ────────────────────────────────────────────────────────────────
+
+
+@given("un algoritmo FAAS inyectado en el aggregate")
+def step_algoritmo_faas(ctx: dict) -> None:
+    ctx["algoritmo"] = AlgoritmoPuntajeFAAS()
+
+
+# ── Given ─────────────────────────────────────────────────────────────────────
+
+
+@given(
+    "una disciplina DNF con Ana (70m Blanca, SENIOR_FEMENINO) y Luis (56m Blanca, SENIOR_MASCULINO)"
+)
+def step_ana_y_luis_dnf(ctx: dict) -> None:
+    ana_id = uuid4()
+    luis_id = uuid4()
+    ctx["atleta_ids"]["Ana"] = ana_id
+    ctx["atleta_ids"]["Luis"] = luis_id
+    ctx["resultados"] = [
+        ResultadoFinal(
+            atleta_id=ana_id,
+            rp=Decimal("70"),
+            unidad="Metros",
+            tarjeta="Blanca",
+            es_dns=False,
+            categoria=Categoria.SENIOR_FEMENINO,
+        ),
+        ResultadoFinal(
+            atleta_id=luis_id,
+            rp=Decimal("56"),
+            unidad="Metros",
+            tarjeta="Blanca",
+            es_dns=False,
+            categoria=Categoria.SENIOR_MASCULINO,
+        ),
+    ]
+    ctx["ranking"] = RankingCompetencia(competencia_id=uuid4(), disciplina=Disciplina.DNF)
+
+
+@given("atletas en tres categorias con resultados DNF")
+def step_atletas_tres_categorias(ctx: dict, datatable: list) -> None:
+    _CATS = {
+        "SENIOR_MASCULINO": Categoria.SENIOR_MASCULINO,
+        "SENIOR_FEMENINO": Categoria.SENIOR_FEMENINO,
+        "MASTER_MASCULINO": Categoria.MASTER_MASCULINO,
+    }
+    resultados = []
+    for row in datatable[1:]:
+        nombre, cat_str, rp_str, tarjeta = (
+            row[0].strip(),
+            row[1].strip(),
+            row[2].strip(),
+            row[3].strip(),
+        )
+        atleta_id = uuid4()
+        ctx["atleta_ids"][nombre] = atleta_id
+        resultados.append(
+            ResultadoFinal(
+                atleta_id=atleta_id,
+                rp=Decimal(rp_str),
+                unidad="Metros",
+                tarjeta=tarjeta,
+                es_dns=False,
+                categoria=_CATS[cat_str],
+            )
+        )
+    ctx["resultados"] = resultados
+    ctx["ranking"] = RankingCompetencia(competencia_id=uuid4(), disciplina=Disciplina.DNF)
+
+
+@given("Pedro con DNS en DNF categoria SENIOR_MASCULINO")
+def step_pedro_dns(ctx: dict) -> None:
+    pedro_id = uuid4()
+    ctx["atleta_ids"]["Pedro"] = pedro_id
+    ctx["resultados"].append(
+        ResultadoFinal(
+            atleta_id=pedro_id,
+            rp=None,
+            unidad=None,
+            tarjeta=None,
+            es_dns=True,
+            categoria=Categoria.SENIOR_MASCULINO,
+        )
+    )
+    if ctx.get("ranking") is None:
+        ctx["ranking"] = RankingCompetencia(competencia_id=uuid4(), disciplina=Disciplina.DNF)
+
+
+@given("Luis con RP 60m Blanca en DNF categoria SENIOR_MASCULINO")
+def step_luis_60m(ctx: dict) -> None:
+    luis_id = uuid4()
+    ctx["atleta_ids"]["Luis"] = luis_id
+    ctx["resultados"].append(
+        ResultadoFinal(
+            atleta_id=luis_id,
+            rp=Decimal("60"),
+            unidad="Metros",
+            tarjeta="Blanca",
+            es_dns=False,
+            categoria=Categoria.SENIOR_MASCULINO,
+        )
+    )
+
+
+@given("un ranking DNF calculado con algoritmo FAAS para Ana (70m) y Luis (56m)")
+def step_ranking_calculado_para_reconstitucion(ctx: dict) -> None:
+    ana_id = uuid4()
+    luis_id = uuid4()
+    ctx["atleta_ids"]["Ana"] = ana_id
+    ctx["atleta_ids"]["Luis"] = luis_id
+    cid = uuid4()
+    ctx["competencia_id"] = cid
+    resultados = [
+        ResultadoFinal(
+            atleta_id=ana_id,
+            rp=Decimal("70"),
+            unidad="Metros",
+            tarjeta="Blanca",
+            es_dns=False,
+            categoria=Categoria.SENIOR_FEMENINO,
+        ),
+        ResultadoFinal(
+            atleta_id=luis_id,
+            rp=Decimal("56"),
+            unidad="Metros",
+            tarjeta="Blanca",
+            es_dns=False,
+            categoria=Categoria.SENIOR_MASCULINO,
+        ),
+    ]
+    ranking = RankingCompetencia(competencia_id=cid, disciplina=Disciplina.DNF)
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+    ctx["ranking"] = ranking
+
+
+# ── When ──────────────────────────────────────────────────────────────────────
+
+
+@when("se calcula el ranking con algoritmo FAAS")
+def step_calcular_con_faas(ctx: dict) -> None:
+    ctx["ranking"].calcular(ctx["resultados"], ctx["algoritmo"])
+
+
+@when("se serializa y reconstituye el aggregate desde el event store")
+def step_serializar_y_reconstituir(ctx: dict) -> None:
+    ranking = ctx["ranking"]
+    events = ranking.pull_events()
+    raw = [{"event_type": e.event_type, "payload": e.to_payload()} for e in events]
+    ctx["ranking_original_puntos"] = {e.atleta_id: e.puntos for e in ranking.entries}
+    ctx["ranking_reconstituido"] = RankingCompetencia.reconstitute(
+        competencia_id=ctx["competencia_id"],
+        disciplina=Disciplina.DNF,
+        events=raw,
+    )
+
+
+# ── Then ──────────────────────────────────────────────────────────────────────
+
+
+@then("Ana tiene puntos = 100.00 en su EntradaRanking")
+def step_ana_100(ctx: dict) -> None:
+    ana_id = ctx["atleta_ids"]["Ana"]
+    entry = next(e for e in ctx["ranking"].entries if e.atleta_id == ana_id)
+    assert entry.puntos == Decimal("100.00"), f"Expected 100.00, got {entry.puntos}"
+
+
+@then("Luis tiene puntos = 80.00 en su EntradaRanking")
+def step_luis_80(ctx: dict) -> None:
+    luis_id = ctx["atleta_ids"]["Luis"]
+    entry = next(e for e in ctx["ranking"].entries if e.atleta_id == luis_id)
+    assert entry.puntos == Decimal("80.00"), f"Expected 80.00, got {entry.puntos}"
+
+
+@then("la posicion 1 en SENIOR_MASCULINO corresponde al atleta con mas puntos")
+def step_pos1_senior_masculino(ctx: dict) -> None:
+    sm = [e for e in ctx["ranking"].entries if e.categoria == Categoria.SENIOR_MASCULINO]
+    pos1 = [e for e in sm if e.posicion == 1]
+    assert len(pos1) >= 1
+    max_puntos = max(e.puntos for e in sm if e.en_podio or e.posicion == 1)
+    assert all(e.puntos == max_puntos for e in pos1)
+
+
+@then("la posicion 1 en SENIOR_FEMENINO corresponde al atleta con mas puntos")
+def step_pos1_senior_femenino(ctx: dict) -> None:
+    sf = [e for e in ctx["ranking"].entries if e.categoria == Categoria.SENIOR_FEMENINO]
+    pos1 = [e for e in sf if e.posicion == 1]
+    assert len(pos1) >= 1
+    max_puntos = max(e.puntos for e in sf if e.en_podio or e.posicion == 1)
+    assert all(e.puntos == max_puntos for e in pos1)
+
+
+@then("Pedro tiene puntos = 0.00")
+def step_pedro_puntos_cero(ctx: dict) -> None:
+    pedro_id = ctx["atleta_ids"]["Pedro"]
+    entry = next(e for e in ctx["ranking"].entries if e.atleta_id == pedro_id)
+    assert entry.puntos == Decimal("0.00"), f"Expected 0.00, got {entry.puntos}"
+
+
+@then("Pedro no tiene posicion de podio")
+def step_pedro_sin_podio(ctx: dict) -> None:
+    pedro_id = ctx["atleta_ids"]["Pedro"]
+    entry = next(e for e in ctx["ranking"].entries if e.atleta_id == pedro_id)
+    assert entry.en_podio is False
+
+
+@then("el aggregate reconstituido tiene los mismos puntos que el original")
+def step_puntos_iguales_tras_reconstitucion(ctx: dict) -> None:
+    reconstituido = ctx["ranking_reconstituido"]
+    original_puntos = ctx["ranking_original_puntos"]
+    for entry in reconstituido.entries:
+        assert entry.puntos == original_puntos[entry.atleta_id], (
+            f"Atleta {entry.atleta_id}: original={original_puntos[entry.atleta_id]}, "
+            f"reconstituido={entry.puntos}"
+        )
+
+
+@then("la reconstitucion no require recalcular")
+def step_reconstitucion_sin_recalculo(ctx: dict) -> None:
+    reconstituido = ctx["ranking_reconstituido"]
+    assert reconstituido.calculado is True
+    assert len(reconstituido.pull_events()) == 0

--- a/tests/integration/resultados/test_calcular_ranking_integration.py
+++ b/tests/integration/resultados/test_calcular_ranking_integration.py
@@ -1,4 +1,4 @@
-"""Tests de integración — CalcularRankingHandler + ObtenerRankingHandler (US-2.4.2)."""
+"""Tests de integración — CalcularRankingHandler + ObtenerRankingHandler (US-2.4.2 / US-5.6.3)."""
 
 from __future__ import annotations
 
@@ -46,6 +46,7 @@ from resultados.application.queries.obtener_ranking import (
 from resultados.infrastructure.repositories.atleta_categoria_adapter import (
     AtletaCategoriaAdapter,
 )
+from resultados.domain.services.algoritmo_faas import AlgoritmoPuntajeFAAS
 from resultados.infrastructure.repositories.resultados_competencia_adapter import (
     ResultadosCompetenciaAdapter,
 )
@@ -579,3 +580,46 @@ async def test_calcular_ranking_spe_2x50_no_incluye_performances_spe_8x50(
 
     assert len(rankings[0].entradas) == 1
     assert rankings[0].entradas[0].atleta_id == str(atleta_spe_2)
+
+
+@pytest.mark.asyncio
+async def test_calcular_ranking_con_algoritmo_faas_incluye_puntos(
+    comp_store: SQLiteEventStore,
+    ranking_store: SQLiteEventStore,
+    stub: StubCompetenciaEstadoAdapter,
+    descriptor: DisciplinaDescriptorAdapter,
+) -> None:
+    """Con AlgoritmoPuntajeFAAS: el ranking incluye puntos y ordena por ellos."""
+    cid = uuid4()
+    pid_1 = uuid4()  # 70m → 100.00 pts
+    pid_2 = uuid4()  # 56m → 80.00 pts
+
+    await _performance_ejecutada(
+        comp_store, stub, descriptor, cid, pid_1, "70", disciplina=Disciplina.DNF, ot=OT_A
+    )
+    await _performance_ejecutada(
+        comp_store, stub, descriptor, cid, pid_2, "56", disciplina=Disciplina.DNF, ot=OT_B
+    )
+
+    handler = CalcularRankingHandler(
+        ranking_store=ranking_store,
+        resultados_port=ResultadosCompetenciaAdapter(comp_store),
+        descriptor=descriptor,
+        algoritmo=AlgoritmoPuntajeFAAS(),
+    )
+    await handler.handle(CalcularRankingCommand(competencia_id=cid, disciplina=Disciplina.DNF))
+
+    query_handler = ObtenerRankingHandler(ranking_store=ranking_store)
+    rankings = await query_handler.handle(
+        ObtenerRankingQuery(competencia_id=cid, disciplina=Disciplina.DNF)
+    )
+
+    assert len(rankings) == 1
+    entradas = rankings[0].entradas
+    assert len(entradas) == 2
+    assert entradas[0].atleta_id == str(pid_1)
+    assert entradas[0].posicion == 1
+    assert entradas[0].puntos == "100.00"
+    assert entradas[1].atleta_id == str(pid_2)
+    assert entradas[1].posicion == 2
+    assert entradas[1].puntos == "80.00"

--- a/tests/integration/resultados/test_obtener_overall_integration.py
+++ b/tests/integration/resultados/test_obtener_overall_integration.py
@@ -34,9 +34,7 @@ async def _init_db(db_path: str) -> None:
         await db.commit()
 
 
-async def _append_overall(
-    store: SQLiteEventStore, torneo_id, entries: list[dict]
-) -> None:
+async def _append_overall(store: SQLiteEventStore, torneo_id, entries: list[dict]) -> None:
     await store.append(
         stream_id=f"ranking-overall-{torneo_id}",
         event_type="RankingOverallCalculado",

--- a/tests/unit/resultados/api/test_router_export.py
+++ b/tests/unit/resultados/api/test_router_export.py
@@ -85,7 +85,10 @@ def test_export_json_devuelve_attachment_y_secciones() -> None:
     response = client.get(f"/resultados/{torneo_id}/export?format=json")
 
     assert response.status_code == 200
-    assert response.headers["content-disposition"] == f'attachment; filename="resultados-{torneo_id}.json"'
+    assert (
+        response.headers["content-disposition"]
+        == f'attachment; filename="resultados-{torneo_id}.json"'
+    )
     payload = response.json()
     assert "disciplinas" in payload
     assert "overall" in payload
@@ -99,9 +102,15 @@ def test_export_csv_devuelve_attachment_y_header_con_punto_y_coma() -> None:
     response = client.get(f"/resultados/{torneo_id}/export?format=csv")
 
     assert response.status_code == 200
-    assert response.headers["content-disposition"] == f'attachment; filename="resultados-{torneo_id}.csv"'
+    assert (
+        response.headers["content-disposition"]
+        == f'attachment; filename="resultados-{torneo_id}.csv"'
+    )
     primera_linea = response.text.splitlines()[0]
-    assert primera_linea == "disciplina;posicion;atleta_nombre;categoria;club;ap;rp;tarjeta;penalizaciones;puntos"
+    assert (
+        primera_linea
+        == "disciplina;posicion;atleta_nombre;categoria;club;ap;rp;tarjeta;penalizaciones;puntos"
+    )
 
 
 def test_export_format_invalido_devuelve_400() -> None:

--- a/tests/unit/resultados/api/test_router_ranking.py
+++ b/tests/unit/resultados/api/test_router_ranking.py
@@ -117,6 +117,7 @@ def test_get_ranking_devuelve_agrupado_por_categoria(tmp_path) -> None:
                         "tarjeta": "Blanca",
                         "es_dns": False,
                         "en_podio": True,
+                        "puntos": "0.00",
                     }
                 ],
             },
@@ -131,6 +132,7 @@ def test_get_ranking_devuelve_agrupado_por_categoria(tmp_path) -> None:
                         "tarjeta": "Blanca",
                         "es_dns": False,
                         "en_podio": True,
+                        "puntos": "0.00",
                     }
                 ],
             },

--- a/tests/unit/resultados/application/test_obtener_overall_handler.py
+++ b/tests/unit/resultados/application/test_obtener_overall_handler.py
@@ -64,9 +64,7 @@ class TestObtenerOverallHandler:
         atleta_id_2 = uuid4()
         ranking_store = AsyncMock()
         ranking_store.load = AsyncMock(
-            return_value=[
-                _raw_event_ranking_overall_calculado(torneo_id, atleta_id_1, atleta_id_2)
-            ]
+            return_value=[_raw_event_ranking_overall_calculado(torneo_id, atleta_id_1, atleta_id_2)]
         )
 
         handler = ObtenerOverallHandler(ranking_store=ranking_store)

--- a/tests/unit/resultados/domain/test_algoritmo_faas.py
+++ b/tests/unit/resultados/domain/test_algoritmo_faas.py
@@ -16,7 +16,9 @@ LUIS = uuid4()
 PEDRO = uuid4()
 
 
-def _resultado(atleta_id: UUID, rp: float | None, tarjeta: str | None, es_dns: bool = False) -> ResultadoFinal:
+def _resultado(
+    atleta_id: UUID, rp: float | None, tarjeta: str | None, es_dns: bool = False
+) -> ResultadoFinal:
     return ResultadoFinal(
         atleta_id=atleta_id,
         rp=Decimal(str(rp)) if rp is not None else None,

--- a/tests/unit/resultados/domain/test_ranking_competencia.py
+++ b/tests/unit/resultados/domain/test_ranking_competencia.py
@@ -1,4 +1,4 @@
-"""Tests unitarios del aggregate RankingCompetencia — US-2.4.2."""
+"""Tests unitarios del aggregate RankingCompetencia — US-2.4.2 / US-5.6.3."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from shared.domain.value_objects.disciplina import Disciplina
 from resultados.domain.aggregates.ranking_competencia import RankingCompetencia
 from resultados.domain.exceptions import ResultadosIncompletos
 from resultados.domain.ports.resultados_competencia_port import ResultadoFinal
+from resultados.domain.services.algoritmo_faas import AlgoritmoPuntajeFAAS
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -349,3 +350,218 @@ def test_calcular_blanca_con_penalizaciones_es_valida_y_ordena_por_rp() -> None:
 
     assert ranking.entries[0].atleta_id == atleta_valido
     assert ranking.entries[1].atleta_id == atleta_penalizado
+
+
+# ── US-5.6.3 — path FAAS con puntos ──────────────────────────────────────────
+
+
+def _make_ranking_dnf(competencia_id: UUID | None = None) -> RankingCompetencia:
+    return RankingCompetencia(
+        competencia_id=competencia_id or uuid4(),
+        disciplina=Disciplina.DNF,
+    )
+
+
+def _resultado_dnf(
+    rp: str,
+    tarjeta: str = "Blanca",
+    atleta_id: UUID | None = None,
+    categoria: Categoria = Categoria.SENIOR_MASCULINO,
+) -> ResultadoFinal:
+    return ResultadoFinal(
+        atleta_id=atleta_id or uuid4(),
+        rp=Decimal(rp),
+        unidad="Metros",
+        tarjeta=tarjeta,
+        es_dns=False,
+        categoria=categoria,
+    )
+
+
+def _dns_dnf(
+    atleta_id: UUID | None = None,
+    categoria: Categoria = Categoria.SENIOR_MASCULINO,
+) -> ResultadoFinal:
+    return ResultadoFinal(
+        atleta_id=atleta_id or uuid4(),
+        rp=None,
+        unidad=None,
+        tarjeta=None,
+        es_dns=True,
+        categoria=categoria,
+    )
+
+
+def test_calcular_con_faas_incluye_puntos_en_entradas() -> None:
+    """Ana (70m) → 100.00 pts; Luis (56m) → 80.00 pts (INV-5.6.3-01)."""
+    ana = uuid4()
+    luis = uuid4()
+    resultados = [
+        _resultado_dnf("70", atleta_id=ana, categoria=Categoria.SENIOR_FEMENINO),
+        _resultado_dnf("56", atleta_id=luis, categoria=Categoria.SENIOR_MASCULINO),
+    ]
+
+    ranking = _make_ranking_dnf()
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+
+    by_id = {e.atleta_id: e for e in ranking.entries}
+    assert by_id[ana].puntos == Decimal("100.00")
+    assert by_id[luis].puntos == Decimal("80.00")
+
+
+def test_calcular_con_faas_ordena_por_puntos_desc_dentro_de_categoria() -> None:
+    """Dentro de cada categoría, la posición se asigna por puntos desc."""
+    atleta_a = uuid4()  # 80m → 100 pts
+    atleta_b = uuid4()  # 60m → 75 pts
+    resultados = [
+        _resultado_dnf("60", atleta_id=atleta_b),
+        _resultado_dnf("80", atleta_id=atleta_a),
+    ]
+
+    ranking = _make_ranking_dnf()
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+
+    entries = ranking.entries
+    assert entries[0].atleta_id == atleta_a
+    assert entries[0].posicion == 1
+    assert entries[1].atleta_id == atleta_b
+    assert entries[1].posicion == 2
+
+
+def test_calcular_con_faas_empate_puntos_comparte_posicion() -> None:
+    """Dos atletas con mismo RP → mismo puntos → comparten posición (INV-5.6.3-02)."""
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    resultados = [
+        _resultado_dnf("70", atleta_id=atleta_a),
+        _resultado_dnf("70", atleta_id=atleta_b),
+    ]
+
+    ranking = _make_ranking_dnf()
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+
+    assert ranking.entries[0].posicion == 1
+    assert ranking.entries[1].posicion == 1
+    assert ranking.entries[0].puntos == Decimal("100.00")
+    assert ranking.entries[1].puntos == Decimal("100.00")
+
+
+def test_calcular_con_faas_dns_puntos_cero_sin_podio() -> None:
+    """DNS → puntos=0.00, en_podio=False (INV-5.6.3-03)."""
+    pedro = uuid4()
+    luis = uuid4()
+    resultados = [
+        _dns_dnf(atleta_id=pedro),
+        _resultado_dnf("60", atleta_id=luis),
+    ]
+
+    ranking = _make_ranking_dnf()
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+
+    by_id = {e.atleta_id: e for e in ranking.entries}
+    assert by_id[pedro].puntos == Decimal("0.00")
+    assert by_id[pedro].en_podio is False
+    assert by_id[luis].puntos == Decimal("100.00")
+
+
+def test_calcular_con_faas_roja_puntos_cero_sin_podio() -> None:
+    """Tarjeta roja → puntos=0.00, en_podio=False (INV-5.6.3-03)."""
+    rojo = uuid4()
+    blanco = uuid4()
+    resultados = [
+        _resultado_dnf("50", tarjeta="Roja", atleta_id=rojo),
+        _resultado_dnf("70", atleta_id=blanco),
+    ]
+
+    ranking = _make_ranking_dnf()
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+
+    by_id = {e.atleta_id: e for e in ranking.entries}
+    assert by_id[rojo].puntos == Decimal("0.00")
+    assert by_id[rojo].en_podio is False
+
+
+def test_calcular_legacy_sin_algoritmo_puntos_son_cero() -> None:
+    """Path legacy (algoritmo=None): puntos siempre 0.00, ordenamiento por RP."""
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    resultados = [
+        _resultado_dnf("50", atleta_id=atleta_b),
+        _resultado_dnf("80", atleta_id=atleta_a),
+    ]
+
+    ranking = _make_ranking_dnf()
+    ranking.calcular(resultados, None)
+
+    assert all(e.puntos == Decimal("0.00") for e in ranking.entries)
+    assert ranking.entries[0].atleta_id == atleta_a  # mayor RP = primero
+
+
+def test_serializar_entrada_incluye_puntos() -> None:
+    """La serialización del evento incluye el campo puntos (INV-5.6.3-05)."""
+    ana = uuid4()
+    resultados = [_resultado_dnf("70", atleta_id=ana, categoria=Categoria.SENIOR_FEMENINO)]
+
+    ranking = _make_ranking_dnf()
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+    events = ranking.pull_events()
+
+    payload = events[0].to_payload()
+    assert "puntos" in payload["entries"][0]
+    assert payload["entries"][0]["puntos"] == "100.00"
+
+
+def test_reconstitute_restaura_puntos_del_evento() -> None:
+    """Reconstitución desde event store recupera puntos sin recalcular."""
+    cid = uuid4()
+    ana = uuid4()
+    resultados = [_resultado_dnf("70", atleta_id=ana, categoria=Categoria.SENIOR_FEMENINO)]
+
+    ranking = RankingCompetencia(competencia_id=cid, disciplina=Disciplina.DNF)
+    ranking.calcular(resultados, AlgoritmoPuntajeFAAS())
+    events = ranking.pull_events()
+
+    raw = [{"event_type": e.event_type, "payload": e.to_payload()} for e in events]
+    ranking2 = RankingCompetencia.reconstitute(
+        competencia_id=cid, disciplina=Disciplina.DNF, events=raw
+    )
+
+    assert ranking2.entries[0].puntos == Decimal("100.00")
+
+
+def test_deserializacion_legacy_sin_puntos_usa_fallback_cero() -> None:
+    """Eventos legacy sin campo puntos se deserializan con puntos=0.00."""
+    cid = uuid4()
+    ana = uuid4()
+
+    # Construir evento legacy sin campo puntos
+    raw = [
+        {
+            "event_type": "ResultadosCalculados",
+            "payload": {
+                "competencia_id": str(cid),
+                "disciplina": "DNF",
+                "total": 1,
+                "entries": [
+                    {
+                        "posicion": 1,
+                        "atleta_id": str(ana),
+                        "categoria": "SENIOR_FEMENINO",
+                        "rp": "70",
+                        "unidad": "Metros",
+                        "tarjeta": "Blanca",
+                        "es_dns": False,
+                        "en_podio": True,
+                        # sin campo "puntos"
+                    }
+                ],
+                "calculado_en": "2026-04-26T10:00:00",
+                "occurred_at": "2026-04-26T10:00:00",
+            },
+        }
+    ]
+
+    ranking = RankingCompetencia.reconstitute(
+        competencia_id=cid, disciplina=Disciplina.DNF, events=raw
+    )
+    assert ranking.entries[0].puntos == Decimal("0.00")


### PR DESCRIPTION
## Summary

- Extiende `EntradaRanking` con campo `puntos: Decimal` (default `0.00`)
- Actualiza `RankingCompetencia.calcular()` con dos paths: FAAS (ordena por puntos desc dentro de cada `Categoría`) y legacy (sin algoritmo, ordena por RP, `puntos=0.00`)
- Serde del event store actualizado con fallback `"0.00"` para compatibilidad con eventos previos (INV-5.6.3-05)
- `CalcularRankingHandler` pasa `self._algoritmo` en lugar de `descriptor`
- Respuesta `GET /ranking` incluye `puntos` por entrada

## Quality gates

| Gate | Resultado |
|------|-----------|
| Pylint | 9.65/10 ✅ |
| Cobertura domain/+application/ | 96% ✅ |
| Tests BC resultados | 80 unit+integration · 4 BDD — todos verdes ✅ |
| Black | ✅ |

## Test plan

- [x] 9 nuevos tests unitarios (path FAAS: puntos, empates, DNS, serde legacy)
- [x] 1 nuevo test de integración con `AlgoritmoPuntajeFAAS` real
- [x] 4 escenarios BDD `US-5.6.3-ranking-puntos-faas.feature` — todos verdes
- [x] 0 regresiones en 16 tests legacy (path sin algoritmo no modificado)
- [x] `test_get_ranking_devuelve_agrupado_por_categoria` actualizado con `"puntos": "0.00"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)