### PR TITLE
feat(frontend): AtletaCard variante compact + paso 6 RpSelector [US-6.1.5]

### DIFF
--- a/.claude/tracking/US-6.1.5-tracking.json
+++ b/.claude/tracking/US-6.1.5-tracking.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "us_id": "US-6.1.5",
+    "us_title": "AtletaCard compacta en paso 5",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-04T10:20:19.958118+00:00",
+    "completed_at": null,
+    "total_elapsed_seconds": 0,
+    "effective_seconds": 0,
+    "paused_seconds": 0
+  },
+  "phases": [],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 0,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -11,7 +11,7 @@
 | **Capa IEDD** | Capa 3 — Especificación (puente con Implementación) |
 | **Fecha** | 2026-05-01 |
 | **Fuentes** | `05-requerimientos_funcionales.md` · Context Map v1.1 · `estrategia-desarrollo-bc.md` · ES Competencia |
-| **Estado** | ✅ v1.34 — SP6 INC-6.1 en curso · US-6.1.1 ✅ · US-6.1.2 ✅ · US-6.1.3 ✅ · US-6.1.4 ✅ |
+| **Estado** | ✅ v1.35 — SP6 INC-6.1 en curso · US-6.1.1 ✅ · US-6.1.2 ✅ · US-6.1.3 ✅ · US-6.1.4 ✅ · US-6.1.5 ✅ |
 
 ---
 
@@ -552,7 +552,7 @@ alcance vigente de SP5 salvo que se reabra explícitamente el scope.
 
 ## 29. US-IEDD SP6 INC-6.1 — Ajustes Juez
 
-> Estado al 2026-05-04: 4/5 US mergeadas a `develop`. INC-6.1 en curso.
+> Estado al 2026-05-04: 5/5 US mergeadas a `develop`. INC-6.1 completo — pendiente DesignReviewer cierre incremento.
 > Quality gates: frontend-only · CodeGuard N/A (sin cambios Python) · DesignReviewer al cierre del INC.
 
 | US | Inc. | Contenido principal | Estado |
@@ -561,7 +561,7 @@ alcance vigente de SP5 salvo que se reabra explícitamente el scope.
 | US-6.1.2 | 6.1 | Colores tarjeta outline/filled (MUX-02) + heading paso 5 corregido · MUX-05 ya estaba resuelto en PerformanceFlowPage · `StepTarjeta.tsx` | ✅ Done (PR #144) |
 | US-6.1.3 | 6.1 | Grilla ordenada por estado + keypad visible móvil · MUX-03 ya resuelto · MUX-01: `RpSelector.tsx` space-y-2 + py-2 en keypad | ✅ Done (PR #145) |
 | US-6.1.4 | 6.1 | Rediseño inicio juez + STA mm:ss + tarjeta amarilla (UI-JUE-01 + MUX-08 + MUX-07) · `DisciplinasPage.tsx`: "Mis asignaciones" + sin Password · `utils/marca.ts`: " min" suffix · `StepRevision.tsx`: labels BLANCA/ROJA | ✅ Done (PR #146) |
-| US-6.1.5 | 6.1 | AtletaCard compacta en paso 5 (MUX-06) | ⏳ Pendiente |
+| US-6.1.5 | 6.1 | AtletaCard compacta en paso 5 (MUX-06) · `AtletaCard.tsx`: prop `variant='full'|'compact'` · `PerformanceFlowPage.tsx`: paso 6 (RpSelector) usa compact | ✅ Done (PR #147) |
 
 ---
 
@@ -692,6 +692,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 | US-6.1.2 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #144) |
 | US-6.1.3 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #145) |
 | US-6.1.4 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #146) |
+| US-6.1.5 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #147) |
 
 ---
 
@@ -710,6 +711,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 
 ---
 
+*v1.35 — 2026-05-04: US-6.1.5 ✅ (PR #147) · §29 5/5 completo · US→Tests actualizados*
 *v1.34 — 2026-05-04: US-6.1.4 ✅ (PR #146) · §29 y US→Tests actualizados*
 *v1.33 — 2026-05-04: US-6.1.3 ✅ (PR #145) · §29 y US→Tests actualizados*
 *v1.32 — 2026-05-03: US-6.1.2 ✅ (PR #144) · §29 y US→Tests actualizados*

--- a/frontend/src/components/juez/AtletaCard.tsx
+++ b/frontend/src/components/juez/AtletaCard.tsx
@@ -7,6 +7,7 @@ interface AtletaCardProps {
   andarivel: number
   otProgramado: string
   estado: string
+  variant?: 'full' | 'compact'
 }
 
 function formatOt(iso: string) {
@@ -23,8 +24,22 @@ export function AtletaCard({
   andarivel,
   otProgramado,
   estado,
+  variant = 'full',
 }: AtletaCardProps) {
   const showEstado = estado !== 'AnunciadaAP'
+
+  if (variant === 'compact') {
+    return (
+      <section className="flex items-center justify-between rounded-[2rem] border border-slate-800 bg-slate-900/80 px-5 py-3">
+        <p className="text-base font-semibold text-white">{nombreAtleta}</p>
+        {showEstado ? (
+          <span className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
+            {estado}
+          </span>
+        ) : null}
+      </section>
+    )
+  }
 
   return (
     <section className="rounded-[2rem] border border-slate-800 bg-slate-900/80 p-5 shadow-[0_24px_80px_-50px_rgba(34,211,238,0.7)]">

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -225,7 +225,15 @@ export function PerformanceFlowPage() {
       {/* Paso 6 — Registrar RP y confirmar marca */}
       {!flow.completed && flow.step === 6 ? (
         <section className="space-y-3">
-          <p className="px-1 text-lg font-semibold text-white">{flow.atletaActivo.nombreAtleta}</p>
+          <AtletaCard
+            variant="compact"
+            nombreAtleta={flow.atletaActivo.nombreAtleta}
+            apDeclarado={flow.atletaActivo.apDeclarado}
+            unidad={flow.atletaActivo.unidad}
+            andarivel={flow.atletaActivo.andarivel}
+            otProgramado={flow.atletaActivo.otProgramado}
+            estado="EN CURSO"
+          />
           <RpSelector
             metros={flow.metros}
             centimetros={flow.centimetros}

--- a/tests/features/US-6.1.5-atletacard-compacta-paso5.feature
+++ b/tests/features/US-6.1.5-atletacard-compacta-paso5.feature
@@ -1,0 +1,37 @@
+Feature: US-6.1.5 — AtletaCard compacta en paso 5 (RpSelector)
+
+  Scenario: AtletaCard variant compact muestra solo nombre y estado
+    Given una AtletaCard renderizada con variant compact
+    When se renderiza el componente
+    Then aparece el nombre del atleta
+    And aparece el estado EN CURSO
+    And no aparece Performance anunciada
+    And no aparece Andarivel
+    And no aparece OT
+
+  Scenario: AtletaCard variant full muestra todos los campos
+    Given una AtletaCard renderizada con variant full
+    When se renderiza el componente
+    Then aparece el nombre del atleta
+    And aparece Performance anunciada
+    And aparece Andarivel
+    And aparece OT
+
+  Scenario: AtletaCard sin prop variant usa full por defecto
+    Given una AtletaCard sin prop variant
+    When se renderiza el componente
+    Then aparece Performance anunciada
+    And aparece Andarivel
+    And aparece OT
+
+  Scenario: Paso 6 RpSelector usa AtletaCard compacta
+    Given un juez en paso 6 del flujo de performance
+    When se renderiza PerformanceFlowPage en paso 6
+    Then la tarjeta del atleta es compacta
+    And el RpSelector esta visible
+    And no aparecen AP ni andarivel ni OT en la tarjeta
+
+  Scenario: Otros pasos del flujo no usan AtletaCard compacta en header
+    Given un juez en pasos 1 2 o 3 del flujo de performance
+    When se renderiza PerformanceFlowPage
+    Then la AtletaCard muestra todos los campos del atleta


### PR DESCRIPTION
## Summary
- Agrega prop `variant?: 'full' | 'compact'` a `AtletaCard` — compact muestra solo nombre + estado badge
- `PerformanceFlowPage` paso 6 (RpSelector): reemplaza `<p>` por `<AtletaCard variant="compact">` para liberar espacio vertical del keypad
- Matrix v1.35 — INC-6.1 completo (5/5 US ✅)

## Test plan
- [x] `tsc --noEmit` — sin errores
- [x] `npm run build` — OK
- [x] ESLint — sin warnings
- [x] BDD waiver — frontend puro (`.feature` como documentación)

🤖 Generated with [Claude Code](https://claude.com/claude-code)