### PR TITLE
feat(resultados): RankingOverall con puntos FAAS por categoría [US-5.6.4]

### DIFF
--- a/docs/plans/sp5/US-5.6.4-plan.md
+++ b/docs/plans/sp5/US-5.6.4-plan.md
@@ -1,0 +1,43 @@
+# Plan de Implementación — US-5.6.4: RankingOverall con puntos acumulados
+
+**Incremento:** INC-5.6 | **Sprint:** SP5
+
+---
+
+## Diagnóstico
+
+`RankingOverall` usa actualmente un algoritmo posicional (suma de posiciones, menor es mejor).
+`EntradaRanking.puntos: Decimal` fue añadido en US-5.6.3. US-5.6.4 extiende `RankingOverall`
+para sumar esos puntos FAAS en lugar de posiciones.
+
+## Cambios por capa
+
+### Domain
+- `entrada_overall.py`: `puntaje: int` → `puntos_overall: Decimal`; `detalle: dict[str, int]` → `dict[str, Decimal]`
+- `exceptions.py`: nueva `DisciplinasNoFinalizadas` (INV-5.6.4-04)
+- `ranking_overall.py`: reescribir algoritmo (sumar `EntradaRanking.puntos` DESC, ausente=0); validar INV-5.6.4-04; eliminar `penalizacion_ausente`; actualizar serialización
+
+### Application
+- `calcular_overall.py`: incluir TODAS las disciplinas en el mapa (incluso con entries vacías) para que el aggregate valide INV-5.6.4-04
+- `obtener_overall.py`: DTO `puntos_overall: Decimal` (reemplaza `puntaje: int`); `detalle: dict[str, Decimal]`
+
+### API
+- `router.py`: respuesta `GET /{torneo_id}/overall` → `puntos_overall` en lugar de `puntaje`
+
+### Tests a actualizar
+- `test_ranking_overall.py` — reescribir para usar puntos FAAS
+- `test_calcular_overall_handler.py` — `_ranking_event` incluye `puntos`; nuevo test INV-5.6.4-04
+- `test_obtener_overall_handler.py` — DTO con `puntos_overall`
+- `test_router_overall.py` — respuesta con `puntos_overall`
+- `test_obtener_overall_integration.py` — payload con `puntos_overall`
+
+## Decisiones clave
+
+- Backward compat del event store: `_dict_a_entrada` usa fallback `"0.00"` para eventos legacy sin `puntos_overall`
+- `penalizacion_ausente` eliminado: ausente en una disciplina aporta 0 puntos FAAS (INV-5.6.4-01)
+- INV-5.6.4-04 vive en el domain aggregate (no en el handler)
+- Orden: `puntos_overall` DESC, estabilidad por `atleta_id` str
+
+## Estimación
+- Domain: 25 min | Application: 15 min | Tests: 30 min | BDD: 20 min | QG: 10 min
+- Total estimado: 100 min

--- a/docs/reports/US-5.6.4-report.md
+++ b/docs/reports/US-5.6.4-report.md
@@ -1,0 +1,52 @@
+# Reporte de Implementación — US-5.6.4
+
+**Historia**: RankingOverall por categoría con puntos acumulados
+**Sprint**: SP5 — La Puesta en Marcha | **Incremento**: INC-5.6
+**Branch**: feature/US-5.6.4-ranking-overall-puntos
+**Fecha**: 2026-04-27
+
+---
+
+## Resumen de Cambios
+
+### Domain
+- `entrada_overall.py`: `puntaje: int` + `detalle: dict[str, int]` → `puntos_overall: Decimal` + `detalle: dict[str, Decimal]`
+- `exceptions.py`: nueva `DisciplinasNoFinalizadas` (INV-5.6.4-04)
+- `ranking_overall.py`: algoritmo reescrito — suma `EntradaRanking.puntos` FAAS DESC en lugar de posiciones; validación INV-5.6.4-04; backward compat para eventos legacy
+
+### Application
+- `calcular_overall.py`: incluye todas las disciplinas en el mapa (incluso vacías) para que el aggregate valide INV-5.6.4-04
+- `obtener_overall.py`: DTO `puntos_overall: Decimal` + `detalle: dict[str, Decimal]`
+- `exportar_resultados.py`: `puntos_totales` actualizado a `Decimal`
+
+### API
+- `router.py`: `GET /{torneo_id}/overall` retorna `puntos_overall` (str) + `detalle` con valores str
+
+## Métricas
+
+| Fase | Artefacto | Resultado |
+|------|-----------|-----------|
+| BDD | 5 escenarios | 5/5 PASS |
+| Unit | `test_ranking_overall.py` | 11 tests nuevos |
+| Unit | `test_calcular_overall_handler.py` | 2 tests (1 nuevo INV-5.6.4-04) |
+| Unit | `test_obtener_overall_handler.py` | 3 tests actualizados |
+| Unit | `test_router_overall.py` | 2 tests actualizados |
+| Integration | `test_calcular_overall_integration.py` | 2 tests (1 nuevo INV-5.6.4-04) |
+| Integration | `test_obtener_overall_integration.py` | 1 test actualizado |
+| **Total** | | **91 tests resultados — 91/91 PASS** |
+| CodeGuard | src/resultados/ | 0 errores |
+
+## Decisiones Técnicas
+
+1. **Eliminación de `penalizacion_ausente`**: ya no aplica — ausente en FAAS = 0 puntos
+2. **INV-5.6.4-04 en el domain**: la validación vive en `RankingOverall.calcular()`, no en el handler
+3. **Backward compat**: `_dict_a_entrada` usa fallback `"0.00"` para eventos sin `puntos_overall`
+4. **Serialización Decimal**: `puntos_overall` y `detalle` serializados como strings en JSON
+
+## Invariantes Verificados
+
+- INV-5.6.4-01: ✅ `puntos_overall = Σ puntos_disciplina` (ausente = 0)
+- INV-5.6.4-02: ✅ Posición determinada por `puntos_overall` DESC
+- INV-5.6.4-03: ✅ Empate comparte posición
+- INV-5.6.4-04: ✅ `DisciplinasNoFinalizadas` si alguna disciplina sin ranking
+- INV-5.6.4-05: ✅ Precisión 2 decimales (`quantize(Decimal("0.01"))`)

--- a/docs/specs/sp5/US-5.6.4.md
+++ b/docs/specs/sp5/US-5.6.4.md
@@ -1,6 +1,6 @@
 # US-5.6.4: RankingOverall por categoría con puntos acumulados
 
-**Estado**: `To Do`
+**Estado**: `Done`
 **Sprint**: SP5 — La Puesta en Marcha
 **Incremento**: INC-5.6
 **Bounded Context**: `resultados`

--- a/quality/reports/codeguard/US-5.6.4-quality.json
+++ b/quality/reports/codeguard/US-5.6.4-quality.json
@@ -1,0 +1,2128 @@
+{
+  "summary": {
+    "total_files": 33,
+    "checks_executed": 6,
+    "elapsed_seconds": 25.56,
+    "timestamp": "2026-04-27T10:23:42.979868",
+    "total_issues": 99,
+    "errors": 0,
+    "warnings": 3,
+    "infos": 96
+  },
+  "results": [
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/api/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/api/router.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/api/router.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/application/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/infrastructure/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/domain/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/exceptions.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/domain/aggregates/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/aggregates/ranking_overall.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "warning",
+      "message": "PEP8: E501 line too long (101 > 100 characters)",
+      "file": "src/resultados/domain/aggregates/ranking_overall.py",
+      "line": 62
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/aggregates/ranking_overall.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/value_objects/entrada_overall.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/value_objects/entrada_overall.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/value_objects/entrada_overall.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/domain/value_objects/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/domain/events/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/events/resultados_calculados.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/events/resultados_calculados.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/events/resultados_calculados.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/domain/ports/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "warning",
+      "message": "PEP8: E501 line too long (106 > 100 characters)",
+      "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+      "line": 27
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/services/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/services/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/domain/services/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/domain/services/algoritmo_faas.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/domain/services/algoritmo_faas.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "warning",
+      "message": "Complexity: AlgoritmoPuntajeFAAS._calcular_tiempo has cyclomatic complexity 11 (grade C). Consider refactoring into smaller functions.",
+      "file": "src/resultados/domain/services/algoritmo_faas.py",
+      "line": 57
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/infrastructure/repositories/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/queries/obtener_overall.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/queries/obtener_overall.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/application/queries/obtener_overall.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/queries/exportar_resultados.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/queries/exportar_resultados.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/application/queries/exportar_resultados.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/application/queries/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/queries/obtener_ranking.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/queries/obtener_ranking.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/application/queries/obtener_ranking.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/commands/calcular_ranking.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/commands/calcular_ranking.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/application/commands/calcular_ranking.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ No complex functions detected",
+      "file": "src/resultados/application/commands/__init__.py",
+      "line": null
+    },
+    {
+      "check": "Security",
+      "severity": "info",
+      "message": "✓ No security issues detected",
+      "file": "src/resultados/application/commands/calcular_overall.py",
+      "line": null
+    },
+    {
+      "check": "PEP8",
+      "severity": "info",
+      "message": "✓ PEP8 compliant",
+      "file": "src/resultados/application/commands/calcular_overall.py",
+      "line": null
+    },
+    {
+      "check": "Complexity",
+      "severity": "info",
+      "message": "✓ All functions below complexity threshold (≤10)",
+      "file": "src/resultados/application/commands/calcular_overall.py",
+      "line": null
+    }
+  ],
+  "by_severity": {
+    "errors": [],
+    "warnings": [
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: E501 line too long (101 > 100 characters)",
+        "file": "src/resultados/domain/aggregates/ranking_overall.py",
+        "line": 62
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: E501 line too long (106 > 100 characters)",
+        "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+        "line": 27
+      },
+      {
+        "check": "Complexity",
+        "severity": "warning",
+        "message": "Complexity: AlgoritmoPuntajeFAAS._calcular_tiempo has cyclomatic complexity 11 (grade C). Consider refactoring into smaller functions.",
+        "file": "src/resultados/domain/services/algoritmo_faas.py",
+        "line": 57
+      }
+    ],
+    "infos": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/aggregates/ranking_overall.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/aggregates/ranking_overall.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/value_objects/entrada_overall.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/value_objects/entrada_overall.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/value_objects/entrada_overall.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/events/resultados_calculados.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/events/resultados_calculados.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/events/resultados_calculados.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/services/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/services/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/services/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/services/algoritmo_faas.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/services/algoritmo_faas.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/obtener_overall.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/obtener_overall.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/queries/obtener_overall.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/exportar_resultados.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/exportar_resultados.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/queries/exportar_resultados.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/obtener_ranking.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/obtener_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/queries/obtener_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/commands/calcular_ranking.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/commands/calcular_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/commands/calcular_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/commands/calcular_overall.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/commands/calcular_overall.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/commands/calcular_overall.py",
+        "line": null
+      }
+    ]
+  },
+  "by_package": {
+    "aggregates": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/aggregates/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/aggregates/ranking_overall.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: E501 line too long (101 > 100 characters)",
+        "file": "src/resultados/domain/aggregates/ranking_overall.py",
+        "line": 62
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/aggregates/ranking_overall.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/aggregates/ranking_competencia.py",
+        "line": null
+      }
+    ],
+    "api": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/api/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/api/router.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/api/router.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/api/router.py",
+        "line": null
+      }
+    ],
+    "application": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/application/__init__.py",
+        "line": null
+      }
+    ],
+    "commands": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/commands/calcular_ranking.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/commands/calcular_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/commands/calcular_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/application/commands/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/commands/calcular_overall.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/commands/calcular_overall.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/commands/calcular_overall.py",
+        "line": null
+      }
+    ],
+    "domain": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/exceptions.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/exceptions.py",
+        "line": null
+      }
+    ],
+    "events": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/events/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/events/ranking_overall_calculado.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/events/resultados_calculados.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/events/resultados_calculados.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/events/resultados_calculados.py",
+        "line": null
+      }
+    ],
+    "infrastructure": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/infrastructure/__init__.py",
+        "line": null
+      }
+    ],
+    "ports": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/ports/algoritmo_puntaje.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/ports/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "warning",
+        "message": "PEP8: E501 line too long (106 > 100 characters)",
+        "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+        "line": 27
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/ports/resultados_competencia_port.py",
+        "line": null
+      }
+    ],
+    "queries": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/obtener_overall.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/obtener_overall.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/queries/obtener_overall.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/exportar_resultados.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/exportar_resultados.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/queries/exportar_resultados.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/application/queries/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/application/queries/obtener_ranking.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/application/queries/obtener_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/application/queries/obtener_ranking.py",
+        "line": null
+      }
+    ],
+    "repositories": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/atleta_categoria_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/resultados_competencia_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/infrastructure/repositories/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/atleta_info_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/infrastructure/repositories/disciplina_descriptor_adapter.py",
+        "line": null
+      }
+    ],
+    "resultados": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/__init__.py",
+        "line": null
+      }
+    ],
+    "services": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/services/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/services/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/services/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/services/algoritmo_faas.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/services/algoritmo_faas.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "warning",
+        "message": "Complexity: AlgoritmoPuntajeFAAS._calcular_tiempo has cyclomatic complexity 11 (grade C). Consider refactoring into smaller functions.",
+        "file": "src/resultados/domain/services/algoritmo_faas.py",
+        "line": 57
+      }
+    ],
+    "value_objects": [
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/value_objects/entrada_overall.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/value_objects/entrada_overall.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/value_objects/entrada_overall.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ No complex functions detected",
+        "file": "src/resultados/domain/value_objects/__init__.py",
+        "line": null
+      },
+      {
+        "check": "Security",
+        "severity": "info",
+        "message": "✓ No security issues detected",
+        "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+        "line": null
+      },
+      {
+        "check": "PEP8",
+        "severity": "info",
+        "message": "✓ PEP8 compliant",
+        "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+        "line": null
+      },
+      {
+        "check": "Complexity",
+        "severity": "info",
+        "message": "✓ All functions below complexity threshold (≤10)",
+        "file": "src/resultados/domain/value_objects/entrada_ranking.py",
+        "line": null
+      }
+    ]
+  }
+}

--- a/src/resultados/api/router.py
+++ b/src/resultados/api/router.py
@@ -179,8 +179,8 @@ async def get_overall(
                         {
                             "posicion": e.posicion,
                             "atleta_id": e.atleta_id,
-                            "puntaje": e.puntaje,
-                            "detalle": e.detalle,
+                            "puntos_overall": str(e.puntos_overall),
+                            "detalle": {k: str(v) for k, v in e.detalle.items()},
                             "en_podio": e.en_podio,
                         }
                         for e in grupo.entradas
@@ -268,7 +268,7 @@ def _exportacion_a_json(exportacion: ExportResultadosDTO) -> dict[str, object]:
                 "atleta_nombre": entry.atleta_nombre,
                 "categoria": entry.categoria,
                 "club": entry.club,
-                "puntos_totales": entry.puntos_totales,
+                "puntos_totales": str(entry.puntos_totales),
             }
             for entry in exportacion.overall
         ],

--- a/src/resultados/application/commands/calcular_overall.py
+++ b/src/resultados/application/commands/calcular_overall.py
@@ -1,12 +1,12 @@
-"""Command y Handler para CalcularOverall — US-3.5.1."""
+"""Command y Handler para CalcularOverall — US-3.5.1 / US-5.6.4."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from uuid import UUID
 
-from resultados.domain.aggregates.ranking_overall import RankingOverall
 from resultados.domain.aggregates.ranking_competencia import RankingCompetencia
+from resultados.domain.aggregates.ranking_overall import RankingOverall
 from shared.domain.ports.event_store_port import EventStorePort
 from shared.domain.value_objects.disciplina import Disciplina
 
@@ -37,7 +37,11 @@ class CalcularOverallHandler:
         self._competencia_store = competencia_store
 
     async def handle(self, command: CalcularOverallCommand) -> list:
-        """Calcula y persiste el overall del torneo."""
+        """Calcula y persiste el overall del torneo.
+
+        Raises:
+            DisciplinasNoFinalizadas: si alguna disciplina no tiene ranking calculado.
+        """
         competencias = await _mapear_competencias_por_torneo(
             self._competencia_store, command.torneo_id, command.disciplinas
         )
@@ -46,8 +50,7 @@ class CalcularOverallHandler:
             stream_id = f"ranking-{competencia_id}-{disciplina.value}"
             events = await self._ranking_store.load(stream_id)
             ranking = RankingCompetencia.reconstitute(competencia_id, disciplina, events)
-            if ranking.entries:
-                rankings_por_disciplina[disciplina] = ranking.entries
+            rankings_por_disciplina[disciplina] = ranking.entries
 
         overall_stream = _build_stream_id(command.torneo_id)
         existing = await self._ranking_store.load(overall_stream)

--- a/src/resultados/application/queries/exportar_resultados.py
+++ b/src/resultados/application/queries/exportar_resultados.py
@@ -76,7 +76,7 @@ class ExportOverallEntradaDTO:
     atleta_nombre: str
     categoria: str
     club: str
-    puntos_totales: int
+    puntos_totales: Decimal
 
 
 @dataclass(frozen=True)
@@ -251,7 +251,7 @@ class ExportarResultadosHandler:
                         atleta_nombre=atleta_info.nombre_completo,
                         categoria=grupo.categoria,
                         club=atleta_info.club,
-                        puntos_totales=entry.puntaje,
+                        puntos_totales=entry.puntos_overall,
                     )
                 )
         return filas

--- a/src/resultados/application/queries/obtener_overall.py
+++ b/src/resultados/application/queries/obtener_overall.py
@@ -1,9 +1,10 @@
-"""Query y Handler para ObtenerOverall — US-3.5.3."""
+"""Query y Handler para ObtenerOverall — US-3.5.3 / US-5.6.4."""
 
 from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from decimal import Decimal
 from uuid import UUID
 
 from resultados.domain.aggregates.ranking_overall import RankingOverall
@@ -23,8 +24,8 @@ class OverallEntradaDTO:
 
     posicion: int
     atleta_id: str
-    puntaje: int
-    detalle: dict[str, int]
+    puntos_overall: Decimal
+    detalle: dict[str, Decimal]
     en_podio: bool
 
 
@@ -50,7 +51,7 @@ class ObtenerOverallHandler:
         """Retorna las entradas calculadas del overall.
 
         Returns:
-            Lista ordenada por posición.
+            Lista ordenada por categoría.
             Lista vacía si el overall aún no fue calculado.
         """
         stream_id = f"ranking-overall-{query.torneo_id}"
@@ -62,7 +63,7 @@ class ObtenerOverallHandler:
                 OverallEntradaDTO(
                     posicion=entry.posicion,
                     atleta_id=str(entry.atleta_id),
-                    puntaje=entry.puntaje,
+                    puntos_overall=entry.puntos_overall,
                     detalle=dict(entry.detalle),
                     en_podio=entry.en_podio,
                 )

--- a/src/resultados/domain/aggregates/ranking_overall.py
+++ b/src/resultados/domain/aggregates/ranking_overall.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
@@ -14,12 +15,19 @@ from shared.domain.base.aggregate_root import AggregateRoot
 from shared.domain.value_objects.disciplina import Disciplina
 
 _CATEGORIA_DEFAULT = Categoria.SENIOR_MASCULINO
+_DOS_DECIMALES = Decimal("0.01")
 
 
 class RankingOverall(AggregateRoot):
     """Aggregate raíz del ranking general por torneo.
 
     Stream ID: "ranking-overall-{torneo_id}"
+
+    Regla de ordenamiento (US-5.6.4):
+        puntos_overall = Σ puntos_disciplina (FAAS). Mayor es mejor.
+        Atleta ausente en una disciplina aporta 0 puntos (INV-5.6.4-01).
+        Empates comparten posición (INV-5.6.4-03).
+        Solo calculable cuando todas las disciplinas tienen ranking (INV-5.6.4-04).
     """
 
     def __init__(self, torneo_id: UUID) -> None:
@@ -47,10 +55,15 @@ class RankingOverall(AggregateRoot):
         self,
         torneo_id: UUID,
         rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
-        penalizacion_ausente: int | None = None,
     ) -> list[EntradaOverall]:
-        """Calcula y registra el ranking overall."""
-        entries = _calcular_entries(rankings_por_disciplina, penalizacion_ausente)
+        """Calcula y registra el ranking overall sumando puntos FAAS.
+
+        Raises:
+            DisciplinasNoFinalizadas: si alguna disciplina no tiene ranking calculado (INV-5.6.4-04).
+        """
+        _validar_disciplinas_finalizadas(rankings_por_disciplina)
+
+        entries = _calcular_entries(rankings_por_disciplina)
         if not entries:
             self._entries = []
             self._calculado = False
@@ -92,114 +105,79 @@ class RankingOverall(AggregateRoot):
         return payload  # type: ignore[return-value]
 
 
+# ── Helpers de dominio ────────────────────────────────────────────────────────
+
+
+def _validar_disciplinas_finalizadas(
+    rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
+) -> None:
+    """INV-5.6.4-04: rechaza si alguna disciplina no tiene ranking calculado."""
+    sin_finalizar = [d for d, e in rankings_por_disciplina.items() if not e]
+    if sin_finalizar:
+        from resultados.domain.exceptions import DisciplinasNoFinalizadas
+
+        nombres = ", ".join(d.value for d in sin_finalizar)
+        raise DisciplinasNoFinalizadas(
+            f"Overall rechazado: disciplinas sin ranking finalizado: {nombres}"
+        )
+
+
 def _calcular_entries(
     rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
-    penalizacion_ausente: int | None,
 ) -> list[EntradaOverall]:
-    """Aplica la fórmula posicional overall."""
-    rankings_validos = _filtrar_rankings_validos(rankings_por_disciplina)
-    if not rankings_validos:
-        return []
-
+    """Suma puntos FAAS por atleta y disciplina, agrupa por Categoría."""
     entries: list[EntradaOverall] = []
-    for categoria in sorted(_categorias_presentes(rankings_validos), key=lambda cat: cat.value):
-        acumulado = _acumular_puntajes_categoria(rankings_validos, categoria, penalizacion_ausente)
-        puntuados = _ordenar_puntuados(acumulado)
-        entries.extend(_crear_entries_categoria(categoria, puntuados))
+    for categoria in sorted(_categorias_presentes(rankings_por_disciplina), key=lambda c: c.value):
+        acumulado = _acumular_puntos_categoria(rankings_por_disciplina, categoria)
+        entries.extend(_crear_entries_categoria(categoria, acumulado))
     return entries
 
 
-def _filtrar_rankings_validos(
-    rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
-) -> dict[Disciplina, list[EntradaRanking]]:
-    return {
-        disciplina: entries for disciplina, entries in rankings_por_disciplina.items() if entries
-    }
-
-
 def _categorias_presentes(
-    rankings_validos: dict[Disciplina, list[EntradaRanking]],
+    rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
 ) -> set[Categoria]:
-    return {entry.categoria for entries in rankings_validos.values() for entry in entries}
+    return {entry.categoria for entries in rankings_por_disciplina.values() for entry in entries}
 
 
-def _acumular_puntajes_categoria(
-    rankings_validos: dict[Disciplina, list[EntradaRanking]],
+def _acumular_puntos_categoria(
+    rankings_por_disciplina: dict[Disciplina, list[EntradaRanking]],
     categoria: Categoria,
-    penalizacion_ausente: int | None,
-) -> dict[UUID, dict[str, int]]:
-    atletas = _atletas_de_categoria(rankings_validos, categoria)
-    acumulado: dict[UUID, dict[str, int]] = {atleta_id: {} for atleta_id in atletas}
-
-    for disciplina, entries in rankings_validos.items():
-        entries_categoria = _entries_de_categoria(entries, categoria)
-        if not entries_categoria:
-            continue
-        _acumular_disciplina(
-            acumulado,
-            atletas,
-            disciplina,
-            entries_categoria,
-            penalizacion_ausente,
-        )
-    return acumulado
-
-
-def _atletas_de_categoria(
-    rankings_validos: dict[Disciplina, list[EntradaRanking]],
-    categoria: Categoria,
-) -> set[UUID]:
-    return {
+) -> dict[UUID, tuple[Decimal, dict[str, Decimal]]]:
+    """Retorna {atleta_id: (puntos_total, {disciplina: puntos})} para la categoría."""
+    atletas = {
         entry.atleta_id
-        for entries in rankings_validos.values()
+        for entries in rankings_por_disciplina.values()
         for entry in entries
         if entry.categoria == categoria
     }
+    detalle: dict[UUID, dict[str, Decimal]] = {a: {} for a in atletas}
 
+    for disciplina, entries in rankings_por_disciplina.items():
+        for entry in entries:
+            if entry.categoria == categoria:
+                detalle[entry.atleta_id][disciplina.value] = entry.puntos
 
-def _entries_de_categoria(
-    entries: list[EntradaRanking],
-    categoria: Categoria,
-) -> list[EntradaRanking]:
-    return [entry for entry in entries if entry.categoria == categoria]
-
-
-def _acumular_disciplina(
-    acumulado: dict[UUID, dict[str, int]],
-    atletas: set[UUID],
-    disciplina: Disciplina,
-    entries_categoria: list[EntradaRanking],
-    penalizacion_ausente: int | None,
-) -> None:
-    posiciones = {entry.atleta_id: entry.posicion for entry in entries_categoria}
-    peor_posicion = _calcular_penalizacion(entries_categoria, penalizacion_ausente)
-    for atleta_id in atletas:
-        acumulado[atleta_id][disciplina.value] = posiciones.get(atleta_id, peor_posicion)
-
-
-def _calcular_penalizacion(entries: list[EntradaRanking], penalizacion_ausente: int | None) -> int:
-    if penalizacion_ausente is not None:
-        return penalizacion_ausente
-    return max(entry.posicion for entry in entries) + 1
-
-
-def _ordenar_puntuados(
-    acumulado: dict[UUID, dict[str, int]],
-) -> list[tuple[UUID, dict[str, int], int]]:
-    return sorted(
-        ((atleta_id, detalle, sum(detalle.values())) for atleta_id, detalle in acumulado.items()),
-        key=lambda item: (item[2], str(item[0])),
-    )
+    result: dict[UUID, tuple[Decimal, dict[str, Decimal]]] = {}
+    for atleta_id, d in detalle.items():
+        total = sum(d.values(), Decimal("0.00")).quantize(_DOS_DECIMALES)
+        result[atleta_id] = (total, d)
+    return result
 
 
 def _crear_entries_categoria(
     categoria: Categoria,
-    puntuados: list[tuple[UUID, dict[str, int], int]],
+    acumulado: dict[UUID, tuple[Decimal, dict[str, Decimal]]],
 ) -> list[EntradaOverall]:
+    """Ordena por puntos_overall DESC y asigna posiciones con empates."""
+    puntuados = sorted(
+        acumulado.items(),
+        key=lambda item: (-item[1][0], str(item[0])),
+    )
+
     entries: list[EntradaOverall] = []
     posicion_actual = 1
-    for index, (atleta_id, detalle, puntaje) in enumerate(puntuados):
-        if index > 0 and puntaje == puntuados[index - 1][2]:
+    for i, (atleta_id, (puntos_overall, detalle)) in enumerate(puntuados):
+        if i > 0 and puntos_overall == puntuados[i - 1][1][0]:
             posicion = entries[-1].posicion
         else:
             posicion = posicion_actual
@@ -209,7 +187,7 @@ def _crear_entries_categoria(
                 posicion=posicion,
                 atleta_id=atleta_id,
                 categoria=categoria,
-                puntaje=puntaje,
+                puntos_overall=puntos_overall,
                 detalle=detalle,
                 en_podio=posicion <= 3,
             )
@@ -224,19 +202,22 @@ def _entrada_a_dict(entry: EntradaOverall) -> dict[str, Any]:
         "posicion": entry.posicion,
         "atleta_id": str(entry.atleta_id),
         "categoria": entry.categoria.value,
-        "puntaje": entry.puntaje,
-        "detalle": entry.detalle,
+        "puntos_overall": str(entry.puntos_overall),
+        "detalle": {k: str(v) for k, v in entry.detalle.items()},
         "en_podio": entry.en_podio,
     }
 
 
 def _dict_a_entrada(data: dict[str, Any]) -> EntradaOverall:
-    """Deserializa payload a EntradaOverall."""
+    """Deserializa payload a EntradaOverall. Soporta eventos legacy (sin puntos_overall)."""
+    puntos_overall = Decimal(str(data.get("puntos_overall", "0.00"))).quantize(_DOS_DECIMALES)
+    detalle_raw = data.get("detalle", {})
+    detalle = {k: Decimal(str(v)).quantize(_DOS_DECIMALES) for k, v in detalle_raw.items()}
     return EntradaOverall(
         posicion=data["posicion"],
         atleta_id=UUID(data["atleta_id"]),
         categoria=Categoria(data.get("categoria", _CATEGORIA_DEFAULT.value)),
-        puntaje=data["puntaje"],
-        detalle=dict(data["detalle"]),
+        puntos_overall=puntos_overall,
+        detalle=detalle,
         en_podio=data["en_podio"],
     )

--- a/src/resultados/domain/exceptions.py
+++ b/src/resultados/domain/exceptions.py
@@ -17,3 +17,7 @@ class RankingYaCalculado(DomainError):
 
 class TorneoNoEncontrado(DomainError):
     """El torneo solicitado no existe en la base de datos de Torneo."""
+
+
+class DisciplinasNoFinalizadas(DomainError):
+    """El overall no puede calcularse porque hay disciplinas sin ranking calculado."""

--- a/src/resultados/domain/value_objects/entrada_overall.py
+++ b/src/resultados/domain/value_objects/entrada_overall.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from uuid import UUID
 
 from registro.domain.value_objects.categoria import Categoria
@@ -16,14 +17,14 @@ class EntradaOverall:
         posicion: Posición overall (1-based). Empates comparten posición.
         atleta_id: Identificador del atleta.
         categoria: Categoría competitiva del atleta.
-        puntaje: Suma de posiciones por disciplina (menor es mejor).
-        detalle: Mapa disciplina -> posición utilizada en la suma.
+        puntos_overall: Suma de puntos FAAS de todas las disciplinas (INV-5.6.4-01).
+        detalle: Mapa disciplina → puntos FAAS aportados.
         en_podio: True si la posición overall está en el podio.
     """
 
     posicion: int
     atleta_id: UUID
     categoria: Categoria
-    puntaje: int
-    detalle: dict[str, int]
+    puntos_overall: Decimal
+    detalle: dict[str, Decimal]
     en_podio: bool

--- a/tests/features/US-5.6.4-ranking-overall-puntos.feature
+++ b/tests/features/US-5.6.4-ranking-overall-puntos.feature
@@ -1,0 +1,32 @@
+Feature: US-5.6.4 — RankingOverall con puntos acumulados
+
+  Background:
+    Given un torneo con dos disciplinas DNF y STA
+
+  Scenario: overall suma puntos de todas las disciplinas
+    Given Ana con 100.00 puntos en DNF y 75.00 en STA en SENIOR_FEMENINO
+    When se calcula el overall
+    Then Ana tiene puntos_overall igual a 175.00
+
+  Scenario: atleta sin participar en una disciplina aporta 0
+    Given Luis con 80.00 puntos en DNF y DNS en STA en SENIOR_MASCULINO
+    When se calcula el overall
+    Then Luis tiene puntos_overall igual a 80.00
+
+  Scenario: empate en overall comparte posicion
+    Given Ana con 100.00 puntos en DNF y 75.00 en STA en SENIOR_FEMENINO
+    And Maria con 75.00 puntos en DNF y 100.00 en STA en SENIOR_FEMENINO
+    When se calcula el overall
+    Then Ana y Maria aparecen con posicion 1
+
+  Scenario: overall rechazado si hay disciplinas sin finalizar
+    Given solo DNF tiene ranking calculado para el torneo
+    When se intenta calcular el overall con DNF y STA
+    Then el sistema rechaza la operacion con DisciplinasNoFinalizadas
+
+  Scenario: overall agrupa por categorias
+    Given un atleta en SENIOR_MASCULINO con 140.00 puntos totales
+    And una atleta en SENIOR_FEMENINO con 175.00 puntos totales
+    When se calcula el overall
+    Then las entradas estan separadas por categoria
+    And el primero de cada categoria tiene la mayor puntuacion

--- a/tests/features/steps/test_US_5_6_4_steps.py
+++ b/tests/features/steps/test_US_5_6_4_steps.py
@@ -1,0 +1,193 @@
+"""Step definitions BDD — US-5.6.4: RankingOverall con puntos acumulados."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+from registro.domain.value_objects.categoria import Categoria
+from resultados.domain.aggregates.ranking_overall import RankingOverall
+from resultados.domain.exceptions import DisciplinasNoFinalizadas
+from resultados.domain.value_objects.entrada_ranking import EntradaRanking
+from shared.domain.value_objects.disciplina import Disciplina
+
+scenarios("../US-5.6.4-ranking-overall-puntos.feature")
+
+
+# ── Fixture de contexto ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ctx() -> dict:
+    return {
+        "ranking": None,
+        "rankings": {},
+        "entries": [],
+        "error": None,
+        "atleta_ids": {},
+    }
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _entry(
+    atleta_id,
+    categoria: Categoria,
+    puntos: str,
+    tarjeta: str = "Blanca",
+    es_dns: bool = False,
+) -> EntradaRanking:
+    return EntradaRanking(
+        posicion=1,
+        atleta_id=atleta_id,
+        categoria=categoria,
+        rp=None,
+        unidad=None,
+        tarjeta=None if es_dns else tarjeta,
+        es_dns=es_dns,
+        en_podio=True,
+        puntos=Decimal(puntos),
+    )
+
+
+# ── Background ────────────────────────────────────────────────────────────────
+
+
+@given("un torneo con dos disciplinas DNF y STA")
+def step_torneo_dos_disciplinas(ctx: dict) -> None:
+    ctx["ranking"] = RankingOverall(uuid4())
+
+
+# ── Givens ────────────────────────────────────────────────────────────────────
+
+
+@given("Ana con 100.00 puntos en DNF y 75.00 en STA en SENIOR_FEMENINO")
+def step_ana_dnf_sta(ctx: dict) -> None:
+    ana_id = ctx["atleta_ids"].setdefault("Ana", uuid4())
+    ctx["rankings"].setdefault(Disciplina.DNF, []).append(
+        _entry(ana_id, Categoria.SENIOR_FEMENINO, "100.00")
+    )
+    ctx["rankings"].setdefault(Disciplina.STA, []).append(
+        _entry(ana_id, Categoria.SENIOR_FEMENINO, "75.00")
+    )
+
+
+@given("Maria con 75.00 puntos en DNF y 100.00 en STA en SENIOR_FEMENINO")
+def step_maria_dnf_sta(ctx: dict) -> None:
+    maria_id = ctx["atleta_ids"].setdefault("Maria", uuid4())
+    ctx["rankings"].setdefault(Disciplina.DNF, []).append(
+        _entry(maria_id, Categoria.SENIOR_FEMENINO, "75.00")
+    )
+    ctx["rankings"].setdefault(Disciplina.STA, []).append(
+        _entry(maria_id, Categoria.SENIOR_FEMENINO, "100.00")
+    )
+
+
+@given("Luis con 80.00 puntos en DNF y DNS en STA en SENIOR_MASCULINO")
+def step_luis_dnf_dns_sta(ctx: dict) -> None:
+    luis_id = ctx["atleta_ids"].setdefault("Luis", uuid4())
+    ctx["rankings"].setdefault(Disciplina.DNF, []).append(
+        _entry(luis_id, Categoria.SENIOR_MASCULINO, "80.00")
+    )
+    ctx["rankings"].setdefault(Disciplina.STA, []).append(
+        _entry(luis_id, Categoria.SENIOR_MASCULINO, "0.00", es_dns=True)
+    )
+
+
+@given("solo DNF tiene ranking calculado para el torneo")
+def step_solo_dnf_calculado(ctx: dict) -> None:
+    atleta_id = uuid4()
+    ctx["rankings"][Disciplina.DNF] = [_entry(atleta_id, Categoria.SENIOR_FEMENINO, "100.00")]
+    ctx["rankings"][Disciplina.STA] = []
+
+
+@given("un atleta en SENIOR_MASCULINO con 140.00 puntos totales")
+def step_atleta_sm(ctx: dict) -> None:
+    sm_id = ctx["atleta_ids"].setdefault("SM", uuid4())
+    ctx["rankings"].setdefault(Disciplina.DNF, []).append(
+        _entry(sm_id, Categoria.SENIOR_MASCULINO, "80.00")
+    )
+    ctx["rankings"].setdefault(Disciplina.STA, []).append(
+        _entry(sm_id, Categoria.SENIOR_MASCULINO, "60.00")
+    )
+
+
+@given("una atleta en SENIOR_FEMENINO con 175.00 puntos totales")
+def step_atleta_sf(ctx: dict) -> None:
+    sf_id = ctx["atleta_ids"].setdefault("SF", uuid4())
+    ctx["rankings"].setdefault(Disciplina.DNF, []).append(
+        _entry(sf_id, Categoria.SENIOR_FEMENINO, "100.00")
+    )
+    ctx["rankings"].setdefault(Disciplina.STA, []).append(
+        _entry(sf_id, Categoria.SENIOR_FEMENINO, "75.00")
+    )
+
+
+# ── Whens ─────────────────────────────────────────────────────────────────────
+
+
+@when("se calcula el overall")
+def step_calcular_overall(ctx: dict) -> None:
+    torneo_id = ctx["ranking"].torneo_id
+    ctx["entries"] = ctx["ranking"].calcular(torneo_id, ctx["rankings"])
+
+
+@when("se intenta calcular el overall con DNF y STA")
+def step_intentar_calcular_incompleto(ctx: dict) -> None:
+    torneo_id = ctx["ranking"].torneo_id
+    try:
+        ctx["ranking"].calcular(torneo_id, ctx["rankings"])
+    except DisciplinasNoFinalizadas as exc:
+        ctx["error"] = exc
+
+
+# ── Thens ─────────────────────────────────────────────────────────────────────
+
+
+@then("Ana tiene puntos_overall igual a 175.00")
+def step_then_ana_175(ctx: dict) -> None:
+    ana_id = ctx["atleta_ids"]["Ana"]
+    by_id = {e.atleta_id: e for e in ctx["entries"]}
+    assert by_id[ana_id].puntos_overall == Decimal("175.00")
+
+
+@then("Luis tiene puntos_overall igual a 80.00")
+def step_then_luis_80(ctx: dict) -> None:
+    luis_id = ctx["atleta_ids"]["Luis"]
+    by_id = {e.atleta_id: e for e in ctx["entries"]}
+    assert by_id[luis_id].puntos_overall == Decimal("80.00")
+
+
+@then("Ana y Maria aparecen con posicion 1")
+def step_then_empate_pos_1(ctx: dict) -> None:
+    ana_id = ctx["atleta_ids"]["Ana"]
+    maria_id = ctx["atleta_ids"]["Maria"]
+    by_id = {e.atleta_id: e for e in ctx["entries"]}
+    assert by_id[ana_id].posicion == 1
+    assert by_id[maria_id].posicion == 1
+
+
+@then("el sistema rechaza la operacion con DisciplinasNoFinalizadas")
+def step_then_rechaza(ctx: dict) -> None:
+    assert isinstance(ctx["error"], DisciplinasNoFinalizadas)
+
+
+@then("las entradas estan separadas por categoria")
+def step_then_separadas_por_categoria(ctx: dict) -> None:
+    categorias = {e.categoria for e in ctx["entries"]}
+    assert Categoria.SENIOR_MASCULINO in categorias
+    assert Categoria.SENIOR_FEMENINO in categorias
+
+
+@then("el primero de cada categoria tiene la mayor puntuacion")
+def step_then_primero_mayor(ctx: dict) -> None:
+    sm = [e for e in ctx["entries"] if e.categoria == Categoria.SENIOR_MASCULINO]
+    sf = [e for e in ctx["entries"] if e.categoria == Categoria.SENIOR_FEMENINO]
+    assert sm[0].posicion == 1
+    assert sm[0].puntos_overall == Decimal("140.00")
+    assert sf[0].posicion == 1
+    assert sf[0].puntos_overall == Decimal("175.00")

--- a/tests/integration/resultados/test_calcular_overall_integration.py
+++ b/tests/integration/resultados/test_calcular_overall_integration.py
@@ -1,8 +1,9 @@
-"""Tests de integración del cálculo overall — US-3.5.1."""
+"""Tests de integración del cálculo overall — US-3.5.1 / US-5.6.4."""
 
 from __future__ import annotations
 
 import tempfile
+from decimal import Decimal
 from uuid import uuid4
 
 import aiosqlite
@@ -13,6 +14,7 @@ from resultados.application.commands.calcular_overall import (
     CalcularOverallHandler,
 )
 from resultados.domain.aggregates.ranking_overall import RankingOverall
+from resultados.domain.exceptions import DisciplinasNoFinalizadas
 from shared.domain.value_objects.disciplina import Disciplina
 from shared.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
 
@@ -70,8 +72,22 @@ async def _append_ranking(
     )
 
 
+def _ranking_entry(atleta_id, posicion: int, puntos: str) -> dict:
+    return {
+        "posicion": posicion,
+        "atleta_id": str(atleta_id),
+        "rp": "300",
+        "unidad": "Segundos",
+        "tarjeta": "Blanca",
+        "es_dns": False,
+        "en_podio": posicion <= 3,
+        "puntos": puntos,
+    }
+
+
 @pytest.mark.asyncio
 async def test_calcular_overall_persiste_y_reconstituye() -> None:
+    """Overall suma puntos FAAS de cada disciplina y ordena DESC."""
     competencia_dir = tempfile.mkdtemp()
     resultados_dir = tempfile.mkdtemp()
     competencia_db = competencia_dir + "/competencia.db"
@@ -91,38 +107,18 @@ async def test_calcular_overall_persiste_y_reconstituye() -> None:
 
     await _append_competencia(competencia_store, competencia_sta, torneo_id, Disciplina.STA)
     await _append_competencia(competencia_store, competencia_dnf, torneo_id, Disciplina.DNF)
+
+    # Atleta A: STA=100, DNF=80 → overall=180
+    # Atleta B: STA=80, DNF=100 → overall=180 (empate)
+    # Atleta C: STA=60, DNF=60 → overall=120
     await _append_ranking(
         ranking_store,
         competencia_sta,
         Disciplina.STA,
         [
-            {
-                "posicion": 1,
-                "atleta_id": str(atleta_a),
-                "rp": "310",
-                "unidad": "Segundos",
-                "tarjeta": "Blanca",
-                "es_dns": False,
-                "en_podio": True,
-            },
-            {
-                "posicion": 2,
-                "atleta_id": str(atleta_b),
-                "rp": "300",
-                "unidad": "Segundos",
-                "tarjeta": "Blanca",
-                "es_dns": False,
-                "en_podio": True,
-            },
-            {
-                "posicion": 3,
-                "atleta_id": str(atleta_c),
-                "rp": "280",
-                "unidad": "Segundos",
-                "tarjeta": "Blanca",
-                "es_dns": False,
-                "en_podio": True,
-            },
+            _ranking_entry(atleta_a, 1, "100.00"),
+            _ranking_entry(atleta_b, 2, "80.00"),
+            _ranking_entry(atleta_c, 3, "60.00"),
         ],
     )
     await _append_ranking(
@@ -130,33 +126,9 @@ async def test_calcular_overall_persiste_y_reconstituye() -> None:
         competencia_dnf,
         Disciplina.DNF,
         [
-            {
-                "posicion": 2,
-                "atleta_id": str(atleta_a),
-                "rp": "80",
-                "unidad": "Metros",
-                "tarjeta": "Blanca",
-                "es_dns": False,
-                "en_podio": True,
-            },
-            {
-                "posicion": 1,
-                "atleta_id": str(atleta_b),
-                "rp": "90",
-                "unidad": "Metros",
-                "tarjeta": "Blanca",
-                "es_dns": False,
-                "en_podio": True,
-            },
-            {
-                "posicion": 3,
-                "atleta_id": str(atleta_c),
-                "rp": "70",
-                "unidad": "Metros",
-                "tarjeta": "Blanca",
-                "es_dns": False,
-                "en_podio": True,
-            },
+            _ranking_entry(atleta_b, 1, "100.00"),
+            _ranking_entry(atleta_a, 2, "80.00"),
+            _ranking_entry(atleta_c, 3, "60.00"),
         ],
     )
 
@@ -169,9 +141,46 @@ async def test_calcular_overall_persiste_y_reconstituye() -> None:
     overall = RankingOverall.reconstitute(torneo_id, events)
 
     assert len(overall.entries) == 3
-    assert overall.entries[0].puntaje == 3
-    assert overall.entries[0].posicion == 1
-    assert overall.entries[1].puntaje == 3
-    assert overall.entries[1].posicion == 1
-    assert overall.entries[2].puntaje == 6
-    assert overall.entries[2].posicion == 3
+    by_id = {e.atleta_id: e for e in overall.entries}
+    assert by_id[atleta_a].puntos_overall == Decimal("180.00")
+    assert by_id[atleta_a].posicion == 1
+    assert by_id[atleta_b].puntos_overall == Decimal("180.00")
+    assert by_id[atleta_b].posicion == 1
+    assert by_id[atleta_c].puntos_overall == Decimal("120.00")
+    assert by_id[atleta_c].posicion == 3
+
+
+@pytest.mark.asyncio
+async def test_calcular_overall_rechaza_si_falta_ranking_de_disciplina() -> None:
+    """INV-5.6.4-04: rechaza si alguna disciplina no tiene ranking calculado."""
+    competencia_dir = tempfile.mkdtemp()
+    resultados_dir = tempfile.mkdtemp()
+    await _init_db(competencia_dir + "/comp.db")
+    await _init_db(resultados_dir + "/res.db")
+
+    competencia_store = SQLiteEventStore(competencia_dir + "/comp.db")
+    ranking_store = SQLiteEventStore(resultados_dir + "/res.db")
+
+    torneo_id = uuid4()
+    competencia_sta = uuid4()
+    competencia_dnf = uuid4()
+    atleta_a = uuid4()
+
+    await _append_competencia(competencia_store, competencia_sta, torneo_id, Disciplina.STA)
+    await _append_competencia(competencia_store, competencia_dnf, torneo_id, Disciplina.DNF)
+    await _append_ranking(
+        ranking_store,
+        competencia_sta,
+        Disciplina.STA,
+        [_ranking_entry(atleta_a, 1, "100.00")],
+    )
+    # DNF no tiene ranking calculado
+
+    handler = CalcularOverallHandler(ranking_store, competencia_store)
+
+    with pytest.raises(DisciplinasNoFinalizadas):
+        await handler.handle(
+            CalcularOverallCommand(
+                torneo_id=torneo_id, disciplinas=[Disciplina.STA, Disciplina.DNF]
+            )
+        )

--- a/tests/integration/resultados/test_obtener_overall_integration.py
+++ b/tests/integration/resultados/test_obtener_overall_integration.py
@@ -1,7 +1,8 @@
-"""Tests de integración de consulta overall — US-3.5.3."""
+"""Tests de integración de consulta overall — US-3.5.3 / US-5.6.4."""
 
 from __future__ import annotations
 
+from decimal import Decimal
 from uuid import uuid4
 
 import aiosqlite
@@ -66,16 +67,16 @@ async def test_obtener_overall_reconstituye_ultima_version(tmp_path) -> None:
                 "posicion": 1,
                 "atleta_id": str(atleta_a),
                 "categoria": Categoria.SENIOR_MASCULINO.value,
-                "puntaje": 3,
-                "detalle": {"STA": 1, "DNF": 2},
+                "puntos_overall": "175.00",
+                "detalle": {"STA": "100.00", "DNF": "75.00"},
                 "en_podio": True,
             },
             {
                 "posicion": 2,
                 "atleta_id": str(atleta_b),
                 "categoria": Categoria.SENIOR_MASCULINO.value,
-                "puntaje": 4,
-                "detalle": {"STA": 2, "DNF": 2},
+                "puntos_overall": "140.00",
+                "detalle": {"STA": "80.00", "DNF": "60.00"},
                 "en_podio": True,
             },
         ],
@@ -87,5 +88,9 @@ async def test_obtener_overall_reconstituye_ultima_version(tmp_path) -> None:
     assert len(entries) == 1
     assert entries[0].categoria == Categoria.SENIOR_MASCULINO.value
     assert len(entries[0].entradas) == 2
-    assert entries[0].entradas[0].detalle == {"STA": 1, "DNF": 2}
+    assert entries[0].entradas[0].puntos_overall == Decimal("175.00")
+    assert entries[0].entradas[0].detalle == {
+        "STA": Decimal("100.00"),
+        "DNF": Decimal("75.00"),
+    }
     assert entries[0].entradas[0].en_podio is True

--- a/tests/unit/resultados/api/test_router_overall.py
+++ b/tests/unit/resultados/api/test_router_overall.py
@@ -1,4 +1,4 @@
-"""Tests HTTP del router de resultados para Overall — US-3.5.3."""
+"""Tests HTTP del router de resultados para Overall — US-3.5.3 / US-5.6.4."""
 
 from __future__ import annotations
 
@@ -42,7 +42,7 @@ def test_get_overall_devuelve_calculado_false_sin_eventos(tmp_path) -> None:
     }
 
 
-def test_get_overall_devuelve_detalle_y_podio(tmp_path) -> None:
+def test_get_overall_devuelve_puntos_overall_y_detalle(tmp_path) -> None:
     db_path = tmp_path / "resultados.db"
     store = SQLiteEventStore(str(db_path))
     from tests.integration.resultados.test_obtener_overall_integration import (
@@ -64,8 +64,8 @@ def test_get_overall_devuelve_detalle_y_podio(tmp_path) -> None:
                     "posicion": 1,
                     "atleta_id": str(atleta_id),
                     "categoria": Categoria.SENIOR_MASCULINO.value,
-                    "puntaje": 3,
-                    "detalle": {"STA": 1, "DNF": 2},
+                    "puntos_overall": "175.00",
+                    "detalle": {"DNF": "100.00", "STA": "75.00"},
                     "en_podio": True,
                 }
             ],
@@ -85,8 +85,8 @@ def test_get_overall_devuelve_detalle_y_podio(tmp_path) -> None:
                     {
                         "posicion": 1,
                         "atleta_id": str(atleta_id),
-                        "puntaje": 3,
-                        "detalle": {"STA": 1, "DNF": 2},
+                        "puntos_overall": "175.00",
+                        "detalle": {"DNF": "100.00", "STA": "75.00"},
                         "en_podio": True,
                     }
                 ],

--- a/tests/unit/resultados/application/test_calcular_overall_handler.py
+++ b/tests/unit/resultados/application/test_calcular_overall_handler.py
@@ -1,4 +1,4 @@
-"""Tests unitarios del CalcularOverallHandler — US-3.5.1."""
+"""Tests unitarios del CalcularOverallHandler — US-3.5.1 / US-5.6.4."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from resultados.application.commands.calcular_overall import (
     CalcularOverallCommand,
     CalcularOverallHandler,
 )
+from resultados.domain.exceptions import DisciplinasNoFinalizadas
 from shared.domain.value_objects.disciplina import Disciplina
 
 
@@ -28,7 +29,9 @@ def _competencia_event(competencia_id, torneo_id, disciplina: Disciplina) -> dic
     }
 
 
-def _ranking_event(competencia_id, disciplina: Disciplina, atleta_id, posicion: int) -> dict:
+def _ranking_event(
+    competencia_id, disciplina: Disciplina, atleta_id, puntos: str = "80.00"
+) -> dict:
     return {
         "event_type": "ResultadosCalculados",
         "payload": {
@@ -37,13 +40,14 @@ def _ranking_event(competencia_id, disciplina: Disciplina, atleta_id, posicion: 
             "total": 1,
             "entries": [
                 {
-                    "posicion": posicion,
+                    "posicion": 1,
                     "atleta_id": str(atleta_id),
                     "rp": "300",
                     "unidad": "Segundos",
                     "tarjeta": "Blanca",
                     "es_dns": False,
                     "en_podio": True,
+                    "puntos": puntos,
                 }
             ],
             "calculado_en": "2026-04-02T12:00:00+00:00",
@@ -61,7 +65,7 @@ async def test_handle_persiste_ranking_overall_calculado() -> None:
     ranking_store = AsyncMock()
     ranking_store.load = AsyncMock(
         side_effect=[
-            [_ranking_event(competencia_sta, Disciplina.STA, atleta_id, 1)],
+            [_ranking_event(competencia_sta, Disciplina.STA, atleta_id, "100.00")],
             [],
         ]
     )
@@ -82,7 +86,8 @@ async def test_handle_persiste_ranking_overall_calculado() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handle_sin_rankings_fuente_no_persiste() -> None:
+async def test_handle_disciplina_sin_ranking_lanza_excepcion() -> None:
+    """INV-5.6.4-04: disciplina sin ranking calculado → DisciplinasNoFinalizadas."""
     torneo_id = uuid4()
     competencia_id = uuid4()
 
@@ -96,9 +101,10 @@ async def test_handle_sin_rankings_fuente_no_persiste() -> None:
     )
 
     handler = CalcularOverallHandler(ranking_store, competencia_store)
-    result = await handler.handle(
-        CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA])
-    )
 
-    assert result == []
+    with pytest.raises(DisciplinasNoFinalizadas):
+        await handler.handle(
+            CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA])
+        )
+
     ranking_store.append.assert_not_called()

--- a/tests/unit/resultados/application/test_obtener_overall_handler.py
+++ b/tests/unit/resultados/application/test_obtener_overall_handler.py
@@ -1,7 +1,8 @@
-"""Tests unitarios de ObtenerOverallHandler — US-3.5.3."""
+"""Tests unitarios de ObtenerOverallHandler — US-3.5.3 / US-5.6.4."""
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -27,16 +28,16 @@ def _raw_event_ranking_overall_calculado(torneo_id, atleta_id_1, atleta_id_2) ->
                     "posicion": 1,
                     "atleta_id": str(atleta_id_1),
                     "categoria": Categoria.SENIOR_MASCULINO.value,
-                    "puntaje": 3,
-                    "detalle": {"STA": 1, "DNF": 2},
+                    "puntos_overall": "175.00",
+                    "detalle": {"STA": "100.00", "DNF": "75.00"},
                     "en_podio": True,
                 },
                 {
                     "posicion": 2,
                     "atleta_id": str(atleta_id_2),
                     "categoria": Categoria.SENIOR_MASCULINO.value,
-                    "puntaje": 4,
-                    "detalle": {"STA": 2, "DNF": 2},
+                    "puntos_overall": "140.00",
+                    "detalle": {"STA": "80.00", "DNF": "60.00"},
                     "en_podio": True,
                 },
             ],
@@ -74,10 +75,14 @@ class TestObtenerOverallHandler:
         assert result[0].categoria == Categoria.SENIOR_MASCULINO.value
         assert len(result[0].entradas) == 2
         assert result[0].entradas[0].atleta_id == str(atleta_id_1)
-        assert result[0].entradas[0].puntaje == 3
-        assert result[0].entradas[0].detalle == {"STA": 1, "DNF": 2}
+        assert result[0].entradas[0].puntos_overall == Decimal("175.00")
+        assert result[0].entradas[0].detalle == {
+            "STA": Decimal("100.00"),
+            "DNF": Decimal("75.00"),
+        }
         assert result[0].entradas[0].en_podio is True
         assert result[0].entradas[1].atleta_id == str(atleta_id_2)
+        assert result[0].entradas[1].puntos_overall == Decimal("140.00")
 
     @pytest.mark.asyncio
     async def test_handle_lee_stream_correcto(self) -> None:

--- a/tests/unit/resultados/domain/test_ranking_overall.py
+++ b/tests/unit/resultados/domain/test_ranking_overall.py
@@ -1,33 +1,94 @@
-"""Tests unitarios del aggregate RankingOverall — US-3.5.1."""
+"""Tests unitarios del aggregate RankingOverall — US-5.6.4 (puntos FAAS)."""
 
 from __future__ import annotations
 
+from decimal import Decimal
 from uuid import uuid4
+
+import pytest
 
 from registro.domain.value_objects.categoria import Categoria
 from resultados.domain.aggregates.ranking_overall import RankingOverall
+from resultados.domain.exceptions import DisciplinasNoFinalizadas
 from resultados.domain.value_objects.entrada_ranking import EntradaRanking
 from shared.domain.value_objects.disciplina import Disciplina
 
 
 def _entry(
-    posicion: int,
     atleta_id=None,
     categoria: Categoria = Categoria.SENIOR_MASCULINO,
+    puntos: str = "0.00",
+    tarjeta: str = "Blanca",
+    es_dns: bool = False,
 ) -> EntradaRanking:
     return EntradaRanking(
-        posicion=posicion,
+        posicion=1,
         atleta_id=atleta_id or uuid4(),
         categoria=categoria,
         rp=None,
         unidad=None,
-        tarjeta="Blanca",
-        es_dns=False,
-        en_podio=posicion <= 3,
+        tarjeta=tarjeta,
+        es_dns=es_dns,
+        en_podio=True,
+        puntos=Decimal(puntos),
     )
 
 
-def test_calcular_overall_suma_posiciones_y_empates() -> None:
+# ── INV-5.6.4-01: puntos_overall = Σ puntos_disciplina ───────────────────────
+
+
+def test_calcular_overall_suma_puntos_faas() -> None:
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    ranking = RankingOverall(uuid4())
+
+    entries = ranking.calcular(
+        ranking.torneo_id,
+        {
+            Disciplina.DNF: [
+                _entry(atleta_a, puntos="100.00"),
+                _entry(atleta_b, puntos="80.00"),
+            ],
+            Disciplina.STA: [
+                _entry(atleta_a, puntos="75.00"),
+                _entry(atleta_b, puntos="95.00"),
+            ],
+        },
+    )
+
+    by_id = {e.atleta_id: e for e in entries}
+    assert by_id[atleta_a].puntos_overall == Decimal("175.00")
+    assert by_id[atleta_b].puntos_overall == Decimal("175.00")
+
+
+def test_calcular_overall_ausente_aporta_cero_puntos() -> None:
+    """INV-5.6.4-01: atleta no presente en una disciplina aporta 0 puntos."""
+    atleta_a = uuid4()
+    atleta_b = uuid4()
+    ranking = RankingOverall(uuid4())
+
+    entries = ranking.calcular(
+        ranking.torneo_id,
+        {
+            Disciplina.DNF: [
+                _entry(atleta_a, puntos="80.00"),
+                _entry(atleta_b, puntos="80.00"),
+            ],
+            Disciplina.STA: [
+                _entry(atleta_b, puntos="60.00"),
+            ],
+        },
+    )
+
+    by_id = {e.atleta_id: e for e in entries}
+    assert by_id[atleta_a].puntos_overall == Decimal("80.00")
+    assert by_id[atleta_b].puntos_overall == Decimal("140.00")
+
+
+# ── INV-5.6.4-02: orden DESC por puntos_overall ──────────────────────────────
+
+
+def test_calcular_overall_ordena_por_puntos_desc() -> None:
     atleta_a = uuid4()
     atleta_b = uuid4()
     atleta_c = uuid4()
@@ -36,81 +97,93 @@ def test_calcular_overall_suma_posiciones_y_empates() -> None:
     entries = ranking.calcular(
         ranking.torneo_id,
         {
-            Disciplina.STA: [_entry(1, atleta_a), _entry(2, atleta_b), _entry(3, atleta_c)],
-            Disciplina.DNF: [_entry(2, atleta_a), _entry(1, atleta_b), _entry(3, atleta_c)],
+            Disciplina.STA: [
+                _entry(atleta_a, puntos="100.00"),
+                _entry(atleta_b, puntos="80.00"),
+                _entry(atleta_c, puntos="60.00"),
+            ],
         },
     )
 
-    by_id = {entry.atleta_id: entry for entry in entries}
-    assert by_id[atleta_a].puntaje == 3
+    by_id = {e.atleta_id: e for e in entries}
     assert by_id[atleta_a].posicion == 1
-    assert by_id[atleta_b].puntaje == 3
-    assert by_id[atleta_b].posicion == 1
-    assert by_id[atleta_c].puntaje == 6
+    assert by_id[atleta_b].posicion == 2
     assert by_id[atleta_c].posicion == 3
 
 
-def test_calcular_overall_penaliza_ausente_con_ultimo_mas_uno() -> None:
+# ── INV-5.6.4-03: empate comparte posición ───────────────────────────────────
+
+
+def test_calcular_overall_empate_comparte_posicion() -> None:
     atleta_a = uuid4()
     atleta_b = uuid4()
+    atleta_c = uuid4()
     ranking = RankingOverall(uuid4())
 
     entries = ranking.calcular(
         ranking.torneo_id,
         {
-            Disciplina.STA: [_entry(1, atleta_a), _entry(2, atleta_b)],
-            Disciplina.DNF: [_entry(1, atleta_b)],
+            Disciplina.DNF: [
+                _entry(atleta_a, puntos="100.00"),
+                _entry(atleta_b, puntos="80.00"),
+            ],
+            Disciplina.STA: [
+                _entry(atleta_a, puntos="75.00"),
+                _entry(atleta_b, puntos="95.00"),
+                _entry(atleta_c, puntos="50.00"),
+            ],
         },
     )
 
-    by_id = {entry.atleta_id: entry for entry in entries}
-    assert by_id[atleta_a].detalle == {"STA": 1, "DNF": 2}
-    assert by_id[atleta_a].puntaje == 3
-    assert by_id[atleta_b].puntaje == 3
+    by_id = {e.atleta_id: e for e in entries}
+    assert by_id[atleta_a].puntos_overall == Decimal("175.00")
+    assert by_id[atleta_b].puntos_overall == Decimal("175.00")
+    assert by_id[atleta_a].posicion == 1
+    assert by_id[atleta_b].posicion == 1
+    assert by_id[atleta_c].posicion == 3
 
 
-def test_calcular_overall_excluye_disciplinas_sin_ranking() -> None:
-    atleta_a = uuid4()
-    atleta_b = uuid4()
+# ── INV-5.6.4-04: rechaza si alguna disciplina no está finalizada ─────────────
+
+
+def test_calcular_overall_rechaza_disciplinas_sin_finalizar() -> None:
     ranking = RankingOverall(uuid4())
 
-    entries = ranking.calcular(
-        ranking.torneo_id,
-        {
-            Disciplina.STA: [_entry(1, atleta_a), _entry(2, atleta_b)],
-            Disciplina.DNF: [],
-        },
-    )
-
-    assert len(entries) == 2
-    assert entries[0].puntaje == 1
-    assert entries[1].puntaje == 2
+    with pytest.raises(DisciplinasNoFinalizadas):
+        ranking.calcular(
+            ranking.torneo_id,
+            {
+                Disciplina.DNF: [_entry(puntos="80.00")],
+                Disciplina.STA: [],
+            },
+        )
 
 
-def test_calcular_overall_sin_rankings_devuelve_vacio() -> None:
+def test_calcular_overall_sin_disciplinas_no_persiste_evento() -> None:
     ranking = RankingOverall(uuid4())
-    assert ranking.calcular(ranking.torneo_id, {}) == []
+
+    result = ranking.calcular(ranking.torneo_id, {})
+
+    assert result == []
     assert ranking.pull_events() == []
 
 
-def test_reconstitute_recupera_estado_desde_evento() -> None:
-    torneo_id = uuid4()
-    atleta_id = uuid4()
-    ranking = RankingOverall(torneo_id)
-    ranking.calcular(
-        torneo_id,
-        {Disciplina.STA: [_entry(1, atleta_id)]},
-    )
-    event = ranking.pull_events()[0]
+# ── INV-5.6.4-05: precisión 2 decimales ──────────────────────────────────────
 
-    reconstituido = RankingOverall.reconstitute(
-        torneo_id,
-        [{"event_type": event.event_type, "payload": event.to_payload()}],
+
+def test_calcular_overall_precision_dos_decimales() -> None:
+    atleta_a = uuid4()
+    ranking = RankingOverall(uuid4())
+
+    entries = ranking.calcular(
+        ranking.torneo_id,
+        {Disciplina.STA: [_entry(atleta_a, puntos="75.50")]},
     )
 
-    assert len(reconstituido.entries) == 1
-    assert reconstituido.entries[0].atleta_id == atleta_id
-    assert reconstituido.calculado is True
+    assert entries[0].puntos_overall == Decimal("75.50")
+
+
+# ── Agrupación por categoría ──────────────────────────────────────────────────
 
 
 def test_calcular_overall_segmenta_por_categoria() -> None:
@@ -122,12 +195,12 @@ def test_calcular_overall_segmenta_por_categoria() -> None:
         ranking.torneo_id,
         {
             Disciplina.STA: [
-                _entry(1, atleta_sf, Categoria.SENIOR_FEMENINO),
-                _entry(1, atleta_mm, Categoria.MASTER_MASCULINO),
+                _entry(atleta_sf, Categoria.SENIOR_FEMENINO, "100.00"),
+                _entry(atleta_mm, Categoria.MASTER_MASCULINO, "80.00"),
             ],
             Disciplina.DNF: [
-                _entry(2, atleta_sf, Categoria.SENIOR_FEMENINO),
-                _entry(2, atleta_mm, Categoria.MASTER_MASCULINO),
+                _entry(atleta_sf, Categoria.SENIOR_FEMENINO, "75.00"),
+                _entry(atleta_mm, Categoria.MASTER_MASCULINO, "60.00"),
             ],
         },
     )
@@ -137,7 +210,87 @@ def test_calcular_overall_segmenta_por_categoria() -> None:
 
     assert len(senior_f) == 1
     assert senior_f[0].posicion == 1
-    assert senior_f[0].puntaje == 3
+    assert senior_f[0].puntos_overall == Decimal("175.00")
     assert len(master_m) == 1
     assert master_m[0].posicion == 1
-    assert master_m[0].puntaje == 3
+    assert master_m[0].puntos_overall == Decimal("140.00")
+
+
+# ── Detalle por disciplina ────────────────────────────────────────────────────
+
+
+def test_calcular_overall_detalle_contiene_puntos_por_disciplina() -> None:
+    atleta_a = uuid4()
+    ranking = RankingOverall(uuid4())
+
+    entries = ranking.calcular(
+        ranking.torneo_id,
+        {
+            Disciplina.DNF: [_entry(atleta_a, puntos="100.00")],
+            Disciplina.STA: [_entry(atleta_a, puntos="75.00")],
+        },
+    )
+
+    assert entries[0].detalle == {
+        "DNF": Decimal("100.00"),
+        "STA": Decimal("75.00"),
+    }
+
+
+# ── Reconstitución ────────────────────────────────────────────────────────────
+
+
+def test_reconstitute_recupera_estado_desde_evento() -> None:
+    torneo_id = uuid4()
+    atleta_id = uuid4()
+    ranking = RankingOverall(torneo_id)
+    ranking.calcular(
+        torneo_id,
+        {Disciplina.STA: [_entry(atleta_id, puntos="100.00")]},
+    )
+    event = ranking.pull_events()[0]
+
+    reconstituido = RankingOverall.reconstitute(
+        torneo_id,
+        [{"event_type": event.event_type, "payload": event.to_payload()}],
+    )
+
+    assert len(reconstituido.entries) == 1
+    assert reconstituido.entries[0].atleta_id == atleta_id
+    assert reconstituido.entries[0].puntos_overall == Decimal("100.00")
+    assert reconstituido.calculado is True
+
+
+def test_reconstitute_evento_legacy_sin_puntos_overall_usa_cero() -> None:
+    """Backward compat: eventos con schema antiguo (puntaje/detalle int) no rompen."""
+    torneo_id = uuid4()
+    atleta_id = uuid4()
+
+    reconstituido = RankingOverall.reconstitute(
+        torneo_id,
+        [
+            {
+                "event_type": "RankingOverallCalculado",
+                "payload": {
+                    "torneo_id": str(torneo_id),
+                    "disciplinas": ["STA"],
+                    "total": 1,
+                    "entries": [
+                        {
+                            "posicion": 1,
+                            "atleta_id": str(atleta_id),
+                            "categoria": "SENIOR_MASCULINO",
+                            "puntaje": 3,
+                            "detalle": {"STA": 1},
+                            "en_podio": True,
+                        }
+                    ],
+                    "calculado_en": "2026-04-01T12:00:00+00:00",
+                    "occurred_at": "2026-04-01T12:00:00+00:00",
+                },
+            }
+        ],
+    )
+
+    assert reconstituido.calculado is True
+    assert reconstituido.entries[0].puntos_overall == Decimal("0.00")


### PR DESCRIPTION
## Summary

- `EntradaOverall` migrado a `puntos_overall: Decimal` + `detalle: dict[str, Decimal]` (puntos FAAS por disciplina)
- `RankingOverall.calcular()` reescrito: suma `EntradaRanking.puntos` DESC; ausente = 0 puntos (INV-5.6.4-01)
- Nueva excepción `DisciplinasNoFinalizadas` — rechaza el overall si alguna disciplina no tiene ranking calculado (INV-5.6.4-04)
- Backward compat: eventos legacy (sin `puntos_overall`) se leen con fallback `0.00`

## Tests

- 91 tests resultados — 91/91 PASS
- 5 escenarios BDD — 5/5 PASS
- CodeGuard: 0 errores

## Invariantes verificados

INV-5.6.4-01 ✅ · INV-5.6.4-02 ✅ · INV-5.6.4-03 ✅ · INV-5.6.4-04 ✅ · INV-5.6.4-05 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)