### PR TITLE
feat(frontend): rankings y podios del atleta [US-5.7.4]

### DIFF
--- a/docs/plans/sp5/US-5.7.4-plan.md
+++ b/docs/plans/sp5/US-5.7.4-plan.md
@@ -1,0 +1,58 @@
+# Plan de Implementacion - US-5.7.4: Rankings y podios del atleta
+
+**Incremento:** INC-5.7 | **Sprint:** SP5
+**Producto:** frontend
+**Patron:** extension de AtletaResultadosPage existente
+**Estimacion total:** 100 min
+
+---
+
+## Diagnostico
+
+`AtletaResultadosPage` (US-5.7.3) ya carga snapshot + rankings. Esta US agrega:
+1. `RankingCard` + `RankingRow`: ranking de categoria propia debajo de cada ResultHero
+2. `OverallCard`: seccion overall al pie de la pagina
+3. Carga de grilla por competencia para resolver nombres (join atleta_id → nombre)
+4. Queries de overall por torneo via `fetchOverall`
+
+La categoria del atleta se obtiene de `entry.inscripcion.categoria`.
+El ranking se filtra por la categoria que coincide con `inscripcion.categoria`.
+
+## Cambios por componente
+
+### 1. RankingRow.tsx (20 min)
+- props: posicion, nombre, rp, puntos, tarjeta, esDns, isSelf
+- chip tarjeta: BLANCA (verde), ROJA (rojo), DNS (gris)
+- top 3: icono 🥇🥈🥉
+- isSelf: fondo sky-500/10 + texto "Vos"
+
+### 2. RankingCard.tsx (20 min)
+- props: categoria, entradas, nombresPorId, atletaId, calculado, unidad
+- filtrar entradas por categoriaAtleta (ya viene filtrado desde la pagina)
+- pie: "Ranking final" / "Ranking parcial"
+
+### 3. OverallCard.tsx (20 min)
+- props: overall (OverallDto | null), atletaId, nombresPorId, categoriaAtleta
+- estado vacio si !overall?.calculado o rankings vacios
+- solo mostrar categoria propia
+
+### 4. AtletaResultadosPage.tsx — extension (30 min)
+- agregar queries de grilla por competencia (useQueries)
+- agregar queries de overall por torneo (useQueries, uno por torneo distinto)
+- construir Map<competenciaId, Map<atleta_id, nombre>>
+- pasar ranking filtrado por categoria a RankingCard
+- agregar OverallCard al final de cada seccion de torneo
+
+### 5. Validacion (10 min)
+- npm run build
+- tsc --noEmit
+- eslint sobre archivos nuevos/modificados
+
+## Decisiones clave
+
+- La grilla se carga por competencia (no por torneo) para mapear nombres.
+- Si la grilla falla, fallback: truncar atleta_id a 8 chars.
+- La categoria del ranking se determina buscando en `ranking.rankings` la categoria
+  que contiene la entrada del atleta propio (no se asume que el string de categoria
+  en el ranking coincide exactamente con el de la inscripcion).
+- Overall: una query por torneo_id unico entre todas las entries.

--- a/frontend/src/components/atleta/OverallCard.tsx
+++ b/frontend/src/components/atleta/OverallCard.tsx
@@ -1,0 +1,78 @@
+import { type OverallDto } from '../../api/resultados'
+
+interface OverallCardProps {
+  overall: OverallDto | null
+  atletaId: string
+  nombresPorId: Map<string, string>
+  categoriaAtleta: string
+  categoriaLabel: string
+}
+
+function OverallEmpty() {
+  return (
+    <div className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5 text-center">
+      <p className="text-2xl">🏆</p>
+      <p className="mt-2 text-sm font-semibold text-white">Ranking Overall</p>
+      <p className="mt-1 text-sm text-slate-400">
+        Disponible al finalizar todas las disciplinas del torneo
+      </p>
+    </div>
+  )
+}
+
+export function OverallCard({
+  overall,
+  atletaId,
+  nombresPorId,
+  categoriaAtleta,
+  categoriaLabel,
+}: OverallCardProps) {
+  if (!overall?.calculado || overall.rankings.length === 0) {
+    return <OverallEmpty />
+  }
+
+  const miCategoria = overall.rankings.find((cat) => cat.categoria === categoriaAtleta)
+
+  if (!miCategoria || miCategoria.entradas.length === 0) {
+    return <OverallEmpty />
+  }
+
+  return (
+    <div className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+        Ranking Overall {categoriaLabel}
+      </p>
+      <div className="mt-3 space-y-1">
+        {miCategoria.entradas.map((entrada) => {
+          const isSelf = entrada.atleta_id === atletaId
+          return (
+            <div
+              key={entrada.atleta_id}
+              className={`flex items-center gap-3 rounded-2xl px-3 py-2.5 ${
+                isSelf ? 'border border-sky-500/30 bg-sky-500/10' : 'border border-transparent'
+              }`}
+            >
+              <span className="w-6 text-center text-sm font-bold text-slate-400">
+                {entrada.posicion}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate text-sm font-semibold text-white">
+                    {nombresPorId.get(entrada.atleta_id) ?? entrada.atleta_id.slice(0, 8)}
+                  </span>
+                  {isSelf ? (
+                    <span className="rounded-full border border-sky-400/40 bg-sky-400/10 px-1.5 py-0.5 text-[10px] font-semibold text-sky-300">
+                      Vos
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <span className="text-sm font-semibold text-white">{entrada.puntos_overall}</span>
+            </div>
+          )
+        })}
+      </div>
+      <p className="mt-3 text-right text-xs text-slate-500">Ranking final</p>
+    </div>
+  )
+}

--- a/frontend/src/components/atleta/RankingCard.tsx
+++ b/frontend/src/components/atleta/RankingCard.tsx
@@ -1,0 +1,53 @@
+import { type RankingEntradaDto } from '../../api/resultados'
+import { formatMarca } from '../../utils/marca'
+import { RankingRow } from './RankingRow'
+
+interface RankingCardProps {
+  categoriaLabel: string
+  entradas: RankingEntradaDto[]
+  unidad: string | null
+  nombresPorId: Map<string, string>
+  atletaId: string
+  calculado: boolean
+}
+
+function formatRp(entrada: RankingEntradaDto, unidad: string | null): string {
+  if (entrada.es_dns || !entrada.rp) return '-'
+  return formatMarca(entrada.rp, unidad ?? entrada.unidad ?? 'Metros')
+}
+
+export function RankingCard({
+  categoriaLabel,
+  entradas,
+  unidad,
+  nombresPorId,
+  atletaId,
+  calculado,
+}: RankingCardProps) {
+  if (entradas.length === 0) return null
+
+  return (
+    <div className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+        Ranking {categoriaLabel}
+      </p>
+      <div className="mt-3 space-y-1">
+        {entradas.map((entrada) => (
+          <RankingRow
+            key={entrada.atleta_id}
+            posicion={entrada.posicion}
+            nombre={nombresPorId.get(entrada.atleta_id) ?? entrada.atleta_id.slice(0, 8)}
+            rp={formatRp(entrada, unidad)}
+            puntos={entrada.es_dns ? '0' : (entrada.puntos ?? '-')}
+            tarjeta={entrada.tarjeta}
+            esDns={entrada.es_dns}
+            isSelf={entrada.atleta_id === atletaId}
+          />
+        ))}
+      </div>
+      <p className="mt-3 text-right text-xs text-slate-500">
+        {calculado ? 'Ranking final' : 'Ranking parcial'}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/atleta/RankingRow.tsx
+++ b/frontend/src/components/atleta/RankingRow.tsx
@@ -1,0 +1,65 @@
+interface RankingRowProps {
+  posicion: number
+  nombre: string
+  rp: string
+  puntos: string
+  tarjeta: string | null
+  esDns: boolean
+  isSelf: boolean
+}
+
+const PODIO_ICONS: Record<number, string> = { 1: '🥇', 2: '🥈', 3: '🥉' }
+
+function ChipTarjeta({ tarjeta, esDns }: { tarjeta: string | null; esDns: boolean }) {
+  if (esDns) {
+    return (
+      <span className="rounded-full border border-slate-600 bg-slate-800 px-2 py-0.5 text-[10px] font-semibold text-slate-300">
+        DNS
+      </span>
+    )
+  }
+  if (tarjeta?.toLowerCase().includes('roja')) {
+    return (
+      <span className="rounded-full border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-[10px] font-semibold text-red-300">
+        ROJA
+      </span>
+    )
+  }
+  if (tarjeta?.toLowerCase().includes('blanca')) {
+    return (
+      <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-300">
+        BLANCA
+      </span>
+    )
+  }
+  return null
+}
+
+export function RankingRow({ posicion, nombre, rp, puntos, tarjeta, esDns, isSelf }: RankingRowProps) {
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-2xl px-3 py-2.5 ${
+        isSelf ? 'border border-sky-500/30 bg-sky-500/10' : 'border border-transparent'
+      }`}
+    >
+      <span className="w-6 text-center text-sm font-bold text-slate-400">
+        {PODIO_ICONS[posicion] ?? posicion}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-sm font-semibold text-white">{nombre}</span>
+          {isSelf ? (
+            <span className="rounded-full border border-sky-400/40 bg-sky-400/10 px-1.5 py-0.5 text-[10px] font-semibold text-sky-300">
+              Vos
+            </span>
+          ) : null}
+        </div>
+        <span className="text-xs text-slate-400">{rp}</span>
+      </div>
+      <div className="flex flex-col items-end gap-1">
+        <span className="text-sm font-semibold text-white">{puntos}</span>
+        <ChipTarjeta tarjeta={tarjeta} esDns={esDns} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/atleta/AtletaResultadosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaResultadosPage.tsx
@@ -1,15 +1,20 @@
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { AtletaShell } from '../../components/atleta/AtletaShell'
 import { DisciplinaPendienteCard } from '../../components/atleta/DisciplinaPendienteCard'
+import { OverallCard } from '../../components/atleta/OverallCard'
+import { RankingCard } from '../../components/atleta/RankingCard'
 import { ResultHero, type ResultHeroEstado } from '../../components/atleta/ResultHero'
 import {
+  fetchOverall,
   fetchRankingCompetencia,
   type RankingCompetenciaDto,
   type RankingEntradaDto,
 } from '../../api/resultados'
+import { fetchGrillaCompetencia } from '../../api/competencia'
 import { formatMarca } from '../../utils/marca'
 import {
   formatAp,
+  formatCategoria,
   formatDisciplina,
   formatHora,
   loadAtletaPortalSnapshot,
@@ -27,12 +32,23 @@ function findMiResultado(
   atletaId: string,
 ): RankingEntradaDto | null {
   if (!ranking?.calculado) return null
-
   return (
     ranking.rankings
       .flatMap((categoria) => categoria.entradas)
       .find((entrada) => entrada.atleta_id === atletaId) ?? null
   )
+}
+
+function findMiCategoriaEntradas(
+  ranking: RankingCompetenciaDto | null,
+  atletaId: string,
+): { entradas: RankingEntradaDto[]; categoria: string } | null {
+  if (!ranking?.calculado) return null
+  const cat = ranking.rankings.find((c) =>
+    c.entradas.some((e) => e.atleta_id === atletaId),
+  )
+  if (!cat) return null
+  return { entradas: cat.entradas, categoria: cat.categoria }
 }
 
 function getEstadoResultado(resultado: RankingEntradaDto): ResultHeroEstado {
@@ -57,7 +73,6 @@ function calcularDiferencia(params: {
   const ap = Number(params.ap)
   const rp = Number(params.rp)
   if (!Number.isFinite(ap) || !Number.isFinite(rp)) return '-'
-
   const diff = rp - ap
   const sign = diff > 0 ? '+' : ''
   const suffix = params.unidad?.toLowerCase() === 'segundos' ? 's' : 'm'
@@ -73,7 +88,6 @@ function groupByTorneo(resultados: ResultadoEntry[]): Array<{
     string,
     { torneoId: string; torneoNombre: string; resultados: ResultadoEntry[] }
   >()
-
   resultados.forEach((resultado) => {
     const torneoId = resultado.entry.torneo.torneo_id
     const current = groups.get(torneoId) ?? {
@@ -84,7 +98,6 @@ function groupByTorneo(resultados: ResultadoEntry[]): Array<{
     current.resultados.push(resultado)
     groups.set(torneoId, current)
   })
-
   return Array.from(groups.values())
 }
 
@@ -94,8 +107,11 @@ export function AtletaResultadosPage() {
     queryFn: loadAtletaPortalSnapshot,
   })
 
+  const entries = snapshotQuery.data?.entries ?? []
+  const atletaId = snapshotQuery.data?.atleta.atleta_id ?? ''
+
   const rankingQueries = useQueries({
-    queries: (snapshotQuery.data?.entries ?? []).map((entry) => ({
+    queries: entries.map((entry) => ({
       queryKey: ['atleta-ranking', entry.competenciaId, entry.disciplina],
       queryFn: () => fetchRankingCompetencia(entry.competenciaId!, entry.disciplina),
       enabled: Boolean(entry.competenciaId),
@@ -103,12 +119,43 @@ export function AtletaResultadosPage() {
     })),
   })
 
-  const resultados: ResultadoEntry[] = (snapshotQuery.data?.entries ?? []).map((entry, index) => {
+  const grillaQueries = useQueries({
+    queries: entries.map((entry) => ({
+      queryKey: ['atleta-grilla-nombres', entry.competenciaId, entry.disciplina],
+      queryFn: () => fetchGrillaCompetencia(entry.competenciaId!, entry.disciplina),
+      enabled: Boolean(entry.competenciaId),
+      retry: false,
+    })),
+  })
+
+  const torneoIds = [...new Set(entries.map((e) => e.torneo.torneo_id))]
+  const overallQueries = useQueries({
+    queries: torneoIds.map((torneoId) => ({
+      queryKey: ['atleta-overall', torneoId],
+      queryFn: () => fetchOverall(torneoId),
+      retry: false,
+    })),
+  })
+
+  const nombresPorCompetencia = new Map<string, Map<string, string>>()
+  entries.forEach((entry, index) => {
+    if (!entry.competenciaId) return
+    const grilla = grillaQueries[index]?.data ?? []
+    const mapa = new Map<string, string>()
+    grilla.forEach((fila) => mapa.set(fila.atleta_id, fila.nombre_atleta))
+    nombresPorCompetencia.set(entry.competenciaId, mapa)
+  })
+
+  const overallPorTorneo = new Map(
+    torneoIds.map((torneoId, index) => [torneoId, overallQueries[index]?.data ?? null]),
+  )
+
+  const resultados: ResultadoEntry[] = entries.map((entry, index) => {
     const ranking = rankingQueries[index]?.data ?? null
     return {
       entry,
       ranking,
-      miResultado: findMiResultado(ranking, snapshotQuery.data?.atleta.atleta_id ?? ''),
+      miResultado: findMiResultado(ranking, atletaId),
     }
   })
   const grupos = groupByTorneo(resultados)
@@ -137,50 +184,92 @@ export function AtletaResultadosPage() {
       ) : null}
 
       {snapshotQuery.data && grupos.length > 0 ? (
-        <div className="space-y-5">
-          {grupos.map((grupo) => (
-            <section key={grupo.torneoId} className="space-y-3">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
-                  Torneo
-                </p>
-                <h2 className="mt-1 text-lg font-semibold text-white">{grupo.torneoNombre}</h2>
-              </div>
+        <div className="space-y-8">
+          {grupos.map((grupo) => {
+            const overall = overallPorTorneo.get(grupo.torneoId) ?? null
+            const categoriaAtleta = grupo.resultados
+              .map(({ ranking }) => findMiCategoriaEntradas(ranking, atletaId)?.categoria)
+              .find(Boolean) ?? ''
+            const categoriaLabel = formatCategoria(categoriaAtleta)
+            const nombresParaOverall = (() => {
+              const mapa = new Map<string, string>()
+              grupo.resultados.forEach(({ entry }) => {
+                if (!entry.competenciaId) return
+                const m = nombresPorCompetencia.get(entry.competenciaId)
+                m?.forEach((nombre, id) => mapa.set(id, nombre))
+              })
+              return mapa
+            })()
 
-              {grupo.resultados.map(({ entry, miResultado }) => {
-                if (!miResultado) {
+            return (
+              <section key={grupo.torneoId} className="space-y-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
+                    Torneo
+                  </p>
+                  <h2 className="mt-1 text-lg font-semibold text-white">{grupo.torneoNombre}</h2>
+                </div>
+
+                {grupo.resultados.map(({ entry, miResultado, ranking }) => {
+                  const nombresPorId = entry.competenciaId
+                    ? (nombresPorCompetencia.get(entry.competenciaId) ?? new Map())
+                    : new Map<string, string>()
+
+                  const miCategoria = findMiCategoriaEntradas(ranking, atletaId)
+
+                  if (!miResultado) {
+                    return (
+                      <DisciplinaPendienteCard
+                        key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
+                        disciplina={formatDisciplina(entry.disciplina)}
+                        ot={entry.ot ? formatHora(entry.ot) : '-'}
+                        ap={formatAp(entry.ap, entry.unidad)}
+                        andarivel={entry.andarivel}
+                      />
+                    )
+                  }
+
+                  const estado = getEstadoResultado(miResultado)
                   return (
-                    <DisciplinaPendienteCard
-                      key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
-                      disciplina={formatDisciplina(entry.disciplina)}
-                      ot={entry.ot ? formatHora(entry.ot) : '-'}
-                      ap={formatAp(entry.ap, entry.unidad)}
-                      andarivel={entry.andarivel}
-                    />
+                    <div key={`${entry.torneo.torneo_id}-${entry.disciplina}`} className="space-y-2">
+                      <ResultHero
+                        disciplina={formatDisciplina(entry.disciplina)}
+                        estado={estado}
+                        rp={formatResultado(miResultado)}
+                        ap={formatAp(entry.ap, entry.unidad)}
+                        diferencia={calcularDiferencia({
+                          ap: entry.ap,
+                          rp: miResultado.rp,
+                          unidad: miResultado.unidad ?? entry.unidad,
+                          esDns: miResultado.es_dns,
+                        })}
+                        puntos={miResultado.es_dns ? '-' : (miResultado.puntos ?? '-')}
+                        enPodio={miResultado.en_podio}
+                      />
+                      {miCategoria ? (
+                        <RankingCard
+                          categoriaLabel={formatCategoria(miCategoria.categoria)}
+                          entradas={miCategoria.entradas}
+                          unidad={entry.unidad}
+                          nombresPorId={nombresPorId}
+                          atletaId={atletaId}
+                          calculado={ranking?.calculado ?? false}
+                        />
+                      ) : null}
+                    </div>
                   )
-                }
+                })}
 
-                const estado = getEstadoResultado(miResultado)
-                return (
-                  <ResultHero
-                    key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
-                    disciplina={formatDisciplina(entry.disciplina)}
-                    estado={estado}
-                    rp={formatResultado(miResultado)}
-                    ap={formatAp(entry.ap, entry.unidad)}
-                    diferencia={calcularDiferencia({
-                      ap: entry.ap,
-                      rp: miResultado.rp,
-                      unidad: miResultado.unidad ?? entry.unidad,
-                      esDns: miResultado.es_dns,
-                    })}
-                    puntos={miResultado.es_dns ? '-' : (miResultado.puntos ?? '-')}
-                    enPodio={miResultado.en_podio}
-                  />
-                )
-              })}
-            </section>
-          ))}
+                <OverallCard
+                  overall={overall}
+                  atletaId={atletaId}
+                  nombresPorId={nombresParaOverall}
+                  categoriaAtleta={categoriaAtleta}
+                  categoriaLabel={categoriaLabel}
+                />
+              </section>
+            )
+          })}
         </div>
       ) : null}
     </AtletaShell>

--- a/tests/features/US-5.7.4-rankings-podios.feature
+++ b/tests/features/US-5.7.4-rankings-podios.feature
@@ -1,0 +1,38 @@
+Feature: US-5.7.4 - Rankings y podios del atleta
+  Como atleta autenticado
+  Quiero ver el ranking de mi categoria y el overall
+  Para conocer mi posicion respecto al resto de competidores
+
+  Background:
+    Given el atleta "ana@email.com" con atleta_id "aaa" y categoria "SENIOR_FEMENINO" esta autenticado
+    And existe la competencia DNF con ranking calculado
+    And el ranking SENIOR_FEMENINO de DNF tiene Ana pos=1 100pts, Laura pos=2 85pts, Maria pos=3 72pts
+    And el torneo NO tiene overall calculado aun
+
+  Scenario: atleta ve ranking de su categoria bajo el ResultHero
+    When Ana navega a "/atleta/resultados"
+    Then ve la card "Ranking Senior Femenino" bajo el ResultHero de DNF
+    And la fila de Ana muestra texto "Vos" y fondo accent tenue
+    And las posiciones 1, 2 y 3 tienen distincion visual de top 3
+    And al pie de la card aparece "Ranking final"
+
+  Scenario: overall no disponible muestra estado vacio con icono trofeo
+    When Ana navega a "/atleta/resultados"
+    Then ve la seccion Overall con texto "Disponible al finalizar todas las disciplinas del torneo"
+    And no ve filas de ranking en la seccion Overall
+
+  Scenario: overall disponible muestra categoria propia resaltada
+    Given el overall fue calculado con Ana pos=2 en SENIOR_FEMENINO con 185 puntos
+    When Ana navega a "/atleta/resultados"
+    Then ve la seccion "Ranking Overall Senior Femenino"
+    And la fila de Ana en overall muestra posicion 2 con fondo accent tenue
+
+  Scenario: ranking parcial muestra pie con advertencia
+    Given el ranking de DNF tiene calculado=false
+    When Ana navega a "/atleta/resultados"
+    Then al pie de la card de DNF aparece "Ranking parcial"
+
+  Scenario: atleta con DNS aparece en el ranking
+    Given Ana tiene DNS en DNF con es_dns=true
+    When Ana navega a "/atleta/resultados"
+    Then la fila de Ana en el ranking muestra chip "DNS"


### PR DESCRIPTION
## Summary

- `RankingCard`: ranking de categoría propia debajo de cada `ResultHero`, con pie "Ranking final/parcial"
- `RankingRow`: fila con distinción top 3 (🥇🥈🥉), chip de tarjeta, resalte "Vos" para el atleta propio
- `OverallCard`: estado vacío (ícono trofeo) o categoría propia resaltada cuando el overall está calculado
- `AtletaResultadosPage`: queries adicionales de grilla (para nombres) y overall por torneo; categoría derivada del ranking, sin dependencia de `InscriptoDto.categoria`

## Test plan

- [x] TypeScript sin errores (`tsc -b`)
- [x] ESLint sin errores en archivos nuevos
- [x] `npm run build` exitoso
- [ ] Smoke manual: atleta con ranking calculado ve `RankingCard` con su fila resaltada
- [ ] Smoke manual: overall vacío muestra ícono trofeo + mensaje

🤖 Generated with [Claude Code](https://claude.com/claude-code)