### PR TITLE
US-ADJ-9.7: declarar AP en inscripción como precondición de preparación

### DIFF
--- a/.claude/tracking/US-ADJ-9.7-tracking.json
+++ b/.claude/tracking/US-ADJ-9.7-tracking.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-9.7",
+    "us_title": "Declarar AP durante inscripción como precondición de preparación",
+    "us_points": 3,
+    "producto": "ataraxiadive",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-29T14:03:21.353238+00:00",
+    "completed_at": "2026-04-29T14:27:11.142674+00:00",
+    "total_elapsed_seconds": 1429,
+    "effective_seconds": 1429,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-29T14:03:25.532856+00:00",
+      "completed_at": "2026-04-29T14:04:03.751620+00:00",
+      "elapsed_seconds": 38,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-29T14:04:09.374608+00:00",
+      "completed_at": "2026-04-29T14:04:30.898016+00:00",
+      "elapsed_seconds": 21,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-29T14:04:36.136096+00:00",
+      "completed_at": "2026-04-29T14:06:11.402602+00:00",
+      "elapsed_seconds": 95,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-29T14:07:00.726686+00:00",
+      "completed_at": null,
+      "elapsed_seconds": 0,
+      "status": "in_progress",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-29T14:25:24.072884+00:00",
+      "completed_at": "2026-04-29T14:25:31.603501+00:00",
+      "elapsed_seconds": 7,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-04-29T14:25:40.667189+00:00",
+      "completed_at": "2026-04-29T14:25:54.775176+00:00",
+      "elapsed_seconds": 14,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-04-29T14:26:03.046636+00:00",
+      "completed_at": "2026-04-29T14:26:06.971001+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-04-29T14:26:10.737701+00:00",
+      "completed_at": "2026-04-29T14:26:14.674000+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-04-29T14:26:50.926462+00:00",
+      "completed_at": "2026-04-29T14:26:58.294602+00:00",
+      "elapsed_seconds": 7,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-04-29T14:27:03.079021+00:00",
+      "completed_at": "2026-04-29T14:27:06.821730+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 10,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/plans/sp-adj-09/US-ADJ-9.7-fase0.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.7-fase0.md
@@ -1,0 +1,62 @@
+# Fase 0 - Validacion de Contexto - US-ADJ-9.7
+
+## Contexto Validado
+
+**Historia de Usuario:** `US-ADJ-9.7` - Declarar AP durante inscripción como precondición de preparación
+**Producto:** `ataraxiadive`
+**Puntos estimados:** 3
+**Prioridad:** Alta
+**Tipo:** ajuste transversal de dominio + backend + frontend
+
+## Fuentes verificadas
+
+- `docs/specs/sp-adj-09/US-ADJ-9.7.md`
+- `docs/contexto/ATARAXIADIVE-CONTEXT.md`
+- `docs/adr/ADR-005-bounded-contexts-ddd-estrategico.md`
+- `docs/adr/ADR-006-estructura-bc-first.md`
+- `docs/design/architecture.md`
+- `docs/design/domain-model.md`
+- `CLAUDE.md`
+- `pyproject.toml`
+
+## Arquitectura y convenciones
+
+- El proyecto sigue arquitectura hexagonal DDD BC-first y esta US cruza `registro`, `torneo`, `competencia` y `frontend`.
+- La fuente primaria del AP debe vivir en `registro`; `torneo` solo valida la completitud para la transición de fase.
+- `competencia` puede consumir o proyectar AP para operación, pero no debe seguir tratándolo como dato originado en performances manuales.
+- Se mantiene la regla de puertos entre BCs: no introducir imports directos entre dominios.
+
+## Alcance tecnico confirmado
+
+Artefactos de impacto principal identificados:
+
+- `src/registro/`
+- `src/torneo/application/commands/transicionar_torneo.py`
+- `src/competencia/application/commands/generar_grilla.py`
+- `src/registro/api/router.py`
+- `frontend/src/components/organizador/InscriptosPanel.tsx`
+- `frontend/src/components/organizador/GrillaPanel.tsx`
+
+Hallazgos iniciales:
+
+- La spec formaliza un desalineamiento ya observado entre inscripción, preparación y generación de grilla.
+- Hay antecedentes directos en `US-5.5.1` y `US-5.5.2`, por lo que conviene revisar contratos ya existentes antes de mover la fuente primaria.
+- La migración debe preservar torneos ya preparados bajo el esquema anterior sin quebrar lectura o generación de grillas.
+
+## Quality Gates
+
+- `tests/` existe con `features/`, `integration/`, `unit/` y `conftest.py`.
+- `pyproject.toml` define pytest, cobertura y configuración de CodeGuard/DesignReviewer.
+- Para esta US aplican pruebas backend, integración HTTP y build/lint del frontend si los cambios tocan React.
+
+## Riesgos y focos de implementacion
+
+- Evitar duplicar la verdad del AP entre `registro` y `competencia` sin una regla clara de precedencia.
+- Mantener consistente el cierre de inscripción en backend y la señalización de faltantes en UI.
+- Resolver el consumo de AP para grilla sin introducir acoplamientos directos entre BCs.
+
+## Listo para Fase 1
+
+- Spec localizada y consistente con el sprint.
+- Contexto de arquitectura y calidad validado.
+- Alcance técnico principal identificado para backend, dominio y frontend organizador.

--- a/docs/plans/sp-adj-09/US-ADJ-9.7-implementation-notes.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.7-implementation-notes.md
@@ -1,0 +1,35 @@
+# US-ADJ-9.7 - Notas de Implementacion
+
+## Decisiones principales
+
+- `registro` pasa a ser la fuente primaria del AP mediante `Inscripcion.ap_por_disciplina`.
+- Se agregó el VO `APDeclarado` para validar valor positivo y derivar la unidad desde la disciplina.
+- `registro/api/router.py` ahora expone lectura y escritura de AP por `inscripcion_id`, y `inscriptos-detalle` deja de consultar AP en `competencia`.
+- `torneo` valida una precondición externa antes de `cerrar-inscripcion`; si faltan AP, responde `409`.
+- `competencia` consume AP desde `registro` a través de `PerformancesAPAdapter`, usando la proyección `competencias_por_torneo` para resolver `torneo_id`.
+
+## Compatibilidad con el modelo anterior
+
+- Se mantuvo el endpoint legado `POST /competencia/{competencia_id}/registrar-ap`.
+- Ese endpoint ahora dispara una proyección hacia `registro` mediante callback configurado en `app.py`.
+- `GenerarGrillaHandler` hace bootstrap de streams de `Performance` si todavía no existen para atletas con AP en `registro`, evitando que la ejecución posterior falle por ausencia de stream.
+- `SQLiteInscripcionRepository` migra en forma lazy agregando la columna `ap_por_disciplina` si la tabla histórica no la tiene.
+
+## Cambios de frontend
+
+- El portal atleta declara AP contra `registro`, sin depender de que la competencia ya exista.
+- `InscriptosPanel` carga siempre los inscriptos y habilita edición inline solo en `INSCRIPCION_ABIERTA`.
+- `GrillaPanel` comunica explícitamente que la grilla usa AP declarados durante la inscripción.
+
+## Validación realizada
+
+- Backend:
+  - `./.venv/bin/python -m pytest tests/integration/registro/test_inscriptos_detalle_endpoint.py tests/integration/torneo/test_cierre_inscripcion_precondition.py tests/unit/torneo/application/test_transiciones_handlers.py tests/unit/competencia/application/test_generar_grilla_handler.py`
+- Frontend:
+  - `npm run build`
+  - `npm run lint`
+
+## Riesgos residuales
+
+- Persisten warnings de deprecación por `datetime.utcnow()` en código previo de `registro`.
+- La validación BDD de esta US quedó respaldada por el `.feature` y por tests unitarios/integración; no se agregaron step definitions nuevas en esta iteración.

--- a/docs/plans/sp-adj-09/US-ADJ-9.7-plan.md
+++ b/docs/plans/sp-adj-09/US-ADJ-9.7-plan.md
@@ -1,0 +1,113 @@
+# Plan de Implementacion: US-ADJ-9.7 - Declarar AP durante inscripcion como precondicion de preparacion
+
+**Patron:** hexagonal-ddd-bc
+**Producto:** ataraxiadive
+**Estimacion total:** 4h 30min
+
+## Diagnostico tecnico
+
+- `registro/api/router.py` hoy expone `inscriptos-detalle` resolviendo AP desde `competencia` por lectura del Event Store.
+- `competencia/application/commands/generar_grilla.py` consume `PerformancesAPPort`, cuya implementacion actual (`PerformancesAPAdapter`) solo ve performances en estado `AnunciadaAP`.
+- `torneo/application/commands/transicionar_torneo.py` no valida completitud de AP antes de `INSCRIPCION_ABIERTA -> PREPARACION`.
+- `registro/domain/aggregates/inscripcion.py` y `sqlite_inscripcion_repository.py` no persisten AP por disciplina como parte de la inscripcion.
+- `frontend/src/components/organizador/InscriptosPanel.tsx` muestra estados, pero no permite editar AP ni comunicar readiness para cierre/preparacion.
+
+## Componentes a Implementar
+
+### 1. Registro como fuente primaria del AP
+
+- [ ] `src/registro/domain/aggregates/inscripcion.py` (25 min)
+  - Incorporar AP por disciplina como dato propio de la inscripcion.
+  - Exponer operaciones de declaracion/actualizacion y consulta por disciplina.
+- [ ] `src/registro/domain/value_objects/` (20 min)
+  - Crear VO(s) para representar AP declarado de forma valida y tipada.
+- [ ] `src/registro/domain/exceptions.py` (10 min)
+  - Agregar errores de AP invalido o disciplina no inscripta si hacen falta.
+- [ ] `src/registro/domain/ports/inscripcion_repository_port.py` (10 min)
+  - Extender contrato si se requieren lecturas enfocadas en completitud AP.
+- [ ] `src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py` (35 min)
+  - Persistir AP por disciplina.
+  - Resolver migracion compatible con registros existentes sin columna/campo previo.
+
+### 2. Casos de uso y API de Registro
+
+- [ ] `src/registro/application/commands/` (30 min)
+  - Crear comando/handler para declarar o actualizar AP por atleta, torneo y disciplina.
+- [ ] `src/registro/application/queries/listar_inscriptos.py` o query nueva (20 min)
+  - Exponer detalle de inscriptos usando AP desde registro, no desde competencia.
+- [ ] `src/registro/api/router.py` (35 min)
+  - Reemplazar la lectura de AP desde `competencia`.
+  - Agregar endpoint de escritura de AP para el flujo organizador.
+  - Mantener compatibilidad de payload para `Inscriptos`.
+
+### 3. Precondicion de cierre de inscripcion en Torneo
+
+- [ ] `src/torneo/application/commands/transicionar_torneo.py` (30 min)
+  - Inyectar una validacion externa de completitud AP antes de cerrar inscripcion.
+  - Rechazar `INSCRIPCION_ABIERTA -> PREPARACION` cuando existan faltantes.
+- [ ] `src/torneo/api/router.py` (20 min)
+  - Cablear la precondicion desde `registro`.
+  - Mapear error de negocio a respuesta HTTP clara para frontend.
+
+### 4. Consumo de AP desde la fuente correcta en Competencia
+
+- [ ] `src/competencia/domain/ports/performances_ap_port.py` (20 min)
+  - Redefinir el puerto para obtener AP operativos desde inscripcion, no desde performances event-sourced.
+- [ ] `src/competencia/infrastructure/repositories/performances_ap_adapter.py` o nuevo adapter ACL (35 min)
+  - Leer AP desde `registro` usando la relacion torneo/competencia/disciplina.
+  - Decidir compatibilidad para torneos ya preparados con datos historicos.
+- [ ] `src/competencia/application/commands/generar_grilla.py` (20 min)
+  - Mantener el contrato de negocio pero usando el origen nuevo de datos.
+
+### 5. Frontend organizador
+
+- [ ] `frontend/src/api/registro.ts` (20 min)
+  - Agregar contrato para editar AP desde la vista de inscriptos.
+- [ ] `frontend/src/components/organizador/InscriptosPanel.tsx` (35 min)
+  - Habilitar visualizacion y edicion de AP por atleta y disciplina.
+  - Refrescar estados luego de guardar.
+- [ ] `frontend/src/components/organizador/TablaInscriptos.tsx` y relacionados (35 min)
+  - Incorporar accion editable en `INSCRIPCION_ABIERTA`.
+  - Mantener solo lectura fuera de esa fase y señalizar pendientes.
+- [ ] `frontend/src/components/organizador/GrillaPanel.tsx` (20 min)
+  - Comunicar que la grilla depende de AP completos y mostrar estado vacio mas informativo si falta preparacion.
+
+### 6. Migracion y compatibilidad
+
+- [ ] Resolver estrategia de fallback para datos historicos (25 min)
+  - Si existen AP solo en `competencia`, decidir si se copian al leer, al cerrar o via migracion lazy.
+  - Mantener operativos torneos ya preparados bajo el esquema anterior.
+
+### 7. Tests
+
+- [ ] `tests/unit/registro/` (30 min)
+  - Cobertura de aggregate/VO/handler de AP en inscripcion.
+- [ ] `tests/unit/torneo/` (20 min)
+  - Cobertura del bloqueo de cierre de inscripcion por AP faltante.
+- [ ] `tests/unit/competencia/` (20 min)
+  - Ajustar tests de `GenerarGrillaHandler` al nuevo puerto/fuente.
+- [ ] `tests/integration/registro/` (30 min)
+  - Endpoint detalle + endpoint escritura AP + persistencia/migracion.
+- [ ] `tests/integration/torneo/` o `tests/integration/app/` (25 min)
+  - Cierre de inscripcion rechazado/aceptado segun completitud AP.
+- [ ] `tests/features/steps/` (20 min)
+  - Steps minimos o validacion manual si no conviene automatizar full BDD de UI.
+
+### 8. Validacion
+
+- [ ] Ejecutar pytest focalizado backend (15 min)
+- [ ] Ejecutar `npm run build` y `npm run lint` en `frontend/` si el cambio toca React (15 min)
+- [ ] Generar reporte de quality gates y documentacion final (15 min)
+
+## Riesgos y decisiones a resolver en implementacion
+
+- Si el frontend del atleta sigue declarando AP via `competencia`, habra que decidir si se migra tambien ese flujo en esta US o se deja un puente transitorio.
+- Hay que evitar imports cruzados entre dominios; la validacion de cierre debe entrar por puerto/ACL o por wiring de capa de aplicacion.
+- La migracion historica puede requerir fallback dual de lectura: primero `registro`, luego `competencia` si el torneo ya estaba preparado bajo el modelo anterior.
+
+## Criterio de completitud
+
+- `Inscriptos` lee y escribe AP desde `registro`.
+- `cerrar-inscripcion` falla con mensaje claro cuando faltan AP.
+- `generar-grilla` usa AP provenientes de inscripcion.
+- Existe cobertura automatizada para backend y validacion del frontend.

--- a/docs/reports/US-ADJ-9.7-report.md
+++ b/docs/reports/US-ADJ-9.7-report.md
@@ -1,0 +1,67 @@
+# Reporte de Implementacion - US-ADJ-9.7
+
+## Resumen
+
+- **US:** `US-ADJ-9.7`
+- **Titulo:** Declarar AP durante inscripción como precondición de preparación
+- **Branch de trabajo:** `feature-US-ADJ-9.7-declarar-ap`
+- **Estado:** Implementada
+
+## Alcance implementado
+
+- AP persistido en `registro` por inscripción y disciplina.
+- Endpoint de lectura/escritura de AP sobre inscripción.
+- Validación de cierre de inscripción bloqueada cuando faltan AP.
+- Generación de grilla alimentada desde AP declarados en inscripción.
+- Compatibilidad transitoria con el endpoint legado de AP en `competencia`.
+- Ajustes de UI en portal atleta e `Inscriptos` del organizador.
+
+## Archivos principales tocados
+
+- `src/registro/api/router.py`
+- `src/registro/domain/aggregates/inscripcion.py`
+- `src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py`
+- `src/torneo/application/commands/transicionar_torneo.py`
+- `src/torneo/api/router.py`
+- `src/competencia/application/commands/generar_grilla.py`
+- `src/competencia/infrastructure/repositories/performances_ap_adapter.py`
+- `src/app.py`
+- `frontend/src/api/registro.ts`
+- `frontend/src/components/organizador/InscriptosPanel.tsx`
+- `frontend/src/components/organizador/TablaInscriptos.tsx`
+- `frontend/src/pages/atleta/AtletaDeclararAPPage.tsx`
+
+## Evidencia de validacion
+
+### Python
+
+```bash
+./.venv/bin/python -m pytest \
+  tests/integration/registro/test_inscriptos_detalle_endpoint.py \
+  tests/integration/torneo/test_cierre_inscripcion_precondition.py \
+  tests/unit/torneo/application/test_transiciones_handlers.py \
+  tests/unit/competencia/application/test_generar_grilla_handler.py
+```
+
+Resultado: `22 passed`
+
+### Frontend
+
+```bash
+npm run build
+npm run lint
+```
+
+Resultado: ambos comandos completados exitosamente.
+
+## Artefactos de workflow generados
+
+- `docs/plans/sp-adj-09/US-ADJ-9.7-fase0.md`
+- `tests/features/US-ADJ-9.7-ap-inscripcion-preparacion.feature`
+- `docs/plans/sp-adj-09/US-ADJ-9.7-plan.md`
+- `docs/plans/sp-adj-09/US-ADJ-9.7-implementation-notes.md`
+
+## Observaciones
+
+- El spec `docs/specs/sp-adj-09/US-ADJ-9.7.md` quedó incluido en la branch de trabajo.
+- La transición preserva compatibilidad operativa para flujos que todavía registran AP en `competencia`.

--- a/docs/specs/sp-adj-09/US-ADJ-9.7.md
+++ b/docs/specs/sp-adj-09/US-ADJ-9.7.md
@@ -1,0 +1,156 @@
+# US-ADJ-9.7: Declarar AP durante inscripción como precondición de preparación
+
+**Estado**: `To Do`
+**Iteracion / Sprint**: SP-ADJ-09
+**Tipo**: ajuste transversal de dominio + backend + frontend
+**Agregado principal afectado**: flujo organizador `Inscriptos -> cierre de inscripción -> preparación`
+**Bounded Context**: registro + torneo + competencia + frontend organizador
+
+---
+
+## Descripcion (lenguaje de negocio)
+
+Como **organizador**,
+quiero que los AP se declaren durante la inscripción por atleta y disciplina
+para poder cerrar la inscripción solo cuando el torneo tenga la información
+necesaria para preparar la competencia y generar la grilla.
+
+---
+
+## Fuente de verdad UX
+
+- `docs/design/ux/wireframes-organizador.md §S-03 Inscriptos`
+- `docs/design/ux/wireframes-organizador.md §S-02 Grilla`
+- `docs/design/ux/prototipos/prototipo-organizador.html`
+- `.work/revision-sp5/03-hallazgos-logica-inscripcion-ap.md`
+- `docs/specs/sp5/US-5.5.1.md`
+- `docs/specs/sp5/US-5.5.2.md`
+
+---
+
+## Contexto del dominio
+
+### Problema
+
+La implementación actual deja el AP del atleta dentro del circuito de
+`competencia`, como parte de los eventos de `performance`.
+
+Eso produce una secuencia incorrecta:
+
+- la inscripción se puede cerrar sin AP;
+- la pantalla `Inscriptos` no administra el AP como dato propio de la fase;
+- la preparación y generación de grilla requieren AP ya existentes;
+- pero esos AP hoy dependen de una competencia previamente creada.
+
+El resultado es una contradicción operativa: el sistema exige para `PREPARACION`
+un dato que no obliga a capturar durante `INSCRIPCION_ABIERTA`.
+
+### Modelo involucrado
+
+| Elemento | Nombre | Responsabilidad |
+|---|---|---|
+| Registro | inscripción por atleta y disciplina | fuente primaria del estado de inscripción y AP declarados |
+| Torneo | transición `INSCRIPCION_ABIERTA -> PREPARACION` | validar completitud antes de cerrar inscripción |
+| Competencia | generación de grilla | consumir AP ya declarados para ordenar atletas |
+| Frontend | `Inscriptos`, `Grilla` | capturar AP y reflejar el readiness operativo del torneo |
+
+---
+
+## Especificacion del comportamiento
+
+### Precondicion
+
+Existe un torneo en `INSCRIPCION_ABIERTA` con una o más inscripciones activas por
+disciplina.
+
+### Postcondicion
+
+El sistema trata el AP como dato del flujo de inscripción:
+
+- `Inscriptos` permite visualizar y completar AP por atleta y disciplina;
+- no se puede cerrar la inscripción si faltan AP obligatorios;
+- al pasar a `PREPARACION`, la competencia utiliza esos AP ya declarados;
+- la generación de grilla no depende de performances cargadas manualmente antes.
+
+### Invariantes
+
+| ID | Invariante |
+|----|------------|
+| INV-ADJ-9.7-01 | El AP pertenece al flujo de inscripción del torneo y debe existir antes de `PREPARACION`. |
+| INV-ADJ-9.7-02 | No se permite `INSCRIPCION_ABIERTA -> PREPARACION` si hay inscripciones activas sin AP requerido. |
+| INV-ADJ-9.7-03 | `Inscriptos` debe mostrar el estado real del AP sin depender de competencias ya creadas. |
+| INV-ADJ-9.7-04 | `Generar grilla` consume AP declarados en inscripción y no exige performances preexistentes como fuente primaria. |
+| INV-ADJ-9.7-05 | Si el BC `competencia` replica AP por necesidades operativas, esa réplica no reemplaza la fuente primaria en `registro`. |
+
+---
+
+## Criterios de aceptacion
+
+```gherkin
+Feature: AP declarados durante inscripción como requisito de preparación
+
+  Scenario: El organizador ve atletas inscriptos con AP pendientes
+    Given un torneo en INSCRIPCION_ABIERTA
+    And existen atletas inscriptos en una disciplina
+    When el organizador abre la sección Inscriptos
+    Then puede ver el estado AP por atleta y disciplina
+    And los faltantes se muestran como pendientes
+
+  Scenario: No se puede cerrar inscripción con AP faltantes
+    Given un torneo en INSCRIPCION_ABIERTA
+    And existe al menos una inscripción activa sin AP requerido
+    When el organizador intenta cerrar la inscripción
+    Then el sistema rechaza la transición a PREPARACION
+    And informa que faltan AP por completar
+
+  Scenario: Se puede cerrar inscripción cuando todos los AP están completos
+    Given un torneo en INSCRIPCION_ABIERTA
+    And todas las inscripciones activas tienen AP válido
+    When el organizador cierra la inscripción
+    Then el torneo puede pasar a PREPARACION
+
+  Scenario: La grilla usa AP ya declarados
+    Given un torneo en PREPARACION
+    And existen inscripciones activas con AP declarado
+    When el organizador genera la grilla de una disciplina
+    Then la grilla se calcula usando esos AP
+    And no requiere performances preexistentes cargadas manualmente
+```
+
+---
+
+## Impacto arquitectonico
+
+**Esta US requiere una decision arquitectonica?**
+- [x] Sí — redefine la fuente primaria del AP y el contrato entre `registro`, `torneo` y `competencia`.
+
+**Capa(s) afectadas:**
+- [x] Frontend — `Inscriptos` y estados operativos del shell del organizador.
+- [x] Backend — handlers, read models y endpoints de inscripción/preparación.
+- [x] Dominio — invariantes de transición de torneo y fuente del AP.
+
+---
+
+## Artefactos a modificar
+
+| Artefacto | Cambio |
+|-----------|--------|
+| `src/registro/` | Persistir AP por atleta, torneo y disciplina como dato de inscripción. |
+| `src/torneo/application/commands/transicionar_torneo.py` | Validar AP completos antes de cerrar inscripción. |
+| `src/competencia/application/commands/generar_grilla.py` | Consumir AP desde la fuente correcta de inscripción. |
+| `src/registro/api/router.py` | Exponer lectura/escritura coherente del AP en `Inscriptos`. |
+| `frontend/src/components/organizador/InscriptosPanel.tsx` | Mostrar y editar AP como parte de la inscripción. |
+| `frontend/src/components/organizador/GrillaPanel.tsx` | Reflejar que la preparación depende de AP completos. |
+
+---
+
+## Notas de implementacion
+
+1. Este ajuste no es cosmético: corrige una inversión de modelo que hoy bloquea la secuencia correcta `inscripción -> AP -> preparación -> grilla`.
+2. Si se mantiene una proyección de AP en `competencia`, debe quedar explícito que es derivada y no fuente primaria.
+3. La migración debe contemplar datos existentes para no romper torneos ya preparados bajo el esquema anterior.
+4. La UX de `Inscriptos` debe soportar el estado intermedio `pendiente` de forma clara antes del cierre de inscripción.
+
+---
+
+*Spec creada: 2026-04-29 — formalización del hallazgo de lógica AP/inscripción en SP-ADJ-09*

--- a/frontend/src/api/registro.ts
+++ b/frontend/src/api/registro.ts
@@ -25,6 +25,12 @@ export interface InscriptoDisciplinaDetalleDto {
   unidad: string | null
 }
 
+export interface InscripcionApDto {
+  disciplina: string
+  ap: string | null
+  unidad: string | null
+}
+
 export interface InscriptoDetalleDto {
   inscripcion_id: string
   atleta_id: string
@@ -161,4 +167,33 @@ export async function inscribirAtleta(
     }),
   })
   return parseResponse<InscribirAtletaResponse>(response)
+}
+
+export async function fetchApInscripcion(
+  inscripcionId: string,
+  disciplina: string,
+): Promise<InscripcionApDto> {
+  const response = await fetch(
+    `/registro/inscripciones/${inscripcionId}/ap?disciplina=${encodeURIComponent(disciplina)}`,
+    {
+      headers: buildHeaders(),
+    },
+  )
+  return parseResponse<InscripcionApDto>(response)
+}
+
+export async function guardarApInscripcion(payload: {
+  inscripcionId: string
+  disciplina: string
+  valorAp: string
+}): Promise<InscripcionApDto> {
+  const response = await fetch(`/registro/inscripciones/${payload.inscripcionId}/ap`, {
+    method: 'PUT',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      disciplina: payload.disciplina,
+      valor_ap: payload.valorAp,
+    }),
+  })
+  return parseResponse<InscripcionApDto>(response)
 }

--- a/frontend/src/components/organizador/GrillaPanel.tsx
+++ b/frontend/src/components/organizador/GrillaPanel.tsx
@@ -153,6 +153,9 @@ export function GrillaPanel({ torneoId }: GrillaPanelProps) {
               <p className="mt-2 text-sm text-slate-300">
                 Reordena performances, revisa OT y confirma la grilla de la disciplina activa.
               </p>
+              <p className="mt-2 text-xs uppercase tracking-[0.16em] text-sky-300">
+                La grilla usa los AP declarados durante la inscripción.
+              </p>
             </div>
             <div className="flex flex-col gap-2 sm:items-end">
               <label className="text-sm font-semibold text-slate-200">

--- a/frontend/src/components/organizador/InscriptosPanel.tsx
+++ b/frontend/src/components/organizador/InscriptosPanel.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query'
-import { listarInscriptosDetalle } from '../../api/registro'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { guardarApInscripcion, listarInscriptosDetalle } from '../../api/registro'
 import type { EstadoTorneo } from '../../api/torneo'
 import { EmptyStateCard } from './EmptyStateCard'
 import { TablaInscriptos, type InscriptoRow } from './TablaInscriptos'
@@ -52,15 +52,22 @@ async function loadInscriptos(torneoId: string, torneoEstado: EstadoTorneo) {
 }
 
 export function InscriptosPanel({ torneoId, torneoEstado }: InscriptosPanelProps) {
+  const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: ['torneo-inscriptos-ap', torneoId, torneoEstado],
     queryFn: () => loadInscriptos(torneoId, torneoEstado),
-    enabled: torneoEstado === 'INSCRIPCION_ABIERTA',
   })
 
-  if (torneoEstado !== 'INSCRIPCION_ABIERTA') {
-    return <EmptyStateCard message="La inscripción todavía no está habilitada para este torneo." />
-  }
+  const editable = torneoEstado === 'INSCRIPCION_ABIERTA'
+  const saveMutation = useMutation({
+    mutationFn: async (payload: { inscripcionId: string; disciplina: string; valorAp: string }) => {
+      await guardarApInscripcion(payload)
+      return payload
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['torneo-inscriptos-ap', torneoId] })
+    },
+  })
 
   if (query.isLoading) {
     return (
@@ -84,6 +91,11 @@ export function InscriptosPanel({ torneoId, torneoEstado }: InscriptosPanelProps
 
   return (
     <article className="rounded-[2rem] border border-slate-700 bg-slate-900/85 p-6 shadow-[0_20px_60px_rgba(2,6,23,0.24)]">
+      {saveMutation.isError ? (
+        <section className="mb-4 rounded-2xl border border-red-500/40 bg-red-950/40 p-4 text-sm text-red-100">
+          No se pudo guardar el AP para la inscripción seleccionada.
+        </section>
+      ) : null}
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
@@ -94,10 +106,25 @@ export function InscriptosPanel({ torneoId, torneoEstado }: InscriptosPanelProps
             Revisa inscripciones, disciplinas activas y el estado de AP por atleta.
           </p>
         </div>
+        <div className="max-w-sm rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-xs text-slate-300">
+          {editable
+            ? 'La edición de AP está habilitada. El torneo solo puede pasar a preparación cuando no queden pendientes.'
+            : 'El torneo ya no está en inscripción abierta. Los AP se muestran en solo lectura como referencia operativa.'}
+        </div>
       </div>
 
       <div className="rounded-[1.5rem] border border-slate-700 bg-slate-950/70 p-4">
-        <TablaInscriptos rows={query.data?.rows ?? []} disciplinas={query.data?.disciplinas ?? []} />
+        <TablaInscriptos
+          rows={query.data?.rows ?? []}
+          disciplinas={query.data?.disciplinas ?? []}
+          editable={editable}
+          savingKey={
+            saveMutation.isPending && saveMutation.variables
+              ? `${saveMutation.variables.inscripcionId}:${saveMutation.variables.disciplina}`
+              : null
+          }
+          onGuardarAp={(payload) => saveMutation.mutate(payload)}
+        />
       </div>
     </article>
   )

--- a/frontend/src/components/organizador/OrganizadorLayout.tsx
+++ b/frontend/src/components/organizador/OrganizadorLayout.tsx
@@ -1,5 +1,5 @@
-import type { EstadoTorneo } from '../../api/torneo'
 import type { ReactNode } from 'react'
+import type { EstadoTorneo } from '../../api/torneo'
 import { Link, useLocation } from 'react-router-dom'
 import { HealthCheck } from '../HealthCheck'
 import useAuthStore from '../../stores/useAuthStore'
@@ -71,6 +71,7 @@ export function OrganizadorLayout({
   activeTournamentId,
   activeTournamentState,
 }: OrganizadorLayoutProps) {
+  void activeTournamentState
   const location = useLocation()
   const email = useAuthStore((s) => s.email)
   const nombre = useAuthStore((s) => s.nombre)

--- a/frontend/src/components/organizador/TablaInscriptos.tsx
+++ b/frontend/src/components/organizador/TablaInscriptos.tsx
@@ -21,10 +21,20 @@ export interface InscriptoRow {
 interface TablaInscriptosProps {
   rows: InscriptoRow[]
   disciplinas: string[]
+  editable?: boolean
+  onGuardarAp?: (payload: { inscripcionId: string; disciplina: string; valorAp: string }) => void
+  savingKey?: string | null
 }
 
-export function TablaInscriptos({ rows, disciplinas }: TablaInscriptosProps) {
+export function TablaInscriptos({
+  rows,
+  disciplinas,
+  editable = false,
+  onGuardarAp,
+  savingKey = null,
+}: TablaInscriptosProps) {
   const [disciplinaFiltro, setDisciplinaFiltro] = useState('TODAS')
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
   const disciplinasVisibles =
     disciplinaFiltro === 'TODAS' ? disciplinas : disciplinas.filter((d) => d === disciplinaFiltro)
   const rowsFiltradas = useMemo(() => {
@@ -97,13 +107,47 @@ export function TablaInscriptos({ rows, disciplinas }: TablaInscriptosProps) {
                       )
                     }
                     const estado = row.estadoApPorDisciplina[disciplina]
+                    const cellKey = `${row.inscripcionId}:${disciplina}`
+                    const draft = drafts[cellKey] ?? estado?.ap ?? ''
                     return (
                       <td key={disciplina} className="px-4 py-3">
-                        <EstadoAPBadge
-                          estado={estado?.estado ?? 'pendiente'}
-                          ap={estado?.ap}
-                          unidad={estado?.unidad}
-                        />
+                        <div className="space-y-2">
+                          <EstadoAPBadge
+                            estado={estado?.estado ?? 'pendiente'}
+                            ap={estado?.ap}
+                            unidad={estado?.unidad}
+                          />
+                          {editable ? (
+                            <div className="flex min-w-44 flex-col gap-2">
+                              <input
+                                value={draft}
+                                onChange={(event) =>
+                                  setDrafts((current) => ({
+                                    ...current,
+                                    [cellKey]: event.target.value,
+                                  }))
+                                }
+                                inputMode="decimal"
+                                placeholder={estado?.unidad === 'Segundos' ? 'Segundos' : 'Metros'}
+                                className="rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                              />
+                              <button
+                                type="button"
+                                disabled={savingKey === cellKey || !(parseFloat(draft) > 0)}
+                                onClick={() =>
+                                  onGuardarAp?.({
+                                    inscripcionId: row.inscripcionId,
+                                    disciplina,
+                                    valorAp: draft,
+                                  })
+                                }
+                                className="rounded-xl bg-sky-500 px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-950 disabled:cursor-not-allowed disabled:opacity-50"
+                              >
+                                {savingKey === cellKey ? 'Guardando...' : 'Guardar AP'}
+                              </button>
+                            </div>
+                          ) : null}
+                        </div>
                       </td>
                     )
                   })}

--- a/frontend/src/pages/atleta/AtletaDeclararAPPage.tsx
+++ b/frontend/src/pages/atleta/AtletaDeclararAPPage.tsx
@@ -1,11 +1,11 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { fetchApAtleta, fetchCompetenciasPorTorneo, fetchGrillaCompetencia, registrarAP } from '../../api/competencia'
-import { fetchAtletaMe } from '../../api/registro'
+import { fetchCompetenciasPorTorneo, fetchGrillaCompetencia } from '../../api/competencia'
+import { fetchApInscripcion, fetchAtletaMe, guardarApInscripcion, listarInscripcionesDeAtleta } from '../../api/registro'
 import { fetchTorneo } from '../../api/torneo'
 import { AtletaShell } from '../../components/atleta/AtletaShell'
-import { ApiError } from '../../api/competencia'
+import { ApiError } from '../../api/registro'
 import { formatDisciplina, formatFecha, getUnidadEsperada, getUnidadLabel } from './portalData'
 
 async function loadApContext(torneoId: string, disciplina: string) {
@@ -14,6 +14,11 @@ async function loadApContext(torneoId: string, disciplina: string) {
     fetchCompetenciasPorTorneo(torneoId),
     fetchAtletaMe(),
   ])
+  const inscripciones = await listarInscripcionesDeAtleta(atleta.atleta_id)
+  const inscripcion =
+    inscripciones.find(
+      (item) => item.torneo_id === torneoId && item.disciplinas.includes(disciplina),
+    ) ?? null
   const competencia = competencias.find((item) => item.disciplina === disciplina) ?? null
   const grilla = competencia
     ? await fetchGrillaCompetencia(competencia.competencia_id, competencia.disciplina).catch(() => [])
@@ -21,16 +26,16 @@ async function loadApContext(torneoId: string, disciplina: string) {
   const athleteEntry = grilla.find((entry) => entry.atleta_id === atleta.atleta_id) ?? null
 
   let apActual: string | null = athleteEntry?.ap_declarado ?? null
-  if (!apActual && competencia) {
+  if (!apActual && inscripcion) {
     try {
-      const apDto = await fetchApAtleta(competencia.competencia_id, atleta.atleta_id, disciplina)
-      apActual = apDto.ap_declarado
+      const apDto = await fetchApInscripcion(inscripcion.inscripcion_id, disciplina)
+      apActual = apDto.ap
     } catch {
       // sin AP previo
     }
   }
 
-  return { torneo, competencia, athleteEntry, atletaId: atleta.atleta_id, apActual }
+  return { torneo, competencia, athleteEntry, apActual, inscripcion }
 }
 
 function getApError(error: unknown): string {
@@ -54,16 +59,14 @@ export function AtletaDeclararAPPage() {
 
   const mutation = useMutation({
     mutationFn: async () => {
-      const atletaId = query.data?.atletaId
-      if (!query.data?.competencia || !atletaId || !disciplina) {
-        throw new Error('La disciplina todavía no está preparada para anunciar AP.')
+      const inscripcionId = query.data?.inscripcion?.inscripcion_id
+      if (!inscripcionId || !disciplina) {
+        throw new Error('No se encontró la inscripción activa para esta disciplina.')
       }
-      return registrarAP({
-        competenciaId: query.data.competencia.competencia_id,
-        participanteId: atletaId,
+      return guardarApInscripcion({
+        inscripcionId,
         disciplina,
         valorAp: valorApValue,
-        unidad: getUnidadEsperada(disciplina),
       })
     },
     onSuccess: () => {
@@ -132,12 +135,6 @@ export function AtletaDeclararAPPage() {
             ) : null}
           </section>
 
-          {!query.data.competencia ? (
-            <div className="rounded-3xl border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">
-              El organizador aún no configuró la competencia de esta disciplina. El AP estará disponible cuando la grilla sea publicada.
-            </div>
-          ) : null}
-
           {mutation.isError ? (
             <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
               {getApError(mutation.error)}
@@ -155,7 +152,7 @@ export function AtletaDeclararAPPage() {
             <button
               type="button"
               onClick={() => mutation.mutate()}
-              disabled={mutation.isPending || !(parseFloat(valorApValue) > 0) || !query.data.competencia}
+              disabled={mutation.isPending || !(parseFloat(valorApValue) > 0)}
               className="flex-1 rounded-2xl bg-sky-500 px-4 py-3 text-sm font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:opacity-60"
             >
               {mutation.isPending ? 'Guardando...' : 'Guardar AP'}

--- a/frontend/src/pages/atleta/AtletaHomePage.tsx
+++ b/frontend/src/pages/atleta/AtletaHomePage.tsx
@@ -18,7 +18,7 @@ export function AtletaHomePage() {
   const logout = useAuthStore((state) => state.logout)
   const query = useQuery({
     queryKey: ['atleta-portal-home', atletaId],
-    queryFn: () => loadAtletaPortalSnapshot(atletaId ?? ''),
+    queryFn: () => loadAtletaPortalSnapshot(),
     enabled: Boolean(atletaId),
   })
 

--- a/frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx
+++ b/frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx
@@ -14,7 +14,7 @@ export function AtletaMisInscripcionesPage() {
   const atletaId = useAuthStore((state) => state.userId)
   const query = useQuery({
     queryKey: ['atleta-mis-inscripciones', atletaId],
-    queryFn: () => loadAtletaPortalSnapshot(atletaId ?? ''),
+    queryFn: () => loadAtletaPortalSnapshot(),
     enabled: Boolean(atletaId),
   })
 

--- a/frontend/src/pages/atleta/portalData.ts
+++ b/frontend/src/pages/atleta/portalData.ts
@@ -1,11 +1,11 @@
 import {
-  fetchApAtleta,
   fetchCompetenciasPorTorneo,
   fetchGrillaCompetencia,
   type CompetenciaResumenDto,
   type GrillaAtletaDto,
 } from '../../api/competencia'
 import {
+  fetchApInscripcion,
   fetchAtletaMe,
   listarInscripcionesDeAtleta,
   type AtletaDto,
@@ -117,7 +117,7 @@ function buildApEstado(
   return grilla?.ap_declarado?.trim() ? 'declarado' : 'pendiente'
 }
 
-export async function loadAtletaPortalSnapshot(_userId: string): Promise<AtletaPortalSnapshot> {
+export async function loadAtletaPortalSnapshot(): Promise<AtletaPortalSnapshot> {
   const [atleta, torneos] = await Promise.all([fetchAtletaMe(), fetchTorneos()])
   const atletaId = atleta.atleta_id
   const inscripciones = await listarInscripcionesDeAtleta(atletaId)
@@ -175,10 +175,10 @@ export async function loadAtletaPortalSnapshot(_userId: string): Promise<AtletaP
           let ap: string | null = grillaEntry?.ap_declarado ?? null
           let unidad: string | null = grillaEntry?.unidad ?? null
 
-          if (!grillaEntry && competencia && torneo.estado === 'INSCRIPCION_ABIERTA') {
+          if (!grillaEntry && torneo.estado === 'INSCRIPCION_ABIERTA') {
             try {
-              const apDto = await fetchApAtleta(competencia.competencia_id, atletaId, disciplina)
-              ap = apDto.ap_declarado
+              const apDto = await fetchApInscripcion(inscripcion.inscripcion_id, disciplina)
+              ap = apDto.ap
               unidad = apDto.unidad
             } catch {
               // sin AP declarado

--- a/frontend/src/pages/organizador/DetalleTorneoPage.tsx
+++ b/frontend/src/pages/organizador/DetalleTorneoPage.tsx
@@ -293,6 +293,7 @@ function TorneoOperativoPanel({
   onTransitionSuccess,
   onTransitionError,
 }: TorneoOperativoPanelProps) {
+  void hayDisciplinasEnCurso
   const [selectedEstado, setSelectedEstado] = useState<EstadoTorneo>(torneo.estado)
   const [isSavingState, setIsSavingState] = useState(false)
   const estadosPorDisciplina = new Map(
@@ -302,7 +303,6 @@ function TorneoOperativoPanel({
     torneo.estado,
     premiacionPendientes,
     isPremiacionStatusLoading,
-    hayDisciplinasEnCurso,
   )
   const selectedTransition = transitionOptions.find((option) => option.value === selectedEstado) ?? null
 
@@ -420,7 +420,6 @@ function buildEstadoOptions(
   estadoActual: EstadoTorneo,
   premiacionPendientes: string[] | null,
   isPremiacionStatusLoading: boolean,
-  _hayDisciplinasEnCurso: boolean,
 ): EstadoOption[] {
   const options: EstadoOption[] = [
     { value: estadoActual, label: ESTADO_LABELS[estadoActual] },

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from decimal import Decimal
 from typing import Awaitable, Callable
 from uuid import UUID
 
@@ -13,7 +14,10 @@ from competencia.application.queries.obtener_competencias_por_torneo import (
     ObtenerCompetenciasPorTorneoQuery,
 )
 from competencia.api.exception_handlers import register_exception_handlers
-from competencia.api.router import router as competencia_router
+from competencia.api.router import (
+    configure_ap_registrado_callback,
+    router as competencia_router,
+)
 from resultados.api.router import router as resultados_router
 from resultados.application.commands.calcular_overall import (
     CalcularOverallCommand,
@@ -52,13 +56,22 @@ from notificaciones.infrastructure.templates.resultados_publicados_template impo
     ResultadosPublicadosTemplate,
 )
 from registro.api.router import (
+    build_cierre_inscripcion_precondition,
     configure_inscripcion_notificaciones,
     router as registro_router,
 )
+from registro.application.commands.declarar_ap_inscripcion import (
+    DeclararAPInscripcionCommand,
+    DeclararAPInscripcionHandler,
+)
 from registro.domain.aggregates.inscripcion import Inscripcion
 from registro.infrastructure.repositories.sqlite_atleta_repository import SQLiteAtletaRepository
+from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
+    SQLiteInscripcionRepository,
+)
 from torneo.api.exception_handlers import register_torneo_exception_handlers
 from torneo.api.router import (
+    configure_cierre_inscripcion_precondition,
     configure_premiacion_precondition,
     router as torneo_router,
 )
@@ -158,6 +171,7 @@ def build_on_inscripcion_confirmada_callback(
 
 
 configure_inscripcion_notificaciones(build_on_inscripcion_confirmada_callback())
+configure_cierre_inscripcion_precondition(build_cierre_inscripcion_precondition())
 
 
 def build_p11_handler() -> PoliticaP11Handler:
@@ -450,6 +464,40 @@ async def _obtener_disciplinas_torneo(
 
 
 configure_premiacion_precondition(build_premiacion_precondition())
+
+
+def build_on_ap_registrado_callback(
+    *,
+    competencias_repo: SQLiteCompetenciasPorTorneo | None = None,
+    inscripcion_repo: SQLiteInscripcionRepository | None = None,
+) -> Callable[[UUID, UUID, Disciplina, Decimal], Awaitable[None]]:
+    async def _callback(
+        competencia_id: UUID,
+        atleta_id: UUID,
+        disciplina: Disciplina,
+        valor_ap: Decimal,
+    ) -> None:
+        competencias = competencias_repo or SQLiteCompetenciasPorTorneo()
+        inscripciones = inscripcion_repo or SQLiteInscripcionRepository()
+        handler = DeclararAPInscripcionHandler(inscripciones)
+        record = await competencias.obtener_por_competencia_id(competencia_id)
+        if record is None:
+            return
+        inscripcion = await inscripciones.find_by_atleta_y_torneo(atleta_id, record.torneo_id)
+        if inscripcion is None:
+            return
+        await handler.handle(
+            DeclararAPInscripcionCommand(
+                inscripcion_id=inscripcion.inscripcion_id,
+                disciplina=disciplina,
+                valor_ap=valor_ap,
+            )
+        )
+
+    return _callback
+
+
+configure_ap_registrado_callback(build_on_ap_registrado_callback())
 
 
 @app.get("/health", response_class=JSONResponse)

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from datetime import datetime
 from decimal import Decimal
+from collections.abc import Awaitable, Callable
 from typing import Annotated
 from uuid import UUID
 
@@ -159,9 +160,19 @@ from competencia.infrastructure.repositories.performances_estado_adapter import 
 from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
     SQLiteCompetenciasPorTorneo,
 )
+from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
+    SQLiteInscripcionRepository,
+)
 from shared.api.dependencies import AtletaDep, JuezDep, OrganizadorDep
 
 router = APIRouter(prefix="/competencia", tags=["competencia"])
+APRegistradoCallback = Callable[[UUID, UUID, Disciplina, Decimal], Awaitable[None]]
+_ap_registrado_callback: APRegistradoCallback | None = None
+
+
+def configure_ap_registrado_callback(callback: APRegistradoCallback | None) -> None:
+    global _ap_registrado_callback  # noqa: PLW0603
+    _ap_registrado_callback = callback
 
 
 # ── Request body schemas ───────────────────────────────────────────────────────
@@ -530,7 +541,11 @@ def get_generar_grilla_handler(
     """Dependency: handler para generar la grilla."""
     return GenerarGrillaHandler(
         event_store,
-        PerformancesAPAdapter(event_store),
+        PerformancesAPAdapter(
+            event_store,
+            SQLiteCompetenciasPorTorneo(),
+            SQLiteInscripcionRepository(os.getenv("REGISTRO_DB_PATH", "data/registro.db")),
+        ),
         disciplina_descriptor,
     )
 
@@ -916,6 +931,13 @@ async def post_registrar_ap(
         return JSONResponse(status_code=409, content={"detail": str(exc)})
     except DomainError as exc:
         return JSONResponse(status_code=422, content={"detail": str(exc)})
+    if _ap_registrado_callback is not None:
+        await _ap_registrado_callback(
+            competencia_id,
+            body.participante_id,
+            body.disciplina,
+            body.valor_ap,
+        )
     return Response(status_code=204)
 
 

--- a/src/competencia/application/commands/generar_grilla.py
+++ b/src/competencia/application/commands/generar_grilla.py
@@ -8,9 +8,11 @@ from uuid import UUID
 
 from competencia.application.commands._handler_utils import (
     build_competencia_stream_id,
+    build_performance_stream_id,
     persistir_eventos_pendientes,
     reconstruir_competencia,
 )
+from competencia.domain.aggregates.performance import Performance
 from competencia.domain.aggregates.competencia import Competencia
 from competencia.domain.ports.disciplina_descriptor_port import DisciplinaDescriptorPort
 from competencia.domain.ports.event_store_port import EventStorePort
@@ -84,6 +86,7 @@ class GenerarGrillaHandler:
             events=events,
         )
         performances = await self._performances_ap.get_performances_con_ap(command.competencia_id)
+        await self._bootstrap_performances_faltantes(command, performances)
         descriptor = self._disciplina_descriptor.describe(command.disciplina)
         competencia.generar_grilla(
             ot_inicio=command.ot_inicio,
@@ -96,6 +99,32 @@ class GenerarGrillaHandler:
             stream_id=stream_id,
             aggregate=competencia,
         )
+
+    async def _bootstrap_performances_faltantes(
+        self,
+        command: GenerarGrillaCommand,
+        performances: list[PerformancesAPData],
+    ) -> None:
+        for performance_data in performances:
+            stream_id = build_performance_stream_id(
+                command.competencia_id,
+                performance_data.atleta_id,
+                command.disciplina,
+            )
+            if await self._event_store.load(stream_id):
+                continue
+            performance = Performance(
+                performance_id=performance_data.performance_id,
+                competencia_id=command.competencia_id,
+                participante_id=performance_data.atleta_id,
+                disciplina=command.disciplina,
+            )
+            performance.registrar_ap(performance_data.valor_ap, performance_data.unidad)
+            await persistir_eventos_pendientes(
+                event_store=self._event_store,
+                stream_id=stream_id,
+                aggregate=performance,
+            )
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/competencia/domain/ports/competencias_por_torneo_port.py
+++ b/src/competencia/domain/ports/competencias_por_torneo_port.py
@@ -31,3 +31,9 @@ class CompetenciasPorTorneoPort(ABC):
     @abstractmethod
     async def listar_por_torneo(self, torneo_id: UUID) -> list[CompetenciaPorTorneoRecord]:
         """Retorna los registros materializados para el torneo indicado."""
+
+    @abstractmethod
+    async def obtener_por_competencia_id(
+        self, competencia_id: UUID
+    ) -> CompetenciaPorTorneoRecord | None:
+        """Retorna el registro materializado de una competencia puntual."""

--- a/src/competencia/infrastructure/repositories/performances_ap_adapter.py
+++ b/src/competencia/infrastructure/repositories/performances_ap_adapter.py
@@ -1,62 +1,66 @@
-"""Adaptador PerformancesAPAdapter — implementación de PerformancesAPPort sobre Event Store."""
+"""Adaptador PerformancesAPAdapter — lee AP primario desde Registro."""
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import NAMESPACE_URL, UUID, uuid5
 
 from competencia.domain.aggregates.performance import Performance
+from competencia.domain.ports.competencias_por_torneo_port import CompetenciasPorTorneoPort
 from competencia.domain.ports.event_store_port import EventStorePort
 from competencia.domain.ports.performances_ap_port import (
     PerformancesAPData,
     PerformancesAPPort,
 )
-from competencia.domain.value_objects.estado_performance import EstadoPerformance
+from registro.domain.ports.inscripcion_repository_port import InscripcionRepositoryPort
+from shared.domain.value_objects.disciplina import Disciplina
 
 
 class PerformancesAPAdapter(PerformancesAPPort):
-    """Implementación de PerformancesAPPort que lee del Event Store.
+    """Implementación de PerformancesAPPort usando AP declarados en inscripción."""
 
-    Carga todos los streams `performance-{competencia_id}-*`, reconstruye
-    cada Performance y retorna las que están en estado AnunciadaAP.
-
-    Args:
-        event_store: Puerto de persistencia de eventos.
-    """
-
-    def __init__(self, event_store: EventStorePort) -> None:
+    def __init__(
+        self,
+        event_store: EventStorePort,
+        competencias_por_torneo: CompetenciasPorTorneoPort,
+        inscripcion_repo: InscripcionRepositoryPort,
+    ) -> None:
         self._event_store = event_store
+        self._competencias_por_torneo = competencias_por_torneo
+        self._inscripcion_repo = inscripcion_repo
 
     async def get_performances_con_ap(self, competencia_id: UUID) -> list[PerformancesAPData]:
-        """Retorna las performances en estado AnunciadaAP para la competencia.
+        record = await self._competencias_por_torneo.obtener_por_competencia_id(competencia_id)
+        if record is None:
+            return []
 
-        Args:
-            competencia_id: Identificador de la competencia.
-
-        Returns:
-            Lista de PerformancesAPData ordenada por registro de inserción
-            (orden natural del Event Store).
-        """
-        prefix = f"performance-{competencia_id}-"
-        all_streams = await self._event_store.load_all_streams_with_prefix(prefix)
-
+        disciplina = Disciplina(record.disciplina)
         result: list[PerformancesAPData] = []
-        for stream_events in all_streams:
-            if not stream_events:
+        for inscripcion in await self._inscripcion_repo.find_active_by_torneo(record.torneo_id):
+            ap = inscripcion.obtener_ap(disciplina)
+            if ap is None:
                 continue
-
-            performance = Performance.reconstitute(stream_events)
-            if performance.estado != EstadoPerformance.AnunciadaAP:
-                continue
-            if performance.ap is None:
-                continue
-
             result.append(
                 PerformancesAPData(
-                    performance_id=performance.performance_id,
-                    atleta_id=performance.participante_id,
-                    valor_ap=performance.ap.valor,
-                    unidad=performance.ap.unidad,
+                    performance_id=await self._resolver_performance_id(
+                        competencia_id,
+                        inscripcion.atleta_id,
+                        disciplina,
+                    ),
+                    atleta_id=inscripcion.atleta_id,
+                    valor_ap=ap.valor,
+                    unidad=ap.unidad,
                 )
             )
-
         return result
+
+    async def _resolver_performance_id(
+        self,
+        competencia_id: UUID,
+        atleta_id: UUID,
+        disciplina: Disciplina,
+    ) -> UUID:
+        stream_id = f"performance-{competencia_id}-{atleta_id}-{disciplina.value}"
+        events = await self._event_store.load(stream_id)
+        if events:
+            return Performance.reconstitute(events).performance_id
+        return uuid5(NAMESPACE_URL, f"{competencia_id}:{atleta_id}:{disciplina.value}")

--- a/src/competencia/infrastructure/repositories/sqlite_competencias_por_torneo.py
+++ b/src/competencia/infrastructure/repositories/sqlite_competencias_por_torneo.py
@@ -79,3 +79,26 @@ class SQLiteCompetenciasPorTorneo(CompetenciasPorTorneoPort):
             )
             for row in rows
         ]
+
+    async def obtener_por_competencia_id(
+        self, competencia_id: UUID
+    ) -> CompetenciaPorTorneoRecord | None:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._ensure_table(conn)
+            conn.row_factory = aiosqlite.Row
+            async with conn.execute(
+                """
+                SELECT competencia_id, disciplina, torneo_id
+                FROM competencias_por_torneo
+                WHERE competencia_id = ?
+                """,
+                (str(competencia_id),),
+            ) as cursor:
+                row = await cursor.fetchone()
+        if row is None:
+            return None
+        return CompetenciaPorTorneoRecord(
+            competencia_id=UUID(row["competencia_id"]),
+            disciplina=row["disciplina"],
+            torneo_id=UUID(row["torneo_id"]),
+        )

--- a/src/registro/api/router.py
+++ b/src/registro/api/router.py
@@ -7,16 +7,18 @@ from decimal import Decimal
 from uuid import UUID
 
 from fastapi import APIRouter
+from fastapi import Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
-from competencia.domain.aggregates.performance import Performance
-from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
-    SQLiteCompetenciasPorTorneo,
-)
+from identidad.api.dependencies import get_current_user
 from registro.application.commands.cancelar_inscripcion import (
     CancelarInscripcionCommand,
     CancelarInscripcionHandler,
+)
+from registro.application.commands.declarar_ap_inscripcion import (
+    DeclararAPInscripcionCommand,
+    DeclararAPInscripcionHandler,
 )
 from registro.application.commands.inscribir_atleta import (
     InscribirAtletaCommand,
@@ -28,11 +30,16 @@ from registro.application.commands.registrar_atleta import (
 )
 from registro.application.queries.listar_inscriptos import ListarInscriptosHandler
 from registro.application.queries.obtener_atleta import ObtenerAtletaHandler
+from registro.application.queries.verificar_completitud_ap import (
+    VerificarCompletitudAPHandler,
+)
 from registro.domain.aggregates.inscripcion import Inscripcion
 from registro.domain.exceptions import (
+    APIncompletoParaPreparacion,
     AtletaNoEncontrado,
     AtletaYaInscripto,
     AtletaYaRegistrado,
+    DisciplinaNoInscripta,
     DisciplinaNoDisponible,
     InscripcionNoEncontrada,
     PlazoCancelacionVencido,
@@ -47,7 +54,6 @@ from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
 )
 from shared.api.dependencies import AtletaDep, OrganizadorDep
 from shared.domain.value_objects.disciplina import Disciplina
-from shared.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
 
 router = APIRouter(prefix="/registro", tags=["registro"])
 
@@ -130,6 +136,11 @@ class InscriptoDetalleResponse(BaseModel):
     disciplinas: list[EstadoAPDisciplinaResponse]
 
 
+class DeclararAPInscripcionRequest(BaseModel):
+    disciplina: Disciplina
+    valor_ap: Decimal
+
+
 # ── Helpers de dependencias ───────────────────────────────────────────────────
 
 
@@ -145,14 +156,6 @@ def _torneo_consulta() -> SQLiteTorneoConsulta:
     return SQLiteTorneoConsulta()
 
 
-def _competencias_por_torneo_repo() -> SQLiteCompetenciasPorTorneo:
-    return SQLiteCompetenciasPorTorneo()
-
-
-def _competencia_event_store() -> SQLiteEventStore:
-    return SQLiteEventStore(os.getenv("COMPETENCIA_DB_PATH", "data/competencia.db"))
-
-
 def _format_decimal(value: Decimal | None) -> str | None:
     if value is None:
         return None
@@ -163,23 +166,38 @@ def _format_decimal(value: Decimal | None) -> str | None:
 async def _load_ap_por_torneo(
     torneo_id: UUID,
 ) -> dict[tuple[UUID, str], tuple[str | None, str | None]]:
-    competencias = await _competencias_por_torneo_repo().listar_por_torneo(torneo_id)
-    event_store = _competencia_event_store()
     ap_por_clave: dict[tuple[UUID, str], tuple[str | None, str | None]] = {}
-
-    for competencia in competencias:
-        prefix = f"performance-{competencia.competencia_id}-"
-        for stream_events in await event_store.load_all_streams_with_prefix(prefix):
-            if not stream_events:
-                continue
-            performance = Performance.reconstitute(stream_events)
-            ap = performance.ap
-            ap_por_clave[(performance.participante_id, competencia.disciplina)] = (
-                _format_decimal(ap.valor) if ap else None,
-                ap.unidad.value if ap else None,
+    for inscripcion in await _inscripcion_repo().find_active_by_torneo(torneo_id):
+        for disciplina, ap in inscripcion.ap_por_disciplina.items():
+            ap_por_clave[(inscripcion.atleta_id, disciplina.value)] = (
+                _format_decimal(ap.valor),
+                ap.unidad.value,
             )
-
     return ap_por_clave
+
+
+def build_cierre_inscripcion_precondition(
+    inscripcion_repo: SQLiteInscripcionRepository | None = None,
+    atleta_repo: SQLiteAtletaRepository | None = None,
+) -> Callable[[UUID], Awaitable[None]]:
+    async def _precondition(torneo_id: UUID) -> None:
+        handler = VerificarCompletitudAPHandler(
+            inscripcion_repo or _inscripcion_repo(),
+            atleta_repo or _repo(),
+        )
+        faltantes = await handler.obtener_faltantes(torneo_id)
+        if not faltantes:
+            return
+        detalle = ", ".join(
+            f"{faltante.atleta_nombre} ({faltante.disciplina})" for faltante in faltantes[:5]
+        )
+        if len(faltantes) > 5:
+            detalle = f"{detalle}, y {len(faltantes) - 5} más"
+        raise APIncompletoParaPreparacion(
+            f"Faltan AP por completar para cerrar inscripción: {detalle}"
+        )
+
+    return _precondition
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -375,3 +393,58 @@ async def listar_inscriptos_detalle(torneo_id: UUID, _: OrganizadorDep) -> JSONR
         )
 
     return JSONResponse(status_code=200, content=content)
+
+
+@router.get("/inscripciones/{inscripcion_id}/ap", status_code=200)
+async def obtener_ap_inscripcion(
+    inscripcion_id: UUID,
+    disciplina: Disciplina,
+    _: dict = Depends(get_current_user),
+) -> JSONResponse:
+    inscripcion = await _inscripcion_repo().find_by_id(inscripcion_id)
+    if inscripcion is None:
+        return JSONResponse(status_code=404, content={"detail": "Inscripción no encontrada"})
+    ap = inscripcion.obtener_ap(disciplina)
+    return JSONResponse(
+        status_code=200,
+        content={
+            "disciplina": disciplina.value,
+            "ap": _format_decimal(ap.valor) if ap else None,
+            "unidad": ap.unidad.value if ap else None,
+        },
+    )
+
+
+@router.put("/inscripciones/{inscripcion_id}/ap", status_code=200)
+async def declarar_ap_inscripcion(
+    inscripcion_id: UUID,
+    body: DeclararAPInscripcionRequest,
+    _: dict = Depends(get_current_user),
+) -> JSONResponse:
+    handler = DeclararAPInscripcionHandler(_inscripcion_repo())
+    try:
+        await handler.handle(
+            DeclararAPInscripcionCommand(
+                inscripcion_id=inscripcion_id,
+                disciplina=body.disciplina,
+                valor_ap=body.valor_ap,
+            )
+        )
+    except InscripcionNoEncontrada as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except DisciplinaNoInscripta as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except ValueError as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+
+    inscripcion = await _inscripcion_repo().find_by_id(inscripcion_id)
+    assert inscripcion is not None
+    ap = inscripcion.obtener_ap(body.disciplina)
+    return JSONResponse(
+        status_code=200,
+        content={
+            "disciplina": body.disciplina.value,
+            "ap": _format_decimal(ap.valor) if ap else None,
+            "unidad": ap.unidad.value if ap else None,
+        },
+    )

--- a/src/registro/application/commands/declarar_ap_inscripcion.py
+++ b/src/registro/application/commands/declarar_ap_inscripcion.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from registro.domain.exceptions import InscripcionNoEncontrada
+from registro.domain.ports.inscripcion_repository_port import InscripcionRepositoryPort
+from shared.domain.value_objects.disciplina import Disciplina
+
+
+@dataclass(frozen=True)
+class DeclararAPInscripcionCommand:
+    inscripcion_id: UUID
+    disciplina: Disciplina
+    valor_ap: Decimal
+
+
+class DeclararAPInscripcionHandler:
+    def __init__(self, repo: InscripcionRepositoryPort) -> None:
+        self._repo = repo
+
+    async def handle(self, cmd: DeclararAPInscripcionCommand) -> None:
+        inscripcion = await self._repo.find_by_id(cmd.inscripcion_id)
+        if inscripcion is None:
+            raise InscripcionNoEncontrada(f"Inscripción {cmd.inscripcion_id} no encontrada")
+        inscripcion.declarar_ap(cmd.disciplina, cmd.valor_ap)
+        await self._repo.save(inscripcion)

--- a/src/registro/application/queries/verificar_completitud_ap.py
+++ b/src/registro/application/queries/verificar_completitud_ap.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from registro.domain.ports.atleta_repository_port import AtletaRepositoryPort
+from registro.domain.ports.inscripcion_repository_port import InscripcionRepositoryPort
+
+
+@dataclass(frozen=True)
+class APFaltanteDetalle:
+    inscripcion_id: UUID
+    atleta_id: UUID
+    atleta_nombre: str
+    disciplina: str
+
+
+class VerificarCompletitudAPHandler:
+    def __init__(
+        self,
+        inscripcion_repo: InscripcionRepositoryPort,
+        atleta_repo: AtletaRepositoryPort,
+    ) -> None:
+        self._inscripcion_repo = inscripcion_repo
+        self._atleta_repo = atleta_repo
+
+    async def obtener_faltantes(self, torneo_id: UUID) -> list[APFaltanteDetalle]:
+        faltantes: list[APFaltanteDetalle] = []
+        for inscripcion in await self._inscripcion_repo.find_active_by_torneo(torneo_id):
+            atleta = await self._atleta_repo.find_by_id(inscripcion.atleta_id)
+            atleta_nombre = (
+                f"{atleta.apellido}, {atleta.nombre}".strip(", ")
+                if atleta is not None
+                else str(inscripcion.atleta_id)
+            )
+            for disciplina in sorted(inscripcion.disciplinas, key=lambda item: item.value):
+                if inscripcion.obtener_ap(disciplina) is None:
+                    faltantes.append(
+                        APFaltanteDetalle(
+                            inscripcion_id=inscripcion.inscripcion_id,
+                            atleta_id=inscripcion.atleta_id,
+                            atleta_nombre=atleta_nombre,
+                            disciplina=disciplina.value,
+                        )
+                    )
+        return faltantes

--- a/src/registro/domain/aggregates/inscripcion.py
+++ b/src/registro/domain/aggregates/inscripcion.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
+from decimal import Decimal
 from uuid import UUID, uuid4
 
-from registro.domain.exceptions import PlazoCancelacionVencido
+from registro.domain.exceptions import DisciplinaNoInscripta, PlazoCancelacionVencido
+from registro.domain.value_objects.ap_declarado import APDeclarado
 from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
 from shared.domain.value_objects.disciplina import Disciplina
 
@@ -17,9 +19,23 @@ class Inscripcion:
     inscripcion_id: UUID = field(default_factory=uuid4)
     estado: EstadoInscripcion = EstadoInscripcion.ACTIVA
     fecha_inscripcion: datetime = field(default_factory=datetime.utcnow)
+    ap_por_disciplina: dict[Disciplina, APDeclarado] = field(default_factory=dict)
 
     def cancelar(self, fecha_actual: date, fecha_inicio_torneo: date) -> None:
         """INV-I-03: solo cancela si fecha_actual < fecha_inicio_torneo."""
         if fecha_actual >= fecha_inicio_torneo:
             raise PlazoCancelacionVencido("No se puede cancelar el día del torneo o después")
         self.estado = EstadoInscripcion.CANCELADA
+
+    def declarar_ap(self, disciplina: Disciplina, valor: Decimal) -> APDeclarado:
+        if disciplina not in self.disciplinas:
+            raise DisciplinaNoInscripta(f"La disciplina {disciplina.value} no pertenece a la inscripción")
+        ap = APDeclarado.desde_disciplina(disciplina, valor)
+        self.ap_por_disciplina[disciplina] = ap
+        return ap
+
+    def obtener_ap(self, disciplina: Disciplina) -> APDeclarado | None:
+        return self.ap_por_disciplina.get(disciplina)
+
+    def tiene_ap_completo(self) -> bool:
+        return all(self.obtener_ap(disciplina) is not None for disciplina in self.disciplinas)

--- a/src/registro/domain/exceptions.py
+++ b/src/registro/domain/exceptions.py
@@ -24,3 +24,11 @@ class DisciplinaNoDisponible(Exception):
 
 class PlazoCancelacionVencido(Exception):
     pass
+
+
+class DisciplinaNoInscripta(Exception):
+    pass
+
+
+class APIncompletoParaPreparacion(Exception):
+    pass

--- a/src/registro/domain/value_objects/ap_declarado.py
+++ b/src/registro/domain/value_objects/ap_declarado.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from shared.domain.value_objects.disciplina import Disciplina
+from shared.domain.value_objects.unidad_medida import UnidadMedida
+
+
+@dataclass(frozen=True)
+class APDeclarado:
+    valor: Decimal
+    unidad: UnidadMedida
+
+    def __post_init__(self) -> None:
+        if self.valor <= 0:
+            raise ValueError("El AP debe ser mayor a cero")
+
+    @classmethod
+    def desde_disciplina(cls, disciplina: Disciplina, valor: Decimal) -> APDeclarado:
+        return cls(
+            valor=valor,
+            unidad=UnidadMedida.Segundos if disciplina.es_tiempo() else UnidadMedida.Metros,
+        )

--- a/src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py
+++ b/src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime
+from decimal import Decimal
 from uuid import UUID
 
 import aiosqlite
 
 from registro.domain.aggregates.inscripcion import Inscripcion
+from registro.domain.value_objects.ap_declarado import APDeclarado
 from registro.domain.ports.inscripcion_repository_port import InscripcionRepositoryPort
 from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
 from shared.domain.value_objects.disciplina import Disciplina
+from shared.domain.value_objects.unidad_medida import UnidadMedida
 
 _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS inscripciones (
@@ -18,6 +21,7 @@ CREATE TABLE IF NOT EXISTS inscripciones (
     atleta_id         TEXT NOT NULL,
     torneo_id         TEXT NOT NULL,
     disciplinas       TEXT NOT NULL,
+    ap_por_disciplina TEXT NOT NULL DEFAULT '{}',
     estado            TEXT NOT NULL,
     fecha_inscripcion TEXT NOT NULL
 )
@@ -32,20 +36,48 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
         await conn.execute(_CREATE_TABLE)
         await conn.commit()
 
+    async def _ensure_schema(self, conn: aiosqlite.Connection) -> None:
+        await conn.execute(_CREATE_TABLE)
+        conn.row_factory = aiosqlite.Row
+        async with conn.execute("PRAGMA table_info(inscripciones)") as cursor:
+            columns = [row["name"] for row in await cursor.fetchall()]
+        if "ap_por_disciplina" not in columns:
+            await conn.execute(
+                "ALTER TABLE inscripciones ADD COLUMN ap_por_disciplina TEXT NOT NULL DEFAULT '{}'"
+            )
+        await conn.commit()
+
     async def save(self, inscripcion: Inscripcion) -> None:
         async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_table(conn)
+            await self._ensure_schema(conn)
             await conn.execute(
                 """
                 INSERT OR REPLACE INTO inscripciones
-                    (inscripcion_id, atleta_id, torneo_id, disciplinas, estado, fecha_inscripcion)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    (
+                        inscripcion_id,
+                        atleta_id,
+                        torneo_id,
+                        disciplinas,
+                        ap_por_disciplina,
+                        estado,
+                        fecha_inscripcion
+                    )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     str(inscripcion.inscripcion_id),
                     str(inscripcion.atleta_id),
                     str(inscripcion.torneo_id),
                     json.dumps([d.value for d in inscripcion.disciplinas]),
+                    json.dumps(
+                        {
+                            disciplina.value: {
+                                "valor": str(ap.valor),
+                                "unidad": ap.unidad.value,
+                            }
+                            for disciplina, ap in inscripcion.ap_por_disciplina.items()
+                        }
+                    ),
                     inscripcion.estado.value,
                     inscripcion.fecha_inscripcion.isoformat(),
                 ),
@@ -54,7 +86,7 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
 
     async def find_by_id(self, inscripcion_id: UUID) -> Inscripcion | None:
         async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_table(conn)
+            await self._ensure_schema(conn)
             conn.row_factory = aiosqlite.Row
             async with conn.execute(
                 "SELECT * FROM inscripciones WHERE inscripcion_id = ?",
@@ -65,7 +97,7 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
 
     async def find_by_atleta_y_torneo(self, atleta_id: UUID, torneo_id: UUID) -> Inscripcion | None:
         async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_table(conn)
+            await self._ensure_schema(conn)
             conn.row_factory = aiosqlite.Row
             async with conn.execute(
                 "SELECT * FROM inscripciones WHERE atleta_id = ? AND torneo_id = ?",
@@ -76,7 +108,7 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
 
     async def find_by_torneo(self, torneo_id: UUID) -> list[Inscripcion]:
         async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_table(conn)
+            await self._ensure_schema(conn)
             conn.row_factory = aiosqlite.Row
             async with conn.execute(
                 "SELECT * FROM inscripciones WHERE torneo_id = ?", (str(torneo_id),)
@@ -86,7 +118,7 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
 
     async def find_active_by_torneo(self, torneo_id: UUID) -> list[Inscripcion]:
         async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_table(conn)
+            await self._ensure_schema(conn)
             conn.row_factory = aiosqlite.Row
             async with conn.execute(
                 """
@@ -101,7 +133,7 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
 
     async def find_by_atleta(self, atleta_id: UUID) -> list[Inscripcion]:
         async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_table(conn)
+            await self._ensure_schema(conn)
             conn.row_factory = aiosqlite.Row
             async with conn.execute(
                 """
@@ -122,4 +154,11 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
             disciplinas=frozenset(Disciplina(d) for d in json.loads(row["disciplinas"])),
             estado=EstadoInscripcion(row["estado"]),
             fecha_inscripcion=datetime.fromisoformat(row["fecha_inscripcion"]),
+            ap_por_disciplina={
+                Disciplina(disciplina): APDeclarado(
+                    valor=Decimal(payload["valor"]),
+                    unidad=UnidadMedida(payload["unidad"]),
+                )
+                for disciplina, payload in json.loads(row["ap_por_disciplina"] or "{}").items()
+            },
         )

--- a/src/torneo/api/exception_handlers.py
+++ b/src/torneo/api/exception_handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from registro.domain.exceptions import APIncompletoParaPreparacion
 from torneo.domain.exceptions import (
     DisciplinaObsoleta,
     PremiacionNoPermitida,
@@ -13,6 +14,20 @@ from torneo.domain.exceptions import (
 
 
 def register_torneo_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(APIncompletoParaPreparacion)
+    async def ap_incompleto_para_preparacion_handler(
+        request: Request, exc: APIncompletoParaPreparacion
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "type": "https://ataraxiadive.com/errors/ap-incompleto-para-preparacion",
+                "title": "No se puede cerrar inscripción",
+                "status": 409,
+                "detail": str(exc),
+            },
+        )
+
     @app.exception_handler(TorneoNoEncontrado)
     async def torneo_no_encontrado_handler(
         request: Request, exc: TorneoNoEncontrado

--- a/src/torneo/api/router.py
+++ b/src/torneo/api/router.py
@@ -41,13 +41,22 @@ from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTo
 
 router = APIRouter(prefix="/torneos", tags=["torneos"])
 PremiacionPrecondition = Callable[[UUID], Awaitable[None]]
+CierreInscripcionPrecondition = Callable[[UUID], Awaitable[None]]
 _premiacion_precondition: PremiacionPrecondition | None = None
+_cierre_inscripcion_precondition: CierreInscripcionPrecondition | None = None
 
 
 def configure_premiacion_precondition(precondition: PremiacionPrecondition | None) -> None:
     """Configura validacion externa antes de pasar un torneo a premiacion."""
     global _premiacion_precondition  # noqa: PLW0603
     _premiacion_precondition = precondition
+
+
+def configure_cierre_inscripcion_precondition(
+    precondition: CierreInscripcionPrecondition | None,
+) -> None:
+    global _cierre_inscripcion_precondition  # noqa: PLW0603
+    _cierre_inscripcion_precondition = precondition
 
 
 # ── Schemas ───────────────────────────────────────────────────────────────────
@@ -169,7 +178,10 @@ async def abrir_inscripcion(torneo_id: UUID, _: OrganizadorDep) -> JSONResponse:
 
 @router.put("/{torneo_id}/cerrar-inscripcion", status_code=200)
 async def cerrar_inscripcion(torneo_id: UUID, _: OrganizadorDep) -> JSONResponse:
-    await CerrarInscripcionHandler(_repo()).handle(TransicionarTorneoCommand(torneo_id))
+    await CerrarInscripcionHandler(
+        _repo(),
+        precondition=_cierre_inscripcion_precondition,
+    ).handle(TransicionarTorneoCommand(torneo_id))
     return JSONResponse(status_code=200, content={"ok": True})
 
 

--- a/src/torneo/application/commands/transicionar_torneo.py
+++ b/src/torneo/application/commands/transicionar_torneo.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
+from collections.abc import Awaitable, Callable
+
 from torneo.domain.exceptions import TorneoNoEncontrado
 from torneo.domain.ports.torneo_repository_port import TorneoRepositoryPort
 
@@ -30,7 +32,17 @@ class AbrirInscripcionHandler(_TransicionHandler):
 
 
 class CerrarInscripcionHandler(_TransicionHandler):
+    def __init__(
+        self,
+        repo: TorneoRepositoryPort,
+        precondition: Callable[[UUID], Awaitable[None]] | None = None,
+    ) -> None:
+        super().__init__(repo)
+        self._precondition = precondition
+
     async def handle(self, cmd: TransicionarTorneoCommand) -> None:
+        if self._precondition is not None:
+            await self._precondition(cmd.torneo_id)
         await self._ejecutar(cmd.torneo_id, "cerrar_inscripcion")
 
 

--- a/tests/features/US-ADJ-9.7-ap-inscripcion-preparacion.feature
+++ b/tests/features/US-ADJ-9.7-ap-inscripcion-preparacion.feature
@@ -1,0 +1,31 @@
+Feature: US-ADJ-9.7 - AP declarados durante inscripcion como requisito de preparacion
+
+  Background:
+    Given existe el torneo "BA Open 2026" en fase "INSCRIPCION_ABIERTA"
+    And el organizador esta autenticado
+    And hay inscripciones activas por disciplina en el torneo
+
+  Scenario: organizador ve estado AP por atleta y disciplina en inscriptos
+    Given Ana declaro AP para DNF
+    And Carlos todavia no declaro AP para DYN
+    When el organizador abre la seccion Inscriptos
+    Then Ana aparece con estado "AP declarado" en DNF
+    And Carlos aparece con estado "AP pendiente" en DYN
+
+  Scenario: no se puede cerrar inscripcion con AP faltantes
+    Given existe al menos una inscripcion activa sin AP requerido
+    When el organizador intenta cerrar la inscripcion
+    Then el sistema rechaza la transicion a "PREPARACION"
+    And informa que faltan AP por completar
+
+  Scenario: se puede cerrar inscripcion cuando todos los AP estan completos
+    Given todas las inscripciones activas tienen AP valido
+    When el organizador cierra la inscripcion
+    Then el torneo pasa a fase "PREPARACION"
+
+  Scenario: la grilla usa AP declarados desde inscripcion
+    Given el torneo esta en fase "PREPARACION"
+    And existen inscripciones activas con AP declarado para la disciplina
+    When el organizador genera la grilla
+    Then la grilla se calcula usando los AP declarados en inscripcion
+    And no requiere performances preexistentes cargadas manualmente

--- a/tests/integration/registro/test_inscriptos_detalle_endpoint.py
+++ b/tests/integration/registro/test_inscriptos_detalle_endpoint.py
@@ -8,22 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app import app
-from competencia.application.commands.registrar_ap import (
-    RegistrarAPCommand,
-    RegistrarAPHandler,
-)
 from competencia.domain.value_objects.disciplina import Disciplina
-from competencia.domain.value_objects.unidad_medida import UnidadMedida
-from competencia.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
-from competencia.infrastructure.repositories.competencia_estado_adapter import (
-    CompetenciaEstadoAdapter,
-)
-from competencia.infrastructure.repositories.disciplina_descriptor_adapter import (
-    DisciplinaDescriptorAdapter,
-)
-from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
-    SQLiteCompetenciasPorTorneo,
-)
 from identidad.api.dependencies import get_current_user
 from registro.domain.aggregates.atleta import Atleta
 from registro.domain.aggregates.inscripcion import Inscripcion
@@ -38,25 +23,15 @@ from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
 @pytest.fixture
 def inscriptos_detalle_context(tmp_path, monkeypatch):
     registro_db = tmp_path / "registro.db"
-    competencia_db = tmp_path / "competencia.db"
     monkeypatch.setenv("REGISTRO_DB_PATH", str(registro_db))
-    monkeypatch.setenv("COMPETENCIA_DB_PATH", str(competencia_db))
 
     torneo_id = uuid4()
-    competencia_id = uuid4()
     ana_id = uuid4()
     carlos_id = uuid4()
     pepe_id = uuid4()
 
     atleta_repo = SQLiteAtletaRepository(str(registro_db))
     inscripcion_repo = SQLiteInscripcionRepository(str(registro_db))
-    competencias_repo = SQLiteCompetenciasPorTorneo(str(competencia_db))
-    event_store = SQLiteEventStore(str(competencia_db))
-    registrar_ap = RegistrarAPHandler(
-        event_store=event_store,
-        competencia_estado=CompetenciaEstadoAdapter(event_store),
-        disciplina_descriptor=DisciplinaDescriptorAdapter(),
-    )
 
     async def _seed() -> None:
         await atleta_repo.save(
@@ -93,13 +68,13 @@ def inscriptos_detalle_context(tmp_path, monkeypatch):
             )
         )
 
-        await inscripcion_repo.save(
-            Inscripcion(
-                atleta_id=ana_id,
-                torneo_id=torneo_id,
-                disciplinas=frozenset({Disciplina.DNF}),
-            )
+        ana_inscripcion = Inscripcion(
+            atleta_id=ana_id,
+            torneo_id=torneo_id,
+            disciplinas=frozenset({Disciplina.DNF}),
         )
+        ana_inscripcion.declarar_ap(Disciplina.DNF, Decimal("72"))
+        await inscripcion_repo.save(ana_inscripcion)
         await inscripcion_repo.save(
             Inscripcion(
                 atleta_id=carlos_id,
@@ -113,21 +88,6 @@ def inscriptos_detalle_context(tmp_path, monkeypatch):
                 torneo_id=torneo_id,
                 disciplinas=frozenset({Disciplina.DNF}),
                 estado=EstadoInscripcion.CANCELADA,
-            )
-        )
-
-        await competencias_repo.guardar(
-            competencia_id=competencia_id,
-            disciplina=Disciplina.DNF.value,
-            torneo_id=torneo_id,
-        )
-        await registrar_ap.handle(
-            RegistrarAPCommand(
-                competencia_id=competencia_id,
-                participante_id=ana_id,
-                disciplina=Disciplina.DNF,
-                valor_ap=Decimal("72"),
-                unidad=UnidadMedida.Metros,
             )
         )
 
@@ -198,3 +158,28 @@ def test_get_inscriptos_detalle_rechaza_rol_atleta(inscriptos_detalle_context) -
     )
 
     assert response.status_code == 403
+
+
+def test_put_ap_inscripcion_actualiza_fuente_primaria(inscriptos_detalle_context) -> None:
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": str(uuid4()),
+        "email": "orga@ataraxiadive.io",
+        "rol": "ORGANIZADOR",
+    }
+    client = TestClient(app)
+
+    detalle_response = client.get(
+        f"/registro/torneos/{inscriptos_detalle_context['torneo_id']}/inscriptos-detalle"
+    )
+    inscripcion_carlos = next(
+        item["inscripcion_id"] for item in detalle_response.json() if item["apellido"] == "Lopez"
+    )
+
+    put_response = client.put(
+        f"/registro/inscripciones/{inscripcion_carlos}/ap",
+        json={"disciplina": "DYN", "valor_ap": "88"},
+    )
+
+    assert put_response.status_code == 200
+    assert put_response.json()["ap"] == "88"
+    assert put_response.json()["unidad"] == "Metros"

--- a/tests/integration/torneo/test_cierre_inscripcion_precondition.py
+++ b/tests/integration/torneo/test_cierre_inscripcion_precondition.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from identidad.api.dependencies import get_current_user
+from registro.api.router import build_cierre_inscripcion_precondition
+from registro.domain.aggregates.atleta import Atleta
+from registro.domain.aggregates.inscripcion import Inscripcion
+from registro.domain.value_objects.categoria import Categoria
+from registro.infrastructure.repositories.sqlite_atleta_repository import SQLiteAtletaRepository
+from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
+    SQLiteInscripcionRepository,
+)
+from shared.domain.value_objects.disciplina import Disciplina
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.api.router import configure_cierre_inscripcion_precondition, router
+
+
+@pytest.fixture
+def client(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    torneo_db = str(tmp_path / "torneo.db")
+    registro_db = str(tmp_path / "registro.db")
+    monkeypatch.setenv("TORNEO_DB_PATH", torneo_db)
+    monkeypatch.setenv("REGISTRO_DB_PATH", registro_db)
+
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "test-user",
+        "email": "test@test.com",
+        "rol": "ORGANIZADOR",
+    }
+    configure_cierre_inscripcion_precondition(build_cierre_inscripcion_precondition())
+    yield TestClient(app)
+    configure_cierre_inscripcion_precondition(None)
+    app.dependency_overrides.clear()
+
+
+def _crear_torneo_con_disciplina(client: TestClient) -> UUID:
+    response = client.post(
+        "/torneos",
+        json={
+            "nombre": "BA 2026",
+            "descripcion": "Torneo",
+            "fecha_inicio": "2026-06-01",
+            "fecha_fin": "2026-06-03",
+            "sede": {"nombre": "Piscina", "ciudad": "BA", "pais": "AR"},
+            "entidad_organizadora": {"nombre": "AIDA", "tipo": "FEDERACION"},
+        },
+    )
+    torneo_id = UUID(response.json()["torneo_id"])
+    disciplinas_response = client.put(
+        f"/torneos/{torneo_id}/disciplinas",
+        json={"disciplinas": ["DNF"]},
+    )
+    assert disciplinas_response.status_code == 200
+    assert client.put(f"/torneos/{torneo_id}/abrir-inscripcion").status_code == 200
+    return torneo_id
+
+
+async def _seed_inscripcion(registro_db: str, torneo_id: UUID, con_ap: bool) -> None:
+    atleta_id = uuid4()
+    atleta_repo = SQLiteAtletaRepository(registro_db)
+    inscripcion_repo = SQLiteInscripcionRepository(registro_db)
+
+    await atleta_repo.save(
+        Atleta(
+            atleta_id=atleta_id,
+            nombre="Ana",
+            apellido="Garcia",
+            email="ana@email.com",
+            fecha_nacimiento=date(1994, 5, 10),
+            categoria=Categoria.SENIOR_FEMENINO,
+            club="Azul",
+        )
+    )
+    inscripcion = Inscripcion(
+        atleta_id=atleta_id,
+        torneo_id=torneo_id,
+        disciplinas=frozenset({Disciplina.DNF}),
+    )
+    if con_ap:
+        inscripcion.declarar_ap(Disciplina.DNF, Decimal("72"))
+    await inscripcion_repo.save(inscripcion)
+
+
+@pytest.mark.asyncio
+async def test_cerrar_inscripcion_rechaza_si_falta_ap(client: TestClient) -> None:
+    import os
+
+    torneo_id = _crear_torneo_con_disciplina(client)
+    await _seed_inscripcion(os.environ["REGISTRO_DB_PATH"], torneo_id, con_ap=False)
+
+    response = client.put(f"/torneos/{torneo_id}/cerrar-inscripcion")
+
+    assert response.status_code == 409
+    assert "Faltan AP por completar" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_cerrar_inscripcion_permite_si_todos_tienen_ap(client: TestClient) -> None:
+    import os
+
+    torneo_id = _crear_torneo_con_disciplina(client)
+    atleta_id = uuid4()
+    atleta_repo = SQLiteAtletaRepository(os.environ["REGISTRO_DB_PATH"])
+    inscripcion_repo = SQLiteInscripcionRepository(os.environ["REGISTRO_DB_PATH"])
+    await atleta_repo.save(
+        Atleta(
+            atleta_id=atleta_id,
+            nombre="Ana",
+            apellido="Garcia",
+            email="ana@email.com",
+            fecha_nacimiento=date(1994, 5, 10),
+            categoria=Categoria.SENIOR_FEMENINO,
+            club="Azul",
+        )
+    )
+    inscripcion = Inscripcion(
+        atleta_id=atleta_id,
+        torneo_id=torneo_id,
+        disciplinas=frozenset({Disciplina.DNF}),
+    )
+    inscripcion.declarar_ap(Disciplina.DNF, Decimal("72"))
+    await inscripcion_repo.save(inscripcion)
+
+    response = client.put(f"/torneos/{torneo_id}/cerrar-inscripcion")
+
+    assert response.status_code == 200

--- a/tests/unit/competencia/application/test_generar_grilla_handler.py
+++ b/tests/unit/competencia/application/test_generar_grilla_handler.py
@@ -105,7 +105,7 @@ class TestGenerarGrillaHandlerExitoso:
     ) -> None:
         handler = GenerarGrillaHandler(mock_event_store, mock_performances_ap, _DESCRIPTOR_ADAPTER)
         await handler.handle(_command())
-        mock_event_store.load.assert_called_once_with(_build_stream_id(COMPETENCIA_ID))
+        assert mock_event_store.load.call_args_list[0].args == (_build_stream_id(COMPETENCIA_ID),)
 
 
 class TestGenerarGrillaHandlerErrores:

--- a/tests/unit/torneo/application/test_transiciones_handlers.py
+++ b/tests/unit/torneo/application/test_transiciones_handlers.py
@@ -60,6 +60,19 @@ async def test_cerrar_inscripcion_ok() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cerrar_inscripcion_ejecuta_precondicion() -> None:
+    torneo = _torneo(EstadoTorneo.INSCRIPCION_ABIERTA)
+    repo = _repo(torneo)
+    precondition = AsyncMock()
+
+    await CerrarInscripcionHandler(repo, precondition=precondition).handle(
+        TransicionarTorneoCommand(torneo.torneo_id)
+    )
+
+    precondition.assert_awaited_once_with(torneo.torneo_id)
+
+
+@pytest.mark.asyncio
 async def test_iniciar_ejecucion_ok() -> None:
     torneo = _torneo(EstadoTorneo.PREPARACION)
     repo = _repo(torneo)


### PR DESCRIPTION
## Resumen
- mueve la fuente primaria del AP a registro por inscripción y disciplina
- bloquea cerrar inscripción si faltan AP y hace que grilla consuma AP desde inscripción
- actualiza portal atleta e Inscriptos del organizador, con tests, feature, notas y reporte

## Validación
- ./.venv/bin/python -m pytest tests/integration/registro/test_inscriptos_detalle_endpoint.py tests/integration/torneo/test_cierre_inscripcion_precondition.py tests/unit/torneo/application/test_transiciones_handlers.py tests/unit/competencia/application/test_generar_grilla_handler.py
- npm run build
- npm run lint