### PR TITLE
feat(frontend): mis resultados del atleta [US-5.7.3]

### DIFF
--- a/.claude/tracking/US-5.7.3-tracking.json
+++ b/.claude/tracking/US-5.7.3-tracking.json
@@ -1,0 +1,110 @@
+{
+  "metadata": {
+    "us_id": "US-5.7.3",
+    "us_title": "Mis Resultados - RP tarjeta y puntos por disciplina",
+    "us_points": 5,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-04-30T16:29:21.562757+00:00",
+    "completed_at": null,
+    "total_elapsed_seconds": 301,
+    "effective_seconds": 301,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-04-30T16:29:35.251284+00:00",
+      "completed_at": "2026-04-30T16:30:28.132739+00:00",
+      "elapsed_seconds": 52,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-04-30T16:30:33.312940+00:00",
+      "completed_at": "2026-04-30T16:30:50.146844+00:00",
+      "elapsed_seconds": 16,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-04-30T16:30:57.767700+00:00",
+      "completed_at": "2026-04-30T16:31:23.524582+00:00",
+      "elapsed_seconds": 25,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-04-30T16:31:49.971532+00:00",
+      "completed_at": "2026-04-30T16:34:13.150358+00:00",
+      "elapsed_seconds": 143,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Crear componentes ResultHero y Pendiente",
+          "task_type": "frontend",
+          "estimated_minutes": 45.0,
+          "started_at": "2026-04-30T16:31:55.901052+00:00",
+          "completed_at": "2026-04-30T16:32:30.883669+00:00",
+          "elapsed_seconds": 34,
+          "actual_minutes": 0.57,
+          "variance_minutes": -44.43,
+          "file_created": "frontend/src/components/atleta/ResultHero.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Implementar AtletaResultadosPage",
+          "task_type": "frontend",
+          "estimated_minutes": 60.0,
+          "started_at": "2026-04-30T16:32:38.794099+00:00",
+          "completed_at": "2026-04-30T16:34:06.688927+00:00",
+          "elapsed_seconds": 87,
+          "actual_minutes": 1.45,
+          "variance_minutes": -58.55,
+          "file_created": "frontend/src/pages/atleta/AtletaResultadosPage.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-04-30T16:34:22.683940+00:00",
+      "completed_at": null,
+      "elapsed_seconds": 0,
+      "status": "in_progress",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 2,
+    "completed_tasks": 2,
+    "total_phases": 5,
+    "estimated_total_minutes": 105.0,
+    "actual_total_minutes": 2.02,
+    "variance_minutes": -102.98,
+    "variance_percent": -98.08
+  }
+}

--- a/docs/plans/sp5/US-5.7.3-fase0.md
+++ b/docs/plans/sp5/US-5.7.3-fase0.md
@@ -1,0 +1,44 @@
+# Fase 0 — Validacion de Contexto: US-5.7.3
+
+## Contexto Validado
+
+**Historia de Usuario:** US-5.7.3 — Mis Resultados: RP, tarjeta y puntos por disciplina  
+**Producto:** frontend  
+**Puntos:** 5  
+**Prioridad:** Alta para INC-5.7
+
+## Arquitectura
+
+- **Patron:** React PWA dentro del producto `frontend`, consumiendo APIs existentes.
+- **Scope principal:** reemplazar placeholder en `frontend/src/pages/atleta/AtletaResultadosPage.tsx`.
+- **Backend:** sin cambios requeridos.
+
+## Fuente de Verdad UX
+
+- `docs/design/ux/wireframes-atleta.md` — S-08 Mis Resultados.
+- `docs/design/ux/flujos-por-rol.md` — Rol: Atleta.
+
+## APIs y Datos Existentes
+
+- `loadAtletaPortalSnapshot()` ya compone atleta, inscripciones, torneos, competencias, grilla, AP, OT, andarivel y posicion.
+- `fetchRankingCompetencia(competenciaId, disciplina)` obtiene `RankingCompetenciaDto`.
+- `RankingEntradaDto` expone `atleta_id`, `rp`, `unidad`, `tarjeta`, `es_dns`, `en_podio`, `puntos`.
+- `formatMarca()` y `formatAp()` ya formatean metros/segundos.
+
+## Decisiones Importantes
+
+- La pagina debe mostrar solo la entrada del atleta autenticado, comparando contra `snapshot.atleta.atleta_id`.
+- Si `fetchRankingCompetencia` falla o devuelve `calculado=false`, se trata como disciplina pendiente, no como error global de pantalla.
+- La diferencia AP-RP se calcula solo cuando ambos valores numericos estan disponibles y no hay DNS.
+- US-5.7.4 extendera esta misma pagina con ranking completo y overall; esta US se limita a resultado propio.
+
+## Quality Gates
+
+- `npm run build`.
+- ESLint focalizado sobre archivos modificados.
+- El lint global puede seguir bloqueado por deuda fuera de scope ya documentada en US-5.7.1.
+
+## Listo Para Fase 1
+
+La US esta localizada, tiene criterios BDD definidos, fuente UX explicita y no requiere
+cambios de backend.

--- a/docs/plans/sp5/US-5.7.3-plan.md
+++ b/docs/plans/sp5/US-5.7.3-plan.md
@@ -1,0 +1,77 @@
+# Plan de Implementacion - US-5.7.3: Mis resultados del atleta
+
+**Incremento:** INC-5.7 | **Sprint:** SP5  
+**Producto:** frontend  
+**Patron:** React/Vite frontend sobre pagina existente  
+**Estimacion total:** 130 min
+
+---
+
+## Diagnostico
+
+`AtletaResultadosPage` existe pero es un placeholder. El portal atleta ya tiene
+`loadAtletaPortalSnapshot()`, que entrega atleta, inscripciones, torneos, competencias,
+AP, OT, andarivel y posicion. Esta US debe enriquecer ese snapshot con rankings para
+mostrar solo el resultado propio del atleta.
+
+## Cambios por componente
+
+### 1. Componentes de resultado
+
+- [ ] `frontend/src/components/atleta/ResultHero.tsx` (25 min)
+  - mostrar disciplina, estado visual, RP, AP, diferencia AP-RP, puntos y chip `EN PODIO`
+  - soportar estados BLANCA, ROJA, DNS y PENDIENTE
+  - aplicar border/color segun estado
+
+- [ ] `frontend/src/components/atleta/DisciplinaPendienteCard.tsx` (20 min)
+  - mostrar disciplina pendiente, OT, AP y andarivel si existen
+  - mostrar texto "Resultado disponible al cierre de la disciplina"
+
+### 2. Composicion de datos
+
+- [ ] `frontend/src/pages/atleta/AtletaResultadosPage.tsx` (45 min)
+  - reemplazar placeholder
+  - cargar `loadAtletaPortalSnapshot()`
+  - para cada entry con `competenciaId`, cargar `fetchRankingCompetencia`
+  - tratar errores de ranking como pendiente
+  - buscar entrada propia por `entrada.atleta_id === snapshot.atleta.atleta_id`
+  - agrupar resultados por torneo
+
+### 3. Helpers de presentacion
+
+- [ ] `frontend/src/pages/atleta/AtletaResultadosPage.tsx` o helper local (15 min)
+  - formatear RP con `formatMarca`
+  - calcular diferencia AP-RP con signo cuando ambos valores son numericos
+  - mapear tarjeta/DNS a estado visual
+
+### 4. Validacion
+
+- [ ] `npm run build` en `frontend/` (5 min)
+- [ ] ESLint focalizado sobre archivos modificados (5 min)
+- [ ] Smoke manual con atleta del torneo en ejecucion (10 min)
+- [ ] documentacion y reporte final (10 min)
+
+## Decisiones clave
+
+- No se agrega backend: se consume `fetchRankingCompetencia`.
+- Si `fetchRankingCompetencia` falla o `ranking.calculado === false`, la disciplina queda pendiente.
+- La pagina muestra solo el resultado del atleta autenticado, no rankings completos. US-5.7.4 agrega rankings/podios.
+- La diferencia AP-RP se calcula solo si AP y RP son numericos y no hay DNS.
+- Para disciplinas de tiempo se reutiliza `formatMarca(value, unidad)`; la diferencia se deja en segundos si la unidad es `Segundos`.
+
+## Riesgos y mitigaciones
+
+- Rankings no existentes pueden devolver error HTTP: se capturan como pendiente.
+- Una disciplina inscripta puede no tener `competenciaId`: se muestra pendiente con datos disponibles.
+- El payload de tarjeta puede venir null: se muestra `PENDIENTE` salvo `es_dns=true`.
+
+## Criterio de salida
+
+La implementacion termina cuando:
+
+1. `/atleta/resultados` deja de ser placeholder.
+2. Las disciplinas con ranking calculado muestran resultado propio, RP, tarjeta y puntos.
+3. Las disciplinas sin ranking muestran card pendiente.
+4. DNS muestra RP y puntos como `-`.
+5. `EN PODIO` aparece solo para `en_podio=true`.
+6. El build y lint focalizado pasan.

--- a/docs/plans/sp5/US-5.7.3-test-notes.md
+++ b/docs/plans/sp5/US-5.7.3-test-notes.md
@@ -1,0 +1,25 @@
+# Test Notes - US-5.7.3
+
+## Tests Unitarios
+
+No se agregan tests unitarios automatizados porque el frontend no tiene harness de
+componentes React configurado para montar paginas con React Query y mocks de API.
+
+La logica agregada queda validada por TypeScript y ESLint focalizado:
+
+- busqueda de resultado propio por `atleta_id`
+- tratamiento de ranking no calculado como pendiente
+- mapeo de tarjeta/DNS a estado visual
+- calculo de diferencia AP-RP con signo
+
+## Tests de Integracion
+
+No hay backend nuevo. La pagina consume contratos existentes:
+
+- `loadAtletaPortalSnapshot()`
+- `GET /resultados/{competencia_id}/ranking?disciplina=...`
+
+## BDD / UI
+
+Escenarios documentados en `tests/features/US-5.7.3-mis-resultados.feature`.
+La validacion UI queda manual/smoke hasta incorporar harness browser.

--- a/frontend/src/components/atleta/DisciplinaPendienteCard.tsx
+++ b/frontend/src/components/atleta/DisciplinaPendienteCard.tsx
@@ -1,0 +1,46 @@
+interface DisciplinaPendienteCardProps {
+  disciplina: string
+  ot: string
+  ap: string
+  andarivel: number | null
+}
+
+export function DisciplinaPendienteCard({
+  disciplina,
+  ot,
+  ap,
+  andarivel,
+}: DisciplinaPendienteCardProps) {
+  return (
+    <article className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+            {disciplina}
+          </p>
+          <p className="mt-2 text-base font-semibold text-white">Resultado pendiente</p>
+        </div>
+        <span className="rounded-full border border-slate-700 bg-slate-950/70 px-3 py-1 text-xs font-semibold text-slate-200">
+          PENDIENTE
+        </span>
+      </div>
+      <dl className="mt-4 grid grid-cols-3 gap-3 text-sm text-slate-300">
+        <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+          <dt className="text-xs uppercase tracking-[0.16em] text-slate-500">OT</dt>
+          <dd className="mt-1 font-semibold text-white">{ot}</dd>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+          <dt className="text-xs uppercase tracking-[0.16em] text-slate-500">AP</dt>
+          <dd className="mt-1 font-semibold text-white">{ap}</dd>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+          <dt className="text-xs uppercase tracking-[0.16em] text-slate-500">And.</dt>
+          <dd className="mt-1 font-semibold text-white">{andarivel ?? '-'}</dd>
+        </div>
+      </dl>
+      <p className="mt-4 text-sm text-slate-400">
+        Resultado disponible al cierre de la disciplina
+      </p>
+    </article>
+  )
+}

--- a/frontend/src/components/atleta/ResultHero.tsx
+++ b/frontend/src/components/atleta/ResultHero.tsx
@@ -1,0 +1,66 @@
+export type ResultHeroEstado = 'BLANCA' | 'ROJA' | 'DNS' | 'PENDIENTE'
+
+interface ResultHeroProps {
+  disciplina: string
+  estado: ResultHeroEstado
+  rp: string
+  ap: string
+  diferencia: string
+  puntos: string
+  enPodio: boolean
+}
+
+const ESTADO_STYLES: Record<ResultHeroEstado, string> = {
+  BLANCA: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100',
+  ROJA: 'border-red-500/40 bg-red-500/10 text-red-100',
+  DNS: 'border-slate-600 bg-slate-900 text-slate-200',
+  PENDIENTE: 'border-slate-800 bg-slate-900 text-slate-200',
+}
+
+export function ResultHero({
+  disciplina,
+  estado,
+  rp,
+  ap,
+  diferencia,
+  puntos,
+  enPodio,
+}: ResultHeroProps) {
+  return (
+    <article className={`rounded-[1.75rem] border p-5 ${ESTADO_STYLES[estado]}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] opacity-80">
+            {disciplina}
+          </p>
+          <p className="mt-3 text-4xl font-semibold leading-none text-white">{rp}</p>
+        </div>
+        <div className="flex flex-col items-end gap-2">
+          <span className="rounded-full border border-current/30 bg-slate-950/30 px-3 py-1 text-xs font-semibold">
+            {estado}
+          </span>
+          {enPodio ? (
+            <span className="rounded-full border border-amber-300/40 bg-amber-300/10 px-3 py-1 text-xs font-semibold text-amber-100">
+              EN PODIO
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <dl className="mt-5 grid grid-cols-3 gap-3 text-sm">
+        <div className="rounded-2xl border border-white/10 bg-slate-950/30 p-3">
+          <dt className="text-xs uppercase tracking-[0.16em] opacity-70">AP</dt>
+          <dd className="mt-1 font-semibold text-white">{ap}</dd>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-slate-950/30 p-3">
+          <dt className="text-xs uppercase tracking-[0.16em] opacity-70">Dif.</dt>
+          <dd className="mt-1 font-semibold text-white">{diferencia}</dd>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-slate-950/30 p-3">
+          <dt className="text-xs uppercase tracking-[0.16em] opacity-70">Puntos</dt>
+          <dd className="mt-1 font-semibold text-white">{puntos}</dd>
+        </div>
+      </dl>
+    </article>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaResultadosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaResultadosPage.tsx
@@ -1,14 +1,188 @@
+import { useQueries, useQuery } from '@tanstack/react-query'
 import { AtletaShell } from '../../components/atleta/AtletaShell'
+import { DisciplinaPendienteCard } from '../../components/atleta/DisciplinaPendienteCard'
+import { ResultHero, type ResultHeroEstado } from '../../components/atleta/ResultHero'
+import {
+  fetchRankingCompetencia,
+  type RankingCompetenciaDto,
+  type RankingEntradaDto,
+} from '../../api/resultados'
+import { formatMarca } from '../../utils/marca'
+import {
+  formatAp,
+  formatDisciplina,
+  formatHora,
+  loadAtletaPortalSnapshot,
+  type AtletaPortalEntry,
+} from './portalData'
+
+interface ResultadoEntry {
+  entry: AtletaPortalEntry
+  ranking: RankingCompetenciaDto | null
+  miResultado: RankingEntradaDto | null
+}
+
+function findMiResultado(
+  ranking: RankingCompetenciaDto | null,
+  atletaId: string,
+): RankingEntradaDto | null {
+  if (!ranking?.calculado) return null
+
+  return (
+    ranking.rankings
+      .flatMap((categoria) => categoria.entradas)
+      .find((entrada) => entrada.atleta_id === atletaId) ?? null
+  )
+}
+
+function getEstadoResultado(resultado: RankingEntradaDto): ResultHeroEstado {
+  if (resultado.es_dns) return 'DNS'
+  if (resultado.tarjeta?.toLowerCase().includes('roja')) return 'ROJA'
+  if (resultado.tarjeta?.toLowerCase().includes('blanca')) return 'BLANCA'
+  return 'PENDIENTE'
+}
+
+function formatResultado(resultado: RankingEntradaDto): string {
+  if (resultado.es_dns || !resultado.rp) return '-'
+  return formatMarca(resultado.rp, resultado.unidad ?? 'Metros')
+}
+
+function calcularDiferencia(params: {
+  ap: string | null
+  rp: string | null
+  unidad: string | null
+  esDns: boolean
+}): string {
+  if (params.esDns || !params.ap || !params.rp) return '-'
+  const ap = Number(params.ap)
+  const rp = Number(params.rp)
+  if (!Number.isFinite(ap) || !Number.isFinite(rp)) return '-'
+
+  const diff = rp - ap
+  const sign = diff > 0 ? '+' : ''
+  const suffix = params.unidad?.toLowerCase() === 'segundos' ? 's' : 'm'
+  return `${sign}${Number(diff.toFixed(2))}${suffix}`
+}
+
+function groupByTorneo(resultados: ResultadoEntry[]): Array<{
+  torneoId: string
+  torneoNombre: string
+  resultados: ResultadoEntry[]
+}> {
+  const groups = new Map<
+    string,
+    { torneoId: string; torneoNombre: string; resultados: ResultadoEntry[] }
+  >()
+
+  resultados.forEach((resultado) => {
+    const torneoId = resultado.entry.torneo.torneo_id
+    const current = groups.get(torneoId) ?? {
+      torneoId,
+      torneoNombre: resultado.entry.torneo.nombre,
+      resultados: [],
+    }
+    current.resultados.push(resultado)
+    groups.set(torneoId, current)
+  })
+
+  return Array.from(groups.values())
+}
 
 export function AtletaResultadosPage() {
+  const snapshotQuery = useQuery({
+    queryKey: ['atleta-resultados-snapshot'],
+    queryFn: loadAtletaPortalSnapshot,
+  })
+
+  const rankingQueries = useQueries({
+    queries: (snapshotQuery.data?.entries ?? []).map((entry) => ({
+      queryKey: ['atleta-ranking', entry.competenciaId, entry.disciplina],
+      queryFn: () => fetchRankingCompetencia(entry.competenciaId!, entry.disciplina),
+      enabled: Boolean(entry.competenciaId),
+      retry: false,
+    })),
+  })
+
+  const resultados: ResultadoEntry[] = (snapshotQuery.data?.entries ?? []).map((entry, index) => {
+    const ranking = rankingQueries[index]?.data ?? null
+    return {
+      entry,
+      ranking,
+      miResultado: findMiResultado(ranking, snapshotQuery.data?.atleta.atleta_id ?? ''),
+    }
+  })
+  const grupos = groupByTorneo(resultados)
+
   return (
     <AtletaShell title="Mis resultados" subtitle="Resultados publicados y ranking por disciplina.">
-      <div className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
-        <p className="text-sm font-semibold text-white">Resultados aún no publicados</p>
-        <p className="mt-2 text-sm text-slate-400">
-          Esta vista queda preparada dentro del shell UX del atleta. Los resultados aparecerán cuando la organización los publique.
-        </p>
-      </div>
+      {snapshotQuery.isLoading ? (
+        <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">
+          Cargando resultados...
+        </div>
+      ) : null}
+
+      {snapshotQuery.isError ? (
+        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          No se pudieron cargar tus resultados.
+        </div>
+      ) : null}
+
+      {snapshotQuery.data && resultados.length === 0 ? (
+        <div className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
+          <p className="text-sm font-semibold text-white">Aún no tenés resultados publicados.</p>
+          <p className="mt-2 text-sm text-slate-400">
+            Tus resultados aparecerán cuando tengas inscripciones con disciplinas publicadas.
+          </p>
+        </div>
+      ) : null}
+
+      {snapshotQuery.data && grupos.length > 0 ? (
+        <div className="space-y-5">
+          {grupos.map((grupo) => (
+            <section key={grupo.torneoId} className="space-y-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+                  Torneo
+                </p>
+                <h2 className="mt-1 text-lg font-semibold text-white">{grupo.torneoNombre}</h2>
+              </div>
+
+              {grupo.resultados.map(({ entry, miResultado }) => {
+                if (!miResultado) {
+                  return (
+                    <DisciplinaPendienteCard
+                      key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
+                      disciplina={formatDisciplina(entry.disciplina)}
+                      ot={entry.ot ? formatHora(entry.ot) : '-'}
+                      ap={formatAp(entry.ap, entry.unidad)}
+                      andarivel={entry.andarivel}
+                    />
+                  )
+                }
+
+                const estado = getEstadoResultado(miResultado)
+                return (
+                  <ResultHero
+                    key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
+                    disciplina={formatDisciplina(entry.disciplina)}
+                    estado={estado}
+                    rp={formatResultado(miResultado)}
+                    ap={formatAp(entry.ap, entry.unidad)}
+                    diferencia={calcularDiferencia({
+                      ap: entry.ap,
+                      rp: miResultado.rp,
+                      unidad: miResultado.unidad ?? entry.unidad,
+                      esDns: miResultado.es_dns,
+                    })}
+                    puntos={miResultado.es_dns ? '-' : (miResultado.puntos ?? '-')}
+                    enPodio={miResultado.en_podio}
+                  />
+                )
+              })}
+            </section>
+          ))}
+        </div>
+      ) : null}
     </AtletaShell>
   )
 }

--- a/tests/features/US-5.7.3-mis-resultados.feature
+++ b/tests/features/US-5.7.3-mis-resultados.feature
@@ -1,0 +1,34 @@
+Feature: US-5.7.3 - Mis resultados por disciplina
+  Como atleta autenticado
+  Quiero ver mi resultado personal por disciplina
+  Para conocer RP, tarjeta y puntos cuando la organizacion publica resultados
+
+  Background:
+    Given el atleta "ana@email.com" con atleta_id "aaa" esta autenticado
+    And Ana esta inscripta en "BA Open 2026" en DNF y STA
+    And la disciplina DNF esta finalizada con ranking calculado
+    And Ana obtuvo en DNF RP 70m, tarjeta blanca, 100.00 puntos, en podio y AP 68m
+    And la disciplina STA aun no tiene ranking calculado
+
+  Scenario: Resultado propio con tarjeta blanca se muestra en ResultHero
+    When Ana navega a "/atleta/resultados"
+    Then ve el ResultHero de DNF con estado "BLANCA"
+    And ve RP "70 m", AP "68 m", diferencia "+2m" y puntos "100.00"
+    And ve el chip "EN PODIO"
+
+  Scenario: Disciplina pendiente muestra estado de espera
+    When Ana navega a "/atleta/resultados"
+    Then ve la card de STA con chip "PENDIENTE"
+    And ve "Resultado disponible al cierre de la disciplina"
+    And no ve RP ni puntos calculados para STA
+
+  Scenario: DNS muestra tarjeta gris sin RP
+    Given Ana tiene DNS en STA
+    When Ana navega a "/atleta/resultados"
+    Then el ResultHero de STA muestra chip "DNS"
+    And RP es "-" y puntos es "-"
+
+  Scenario: Atleta sin inscripciones ve estado vacio
+    Given el atleta no esta inscripto en ningun torneo
+    When navega a "/atleta/resultados"
+    Then ve el mensaje "Aun no tenes resultados publicados."


### PR DESCRIPTION
## Summary

- `AtletaResultadosPage` reemplaza el placeholder con resultados reales por disciplina
- `ResultHero`: tarjeta visual con RP, tarjeta (BLANCA/ROJA/DNS/PENDIENTE), AP, diferencia y puntos FAAS
- `DisciplinaPendienteCard`: estado de espera para disciplinas sin ranking calculado aún
- Agrupación por torneo; chip `EN PODIO` condicionado a `en_podio === true`
- Sin cambios de backend — consume `loadAtletaPortalSnapshot()` + `fetchRankingCompetencia`

## Test plan

- [x] TypeScript `--noEmit` sin errores
- [x] ESLint sin errores en archivos nuevos
- [x] `npm run build` exitoso (4.84s)
- [ ] Smoke manual: atleta con resultados publicados ve `ResultHero` correcto
- [ ] Smoke manual: disciplina sin ranking muestra `DisciplinaPendienteCard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)