### PR TITLE
feat(frontend): formalizar home del organizador [US-ADJ-9.3]

### DIFF
--- a/.claude/tracking/US-ADJ-9.3-tracking.json
+++ b/.claude/tracking/US-ADJ-9.3-tracking.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-9.3",
+    "us_title": "Home del organizador torneos vigentes e historico",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-28T13:32:00+00:00",
+    "completed_at": null,
+    "total_elapsed_seconds": 600,
+    "effective_seconds": 600,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de Contexto",
+      "started_at": "2026-04-28T13:32:00+00:00",
+      "completed_at": "2026-04-28T13:34:00+00:00",
+      "elapsed_seconds": 120,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generacion de Escenarios BDD",
+      "started_at": "2026-04-28T13:34:01+00:00",
+      "completed_at": "2026-04-28T13:35:00+00:00",
+      "elapsed_seconds": 59,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementacion",
+      "started_at": "2026-04-28T13:35:01+00:00",
+      "completed_at": "2026-04-28T13:36:00+00:00",
+      "elapsed_seconds": 59,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementacion",
+      "started_at": "2026-04-28T13:36:01+00:00",
+      "completed_at": "2026-04-28T13:40:30+00:00",
+      "elapsed_seconds": 269,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-28T13:40:31+00:00",
+      "completed_at": "2026-04-28T13:40:31+00:00",
+      "elapsed_seconds": 0,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integracion",
+      "started_at": "2026-04-28T13:40:31+00:00",
+      "completed_at": "2026-04-28T13:40:31+00:00",
+      "elapsed_seconds": 0,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validacion BDD",
+      "started_at": "2026-04-28T13:40:31+00:00",
+      "completed_at": "2026-04-28T13:40:31+00:00",
+      "elapsed_seconds": 0,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-28T13:40:32+00:00",
+      "completed_at": "2026-04-28T13:42:20+00:00",
+      "elapsed_seconds": 108,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentacion",
+      "started_at": "2026-04-28T13:42:21+00:00",
+      "completed_at": "2026-04-28T13:43:00+00:00",
+      "elapsed_seconds": 39,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": null,
+      "completed_at": null,
+      "elapsed_seconds": 0,
+      "status": "pending",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 10,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 10,
+    "variance_minutes": 0,
+    "variance_percent": 0
+  }
+}

--- a/docs/plans/sp-adj-09/US-ADJ-9.3-fase0.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.3-fase0.md
@@ -1,0 +1,94 @@
+# US-ADJ-9.3 - Fase 0: Validacion de Contexto
+
+**Fecha:** 2026-04-28
+**Producto:** `frontend`
+**Sprint:** `SP-ADJ-09`
+**Spec canonica:** `docs/specs/sp-adj-09/US-ADJ-9.3.md`
+
+---
+
+## Historia
+
+**US:** US-ADJ-9.3 - Home del organizador
+
+Como **organizador**, quiero una pagina inicial que liste los torneos bajo mi
+responsabilidad, priorizando los torneos vigentes y permitiendo acceder al historico
+para entrar rapidamente al torneo que estoy operando y consultar anteriores cuando haga falta.
+
+---
+
+## Fuentes de Verdad Validadas
+
+- `docs/specs/sp-adj-09/US-ADJ-9.3.md`
+- `docs/design/ux/wireframes-organizador.md`
+- `docs/design/ux/decisiones-frontend.md`
+- `docs/plans/sp-adj-09/PLAN-SP-ADJ-09.md`
+- `frontend/src/pages/organizador/DashboardPage.tsx`
+- `frontend/src/App.tsx`
+
+---
+
+## Contexto Relevante
+
+### Estado actual de la home del organizador
+
+- La ruta principal del organizador ya aterriza en `/organizador/torneo`.
+- `DashboardPage.tsx` hoy funciona como listado de torneos, no como dashboard operativo.
+- El título ya fue movido a `Torneos`, pero el comportamiento todavía usa filtros heredados:
+  - `todos`
+  - `abiertos`
+  - `cerrados`
+  - `cancelados`
+
+### Gap funcional respecto de la spec
+
+- La spec define dos agrupaciones de negocio:
+  - `vigentes`
+  - `historico`
+- La vista actual mezcla ambos conceptos con filtros más técnicos y menos intencionales.
+- También sigue incluyendo `CREADO` dentro del universo "abierto", cuando la spec de `9.3`
+  formaliza vigencia a partir de:
+  - `INSCRIPCION_ABIERTA`
+  - `PREPARACION`
+  - `EJECUCION`
+  - `PREMIACION`
+
+### Separacion conceptual confirmada
+
+- Esta pantalla ya no debe llamarse ni comportarse como dashboard operativo.
+- El dashboard operativo con KPIs y disciplina activa queda diferido explícitamente a `US-ADJ-9.4`.
+
+---
+
+## Gaps Detectados
+
+1. La home no usa todavía la clasificación formal `vigentes` vs `historico`.
+2. El filtro por defecto sigue expresado como `abiertos`, no como torneos vigentes.
+3. La clasificación actual puede incluir estados fuera de la definición formal de vigencia.
+4. Falta explicitar mejor en copy/UI que esta pantalla es un acceso a torneos y no un panel operativo.
+
+---
+
+## Riesgos Detectados
+
+- Cambiar la clasificación puede alterar qué torneos aparecen por defecto.
+- Si se mezcla esta US con `9.4`, vuelve a confundirse home con dashboard operativo.
+- Un cambio de copy/títulos debe ser consistente con las rutas ya estabilizadas en `9.2`.
+
+---
+
+## Quality Gates Esperables
+
+- `npm run build` en `frontend/`
+- `npm run lint` en `frontend/`
+- validacion UI/manual del filtro `vigentes` / `historico`
+
+---
+
+## Resultado
+
+Contexto validado. La US queda lista para:
+
+1. Fase 1 - Escenarios BDD
+2. Fase 2 - Plan de implementacion
+3. Espera de aprobacion explicita antes de Fase 3

--- a/docs/plans/sp-adj-09/US-ADJ-9.3-implementation-notes.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.3-implementation-notes.md
@@ -1,0 +1,75 @@
+# US-ADJ-9.3 - Implementation Notes
+
+**Fecha:** 2026-04-28
+**Sprint:** `SP-ADJ-09`
+**US:** `US-ADJ-9.3`
+
+---
+
+## Resumen
+
+La home del organizador quedó formalizada como listado inicial de torneos bajo su
+responsabilidad, con foco en torneos vigentes y acceso explícito al histórico.
+
+---
+
+## Cambios implementados
+
+### Home del organizador
+
+- `frontend/src/pages/organizador/DashboardPage.tsx`
+  - la vista quedó expresada como `Home de torneos`
+  - se reemplazaron los filtros heredados:
+    - `Todos`
+    - `Abiertos`
+    - `Cerrados`
+    - `Cancelados`
+  - por la semántica formal:
+    - `Vigentes`
+    - `Histórico`
+
+### Clasificación de estados
+
+- se definieron helpers explícitos:
+  - `esTorneoVigente`
+  - `esTorneoHistorico`
+  - `esTorneoPendienteActivacion`
+
+- la vista por defecto muestra solo:
+  - `INSCRIPCION_ABIERTA`
+  - `PREPARACION`
+  - `EJECUCION`
+  - `PREMIACION`
+
+- el filtro histórico muestra solo:
+  - `CERRADO`
+  - `CANCELADO`
+
+### Tratamiento de torneos en estado `CREADO`
+
+- los torneos `CREADO` no se consideran vigentes por defecto
+- si existen, la home muestra una advertencia separada indicando que permanecen
+  pendientes de activación y no integran el listado vigente hasta abrir inscripción
+
+### Claridad de rol de la pantalla
+
+- se agregó copy explícito aclarando que esta pantalla es la home del organizador
+  y no el dashboard operativo del torneo
+- se mantuvo la acción principal `Gestionar` por torneo hacia `/organizador/panel`
+
+---
+
+## Quality Gates
+
+- `npm run build` en `frontend/`: OK
+- `npm run lint` en `frontend/`: falla solo por error preexistente fuera de alcance en:
+  - `frontend/src/pages/atleta/portalData.ts:120`
+
+---
+
+## Observaciones
+
+- `US-ADJ-9.3` deja explícita la separación conceptual entre:
+  - home de torneos del organizador
+  - dashboard operativo del torneo activo
+- el dashboard operativo sigue diferido a `US-ADJ-9.4`

--- a/docs/plans/sp-adj-09/US-ADJ-9.3-plan.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.3-plan.md
@@ -1,0 +1,73 @@
+# Plan de Implementacion - US-ADJ-9.3: Home del organizador
+
+**Sprint:** SP-ADJ-09
+**Patron:** React/Vite frontend
+**Estimacion total:** 90 min
+
+---
+
+## Diagnostico
+
+La base estructural ya existe desde `US-ADJ-9.2`: la ruta principal del organizador
+ya aterriza en una home de torneos. El ajuste de `9.3` consiste en formalizar esa
+pantalla como home del rol, alineando la clasificación funcional de estados, el copy
+y el filtro principal con la spec aprobada.
+
+## Cambios por area
+
+### 1. Clasificacion de torneos
+
+- [ ] Definir helpers explícitos para `vigentes` e `historico` (15 min)
+  - vigentes:
+    - `INSCRIPCION_ABIERTA`
+    - `PREPARACION`
+    - `EJECUCION`
+    - `PREMIACION`
+  - historico:
+    - `CERRADO`
+    - `CANCELADO`
+
+- [ ] Excluir `CREADO` del set de vigentes por defecto, salvo decisión contraria en la UI (10 min)
+
+### 2. Home del organizador
+
+- [ ] Ajustar `DashboardPage.tsx` para presentar explícitamente:
+  - torneos vigentes
+  - acceso a histórico
+  - copy de home de torneos, no dashboard operativo (20 min)
+
+- [ ] Renombrar filtros heredados (`abiertos`, `todos`, etc.) a la semántica aprobada (10 min)
+
+### 3. Claridad visual y navegación
+
+- [ ] Mantener la acción principal de cada torneo hacia su gestión (5 min)
+- [ ] Refinar empty states para vigentes e histórico (10 min)
+
+### 4. Validación
+
+- [ ] `npm run build` en `frontend/` (5 min)
+- [ ] `npm run lint` en `frontend/` (5 min)
+- [ ] validación manual del filtro default y del histórico (10 min)
+
+## Decisiones clave
+
+- Esta US no implementa todavía el dashboard operativo del torneo activo.
+- La pantalla debe seguir siendo una lista de torneos, pero con semántica formalizada.
+- Si `CREADO` no entra en vigencia según spec, no debe contaminar el listado default.
+
+## Riesgos y mitigaciones
+
+- Riesgo: perder acceso visible a torneos en `CREADO`.
+  Mitigacion: decidir un fallback controlado en la UI sin romper la definición principal de vigencia.
+
+- Riesgo: cambios demasiado cosméticos y no funcionales.
+  Mitigacion: centrar la implementación en clasificación, filtro y semántica observable.
+
+## Criterio de salida
+
+La implementación de esta US termina cuando:
+
+1. la home del organizador muestra por defecto torneos vigentes;
+2. el histórico queda disponible con un filtro explícito;
+3. la pantalla se presenta como home de torneos y no como dashboard operativo;
+4. build y lint quedan ejecutados.

--- a/frontend/src/pages/organizador/DashboardPage.tsx
+++ b/frontend/src/pages/organizador/DashboardPage.tsx
@@ -5,7 +5,7 @@ import { fetchTorneos, type EstadoTorneo, type TorneoDto } from '../../api/torne
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 import useAuthStore from '../../stores/useAuthStore'
 
-const ESTADO_TORNEO_LABELS: Record<string, string> = {
+const ESTADO_TORNEO_LABELS: Record<EstadoTorneo, string> = {
   CREADO: 'Creado',
   INSCRIPCION_ABIERTA: 'Inscripción abierta',
   PREPARACION: 'Preparación',
@@ -15,42 +15,49 @@ const ESTADO_TORNEO_LABELS: Record<string, string> = {
   CANCELADO: 'Cancelado',
 }
 
-type FiltroTorneos = 'abiertos' | 'todos' | 'cerrados' | 'cancelados'
+type FiltroTorneos = 'vigentes' | 'historico'
 
 const FILTROS_TORNEOS: Array<{ value: FiltroTorneos; label: string }> = [
-  { value: 'todos', label: 'Todos' },
-  { value: 'abiertos', label: 'Abiertos' },
-  { value: 'cerrados', label: 'Cerrados' },
-  { value: 'cancelados', label: 'Cancelados' },
+  { value: 'vigentes', label: 'Vigentes' },
+  { value: 'historico', label: 'Histórico' },
 ]
 
 function formatEstadoTorneo(estado: string): string {
-  return ESTADO_TORNEO_LABELS[estado] ?? estado
+  return ESTADO_TORNEO_LABELS[estado as EstadoTorneo] ?? estado
 }
 
-function esTorneoAbierto(estado: EstadoTorneo): boolean {
-  return estado !== 'CERRADO' && estado !== 'CANCELADO'
+function esTorneoVigente(estado: EstadoTorneo): boolean {
+  return (
+    estado === 'INSCRIPCION_ABIERTA' ||
+    estado === 'PREPARACION' ||
+    estado === 'EJECUCION' ||
+    estado === 'PREMIACION'
+  )
+}
+
+function esTorneoHistorico(estado: EstadoTorneo): boolean {
+  return estado === 'CERRADO' || estado === 'CANCELADO'
+}
+
+function esTorneoPendienteActivacion(estado: EstadoTorneo): boolean {
+  return estado === 'CREADO'
 }
 
 function filtrarTorneos(torneos: TorneoDto[], filtro: FiltroTorneos): TorneoDto[] {
-  if (filtro === 'todos') return torneos
-  if (filtro === 'abiertos') return torneos.filter((torneo) => esTorneoAbierto(torneo.estado))
-  if (filtro === 'cerrados') return torneos.filter((torneo) => torneo.estado === 'CERRADO')
-  return torneos.filter((torneo) => torneo.estado === 'CANCELADO')
+  if (filtro === 'vigentes') return torneos.filter((torneo) => esTorneoVigente(torneo.estado))
+  return torneos.filter((torneo) => esTorneoHistorico(torneo.estado))
 }
 
 function emptyMessage(filtro: FiltroTorneos): string {
-  if (filtro === 'abiertos') return 'No hay torneos abiertos.'
-  if (filtro === 'cerrados') return 'No hay torneos cerrados.'
-  if (filtro === 'cancelados') return 'No hay torneos cancelados.'
-  return 'No hay torneos disponibles.'
+  if (filtro === 'vigentes') return 'No hay torneos vigentes.'
+  return 'No hay torneos en el histórico.'
 }
 
 export function DashboardPage() {
   const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
   const email = useAuthStore((s) => s.email)
-  const [filtro, setFiltro] = useState<FiltroTorneos>('abiertos')
+  const [filtro, setFiltro] = useState<FiltroTorneos>('vigentes')
   const torneosQuery = useQuery({
     queryKey: ['torneos-organizador'],
     queryFn: fetchTorneos,
@@ -59,12 +66,18 @@ export function DashboardPage() {
     () => filtrarTorneos(torneosQuery.data ?? [], filtro),
     [filtro, torneosQuery.data],
   )
+  const torneosPendientesActivacion = useMemo(
+    () => (torneosQuery.data ?? []).filter((torneo) => esTorneoPendienteActivacion(torneo.estado)),
+    [torneosQuery.data],
+  )
 
   return (
     <OrganizadorLayout
-      title="Torneos"
+      title="Home de torneos"
       subtitle={
-        email ? `Torneos bajo tu responsabilidad · Sesion activa: ${email}` : 'Gestion de torneos'
+        email
+          ? `Torneos bajo tu responsabilidad · Sesion activa: ${email}`
+          : 'Acceso a torneos vigentes e histórico'
       }
       actions={
         <>
@@ -103,24 +116,42 @@ export function DashboardPage() {
       ) : null}
 
       {!torneosQuery.isLoading && !torneosQuery.isError ? (
-        <section className="flex flex-wrap items-center gap-2">
-          {FILTROS_TORNEOS.map((item) => {
-            const isActive = filtro === item.value
-            return (
-              <button
-                key={item.value}
-                type="button"
-                onClick={() => setFiltro(item.value)}
-                className={
-                  isActive
-                    ? 'rounded-full border border-sky-400 bg-sky-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-sky-300'
-                    : 'rounded-full border border-slate-700 bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-300'
-                }
-              >
-                {item.label}
-              </button>
-            )
-          })}
+        <>
+          <section className="rounded-[2rem] border border-slate-700 bg-slate-900/70 p-5 text-sm text-slate-300">
+            Esta pantalla es la home del organizador. Prioriza torneos vigentes y permite consultar el histórico sin reemplazar el dashboard operativo del torneo.
+          </section>
+
+          <section className="flex flex-wrap items-center gap-2">
+            {FILTROS_TORNEOS.map((item) => {
+              const isActive = filtro === item.value
+              return (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setFiltro(item.value)}
+                  className={
+                    isActive
+                      ? 'rounded-full border border-sky-400 bg-sky-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-sky-300'
+                      : 'rounded-full border border-slate-700 bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-300'
+                  }
+                >
+                  {item.label}
+                </button>
+              )
+            })}
+          </section>
+        </>
+      ) : null}
+
+      {!torneosQuery.isLoading &&
+      !torneosQuery.isError &&
+      filtro === 'vigentes' &&
+      torneosPendientesActivacion.length > 0 ? (
+        <section className="rounded-[2rem] border border-amber-500/40 bg-amber-950/30 p-5 text-sm text-amber-100">
+          {torneosPendientesActivacion.length}{' '}
+          {torneosPendientesActivacion.length === 1
+            ? 'torneo permanece en estado Creado y no aparece como vigente hasta abrir inscripción.'
+            : 'torneos permanecen en estado Creado y no aparecen como vigentes hasta abrir inscripción.'}
         </section>
       ) : null}
 
@@ -139,7 +170,7 @@ export function DashboardPage() {
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                    Torneo
+                    {filtro === 'vigentes' ? 'Torneo vigente' : 'Torneo histórico'}
                   </p>
                   <h2 className="mt-2 text-xl font-semibold text-white">{torneo.nombre}</h2>
                   <p className="mt-2 text-sm text-slate-300">

--- a/tests/features/US-ADJ-9.3-home-organizador.feature
+++ b/tests/features/US-ADJ-9.3-home-organizador.feature
@@ -1,0 +1,25 @@
+Feature: US-ADJ-9.3 - Home del organizador
+
+  Background:
+    Given existe un usuario autenticado con rol ORGANIZADOR
+
+  Scenario: La vista inicial muestra torneos vigentes
+    Given existen torneos en INSCRIPCION_ABIERTA, PREPARACION, EJECUCION y CERRADO
+    When el organizador entra a la home del organizador
+    Then ve los torneos en INSCRIPCION_ABIERTA, PREPARACION y EJECUCION
+    And no ve por defecto el torneo CERRADO
+
+  Scenario: El filtro historico muestra torneos anteriores
+    Given existen torneos CERRADO y CANCELADO
+    When el organizador activa el filtro de historico
+    Then ve los torneos CERRADO y CANCELADO
+
+  Scenario: Cada torneo permite entrar a su gestion
+    Given el organizador ve un torneo vigente
+    When selecciona la accion principal del torneo
+    Then entra al flujo de gestion de ese torneo
+
+  Scenario: La home no se presenta como dashboard operativo
+    Given el organizador esta en la pagina inicial
+    Then ve una lista de torneos
+    And no ve KPIs operativos ni alertas de disciplina activa como contenido principal


### PR DESCRIPTION
## Resumen
- formaliza la pantalla inicial del organizador como home de torneos
- reemplaza filtros heredados por `Vigentes` e `Histórico`
- excluye torneos en `CREADO` del listado vigente y muestra advertencia de activación pendiente
- agrega documentación y escenario BDD de `US-ADJ-9.3`

## Validación
- `npm run build` en `frontend`: OK
- `npm run lint` en `frontend`: falla por error preexistente fuera de alcance en `frontend/src/pages/atleta/portalData.ts:120`