### PR TITLE
feat(frontend): US-6.1.3 — Grilla ordenada + RpSelector compactado móvil

### DIFF
--- a/.claude/tracking/US-6.1.3-tracking.json
+++ b/.claude/tracking/US-6.1.3-tracking.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "us_id": "US-6.1.3",
+    "us_title": "Grilla Ordenada por Estado + Keypad Visible en Móvil",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-04T10:00:17.175228+00:00",
+    "completed_at": null,
+    "total_elapsed_seconds": 0,
+    "effective_seconds": 0,
+    "paused_seconds": 0
+  },
+  "phases": [],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 0,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -11,7 +11,7 @@
 | **Capa IEDD** | Capa 3 — Especificación (puente con Implementación) |
 | **Fecha** | 2026-05-01 |
 | **Fuentes** | `05-requerimientos_funcionales.md` · Context Map v1.1 · `estrategia-desarrollo-bc.md` · ES Competencia |
-| **Estado** | ✅ v1.32 — SP6 INC-6.1 en curso · US-6.1.1 ✅ · US-6.1.2 ✅ |
+| **Estado** | ✅ v1.33 — SP6 INC-6.1 en curso · US-6.1.1 ✅ · US-6.1.2 ✅ · US-6.1.3 ✅ |
 
 ---
 
@@ -552,14 +552,14 @@ alcance vigente de SP5 salvo que se reabra explícitamente el scope.
 
 ## 29. US-IEDD SP6 INC-6.1 — Ajustes Juez
 
-> Estado al 2026-05-03: 1/5 US mergeada a `develop` (en PR). INC-6.1 en curso.
+> Estado al 2026-05-04: 3/5 US mergeadas a `develop`. INC-6.1 en curso.
 > Quality gates: frontend-only · CodeGuard N/A (sin cambios Python) · DesignReviewer al cierre del INC.
 
 | US | Inc. | Contenido principal | Estado |
 |----|------|---------------------|--------|
 | US-6.1.1 | 6.1 | Fix `canSubmitBko` (limpieza remanente) + reorden flujo juez: tarjeta (paso 5) → marca (paso 6) · `usePerformanceFlow.ts` + `PerformanceFlowPage.tsx` | ✅ Done (PR #143) |
 | US-6.1.2 | 6.1 | Colores tarjeta outline/filled (MUX-02) + heading paso 5 corregido · MUX-05 ya estaba resuelto en PerformanceFlowPage · `StepTarjeta.tsx` | ✅ Done (PR #144) |
-| US-6.1.3 | 6.1 | Grilla ordenada por estado + keypad visible móvil (MUX-03 + MUX-01) | ⏳ Pendiente |
+| US-6.1.3 | 6.1 | Grilla ordenada por estado + keypad visible móvil · MUX-03 ya resuelto · MUX-01: `RpSelector.tsx` space-y-2 + py-2 en keypad | ✅ Done (PR #145) |
 | US-6.1.4 | 6.1 | Rediseño inicio juez + STA mm:ss + tarjeta amarilla (UI-JUE-01 + MUX-08 + MUX-07) | ⏳ Pendiente |
 | US-6.1.5 | 6.1 | AtletaCard compacta en paso 5 (MUX-06) | ⏳ Pendiente |
 
@@ -690,6 +690,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 | US-5.7.4 | frontend (build + eslint) · UAT visual INC-5.7 (BDD waiver — frontend puro) | ✅ Done (PR #140) |
 | US-6.1.1 | frontend (build) · `tests/features/US-6.1.1-flow-juez.feature` · 362 unit/competencia sin regresiones (BDD waiver — frontend puro) | ✅ Done (PR #143) |
 | US-6.1.2 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #144) |
+| US-6.1.3 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #145) |
 
 ---
 
@@ -708,6 +709,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 
 ---
 
+*v1.33 — 2026-05-04: US-6.1.3 ✅ (PR #145) · §29 y US→Tests actualizados*
 *v1.32 — 2026-05-03: US-6.1.2 ✅ (PR #144) · §29 y US→Tests actualizados*
 *v1.31 — 2026-05-03: SP6 iniciado · §29 INC-6.1 agregado · US-6.1.1 ✅ (PR #143) · US→Tests US-6.1.1 agregado · header actualizado*
 *v1.30 — 2026-05-01: INC-5.7 cerrado (§28 nuevo · 4/4 US ✅ · PRs #137–#140 · DesignReviewer 0 CRITICAL · 256 WARNING) · INC-5.8 desestimado (absorbido SP6) · §§ renumerados 29..33 · US→Tests US-5.7.x · §2 cobertura actualizada*

--- a/frontend/src/components/juez/RpSelector.tsx
+++ b/frontend/src/components/juez/RpSelector.tsx
@@ -49,7 +49,7 @@ export function RpSelector({
   }
 
   return (
-    <section className="space-y-3 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-3">
+    <section className="space-y-2 rounded-[2rem] border border-slate-800 bg-slate-900/80 p-3">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
           {isSecondsMode ? 'Tiempo' : 'Marca'}
@@ -127,7 +127,7 @@ export function RpSelector({
               key={digit}
               type="button"
               onClick={() => pushDigit(digit)}
-              className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-base font-semibold text-white"
+              className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2 text-base font-semibold text-white"
             >
               {digit}
             </button>
@@ -135,21 +135,21 @@ export function RpSelector({
           <button
             type="button"
             onClick={() => onCentimetrosChange('')}
-            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-xs font-semibold text-slate-200"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2 text-xs font-semibold text-slate-200"
           >
             CLR
           </button>
           <button
             type="button"
             onClick={() => pushDigit('0')}
-            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-base font-semibold text-white"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2 text-base font-semibold text-white"
           >
             0
           </button>
           <button
             type="button"
             onClick={() => onCentimetrosChange(centimetros.slice(0, -1))}
-            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2.5 text-xs font-semibold text-slate-200"
+            className="rounded-xl border border-slate-700 bg-slate-950/70 px-3 py-2 text-xs font-semibold text-slate-200"
           >
             DEL
           </button>

--- a/tests/features/US-6.1.3-grilla-ordenada-keypad-movil.feature
+++ b/tests/features/US-6.1.3-grilla-ordenada-keypad-movil.feature
@@ -1,0 +1,29 @@
+Feature: US-6.1.3 — Grilla ordenada por estado + Keypad visible en móvil
+
+  Scenario: Grilla renderizada con SIGUIENTE en primer lugar
+    Given una competencia con performances en varios estados
+    When se carga GrillaPage
+    Then el atleta con estado SIGUIENTE aparece en la primera fila
+    And el segundo atleta tiene estado EN_CURSO o PENDIENTE según disponibilidad
+
+  Scenario: Dentro del mismo estado mantener orden original del backend
+    Given dos atletas con estado SIGUIENTE
+    When se ordena la grilla
+    Then el orden relativo entre ambos es el original del backend
+
+  Scenario: Orden final respeta prioridad de estados
+    Given performances con estados FINALIZADA SIGUIENTE EN_CURSO REVISION y PENDIENTE
+    When se renderiza GrillaPage
+    Then el orden es SIGUIENTE luego EN_CURSO luego REVISION luego PENDIENTE luego FINALIZADA
+
+  Scenario: RpSelector compactado mantiene funcionalidad de ingreso de marca
+    Given un juez en paso 4 con RpSelector visible
+    When ingresa la marca 75 metros con centímetros 50
+    Then la marca se registra correctamente como 75.50 m
+    And los presets funcionan igual que antes
+
+  Scenario: RpSelector compactado mantiene funcionalidad en modo segundos
+    Given un juez en modo segundos con RpSelector visible
+    When selecciona el preset de 3 minutos
+    Then el display muestra 3:00 min
+    And los botones de ajuste modifican correctamente el tiempo


### PR DESCRIPTION
## Summary

- **MUX-01**: Compactar `RpSelector.tsx` para visibilidad completa del keypad en iPhone 12 (812px) sin scroll — `space-y-3`→`space-y-2`, `py-2.5`→`py-2` en botones del keypad
- **MUX-03**: Ya estaba resuelto — `GrillaPage.tsx` tiene `STATUS_ORDER` y sort por estado implementados desde versiones anteriores
- BDD: `tests/features/US-6.1.3-grilla-ordenada-keypad-movil.feature` con 5 escenarios

## Test plan

- [ ] ESLint ✅ (0 warnings)
- [ ] tsc --noEmit ✅ (0 errores)
- [ ] Verificar RpSelector en móvil: keypad completamente visible sin scroll
- [ ] Verificar grilla: atleta SIGUIENTE aparece primero en la lista

🤖 Generated with [Claude Code](https://claude.com/claude-code)