### PR TITLE
feat(frontend): reencuadrar resultados y shell organizador [US-ADJ-9.5]

### DIFF
--- a/.claude/tracking/US-ADJ-9.5-tracking.json
+++ b/.claude/tracking/US-ADJ-9.5-tracking.json
@@ -1,0 +1,152 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-9.5",
+    "us_title": "Reencuadrar Resultados dentro del shell aprobado S-04",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-28T18:03:58.786735+00:00",
+    "completed_at": "2026-04-28T18:14:33.152169+00:00",
+    "total_elapsed_seconds": 634,
+    "effective_seconds": 634,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de Contexto",
+      "started_at": "2026-04-28T18:04:02.674455+00:00",
+      "completed_at": "2026-04-28T18:05:18.838802+00:00",
+      "elapsed_seconds": 76,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generacion de Escenarios BDD",
+      "started_at": "2026-04-28T18:05:27.394216+00:00",
+      "completed_at": "2026-04-28T18:06:03.844579+00:00",
+      "elapsed_seconds": 36,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementacion",
+      "started_at": "2026-04-28T18:06:08.096806+00:00",
+      "completed_at": "2026-04-28T18:08:59.458294+00:00",
+      "elapsed_seconds": 171,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementacion",
+      "started_at": "2026-04-28T18:09:03.439619+00:00",
+      "completed_at": "2026-04-28T18:12:06.960073+00:00",
+      "elapsed_seconds": 183,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Reencuadrar resultados S-04",
+          "task_type": "frontend",
+          "estimated_minutes": 75.0,
+          "started_at": "2026-04-28T18:09:15.652629+00:00",
+          "completed_at": "2026-04-28T18:12:03.555128+00:00",
+          "elapsed_seconds": 167,
+          "actual_minutes": 2.78,
+          "variance_minutes": -72.22,
+          "file_created": "frontend/src/pages/organizador/ResultadosPage.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-28T18:12:15.167490+00:00",
+      "completed_at": "2026-04-28T18:12:30.095649+00:00",
+      "elapsed_seconds": 14,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integracion",
+      "started_at": "2026-04-28T18:12:33.385646+00:00",
+      "completed_at": "2026-04-28T18:12:38.993183+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validacion BDD",
+      "started_at": "2026-04-28T18:12:42.217550+00:00",
+      "completed_at": "2026-04-28T18:12:45.501387+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-28T18:12:48.832548+00:00",
+      "completed_at": "2026-04-28T18:12:51.940358+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentacion",
+      "started_at": "2026-04-28T18:12:56.157105+00:00",
+      "completed_at": "2026-04-28T18:13:50.500688+00:00",
+      "elapsed_seconds": 54,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-28T18:13:53.931674+00:00",
+      "completed_at": "2026-04-28T18:14:29.304842+00:00",
+      "elapsed_seconds": 35,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 1,
+    "completed_tasks": 1,
+    "total_phases": 10,
+    "estimated_total_minutes": 75.0,
+    "actual_total_minutes": 2.78,
+    "variance_minutes": -72.22,
+    "variance_percent": -96.29
+  }
+}

--- a/docs/plans/sp-adj-09/US-ADJ-9.5-fase0.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.5-fase0.md
@@ -1,0 +1,136 @@
+# US-ADJ-9.5 - Fase 0: Validacion de Contexto
+
+**Fecha:** 2026-04-28
+**Producto:** `frontend`
+**Sprint:** `SP-ADJ-09`
+**Spec canonica:** `docs/specs/sp-adj-09/US-ADJ-9.5.md`
+
+---
+
+## Historia
+
+**US:** US-ADJ-9.5 - Reencuadrar Resultados dentro del shell aprobado - S-04
+
+Como **organizador**, quiero que la pantalla de resultados respete el shell y el
+layout aprobados para leer la disciplina activa y el overall del torneo dentro de
+una experiencia coherente con el panel.
+
+---
+
+## Fuentes de Verdad Validadas
+
+- `docs/specs/sp-adj-09/US-ADJ-9.5.md`
+- `docs/design/ux/wireframes-organizador.md`
+- `docs/design/ux/prototipos/prototipo-organizador.html`
+- `docs/design/ux/decisiones-frontend.md`
+- `docs/specs/sp5/US-5.6.5.md`
+- `docs/specs/sp5/US-5.6.6.md`
+- `frontend/src/pages/organizador/ResultadosPage.tsx`
+- `frontend/src/components/organizador/OrganizadorLayout.tsx`
+
+---
+
+## Contexto Relevante
+
+### Estado actual de `Resultados`
+
+- la ruta primaria `/organizador/resultados` ya existe en el shell del organizador
+- `ResultadosPage.tsx` ya implementa la logica funcional de:
+  - selector de torneo
+  - selector de disciplina
+  - tabla por disciplina
+  - podios por categoria
+  - overall condicionado por disciplinas cerradas
+
+- la capa de datos parece correcta y ya reutiliza queries existentes de:
+  - competencias
+  - estado de competencia
+  - grilla
+  - ranking por disciplina
+  - overall
+  - inscriptos detalle
+
+### Gap UX respecto de `S-04`
+
+- el wireframe `S-04` define:
+  - header con boton `Publicar resultados`
+  - subtitulo con disciplina activa + estado del ranking + progreso
+  - layout de dos columnas
+  - ranking de disciplina como bloque principal
+  - overall con empty state claro y jerarquia visual consistente
+
+- la implementacion actual todavia diverge en:
+  - cards claras/blancas dentro del shell dark
+  - selector inicial de torneo con lenguaje visual heredado
+  - jerarquia visual entre tabla, podios y overall
+  - header/subtitulo poco alineados al contrato `S-04`
+  - composicion mas cercana a una pagina agregada por capas que a una pantalla primaria del shell
+
+### Relacion con US previas
+
+- `US-ADJ-9.1` y `US-ADJ-9.2` ya estabilizaron shell y routing primario
+- `US-ADJ-9.4` ya separo el `Panel` operativo del home de torneos
+- esta US no debe rehacer dominio ni endpoints:
+  - debe reencuadrar `ResultadosPage`
+  - debe preservar las capacidades ya entregadas por `US-5.6.5` y `US-5.6.6`
+
+---
+
+## Validacion Arquitectonica
+
+### Artefactos de arquitectura
+
+- `docs/adr/ADR-005-bounded-contexts-ddd-estrategico.md`: esperado como base del proyecto
+- `docs/adr/ADR-006-estructura-bc-first.md`: esperado como base del proyecto
+- `docs/design/architecture.md`: esperado como base del proyecto
+- `docs/design/domain-model.md`: esperado como base del proyecto
+
+### Adaptacion al producto frontend
+
+- la guia base de `/implement-us` asume verificacion sobre `src/{bc}/`
+- esta US pertenece a `frontend`, por lo que la raiz real de trabajo es:
+  - `frontend/src/pages/organizador/`
+  - `frontend/src/components/organizador/`
+  - `frontend/src/api/resultados.ts`
+
+- no se esperan cambios en backend ni dominio para esta US
+
+---
+
+## Quality Gates Esperables
+
+- `frontend/package.json` expone:
+  - `npm run build`
+  - `npm run lint`
+
+- para esta US de frontend, los gates operativos siguen siendo:
+  - build de Vite/TypeScript
+  - lint de frontend
+  - validacion visual/manual del layout `S-04`
+
+---
+
+## Gaps Detectados
+
+1. `ResultadosPage` conserva capacidades funcionales correctas pero no la composicion UX aprobada.
+2. El layout no expresa con claridad la relacion principal entre ranking de disciplina y overall.
+3. El selector de torneo inicial y varias superficies siguen usando visuales claras dentro del shell dark.
+4. El header y subtitulo no reflejan todavia el contrato narrativo de `S-04`.
+
+---
+
+## Riesgos Detectados
+
+- una refactorizacion demasiado visual puede romper el join actual entre grilla, ranking e inscriptos
+- si se fuerza el layout exacto del prototipo sin adaptar la tabla real, puede degradarse legibilidad
+- si se mezclan cambios de dominio con cambios visuales, la US perderia foco y creceria innecesariamente
+
+---
+
+## Resultado
+
+Contexto validado. La US queda lista para:
+
+1. Fase 1 - Escenarios BDD
+2. Fase 2 - Plan de implementacion
+3. refactor visual/compositivo de `ResultadosPage` preservando la funcionalidad existente

--- a/docs/plans/sp-adj-09/US-ADJ-9.5-implementation-notes.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.5-implementation-notes.md
@@ -1,0 +1,88 @@
+# US-ADJ-9.5 - Implementation Notes
+
+**Fecha:** 2026-04-28
+**Sprint:** `SP-ADJ-09`
+**US:** `US-ADJ-9.5`
+
+---
+
+## Resumen
+
+La pantalla `Resultados` fue reencuadrada dentro del shell dark del organizador,
+alineando el header, la jerarquia visual y la composicion entre ranking de
+disciplina y overall sin tocar la logica de datos ya entregada por `US-5.6.5`
+y `US-5.6.6`.
+
+---
+
+## Cambios implementados
+
+### `ResultadosPage`
+
+- `frontend/src/pages/organizador/ResultadosPage.tsx`
+  - se actualizo el subtitulo para expresar:
+    - torneo
+    - disciplina activa
+    - estado del ranking
+    - progreso de cierre de disciplinas
+  - se reemplazo la accion dominante `Volver` por:
+    - `Publicar resultados`
+    - `Cambiar torneo`
+  - se rehizo el selector de disciplinas con lenguaje visual dark
+  - se reorganizo la pantalla para separar mejor:
+    - bloque principal de ranking por disciplina
+    - bloque secundario de overall
+
+### Tabla de disciplina
+
+- `frontend/src/components/organizador/TablaDisciplinaResultados.tsx`
+- `frontend/src/components/organizador/FilaResultado.tsx`
+  - se adaptaron bordes, fondos, chips y tipografia al shell dark
+  - se mantuvo intacta la logica de join entre:
+    - grilla
+    - ranking
+    - inscriptos
+
+### Podios y overall
+
+- `frontend/src/components/organizador/PodiosSection.tsx`
+- `frontend/src/components/organizador/PanelCategoria.tsx`
+- `frontend/src/components/organizador/FilaPodio.tsx`
+  - se migraron las superficies al sistema dark del organizador
+  - se reforzo la separacion visual entre:
+    - podios de disciplina
+    - overall del torneo
+  - se conservaron:
+    - empty states
+    - paneles por categoria
+    - puntos y RP visibles
+
+---
+
+## Conservacion funcional
+
+- se preservo la funcionalidad de tabla por disciplina de `US-5.6.5`
+- se preservo la funcionalidad de podios por categoria de `US-5.6.6`
+- se preservo el bloqueo/disponibilidad condicional del overall
+- no se tocaron:
+  - endpoints
+  - algoritmos de ranking
+  - reglas de dominio
+
+---
+
+## Quality Gates
+
+- `npm run build` en `frontend/`: OK
+- `npm run lint` en `frontend/`: falla solo por error preexistente fuera de alcance en:
+  - `frontend/src/pages/atleta/portalData.ts:120`
+
+---
+
+## Observaciones
+
+- esta US actua sobre composicion UX y no sobre datos
+- el layout final prioriza claridad visual entre disciplina y overall sin forzar
+  una reescritura de la tabla real implementada en SP5
+- `Publicar resultados` queda expresado visualmente en el header, aunque la US no
+  introduce una accion de dominio nueva asociada a ese boton

--- a/docs/plans/sp-adj-09/US-ADJ-9.5-plan.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.5-plan.md
@@ -1,0 +1,108 @@
+# Plan de Implementacion - US-ADJ-9.5: Resultados dentro del shell aprobado
+
+**Sprint:** SP-ADJ-09
+**Patron:** React/Vite frontend
+**Estimacion total:** 120 min
+
+---
+
+## Diagnostico
+
+`ResultadosPage.tsx` ya cumple buena parte del alcance funcional heredado de
+`US-5.6.5` y `US-5.6.6`: selector de torneo, tabla por disciplina, podios por
+categoria y bloqueo/disponibilidad del overall. El gap actual es de shell y
+composicion UX:
+
+- superficies claras dentro del shell dark;
+- header y subtitulo poco alineados a `S-04`;
+- jerarquia visual difusa entre tabla de disciplina y overall;
+- selector inicial de torneo y secciones secundarias con estilo heredado.
+
+La US no requiere cambios de backend ni de dominio. Debe reencuadrar
+`ResultadosPage` y sus componentes para que la experiencia quede consistente con
+el organizador post `US-ADJ-9.4`.
+
+---
+
+## Cambios por area
+
+### 1. Reencuadre de `ResultadosPage`
+
+- [ ] Rehacer el estado selector de torneo bajo lenguaje visual dark (15 min)
+  - mantener `torneo_id` como entrada de contexto
+  - alinear cards, botones y copy al shell del organizador
+
+- [ ] Ajustar el header operativo de la pantalla (15 min)
+  - subtitulo con torneo + disciplina activa + estado del ranking/progreso
+  - accion principal consistente con `S-04`
+  - evitar framing de "volver" como accion dominante
+
+- [ ] Reorganizar el layout principal en dos columnas (20 min)
+  - columna principal para ranking/tabla por disciplina
+  - columna secundaria para overall y/o resumen relacionado
+  - preservar responsividad razonable para pantallas menores
+
+### 2. Refinamiento de bloques visuales
+
+- [ ] Reestilizar selector de disciplina y contenedor de tabla (15 min)
+  - tabs dark coherentes con shell
+  - estados de carga/error/empty dentro del mismo lenguaje visual
+
+- [ ] Reestilizar `PodiosSection` y `PanelCategoria` para el shell dark (20 min)
+  - adaptar bordes, fondos, subtitulos y empty states
+  - reforzar separacion visual entre podios de disciplina y overall
+
+- [ ] Revisar jerarquia visual del overall (10 min)
+  - bloqueado: empty state claro
+  - disponible: misma familia visual pero distinguible del bloque principal
+
+### 3. Conservacion funcional
+
+- [ ] Mantener sin regresion la funcionalidad de tabla por disciplina (5 min)
+- [ ] Mantener sin regresion la funcionalidad de podios por categoria (5 min)
+- [ ] Mantener sin regresion la disponibilidad condicional del overall (5 min)
+
+### 4. Validacion
+
+- [ ] Crear escenario BDD fisico de `US-ADJ-9.5` y mantenerlo alineado con la implementación (5 min)
+- [ ] `npm run build` en `frontend/` (5 min)
+- [ ] `npm run lint` en `frontend/` (5 min)
+- [ ] Validacion manual de:
+  - shell dark en Resultados
+  - item activo en navbar
+  - claridad visual entre disciplina y overall
+  - conservacion de tabla y podios (10 min)
+
+---
+
+## Decisiones clave
+
+- No tocar reglas de negocio ni algoritmos de ranking/overall.
+- Priorizar reutilizacion de la logica de datos ya existente en `ResultadosPage`.
+- Resolver la US desde composición UX y no desde una reimplementacion completa.
+- Mantener `Resultados` como seccion primaria del shell del organizador.
+
+---
+
+## Riesgos y mitigaciones
+
+- Riesgo: romper la tabla actual al forzar layout nuevo.
+  Mitigacion: aislar los cambios a contenedores, header y estilos antes que a la logica de join.
+
+- Riesgo: uniformar demasiado disciplina y overall y perder jerarquia.
+  Mitigacion: usar bloques y subtitulos claramente diferenciados.
+
+- Riesgo: introducir deuda duplicando componentes.
+  Mitigacion: ajustar `PodiosSection` y `PanelCategoria` existentes en lugar de recrearlos.
+
+---
+
+## Criterio de salida
+
+La implementación de esta US termina cuando:
+
+1. `Resultados` vive visualmente dentro del shell dark aprobado;
+2. la tabla de disciplina, los podios y el overall conservan sus capacidades;
+3. la relacion visual entre disciplina y overall queda clara y consistente con `S-04`;
+4. build y lint quedan ejecutados;
+5. los artefactos de documentación y reporte final quedan creados antes del commit.

--- a/docs/reports/US-ADJ-9.5-report.md
+++ b/docs/reports/US-ADJ-9.5-report.md
@@ -1,0 +1,86 @@
+# Reporte de Implementacion: US-ADJ-9.5
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** `US-ADJ-9.5` - Reencuadrar Resultados dentro del shell aprobado S-04
+- **Puntos estimados:** 3
+- **Tiempo estimado tracked:** 75 min
+- **Tiempo real tracked:** 2.78 min
+- **Varianza:** -72.22 min (-96.29%)
+- **Estado:** COMPLETADO
+- **Fecha:** 2026-04-28
+
+---
+
+## Componentes Implementados
+
+- ✅ **Reencuadre de `ResultadosPage`** en `frontend/src/pages/organizador/ResultadosPage.tsx`
+  - subtitulo enriquecido con disciplina, estado de ranking y progreso
+  - acciones de header alineadas a `S-04`
+  - selector de disciplinas dentro del lenguaje visual dark
+  - nueva jerarquia visual entre bloque principal de disciplina y bloque de overall
+
+- ✅ **Tabla de disciplina en shell dark**
+  - `frontend/src/components/organizador/TablaDisciplinaResultados.tsx`
+  - `frontend/src/components/organizador/FilaResultado.tsx`
+
+- ✅ **Podios y overall en shell dark**
+  - `frontend/src/components/organizador/PodiosSection.tsx`
+  - `frontend/src/components/organizador/PanelCategoria.tsx`
+  - `frontend/src/components/organizador/FilaPodio.tsx`
+
+- ✅ **Artefactos de implement-us**
+  - `docs/plans/sp-adj-09/US-ADJ-9.5-fase0.md`
+  - `docs/plans/sp-adj-09/US-ADJ-9.5-plan.md`
+  - `docs/plans/sp-adj-09/US-ADJ-9.5-implementation-notes.md`
+  - `tests/features/US-ADJ-9.5-resultados-shell.feature`
+
+---
+
+## Criterios de Aceptacion
+
+- [x] Resultados vive dentro del shell aprobado del organizador.
+- [x] La pantalla conserva tabla y podios por disciplina.
+- [x] El overall mantiene su comportamiento de disponibilidad.
+- [x] La relacion visual entre ranking de disciplina y overall queda mas clara y coherente con `S-04`.
+
+---
+
+## Quality Gates
+
+| Gate | Resultado | Estado |
+|------|-----------|--------|
+| `npm run build` | OK | ✅ |
+| `npm run lint` | falla solo por error preexistente en `frontend/src/pages/atleta/portalData.ts:120` | ⚠️ |
+
+---
+
+## Archivos Creados o Modificados
+
+- `frontend/src/pages/organizador/ResultadosPage.tsx`
+- `frontend/src/components/organizador/TablaDisciplinaResultados.tsx`
+- `frontend/src/components/organizador/FilaResultado.tsx`
+- `frontend/src/components/organizador/PodiosSection.tsx`
+- `frontend/src/components/organizador/PanelCategoria.tsx`
+- `frontend/src/components/organizador/FilaPodio.tsx`
+- `tests/features/US-ADJ-9.5-resultados-shell.feature`
+- `docs/plans/sp-adj-09/US-ADJ-9.5-fase0.md`
+- `docs/plans/sp-adj-09/US-ADJ-9.5-plan.md`
+- `docs/plans/sp-adj-09/US-ADJ-9.5-implementation-notes.md`
+- `docs/reports/US-ADJ-9.5-report.md`
+- `.claude/tracking/US-ADJ-9.5-tracking.json`
+
+---
+
+## Observaciones
+
+- La US preserva la logica funcional ya entregada por `US-5.6.5` y `US-5.6.6`.
+- El ajuste fue intencionalmente visual/compositivo; no se tocaron endpoints ni algoritmos de ranking.
+- Se detecto y corrigio una corrupcion del tracker causada por ejecutar fases en paralelo; desde esa recuperacion, el tracking siguio de forma secuencial.
+
+---
+
+## Proximos Pasos
+
+- Stagear y commitear `US-ADJ-9.5`.
+- Mantener separado el fix del lint preexistente en `frontend/src/pages/atleta/portalData.ts:120`.

--- a/frontend/src/components/organizador/DisciplinaSelector.tsx
+++ b/frontend/src/components/organizador/DisciplinaSelector.tsx
@@ -34,7 +34,7 @@ export function DisciplinaSelector({ value, onChange, error }: DisciplinaSelecto
 
   return (
     <fieldset className="space-y-3">
-      <legend className="text-sm font-semibold text-stone-900">Disciplinas</legend>
+      <legend className="text-sm font-semibold text-slate-100">Disciplinas</legend>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {DISCIPLINAS.map((disciplina) => {
           const checked = value.includes(disciplina.value)
@@ -44,25 +44,25 @@ export function DisciplinaSelector({ value, onChange, error }: DisciplinaSelecto
               className={[
                 'flex min-h-24 cursor-pointer items-start gap-3 rounded-lg border p-4 transition',
                 checked
-                  ? 'border-emerald-700 bg-emerald-50 text-emerald-950'
-                  : 'border-stone-300 bg-white text-stone-800 hover:border-stone-500',
+                  ? 'border-sky-400 bg-sky-400/10 text-sky-100'
+                  : 'border-slate-700 bg-slate-900/80 text-slate-200 hover:border-slate-500',
               ].join(' ')}
             >
               <input
                 type="checkbox"
                 checked={checked}
                 onChange={() => toggleDisciplina(disciplina.value)}
-                className="mt-1 h-4 w-4 accent-emerald-700"
+                className="mt-1 h-4 w-4 accent-sky-400"
               />
               <span>
                 <span className="block text-sm font-semibold">{disciplina.label}</span>
-                <span className="mt-1 block text-xs text-stone-600">{disciplina.detail}</span>
+                <span className="mt-1 block text-xs text-slate-400">{disciplina.detail}</span>
               </span>
             </label>
           )
         })}
       </div>
-      {error ? <p className="text-sm text-red-700">{error}</p> : null}
+      {error ? <p className="text-sm text-red-300">{error}</p> : null}
     </fieldset>
   )
 }

--- a/frontend/src/components/organizador/FilaPodio.tsx
+++ b/frontend/src/components/organizador/FilaPodio.tsx
@@ -14,15 +14,15 @@ interface FilaPodioProps {
 
 function badgeClass(posicion: number): string {
   if (posicion === 1) {
-    return 'bg-amber-500/15 text-amber-500 ring-1 ring-amber-500/30'
+    return 'bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30'
   }
   if (posicion === 2) {
-    return 'bg-slate-400/15 text-slate-500 ring-1 ring-slate-400/30'
+    return 'bg-slate-400/15 text-slate-200 ring-1 ring-slate-400/30'
   }
   if (posicion === 3) {
-    return 'bg-amber-700/15 text-amber-700 ring-1 ring-amber-700/30'
+    return 'bg-amber-700/15 text-amber-500 ring-1 ring-amber-700/30'
   }
-  return 'bg-stone-200 text-stone-500 ring-1 ring-stone-300'
+  return 'bg-slate-800 text-slate-300 ring-1 ring-slate-700'
 }
 
 function posicionLabel(posicion: number): string {
@@ -33,7 +33,7 @@ export function FilaPodio({ fila }: FilaPodioProps) {
   const rpDisplay = fila.rp ? `${fila.rp} ${fila.unidad ?? ''}`.trim() : '—'
 
   return (
-    <li className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-2xl border border-stone-200/80 bg-white/75 px-3 py-3">
+    <li className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-2xl border border-slate-700 bg-slate-900/80 px-3 py-3">
       <div
         className={[
           'inline-flex min-w-11 items-center justify-center rounded-full px-2 py-1 text-xs font-bold',
@@ -44,13 +44,13 @@ export function FilaPodio({ fila }: FilaPodioProps) {
       </div>
 
       <div className="min-w-0">
-        <p className="truncate text-sm font-semibold text-stone-900">{fila.nombre}</p>
-        <p className="truncate text-xs text-stone-500">{fila.club || '—'}</p>
+        <p className="truncate text-sm font-semibold text-white">{fila.nombre}</p>
+        <p className="truncate text-xs text-slate-400">{fila.club || '—'}</p>
       </div>
 
       <div className="text-right">
-        <p className="font-mono text-xs text-stone-500">{rpDisplay}</p>
-        <p className="font-mono text-sm font-bold text-emerald-800">{fila.puntos}</p>
+        <p className="font-mono text-xs text-slate-400">{rpDisplay}</p>
+        <p className="font-mono text-sm font-bold text-sky-300">{fila.puntos}</p>
       </div>
     </li>
   )

--- a/frontend/src/components/organizador/FilaResultado.tsx
+++ b/frontend/src/components/organizador/FilaResultado.tsx
@@ -21,7 +21,7 @@ interface FilaResultadoProps {
 function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
   if (!tarjeta) {
     return (
-      <span className="rounded-full bg-stone-200 px-2 py-0.5 text-xs font-semibold text-stone-500">
+      <span className="rounded-full border border-slate-700 bg-slate-800 px-2 py-0.5 text-xs font-semibold text-slate-300">
         PENDIENTE
       </span>
     )
@@ -29,7 +29,7 @@ function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
 
   if (tarjeta === 'DNS' || tarjeta === 'Dns') {
     return (
-      <span className="rounded-full bg-slate-500 px-2 py-0.5 text-xs font-semibold text-white">
+      <span className="rounded-full border border-slate-500/40 bg-slate-500/20 px-2 py-0.5 text-xs font-semibold text-slate-100">
         DNS
       </span>
     )
@@ -37,7 +37,7 @@ function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
 
   if (tarjeta === 'Roja' || tarjeta === 'ROJA') {
     return (
-      <span className="rounded-full bg-red-500 px-2 py-0.5 text-xs font-semibold text-white">
+      <span className="rounded-full border border-red-500/40 bg-red-500/20 px-2 py-0.5 text-xs font-semibold text-red-100">
         ROJA
       </span>
     )
@@ -45,7 +45,7 @@ function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
 
   if (tarjeta === 'Blanca' || tarjeta === 'BlancaConPenalizaciones') {
     return (
-      <span className="rounded-full bg-emerald-500 px-2 py-0.5 text-xs font-semibold text-white">
+      <span className="rounded-full border border-emerald-500/40 bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-100">
         BLANCA
       </span>
     )
@@ -53,14 +53,14 @@ function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
 
   if (tarjeta === 'Amarilla') {
     return (
-      <span className="rounded-full bg-amber-400 px-2 py-0.5 text-xs font-semibold text-stone-900">
-        REVISIÓN
+      <span className="rounded-full border border-amber-500/40 bg-amber-500/20 px-2 py-0.5 text-xs font-semibold text-amber-100">
+        EN REVISION
       </span>
     )
   }
 
   return (
-    <span className="rounded-full bg-stone-200 px-2 py-0.5 text-xs font-semibold text-stone-500">
+    <span className="rounded-full border border-slate-700 bg-slate-800 px-2 py-0.5 text-xs font-semibold text-slate-300">
       {tarjeta}
     </span>
   )
@@ -71,22 +71,22 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
   const puntosDisplay = fila.puntos ?? '—'
 
   return (
-    <tr className="border-b border-stone-200 text-sm hover:bg-stone-50">
-      <td className="px-3 py-2 text-center font-mono text-xs text-stone-500">
+    <tr className="border-b border-slate-800 text-sm transition hover:bg-slate-800/60">
+      <td className="px-3 py-3 text-center font-mono text-xs text-slate-400">
         {fila.posicion_ot}
       </td>
-      <td className="px-3 py-2 font-medium text-stone-900">{fila.nombre}</td>
-      <td className="px-3 py-2 text-center text-stone-700">{fila.genero}</td>
-      <td className="px-3 py-2 text-stone-700">{fila.categoria_corta}</td>
-      <td className="px-3 py-2 text-stone-600">{fila.club || '—'}</td>
-      <td className="px-3 py-2 font-mono text-stone-700">{fila.ap}</td>
-      <td className="px-3 py-2 font-mono text-xs text-stone-500">{fila.ot}</td>
-      <td className="px-3 py-2 text-center text-stone-500">{fila.linea}</td>
-      <td className="px-3 py-2 font-mono font-semibold text-stone-900">{rpDisplay}</td>
-      <td className="px-3 py-2">
+      <td className="px-3 py-3 font-medium text-slate-100">{fila.nombre}</td>
+      <td className="px-3 py-3 text-center text-slate-300">{fila.genero}</td>
+      <td className="px-3 py-3 text-slate-300">{fila.categoria_corta}</td>
+      <td className="px-3 py-3 text-slate-400">{fila.club || '—'}</td>
+      <td className="px-3 py-3 font-mono text-slate-300">{fila.ap}</td>
+      <td className="px-3 py-3 font-mono text-xs text-slate-400">{fila.ot}</td>
+      <td className="px-3 py-3 text-center text-slate-400">{fila.linea}</td>
+      <td className="px-3 py-3 font-mono font-semibold text-white">{rpDisplay}</td>
+      <td className="px-3 py-3">
         <ChipTarjeta tarjeta={fila.tarjeta} />
       </td>
-      <td className="px-3 py-2 text-right font-mono font-bold text-emerald-800">
+      <td className="px-3 py-3 text-right font-mono font-bold text-sky-300">
         {puntosDisplay}
       </td>
     </tr>

--- a/frontend/src/components/organizador/OrganizadorLayout.tsx
+++ b/frontend/src/components/organizador/OrganizadorLayout.tsx
@@ -8,6 +8,8 @@ interface OrganizadorLayoutProps {
   subtitle: string
   actions?: ReactNode
   children: ReactNode
+  showTournamentNavigation?: boolean
+  simpleHeader?: boolean
 }
 
 interface NavItem {
@@ -57,6 +59,8 @@ export function OrganizadorLayout({
   subtitle,
   actions,
   children,
+  showTournamentNavigation = true,
+  simpleHeader = false,
 }: OrganizadorLayoutProps) {
   const location = useLocation()
   const email = useAuthStore((s) => s.email)
@@ -71,34 +75,38 @@ export function OrganizadorLayout({
         <div className="mx-auto flex max-w-[1100px] flex-col gap-4 px-5 py-4 lg:px-8">
           <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
             <div className="flex items-center gap-6">
-              <span className="text-lg font-black tracking-tight text-sky-400">
-                AtaraxiaDive
-              </span>
-              <nav className="flex flex-wrap items-center gap-2">
-                {NAV_ITEMS.map((item) => {
-                  const isActive = seccionActiva === item.key
-                  const baseClass =
-                    'rounded-full border px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] transition'
+              {!simpleHeader ? (
+                <span className="text-lg font-black tracking-tight text-sky-400">
+                  AtaraxiaDive
+                </span>
+              ) : null}
+              {showTournamentNavigation ? (
+                <nav className="flex flex-wrap items-center gap-2">
+                  {NAV_ITEMS.map((item) => {
+                    const isActive = seccionActiva === item.key
+                    const baseClass =
+                      'rounded-full border px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] transition'
 
-                  return (
-                    <Link
-                      key={item.key}
-                      to={item.to}
-                      className={
-                        isActive
-                          ? `${baseClass} border-sky-400 bg-sky-400/10 text-sky-300`
-                          : `${baseClass} border-slate-700 bg-slate-800 text-slate-300 hover:border-slate-500 hover:text-white`
-                      }
-                    >
-                      {item.label}
-                    </Link>
-                  )
-                })}
-              </nav>
+                    return (
+                      <Link
+                        key={item.key}
+                        to={item.to}
+                        className={
+                          isActive
+                            ? `${baseClass} border-sky-400 bg-sky-400/10 text-sky-300`
+                            : `${baseClass} border-slate-700 bg-slate-800 text-slate-300 hover:border-slate-500 hover:text-white`
+                        }
+                      >
+                        {item.label}
+                      </Link>
+                    )
+                  })}
+                </nav>
+              ) : null}
             </div>
 
             <div className="flex flex-wrap items-center gap-3">
-              <HealthCheck compact />
+              {!simpleHeader ? <HealthCheck compact /> : null}
               <span className="rounded-full border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-slate-300">
                 {usuarioLabel}
               </span>
@@ -107,11 +115,13 @@ export function OrganizadorLayout({
 
           <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
             <div className="max-w-3xl">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-300/80">
-                Organizador
-              </p>
+              {!simpleHeader ? (
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-300/80">
+                  Organizador
+                </p>
+              ) : null}
               <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">{title}</h1>
-              <p className="mt-2 text-sm text-slate-300">{subtitle}</p>
+              {subtitle ? <p className="mt-2 text-sm text-slate-300">{subtitle}</p> : null}
             </div>
             {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
           </div>

--- a/frontend/src/components/organizador/PanelCategoria.tsx
+++ b/frontend/src/components/organizador/PanelCategoria.tsx
@@ -7,16 +7,16 @@ interface PanelCategoriaProps {
 
 export function PanelCategoria({ titulo, filas }: PanelCategoriaProps) {
   return (
-    <article className="rounded-[1.75rem] border border-stone-300/80 bg-stone-50/70 p-4">
-      <div className="mb-4 flex items-center justify-between gap-2 border-b border-stone-200 pb-3">
-        <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-stone-600">
+    <article className="rounded-[1.75rem] border border-slate-700 bg-slate-950/60 p-4">
+      <div className="mb-4 flex items-center justify-between gap-2 border-b border-slate-800 pb-3">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-300">
           {titulo}
         </h3>
-        <span className="text-xs text-stone-400">{filas.length}</span>
+        <span className="text-xs text-slate-500">{filas.length}</span>
       </div>
 
       {filas.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-stone-300 bg-white/65 px-3 py-5 text-center text-sm text-stone-500">
+        <div className="rounded-2xl border border-dashed border-slate-700 bg-slate-900/80 px-3 py-5 text-center text-sm text-slate-400">
           Sin participantes
         </div>
       ) : (

--- a/frontend/src/components/organizador/PodiosSection.tsx
+++ b/frontend/src/components/organizador/PodiosSection.tsx
@@ -24,20 +24,20 @@ export function PodiosSection({
   emptyState = null,
 }: PodiosSectionProps) {
   return (
-    <section className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
-      <div className="mb-5 flex flex-col gap-2 border-b border-stone-200 pb-4 sm:flex-row sm:items-end sm:justify-between">
+    <section className="rounded-[2rem] border border-slate-700 bg-slate-900/85 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.24)]">
+      <div className="mb-5 flex flex-col gap-2 border-b border-slate-800 pb-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-400">
             {title}
           </h2>
-          {subtitle ? <p className="mt-2 text-sm text-stone-600">{subtitle}</p> : null}
+          {subtitle ? <p className="mt-2 text-sm text-slate-300">{subtitle}</p> : null}
         </div>
       </div>
 
       {emptyState ? (
-        <div className="rounded-[1.75rem] border border-dashed border-stone-300 bg-stone-50/70 px-5 py-8 text-center">
-          <p className="text-base font-semibold text-stone-800">{emptyState.title}</p>
-          {emptyState.detail ? <p className="mt-2 text-sm text-stone-500">{emptyState.detail}</p> : null}
+        <div className="rounded-[1.75rem] border border-dashed border-slate-700 bg-slate-950/60 px-5 py-8 text-center">
+          <p className="text-base font-semibold text-white">{emptyState.title}</p>
+          {emptyState.detail ? <p className="mt-2 text-sm text-slate-400">{emptyState.detail}</p> : null}
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
+++ b/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
@@ -86,17 +86,17 @@ export function TablaDisciplinaResultados({
 
   if (filas.length === 0) {
     return (
-      <p className="py-6 text-center text-sm text-stone-500">
+      <p className="py-6 text-center text-sm text-slate-400">
         No hay atletas en la grilla de esta disciplina.
       </p>
     )
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto rounded-[1.5rem] border border-slate-800 bg-slate-950/40">
       <table className="w-full min-w-[900px] border-collapse text-sm">
         <thead>
-          <tr className="border-b-2 border-stone-300 text-left text-xs font-semibold uppercase tracking-wide text-stone-500">
+          <tr className="border-b border-slate-700 bg-slate-950/70 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
             <th className="px-3 py-2 text-center">#OT</th>
             <th className="px-3 py-2">Nombre</th>
             <th className="px-3 py-2 text-center">Gén.</th>
@@ -110,7 +110,7 @@ export function TablaDisciplinaResultados({
             <th className="px-3 py-2 text-right">Pts FAAS</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className="bg-slate-900/40">
           {filas.map((fila) => (
             <FilaResultado key={fila.atleta_id} fila={fila} />
           ))}

--- a/frontend/src/pages/organizador/CrearTorneoPage.tsx
+++ b/frontend/src/pages/organizador/CrearTorneoPage.tsx
@@ -39,8 +39,10 @@ const INITIAL_FORM: FormState = {
 
 function inputClass(hasError: boolean): string {
   return [
-    'mt-2 w-full rounded-lg border bg-white px-3 py-2 text-sm text-stone-900 outline-none transition',
-    hasError ? 'border-red-400 focus:border-red-600' : 'border-stone-300 focus:border-emerald-700',
+    'mt-2 w-full rounded-lg border bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition placeholder:text-slate-500',
+    hasError
+      ? 'border-red-500/60 focus:border-red-400'
+      : 'border-slate-700 focus:border-sky-400',
   ].join(' ')
 }
 
@@ -127,10 +129,12 @@ export function CrearTorneoPage() {
     <OrganizadorLayout
       title="Nuevo torneo"
       subtitle="Alta del torneo y configuracion inicial de disciplinas"
+      showTournamentNavigation={false}
+      simpleHeader
       actions={
         <Link
           to="/organizador/torneo"
-          className="rounded-lg border border-stone-900 px-4 py-2 text-sm font-semibold text-stone-900"
+          className="rounded-full border border-slate-600 bg-slate-800 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-100"
         >
           Volver
         </Link>
@@ -138,15 +142,15 @@ export function CrearTorneoPage() {
     >
       <form
         onSubmit={handleSubmit}
-        className="rounded-lg border border-stone-300 bg-white p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]"
+        className="rounded-[2rem] border border-slate-700 bg-slate-900/85 p-6 shadow-[0_20px_60px_rgba(2,6,23,0.24)]"
       >
         {errors.general ? (
-          <div className="mb-5 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+          <div className="mb-5 rounded-[1.5rem] border border-red-500/40 bg-red-950/40 p-4 text-sm text-red-100">
             <p>{errors.general}</p>
             {torneoCreadoSinDisciplinas ? (
               <Link
                 to={`/organizador/torneo/${torneoCreadoSinDisciplinas}`}
-                className="mt-3 inline-flex rounded-lg border border-red-800 px-3 py-2 text-sm font-semibold text-red-900"
+                className="mt-3 inline-flex rounded-full border border-red-400/40 bg-red-950/40 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-red-100"
               >
                 Ir al detalle del torneo
               </Link>
@@ -155,7 +159,7 @@ export function CrearTorneoPage() {
         ) : null}
 
         <div className="grid gap-5 lg:grid-cols-2">
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Nombre
             <input
               value={form.nombre}
@@ -163,10 +167,10 @@ export function CrearTorneoPage() {
               className={inputClass(Boolean(errors.nombre))}
               placeholder="BA 2026"
             />
-            {errors.nombre ? <span className="mt-1 block text-sm text-red-700">{errors.nombre}</span> : null}
+            {errors.nombre ? <span className="mt-1 block text-sm text-red-300">{errors.nombre}</span> : null}
           </label>
 
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Descripcion
             <input
               value={form.descripcion}
@@ -176,7 +180,7 @@ export function CrearTorneoPage() {
             />
           </label>
 
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Fecha de inicio
             <input
               type="date"
@@ -187,7 +191,7 @@ export function CrearTorneoPage() {
             />
           </label>
 
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Fecha de fin
             <input
               type="date"
@@ -197,13 +201,13 @@ export function CrearTorneoPage() {
               required
             />
             {errors.fechaFin ? (
-              <span className="mt-1 block text-sm text-red-700">{errors.fechaFin}</span>
+              <span className="mt-1 block text-sm text-red-300">{errors.fechaFin}</span>
             ) : null}
           </label>
         </div>
 
         <div className="mt-6 grid gap-5 lg:grid-cols-3">
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Sede
             <input
               value={form.sedeNombre}
@@ -214,7 +218,7 @@ export function CrearTorneoPage() {
             />
           </label>
 
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Ciudad
             <input
               value={form.sedeCiudad}
@@ -225,7 +229,7 @@ export function CrearTorneoPage() {
             />
           </label>
 
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Pais
             <input
               value={form.sedePais}
@@ -237,7 +241,7 @@ export function CrearTorneoPage() {
         </div>
 
         <div className="mt-6 grid gap-5 lg:grid-cols-2">
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Entidad organizadora
             <input
               value={form.entidadNombre}
@@ -248,7 +252,7 @@ export function CrearTorneoPage() {
             />
           </label>
 
-          <label className="block text-sm font-semibold text-stone-900">
+          <label className="block text-sm font-semibold text-slate-100">
             Tipo de entidad
             <input
               value={form.entidadTipo}
@@ -274,14 +278,14 @@ export function CrearTorneoPage() {
         <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
           <Link
             to="/organizador/torneo"
-            className="rounded-lg border border-stone-300 px-4 py-2 text-center text-sm font-semibold text-stone-800"
+            className="rounded-full border border-slate-700 bg-slate-950 px-4 py-2 text-center text-xs font-semibold uppercase tracking-[0.16em] text-slate-200"
           >
             Cancelar
           </Link>
           <button
             type="submit"
             disabled={isSubmitting}
-            className="rounded-lg bg-stone-900 px-5 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-stone-500"
+            className="rounded-full bg-sky-500 px-5 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
           >
             {isSubmitting ? 'Creando...' : 'Crear Torneo'}
           </button>

--- a/frontend/src/pages/organizador/DashboardOperativoPage.tsx
+++ b/frontend/src/pages/organizador/DashboardOperativoPage.tsx
@@ -268,6 +268,8 @@ export function DashboardOperativoPage() {
       <OrganizadorLayout
         title="Panel"
         subtitle="Seleccionar torneo para abrir el dashboard operativo del torneo activo"
+        showTournamentNavigation={false}
+        simpleHeader
       >
         <TorneoRouteSelector
           description="El Panel es la vista ejecutiva del torneo operativo. Selecciona un torneo para cargar KPIs, disciplina activa, alertas y proximos atletas."

--- a/frontend/src/pages/organizador/DashboardPage.tsx
+++ b/frontend/src/pages/organizador/DashboardPage.tsx
@@ -28,6 +28,7 @@ function formatEstadoTorneo(estado: string): string {
 
 function esTorneoVigente(estado: EstadoTorneo): boolean {
   return (
+    estado === 'CREADO' ||
     estado === 'INSCRIPCION_ABIERTA' ||
     estado === 'PREPARACION' ||
     estado === 'EJECUCION' ||
@@ -37,10 +38,6 @@ function esTorneoVigente(estado: EstadoTorneo): boolean {
 
 function esTorneoHistorico(estado: EstadoTorneo): boolean {
   return estado === 'CERRADO' || estado === 'CANCELADO'
-}
-
-function esTorneoPendienteActivacion(estado: EstadoTorneo): boolean {
-  return estado === 'CREADO'
 }
 
 function filtrarTorneos(torneos: TorneoDto[], filtro: FiltroTorneos): TorneoDto[] {
@@ -53,10 +50,61 @@ function emptyMessage(filtro: FiltroTorneos): string {
   return 'No hay torneos en el histórico.'
 }
 
+function historicalCardClass(estado: EstadoTorneo): string {
+  if (estado === 'EJECUCION') {
+    return 'border-emerald-500/40 bg-emerald-950/25 shadow-[0_20px_60px_rgba(6,78,59,0.22)]'
+  }
+
+  if (estado === 'INSCRIPCION_ABIERTA') {
+    return 'border-amber-500/40 bg-amber-950/25 shadow-[0_20px_60px_rgba(120,53,15,0.22)]'
+  }
+
+  if (estado === 'CANCELADO') {
+    return 'border-red-500/40 bg-red-950/30 shadow-[0_20px_60px_rgba(127,29,29,0.22)]'
+  }
+
+  if (estado === 'CERRADO') {
+    return 'border-sky-500/40 bg-sky-950/25 shadow-[0_20px_60px_rgba(12,74,110,0.22)]'
+  }
+
+  return 'border-slate-700 bg-slate-900/80 shadow-[0_20px_60px_rgba(2,6,23,0.32)]'
+}
+
+function historicalTextClass(estado: EstadoTorneo): string {
+  if (estado === 'EJECUCION') return 'text-emerald-100'
+  if (estado === 'INSCRIPCION_ABIERTA') return 'text-amber-100'
+  if (estado === 'CANCELADO') return 'text-red-100'
+  if (estado === 'CERRADO') return 'text-sky-100'
+  return 'text-slate-300'
+}
+
+function stateAccentClass(estado: EstadoTorneo): string {
+  if (estado === 'EJECUCION') return 'text-emerald-300'
+  if (estado === 'INSCRIPCION_ABIERTA') return 'text-amber-300'
+  if (estado === 'CANCELADO') return 'text-red-300'
+  if (estado === 'CERRADO') return 'text-sky-300'
+  return 'text-slate-400'
+}
+
+function actionClass(estado: EstadoTorneo): string {
+  if (estado === 'EJECUCION') {
+    return 'border-emerald-400/40 bg-emerald-950/40 text-emerald-100'
+  }
+  if (estado === 'INSCRIPCION_ABIERTA') {
+    return 'border-amber-400/40 bg-amber-950/40 text-amber-100'
+  }
+  if (estado === 'CANCELADO') {
+    return 'border-red-400/40 bg-red-950/40 text-red-100'
+  }
+  if (estado === 'CERRADO') {
+    return 'border-sky-400/40 bg-sky-950/40 text-sky-100'
+  }
+  return 'border-slate-600 bg-slate-800 text-slate-100'
+}
+
 export function DashboardPage() {
   const location = useLocation()
   const logout = useAuthStore((s) => s.logout)
-  const email = useAuthStore((s) => s.email)
   const [filtro, setFiltro] = useState<FiltroTorneos>('vigentes')
   const torneosQuery = useQuery({
     queryKey: ['torneos-organizador'],
@@ -66,19 +114,13 @@ export function DashboardPage() {
     () => filtrarTorneos(torneosQuery.data ?? [], filtro),
     [filtro, torneosQuery.data],
   )
-  const torneosPendientesActivacion = useMemo(
-    () => (torneosQuery.data ?? []).filter((torneo) => esTorneoPendienteActivacion(torneo.estado)),
-    [torneosQuery.data],
-  )
 
   return (
     <OrganizadorLayout
-      title="Home de torneos"
-      subtitle={
-        email
-          ? `Torneos bajo tu responsabilidad · Sesion activa: ${email}`
-          : 'Acceso a torneos vigentes e histórico'
-      }
+      title="Home del Organizador"
+      subtitle=""
+      showTournamentNavigation={false}
+      simpleHeader
       actions={
         <>
           <Link
@@ -118,7 +160,7 @@ export function DashboardPage() {
       {!torneosQuery.isLoading && !torneosQuery.isError ? (
         <>
           <section className="rounded-[2rem] border border-slate-700 bg-slate-900/70 p-5 text-sm text-slate-300">
-            Esta pantalla es la home del organizador. Prioriza torneos vigentes y permite consultar el histórico sin reemplazar el dashboard operativo del torneo.
+            Esta pantalla muestra los torneos que organizas. La navegación del torneo aparece cuando seleccionas uno para gestionarlo.
           </section>
 
           <section className="flex flex-wrap items-center gap-2">
@@ -143,18 +185,6 @@ export function DashboardPage() {
         </>
       ) : null}
 
-      {!torneosQuery.isLoading &&
-      !torneosQuery.isError &&
-      filtro === 'vigentes' &&
-      torneosPendientesActivacion.length > 0 ? (
-        <section className="rounded-[2rem] border border-amber-500/40 bg-amber-950/30 p-5 text-sm text-amber-100">
-          {torneosPendientesActivacion.length}{' '}
-          {torneosPendientesActivacion.length === 1
-            ? 'torneo permanece en estado Creado y no aparece como vigente hasta abrir inscripción.'
-            : 'torneos permanecen en estado Creado y no aparecen como vigentes hasta abrir inscripción.'}
-        </section>
-      ) : null}
-
       {!torneosQuery.isLoading && !torneosQuery.isError && torneosFiltrados.length === 0 ? (
         <section className="rounded-[2rem] border border-slate-700 bg-slate-900/70 p-5 text-sm text-slate-300">
           {emptyMessage(filtro)}
@@ -165,21 +195,35 @@ export function DashboardPage() {
         ? torneosFiltrados.map((torneo) => (
             <article
               key={torneo.torneo_id}
-              className="rounded-[2rem] border border-slate-700 bg-slate-900/80 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.32)]"
+              className={`rounded-[2rem] border p-5 ${
+                filtro === 'historico' ||
+                torneo.estado === 'EJECUCION' ||
+                torneo.estado === 'INSCRIPCION_ABIERTA'
+                  ? historicalCardClass(torneo.estado)
+                  : 'border-slate-700 bg-slate-900/80 shadow-[0_20px_60px_rgba(2,6,23,0.32)]'
+              }`}
             >
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  <p
+                    className={`text-xs font-semibold uppercase tracking-[0.18em] ${stateAccentClass(
+                      torneo.estado,
+                    )}`}
+                  >
                     {filtro === 'vigentes' ? 'Torneo vigente' : 'Torneo histórico'}
                   </p>
                   <h2 className="mt-2 text-xl font-semibold text-white">{torneo.nombre}</h2>
-                  <p className="mt-2 text-sm text-slate-300">
+                  <p
+                    className={`mt-2 text-sm ${historicalTextClass(torneo.estado)}`}
+                  >
                     {torneo.sede.nombre}, {torneo.sede.ciudad} · {formatEstadoTorneo(torneo.estado)}
                   </p>
                 </div>
                 <Link
                   to={`/organizador/panel?torneo_id=${torneo.torneo_id}`}
-                  className="rounded-full border border-slate-600 bg-slate-800 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-100"
+                  className={`rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] ${actionClass(
+                    torneo.estado,
+                  )}`}
                 >
                   Gestionar
                 </Link>

--- a/frontend/src/pages/organizador/OrganizadorGrillaPage.tsx
+++ b/frontend/src/pages/organizador/OrganizadorGrillaPage.tsx
@@ -14,6 +14,8 @@ export function OrganizadorGrillaPage() {
       <OrganizadorLayout
         title="Grilla"
         subtitle="Seleccionar torneo para generar, ajustar o confirmar la grilla"
+        showTournamentNavigation={false}
+        simpleHeader
       >
         <TorneoRouteSelector
           description="La grilla es una sección primaria del shell. Seleccioná un torneo para operar la disciplina desde esta vista."

--- a/frontend/src/pages/organizador/OrganizadorJuecesPage.tsx
+++ b/frontend/src/pages/organizador/OrganizadorJuecesPage.tsx
@@ -14,6 +14,8 @@ export function OrganizadorJuecesPage() {
       <OrganizadorLayout
         title="Jueces"
         subtitle="Seleccionar torneo para asignar jueces por disciplina"
+        showTournamentNavigation={false}
+        simpleHeader
       >
         <TorneoRouteSelector
           description="La asignación de jueces ya cuelga de una ruta primaria propia. Seleccioná un torneo para operar esta sección sin pasar por tabs internas."

--- a/frontend/src/pages/organizador/ResultadosPage.tsx
+++ b/frontend/src/pages/organizador/ResultadosPage.tsx
@@ -45,10 +45,12 @@ function SelectorTorneo() {
     queryFn: fetchTorneos,
   })
 
-  return (
-    <OrganizadorLayout
+    return (
+      <OrganizadorLayout
       title="Resultados"
       subtitle="Seleccionar torneo para ver los resultados"
+      showTournamentNavigation={false}
+      simpleHeader
       actions={
         <Link
           to="/organizador/torneo"
@@ -290,70 +292,109 @@ function ResultadosTorneo({ torneoId }: ResultadosTorneoProps) {
   const subtitulo = torneo
     ? `${torneo.nombre} · ${torneo.sede.ciudad}`
     : 'Resultados por disciplina'
+  const estadoRankingLabel = overallDisponible ? 'Ranking final' : 'Ranking parcial'
+  const progresoLabel =
+    totalDisciplinas > 0 ? `${disciplinasCerradas} de ${totalDisciplinas} disciplinas cerradas` : null
 
   return (
     <OrganizadorLayout
       title="Resultados"
-      subtitle={subtitulo}
+      subtitle={
+        disciplinaActiva
+          ? `${subtitulo} · ${disciplinaActiva} · ${estadoRankingLabel}${progresoLabel ? ` · ${progresoLabel}` : ''}`
+          : `${subtitulo} · ${estadoRankingLabel}${progresoLabel ? ` · ${progresoLabel}` : ''}`
+      }
       actions={
-        <Link
-          to="/organizador/torneo"
-          className="rounded-full border border-slate-600 bg-slate-800 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-100"
-        >
-          Volver
-        </Link>
+        <>
+          <button
+            type="button"
+            disabled={!overallDisponible}
+            className={
+              overallDisponible
+                ? 'rounded-full border border-sky-400 bg-sky-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-sky-300'
+                : 'cursor-not-allowed rounded-full border border-slate-700 bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500'
+            }
+          >
+            Publicar resultados
+          </button>
+          <Link
+            to="/organizador/resultados"
+            className="rounded-full border border-slate-600 bg-slate-800 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-100"
+          >
+            Cambiar torneo
+          </Link>
+        </>
       }
     >
       {competenciasQuery.isLoading ? (
-        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+        <section className="rounded-[2rem] border border-slate-700 bg-slate-900/75 p-5 text-sm text-slate-300">
           Cargando disciplinas...
         </section>
       ) : null}
 
       {competenciasQuery.isError ? (
-        <section className="rounded-[2rem] border border-red-300/60 bg-red-50 p-5 text-sm text-red-900">
+        <section className="rounded-[2rem] border border-red-500/40 bg-red-950/40 p-5 text-sm text-red-100">
           No se pudieron cargar las disciplinas del torneo.
         </section>
       ) : null}
 
       {!competenciasQuery.isLoading && !competenciasQuery.isError && disciplinas.length === 0 ? (
-        <section className="rounded-[2rem] border border-stone-300/80 bg-white/80 p-5 text-sm text-stone-600">
+        <section className="rounded-[2rem] border border-slate-700 bg-slate-900/75 p-5 text-sm text-slate-300">
           Este torneo aún no tiene competencias generadas.
         </section>
       ) : null}
 
       {disciplinas.length > 0 ? (
-        <section className="rounded-[2rem] border border-stone-300/80 bg-white/85 p-5 shadow-[0_20px_60px_rgba(120,93,54,0.08)]">
-          <div className="flex flex-wrap gap-2 border-b border-stone-200 pb-4">
-            {disciplinas.map((comp) => (
-              <button
-                key={comp.disciplina}
-                type="button"
-                onClick={() => setDisciplinaSeleccionada(comp.disciplina)}
-                className={
-                  disciplinaActiva === comp.disciplina
-                    ? 'rounded-full bg-stone-900 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-white'
-                    : 'rounded-full border border-stone-300 bg-white px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-stone-700 hover:bg-stone-50'
-                }
-              >
-                {comp.disciplina}
-              </button>
-            ))}
+        <section className="rounded-[2rem] border border-slate-700 bg-slate-900/85 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.24)]">
+          <div className="flex flex-col gap-4 border-b border-slate-800 pb-4">
+            <div className="flex flex-wrap items-center gap-2">
+              {disciplinas.map((comp) => (
+                <button
+                  key={comp.disciplina}
+                  type="button"
+                  onClick={() => setDisciplinaSeleccionada(comp.disciplina)}
+                  className={
+                    disciplinaActiva === comp.disciplina
+                      ? 'rounded-full border border-sky-400 bg-sky-400/10 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-sky-300'
+                      : 'rounded-full border border-slate-700 bg-slate-950 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300 hover:border-slate-500 hover:text-white'
+                  }
+                >
+                  {comp.disciplina}
+                </button>
+              ))}
+            </div>
+
+            {disciplinaActiva ? (
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Ranking por disciplina
+                  </p>
+                  <h2 className="mt-2 text-2xl font-semibold text-white">{disciplinaActiva}</h2>
+                  <p className="mt-2 text-sm text-slate-300">
+                    Tabla de ejecucion ordenada por OT con AP, RP, tarjeta y puntos FAAS.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.16em] text-slate-400">
+                  <span className="rounded-full border border-slate-700 bg-slate-950 px-3 py-1.5">
+                    {disciplinaActivaFinalizada ? 'Disciplina finalizada' : 'Disciplina en seguimiento'}
+                  </span>
+                  {isLoading ? (
+                    <span className="rounded-full border border-slate-700 bg-slate-950 px-3 py-1.5">
+                      Actualizando
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </div>
 
           {disciplinaActiva ? (
             <div className="mt-4">
-              <div className="mb-3 flex items-center justify-between">
-                <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">
-                  Tabla de ejecución — {disciplinaActiva}
-                </h2>
-                {isLoading ? (
-                  <span className="text-xs text-stone-400">Actualizando...</span>
-                ) : null}
-              </div>
-
               {grillaQuery.isError ? (
-                <p className="text-sm text-red-700">Error al cargar la grilla.</p>
+                <p className="rounded-[1.5rem] border border-red-500/40 bg-red-950/30 p-4 text-sm text-red-100">
+                  Error al cargar la grilla.
+                </p>
               ) : null}
 
               {!grillaQuery.isLoading && !grillaQuery.isError ? (
@@ -365,68 +406,74 @@ function ResultadosTorneo({ torneoId }: ResultadosTorneoProps) {
               ) : null}
 
               {grillaQuery.isLoading ? (
-                <p className="py-6 text-center text-sm text-stone-400">Cargando tabla...</p>
+                <p className="py-6 text-center text-sm text-slate-400">Cargando tabla...</p>
               ) : null}
             </div>
           ) : null}
         </section>
       ) : null}
 
-      {disciplinas.length > 0 && disciplinaActiva ? (
-        <PodiosSection
-          title={`Podios — ${disciplinaActiva}`}
-          subtitle="Resultados agrupados por categoria y genero con puntaje FAAS."
-          groups={podioDisciplina}
-          emptyState={
-            !disciplinaActivaFinalizada
-              ? {
-                  title: 'Podios disponibles al cerrar la disciplina',
-                  detail: 'La disciplina seleccionada todavia no esta finalizada.',
-                }
-              : rankingQuery.isError
-                ? {
-                    title: 'No se pudo cargar el ranking de la disciplina',
-                    detail: 'Volve a intentar cuando el calculo de resultados este disponible.',
-                  }
-                : rankingQuery.data && !rankingQuery.data.calculado
-                  ? {
-                      title: 'Ranking aun no calculado',
-                      detail: 'Los podios se publican cuando la disciplina finaliza con ranking calculado.',
-                    }
-                  : null
-          }
-        />
-      ) : null}
-
       {disciplinas.length > 0 ? (
-        <PodiosSection
-          title="Overall"
-          subtitle="Acumulado del torneo por categoria y genero."
-          groups={podioOverall}
-          emptyState={
-            estadosLoading
-              ? {
-                  title: 'Verificando cierre de disciplinas',
-                  detail: 'Estamos comprobando el estado operativo del torneo.',
-                }
-              : !overallDisponible
-                ? {
-                    title: 'Disponible al cerrar todas las disciplinas',
-                    detail: `(${disciplinasCerradas} de ${totalDisciplinas} disciplinas cerradas)`,
-                  }
-                : overallQuery.isError
-                  ? {
-                      title: 'No se pudo cargar el overall del torneo',
-                      detail: 'El calculo acumulado todavia no esta disponible.',
-                    }
-                  : overallQuery.data && !overallQuery.data.calculado
+        <section className="grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+          <div className="flex flex-col gap-4">
+            {disciplinaActiva ? (
+              <PodiosSection
+                title={`Podios — ${disciplinaActiva}`}
+                subtitle="Resultados agrupados por categoria y genero con puntaje FAAS."
+                groups={podioDisciplina}
+                emptyState={
+                  !disciplinaActivaFinalizada
                     ? {
-                        title: 'Overall aun no calculado',
-                        detail: 'El acumulado se habilita cuando el backend publica el ranking overall.',
+                        title: 'Podios disponibles al cerrar la disciplina',
+                        detail: 'La disciplina seleccionada todavia no esta finalizada.',
                       }
-                    : null
-          }
-        />
+                    : rankingQuery.isError
+                      ? {
+                          title: 'No se pudo cargar el ranking de la disciplina',
+                          detail: 'Volve a intentar cuando el calculo de resultados este disponible.',
+                        }
+                      : rankingQuery.data && !rankingQuery.data.calculado
+                        ? {
+                            title: 'Ranking aun no calculado',
+                            detail: 'Los podios se publican cuando la disciplina finaliza con ranking calculado.',
+                          }
+                        : null
+                }
+              />
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <PodiosSection
+              title="Overall"
+              subtitle="Acumulado del torneo por categoria y genero."
+              groups={podioOverall}
+              emptyState={
+                estadosLoading
+                  ? {
+                      title: 'Verificando cierre de disciplinas',
+                      detail: 'Estamos comprobando el estado operativo del torneo.',
+                    }
+                  : !overallDisponible
+                    ? {
+                        title: 'Disponible al cerrar todas las disciplinas',
+                        detail: `(${disciplinasCerradas} de ${totalDisciplinas} disciplinas cerradas)`,
+                      }
+                    : overallQuery.isError
+                      ? {
+                          title: 'No se pudo cargar el overall del torneo',
+                          detail: 'El calculo acumulado todavia no esta disponible.',
+                        }
+                      : overallQuery.data && !overallQuery.data.calculado
+                        ? {
+                            title: 'Overall aun no calculado',
+                            detail: 'El acumulado se habilita cuando el backend publica el ranking overall.',
+                          }
+                        : null
+              }
+            />
+          </div>
+        </section>
       ) : null}
     </OrganizadorLayout>
   )

--- a/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
+++ b/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
@@ -28,6 +28,8 @@ export function TorneoCompetenciasPage() {
       <OrganizadorLayout
         title="Audit Log"
         subtitle="Seleccionar torneo para inspeccionar competencias y trazas"
+        showTournamentNavigation={false}
+        simpleHeader
       >
         <TorneoRouteSelector
           description="El audit log ahora es una sección primaria. Seleccioná un torneo para revisar las competencias y abrir la trazabilidad por atleta."

--- a/tests/features/US-ADJ-9.5-resultados-shell.feature
+++ b/tests/features/US-ADJ-9.5-resultados-shell.feature
@@ -1,0 +1,29 @@
+Feature: US-ADJ-9.5 - Resultados del organizador alineados a S-04
+
+  Background:
+    Given existe un usuario autenticado con rol ORGANIZADOR
+    And existe al menos un torneo con competencias visibles para el organizador
+
+  Scenario: Resultados vive dentro del shell aprobado
+    When el organizador abre la seccion Resultados
+    Then ve la pantalla dentro del shell dark del organizador
+    And el item Resultados aparece activo en la navbar
+
+  Scenario: La pantalla conserva tabla y podios por disciplina
+    Given existe una disciplina finalizada con ranking calculado
+    When el organizador abre Resultados
+    Then puede ver la tabla de ejecucion de la disciplina seleccionada
+    And puede ver los podios por categoria y genero
+
+  Scenario: El overall mantiene su comportamiento de disponibilidad
+    Given no todas las disciplinas estan cerradas
+    When el organizador ve Resultados
+    Then el overall se muestra bloqueado
+    Given todas las disciplinas estan cerradas
+    Then el overall se muestra disponible
+
+  Scenario: La relacion visual entre disciplina y overall es clara
+    Given existe una disciplina activa seleccionada en Resultados
+    When el organizador observa la pantalla
+    Then distingue claramente el bloque principal de resultados por disciplina
+    And distingue el bloque de overall como seccion separada y coherente


### PR DESCRIPTION
## Resumen\n- reencuadra Resultados dentro del shell dark del organizador\n- mejora la jerarquía visual entre ranking por disciplina, overall y podios\n- oculta la navegación primaria de torneo cuando no hay  seleccionado\n- simplifica el header de Home/Nuevo torneo y lleva Nuevo torneo al mismo lenguaje visual dark\n- ajusta la home del organizador para incluir  en vigentes y destacar estados clave por color\n\n## Validación\n-  en  OK\n-  en  falla solo por el error preexistente en 