### PR TITLE
feat(frontend): ordenar torneos por fecha [US-6.2.1]

### DIFF
--- a/.claude/tracking/US-6.2.1-tracking.json
+++ b/.claude/tracking/US-6.2.1-tracking.json
@@ -1,0 +1,143 @@
+{
+  "metadata": {
+    "us_id": "US-6.2.1",
+    "us_title": "Inicio Organizador - ordenar torneos por fecha y mostrar fecha",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-05T11:51:12.946535+00:00",
+    "completed_at": "2026-05-05T12:03:11.353654+00:00",
+    "total_elapsed_seconds": 718,
+    "effective_seconds": 718,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-05T11:51:19.278978+00:00",
+      "completed_at": "2026-05-05T11:51:50.079498+00:00",
+      "elapsed_seconds": 30,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación de Plan de Implementación",
+      "started_at": "2026-05-05T11:51:57.575892+00:00",
+      "completed_at": "2026-05-05T11:52:44.312911+00:00",
+      "elapsed_seconds": 46,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-05T11:53:09.751881+00:00",
+      "completed_at": "2026-05-05T11:54:17.198998+00:00",
+      "elapsed_seconds": 67,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Actualizar dashboard organizador",
+          "task_type": "frontend",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-05T11:53:16.888083+00:00",
+          "completed_at": "2026-05-05T11:53:44.561075+00:00",
+          "elapsed_seconds": 27,
+          "actual_minutes": 0.45,
+          "variance_minutes": -14.55,
+          "file_created": "frontend/src/pages/organizador/DashboardPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Actualizar fuente UX en spec",
+          "task_type": "docs",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-05T11:53:56.576671+00:00",
+          "completed_at": "2026-05-05T11:54:11.194228+00:00",
+          "elapsed_seconds": 14,
+          "actual_minutes": 0.23,
+          "variance_minutes": -4.77,
+          "file_created": "docs/specs/sp6/US-6.2.1.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-05-05T11:54:37.861674+00:00",
+      "completed_at": "2026-05-05T11:54:53.565878+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-05-05T11:55:09.114337+00:00",
+      "completed_at": "2026-05-05T11:55:30.057597+00:00",
+      "elapsed_seconds": 20,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-05T11:55:48.772208+00:00",
+      "completed_at": "2026-05-05T11:58:11.753724+00:00",
+      "elapsed_seconds": 142,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-05T11:58:38.987301+00:00",
+      "completed_at": "2026-05-05T11:59:39.444502+00:00",
+      "elapsed_seconds": 60,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-05T12:01:22.762978+00:00",
+      "completed_at": "2026-05-05T12:03:05.423043+00:00",
+      "elapsed_seconds": 102,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 2,
+    "completed_tasks": 2,
+    "total_phases": 8,
+    "estimated_total_minutes": 20.0,
+    "actual_total_minutes": 0.68,
+    "variance_minutes": -19.32,
+    "variance_percent": -96.58
+  }
+}

--- a/docs/plans/sp6/US-6.2.1-plan.md
+++ b/docs/plans/sp6/US-6.2.1-plan.md
@@ -1,0 +1,94 @@
+# Plan de Implementación — US-6.2.1
+
+**US:** US-6.2.1 — Inicio Organizador: ordenar torneos por fecha + mostrar fecha  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature/US-6.2.1-torneos-fecha`  
+**Estimación:** 35 min  
+**Estado:** Completado  
+**Fecha implementación:** 2026-05-05  
+
+---
+
+## Contexto Validado
+
+- Spec fuente: `docs/specs/sp6/US-6.2.1.md`
+- Hallazgo fuente: `docs/plans/sp6/PLAN-SP6.md` — UI-ORG-01
+- Fuente UX consultada:
+  - `docs/design/ux/wireframes-organizador.md`
+  - `docs/design/ux/prototipos/prototipo-organizador.html`
+  - `docs/design/ux/README.md`
+- Componente afectado: `frontend/src/pages/organizador/DashboardPage.tsx`
+- DTO validado: `frontend/src/api/torneo.ts` — `TorneoDto.fecha_inicio`, `TorneoDto.fecha_fin`
+
+La US es frontend puro. Por instrucción operativa del usuario, se omiten Fase 1 y Fase 6 de BDD para esta US. La validación se hará con build/lint de frontend y revisión manual del comportamiento.
+
+---
+
+## Hallazgos de Fase 0
+
+- `filtrarTorneos` filtra por estado pero conserva el orden recibido desde backend.
+- La tarjeta muestra nombre, sede, ciudad y estado, pero no `fecha_inicio`/`fecha_fin`.
+- `TorneoDto` ya expone `fecha_inicio` y `fecha_fin`; no se requieren cambios de API/backend.
+- La spec `US-6.2.1` no incluye el campo obligatorio `## Fuente de verdad UX` definido por `WORKFLOW-DESARROLLO.md` para US que tocan `frontend/`.
+
+---
+
+## Tareas
+
+### 1. Implementación UI — Dashboard organizador (15 min)
+
+- [x] Actualizar `filtrarTorneos` para ordenar por `fecha_inicio` descendente dentro de cada filtro.
+- [x] Mantener estabilidad relativa para torneos con la misma fecha.
+- [x] Evitar mutar el array original recibido desde React Query.
+- [x] Agregar helper `formatFechaTorneo(inicio, fin)` usando `T00:00:00` para evitar off-by-one por UTC.
+- [x] Renderizar la fecha bajo la línea de sede/estado en cada tarjeta.
+
+### 2. Ajuste documental mínimo de la spec (5 min)
+
+- [x] Agregar `## Fuente de verdad UX` a `docs/specs/sp6/US-6.2.1.md`.
+- [x] Referenciar `wireframes-organizador.md`, `prototipo-organizador.html`, `PLAN-SP6.md` y el componente React comparado.
+
+### 3. Validación frontend (10 min)
+
+- [x] Ejecutar `cd frontend && npm run build`.
+- [x] Ejecutar `cd frontend && npm run lint` si el build pasa o si el error no bloquea lint.
+- [x] Verificar que no se tocaron archivos de backend.
+
+### 4. Cierre de US (5 min)
+
+- [x] Actualizar estado de `US-6.2.1` de `Pending` a `Done` si la validación pasa.
+- [x] Generar `docs/reports/US-6.2.1-report.md`.
+- [x] Cerrar tracker de `US-6.2.1`.
+
+---
+
+## Validación Esperada
+
+- Torneos vigentes ordenados por `fecha_inicio` descendente.
+- Torneos históricos ordenados por `fecha_inicio` descendente.
+- Fecha visible como fecha simple cuando inicio y fin coinciden.
+- Fecha visible como rango cuando inicio y fin difieren.
+- Sin cambios en contratos API ni modelos backend.
+
+---
+
+## Riesgos
+
+- `toLocaleDateString('es-AR')` puede variar levemente el punto final de abreviaturas según runtime. El criterio es formato legible, no string exacta rígida.
+- La ordenación descendente documentada en la spec dice "más próximo primero", pero descendente realmente muestra fechas futuras más lejanas antes que fechas futuras próximas. Para esta US se implementa literalmente la postcondición de la spec: `fecha_inicio` descendente.
+
+---
+
+## Resultado de Validación
+
+- `npm run build`: OK.
+- `./node_modules/.bin/eslint src/pages/organizador/DashboardPage.tsx`: OK.
+- `npm run lint`: falla por hallazgo preexistente fuera de alcance en `frontend/src/pages/juez/GrillaPage.tsx` y warning en `JuecesPanel.tsx`.
+
+---
+
+## Lecciones Aprendidas
+
+- Las US frontend necesitan registrar explícitamente `Fuente de verdad UX` en la spec; esta spec fue creada antes de completar ese campo y se corrigió durante Fase 8.
+- Para cambios de presentación sin harness UI automatizado, el gate útil de US es build + lint focalizado sobre los archivos tocados, dejando documentados los bloqueos globales ajenos.

--- a/docs/reports/US-6.2.1-report.md
+++ b/docs/reports/US-6.2.1-report.md
@@ -1,0 +1,68 @@
+# Reporte de Implementación — US-6.2.1
+
+**US:** US-6.2.1 — Inicio Organizador: ordenar torneos por fecha + mostrar fecha  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature/US-6.2.1-torneos-fecha`  
+**Estado:** Completado  
+**Fecha:** 2026-05-05  
+
+---
+
+## Resumen
+
+Se implementó el ajuste UI-ORG-01 en el inicio del organizador. La lista de torneos ahora se filtra por estado y se ordena por `fecha_inicio` descendente dentro de cada filtro. Las tarjetas muestran la fecha del torneo usando `fecha_inicio` y `fecha_fin` ya disponibles en `TorneoDto`.
+
+La US es frontend puro. Por instrucción operativa, se omitieron las fases BDD y se validó con build/lint de frontend.
+
+---
+
+## Componentes Implementados
+
+- `frontend/src/pages/organizador/DashboardPage.tsx`
+  - `filtrarTorneos` ahora ordena por `fecha_inicio` descendente.
+  - El orden mantiene estabilidad relativa cuando dos torneos tienen la misma fecha.
+  - La implementación evita mutar el array recibido desde React Query.
+  - Se agregaron helpers de presentación para fechas de torneo.
+  - Cada tarjeta muestra fecha simple o rango según `fecha_inicio`/`fecha_fin`.
+
+---
+
+## Documentación Actualizada
+
+- `docs/specs/sp6/US-6.2.1.md`
+  - Estado actualizado a `Done`.
+  - Agregada sección `Fuente de verdad UX`, requerida por `WORKFLOW-DESARROLLO.md` para US frontend.
+- `docs/plans/sp6/US-6.2.1-plan.md`
+  - Plan de Fase 2 creado y actualizado con tareas completadas.
+- `docs/reports/US-6.2.1-report.md`
+  - Reporte final de implementación.
+- `.claude/tracking/US-6.2.1-tracking.json`
+  - Tracking de fases y tareas de la US.
+
+---
+
+## Validación
+
+| Comando | Resultado | Observación |
+|---|---:|---|
+| `npm run build` | OK | TypeScript + Vite + PWA build pasan. |
+| `./node_modules/.bin/eslint src/pages/organizador/DashboardPage.tsx` | OK | El archivo modificado no introduce problemas de lint. |
+| `npm run lint` | Falla | Bloqueado por hallazgo preexistente en `frontend/src/pages/juez/GrillaPage.tsx` y warning en `JuecesPanel.tsx`, fuera de esta US. |
+
+---
+
+## Criterios de Aceptación
+
+- [x] Torneos vigentes ordenados por `fecha_inicio` descendente.
+- [x] Torneos históricos ordenados por `fecha_inicio` descendente.
+- [x] Fecha visible en cada tarjeta.
+- [x] Rango visible cuando `fecha_inicio` y `fecha_fin` difieren.
+- [x] Sin cambios en backend ni contratos API.
+
+---
+
+## Notas
+
+La spec usa la frase "más próximo primero" junto con orden descendente por fecha. Se implementó literalmente la postcondición técnica documentada: `fecha_inicio` descendente.
+

--- a/docs/specs/sp6/US-6.2.1.md
+++ b/docs/specs/sp6/US-6.2.1.md
@@ -1,6 +1,6 @@
 # US-6.2.1: Inicio Organizador — Ordenar Torneos por Fecha + Mostrar Fecha
 
-**Estado**: `Pending`  
+**Estado**: `Done`
 **Incremento**: INC-6.2 — Ajustes Organizador  
 **Hallazgos**: UI-ORG-01  
 **Bounded Context**: `frontend`  
@@ -23,6 +23,13 @@ para **identificar rápidamente el próximo torneo sin tener que abrir cada uno*
 **Ubicación**: `frontend/src/pages/organizador/DashboardPage.tsx`
 
 La función `filtrarTorneos` filtra por estado (vigentes/histórico) pero no aplica ningún ordenamiento. Las tarjetas muestran: nombre, sede, ciudad y estado — pero omiten `fecha_inicio` y `fecha_fin`, que ya están disponibles en el DTO (`TorneoDto.fecha_inicio: string`, `TorneoDto.fecha_fin: string`).
+
+## Fuente de verdad UX
+
+- `docs/design/ux/wireframes-organizador.md` — navegación y estructura base del portal organizador.
+- `docs/design/ux/prototipos/prototipo-organizador.html` — prototipo navegable aprobado para el rol organizador.
+- `docs/plans/sp6/PLAN-SP6.md` — hallazgo UI-ORG-01 detectado en validación SP5.
+- `frontend/src/pages/organizador/DashboardPage.tsx` — implementación React actual comparada contra el hallazgo.
 
 ---
 

--- a/frontend/src/pages/organizador/DashboardPage.tsx
+++ b/frontend/src/pages/organizador/DashboardPage.tsx
@@ -41,8 +41,39 @@ function esTorneoHistorico(estado: EstadoTorneo): boolean {
 }
 
 function filtrarTorneos(torneos: TorneoDto[], filtro: FiltroTorneos): TorneoDto[] {
-  if (filtro === 'vigentes') return torneos.filter((torneo) => esTorneoVigente(torneo.estado))
-  return torneos.filter((torneo) => esTorneoHistorico(torneo.estado))
+  const filtrados =
+    filtro === 'vigentes'
+      ? torneos.filter((torneo) => esTorneoVigente(torneo.estado))
+      : torneos.filter((torneo) => esTorneoHistorico(torneo.estado))
+
+  return filtrados
+    .map((torneo, index) => ({ torneo, index }))
+    .sort((a, b) => {
+      const fechaComparison = b.torneo.fecha_inicio.localeCompare(a.torneo.fecha_inicio)
+      if (fechaComparison !== 0) return fechaComparison
+      return a.index - b.index
+    })
+    .map(({ torneo }) => torneo)
+}
+
+function formatFechaCorta(fecha: string): string {
+  return new Date(`${fecha}T00:00:00`).toLocaleDateString('es-AR', {
+    day: 'numeric',
+    month: 'short',
+  })
+}
+
+function formatFechaCompleta(fecha: string): string {
+  return new Date(`${fecha}T00:00:00`).toLocaleDateString('es-AR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+function formatFechaTorneo(inicio: string, fin: string): string {
+  if (inicio === fin) return formatFechaCompleta(inicio)
+  return `${formatFechaCorta(inicio)}-${formatFechaCompleta(fin)}`
 }
 
 function emptyMessage(filtro: FiltroTorneos): string {
@@ -216,6 +247,9 @@ export function DashboardPage() {
                     className={`mt-2 text-sm ${historicalTextClass(torneo.estado)}`}
                   >
                     {torneo.sede.nombre}, {torneo.sede.ciudad} · {formatEstadoTorneo(torneo.estado)}
+                  </p>
+                  <p className={`mt-1 text-xs ${historicalTextClass(torneo.estado)}`}>
+                    {formatFechaTorneo(torneo.fecha_inicio, torneo.fecha_fin)}
                   </p>
                 </div>
                 <Link


### PR DESCRIPTION
## Resumen
- Ordena torneos vigentes e historicos por fecha de inicio descendente en el inicio del organizador.
- Muestra fecha simple o rango de fechas en cada tarjeta de torneo.
- Agrega Fuente de verdad UX, plan, reporte y tracker cerrado de US-6.2.1.

## Validacion
- npm run build: OK
- ./node_modules/.bin/eslint src/pages/organizador/DashboardPage.tsx: OK
- npm run lint global: falla por deuda previa fuera de alcance en GrillaPage.tsx/JuecesPanel.tsx