### PR TITLE
feat(frontend): clarificar anuncios en organizador [US-6.2.2]

### DIFF
--- a/.claude/tracking/US-6.2.2-tracking.json
+++ b/.claude/tracking/US-6.2.2-tracking.json
@@ -1,0 +1,156 @@
+{
+  "metadata": {
+    "us_id": "US-6.2.2",
+    "us_title": "Inscriptos y grilla - categoria legible y AP como Anuncio",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-05T12:14:38.650211+00:00",
+    "completed_at": "2026-05-05T12:29:08.554798+00:00",
+    "total_elapsed_seconds": 869,
+    "effective_seconds": 869,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-05T12:14:49.077559+00:00",
+      "completed_at": "2026-05-05T12:15:08.957290+00:00",
+      "elapsed_seconds": 19,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación de Plan de Implementación",
+      "started_at": "2026-05-05T12:16:10.023774+00:00",
+      "completed_at": "2026-05-05T12:16:51.335450+00:00",
+      "elapsed_seconds": 41,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-05T12:18:02.866042+00:00",
+      "completed_at": "2026-05-05T12:23:18.128824+00:00",
+      "elapsed_seconds": 315,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Actualizar TablaInscriptos",
+          "task_type": "frontend",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-05T12:18:10.073153+00:00",
+          "completed_at": "2026-05-05T12:19:16.549652+00:00",
+          "elapsed_seconds": 66,
+          "actual_minutes": 1.1,
+          "variance_minutes": -13.9,
+          "file_created": "frontend/src/components/organizador/TablaInscriptos.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Actualizar TablaGrilla",
+          "task_type": "frontend",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-05T12:19:22.397671+00:00",
+          "completed_at": "2026-05-05T12:21:29.324288+00:00",
+          "elapsed_seconds": 126,
+          "actual_minutes": 2.1,
+          "variance_minutes": -2.9,
+          "file_created": "frontend/src/components/organizador/TablaGrilla.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Actualizar fuente UX en spec",
+          "task_type": "docs",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-05T12:21:35.989239+00:00",
+          "completed_at": "2026-05-05T12:22:56.708324+00:00",
+          "elapsed_seconds": 80,
+          "actual_minutes": 1.33,
+          "variance_minutes": -3.67,
+          "file_created": "docs/specs/sp6/US-6.2.2.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-05-05T12:24:04.801194+00:00",
+      "completed_at": "2026-05-05T12:24:39.337400+00:00",
+      "elapsed_seconds": 34,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-05-05T12:24:45.076237+00:00",
+      "completed_at": "2026-05-05T12:24:51.269304+00:00",
+      "elapsed_seconds": 6,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-05T12:25:06.302139+00:00",
+      "completed_at": "2026-05-05T12:26:27.630852+00:00",
+      "elapsed_seconds": 81,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-05T12:26:59.596909+00:00",
+      "completed_at": "2026-05-05T12:27:38.789363+00:00",
+      "elapsed_seconds": 39,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-05T12:28:04.047133+00:00",
+      "completed_at": "2026-05-05T12:29:02.219960+00:00",
+      "elapsed_seconds": 58,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 8,
+    "estimated_total_minutes": 25.0,
+    "actual_total_minutes": 4.53,
+    "variance_minutes": -20.47,
+    "variance_percent": -81.87
+  }
+}

--- a/docs/plans/sp6/US-6.2.2-plan.md
+++ b/docs/plans/sp6/US-6.2.2-plan.md
@@ -1,0 +1,101 @@
+# Plan de Implementación — US-6.2.2
+
+**US:** US-6.2.2 — Inscriptos + Grilla: categoría legible + AP como Anuncio  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature/US-6.2.2-inscriptos-grilla-anuncios`  
+**Estimación:** 35 min  
+**Estado:** Completado  
+**Fecha implementación:** 2026-05-05  
+
+---
+
+## Contexto Validado
+
+- Spec fuente: `docs/specs/sp6/US-6.2.2.md`
+- Hallazgos fuente: `docs/plans/sp6/PLAN-SP6.md` — UI-ORG-03, UI-ORG-04
+- Fuente UX consultada:
+  - `docs/design/ux/wireframes-organizador.md`
+  - `docs/design/ux/prototipos/prototipo-organizador.html`
+  - `docs/design/ux/README.md`
+- Componentes afectados:
+  - `frontend/src/components/organizador/TablaInscriptos.tsx`
+  - `frontend/src/components/organizador/TablaGrilla.tsx`
+
+La US es frontend puro. Por instrucción operativa del usuario, se omiten Fase 1 y Fase 6 de BDD. La validación se hará con build/lint de frontend y revisión manual del comportamiento.
+
+---
+
+## Hallazgos de Fase 0
+
+- `TablaInscriptos` muestra `row.categoria` sin formateo.
+- `TablaInscriptos` usa el código de disciplina como header de columna, sin indicar que representa el anuncio/AP.
+- `TablaGrilla` muestra el header `AP`.
+- La spec `US-6.2.2` no incluye el campo obligatorio `## Fuente de verdad UX` definido por `WORKFLOW-DESARROLLO.md` para US que tocan `frontend/`.
+
+---
+
+## Tareas
+
+### 1. Implementación UI — TablaInscriptos (15 min)
+
+- [x] Agregar mapeo local `CATEGORIA_LABELS`.
+- [x] Agregar helper `formatCategoria(categoria)`.
+- [x] Renderizar categoría como `Senior M`, `Senior F`, `Master M`, `Master F`, `Junior M`, `Junior F`.
+- [x] Mantener fallback al valor raw para categorías no mapeadas.
+- [x] Cambiar headers dinámicos de disciplina a `Anuncio · {disciplina}`.
+
+### 2. Implementación UI — TablaGrilla (5 min)
+
+- [x] Cambiar header `AP` por `Anuncio`.
+- [x] No modificar el dato mostrado ni el formato de marca.
+
+### 3. Ajuste documental mínimo de la spec (5 min)
+
+- [x] Agregar `## Fuente de verdad UX` a `docs/specs/sp6/US-6.2.2.md`.
+- [x] Referenciar wireframes, prototipo, PLAN-SP6 y componentes React comparados.
+
+### 4. Validación frontend (10 min)
+
+- [x] Ejecutar `cd frontend && npm run build`.
+- [x] Ejecutar ESLint focalizado sobre los archivos modificados.
+- [x] Ejecutar `cd frontend && npm run lint` para registrar estado global.
+- [x] Verificar que no se tocaron archivos de backend.
+
+### 5. Cierre de US (5 min)
+
+- [x] Actualizar estado de `US-6.2.2` de `Pending` a `Done` si la validación pasa.
+- [x] Generar `docs/reports/US-6.2.2-report.md`.
+- [x] Cerrar tracker de `US-6.2.2`.
+- [ ] Commit atómico con referencia `[US-6.2.2]`.
+
+---
+
+## Validación Esperada
+
+- La columna `Categoria` no expone claves técnicas para las seis categorías estándar.
+- Categorías no reconocidas mantienen fallback raw.
+- Los headers de anuncio en inscriptos dicen `Anuncio · DNF`, `Anuncio · STA`, etc.
+- La columna de grilla dice `Anuncio`, no `AP`.
+- Sin cambios en backend ni contratos API.
+
+---
+
+## Riesgos
+
+- El término de la spec alterna singular/plural entre `Anuncio` y `Anuncios`. Para mantener consistencia con la tarea detallada, se usará singular en headers de columna (`Anuncio` y `Anuncio · DNF`), porque cada celda contiene un anuncio por disciplina.
+
+---
+
+## Resultado de Validación
+
+- `npm run build`: OK.
+- `./node_modules/.bin/eslint src/components/organizador/TablaInscriptos.tsx src/components/organizador/TablaGrilla.tsx`: OK.
+- `npm run lint`: falla por hallazgo preexistente fuera de alcance en `frontend/src/pages/juez/GrillaPage.tsx` y warning en `frontend/src/components/organizador/JuecesPanel.tsx`.
+
+---
+
+## Lecciones Aprendidas
+
+- El mapeo de categorías se mantuvo local porque esta US es la única que lo requiere por ahora; se puede extraer a `frontend/src/utils/formatters.ts` cuando otra pantalla lo consuma.
+- Para lenguaje de columna conviene usar singular cuando el dato por fila representa un único valor, aunque el hallazgo esté redactado en plural.

--- a/docs/reports/US-6.2.2-report.md
+++ b/docs/reports/US-6.2.2-report.md
@@ -1,0 +1,71 @@
+# Reporte de Implementación — US-6.2.2
+
+**US:** US-6.2.2 — Inscriptos + Grilla: categoría legible + AP como Anuncio  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature/US-6.2.2-inscriptos-grilla-anuncios`  
+**Estado:** Completado  
+**Fecha:** 2026-05-05  
+
+---
+
+## Resumen
+
+Se implementaron los ajustes UI-ORG-03 y UI-ORG-04. En la tabla de inscriptos, las categorías estándar dejan de exponerse como claves técnicas y las columnas de disciplina explicitan que el valor corresponde al anuncio. En la tabla de grilla, la columna `AP` fue renombrada a `Anuncio` sin cambiar el dato renderizado.
+
+La US es frontend puro. Por instrucción operativa, se omitieron las fases BDD y se validó con build/lint de frontend.
+
+---
+
+## Componentes Implementados
+
+- `frontend/src/components/organizador/TablaInscriptos.tsx`
+  - Se agregó `CATEGORIA_LABELS`.
+  - Se agregó `formatCategoria(categoria)` con fallback al valor raw.
+  - La columna `Categoria` muestra etiquetas legibles para Junior, Senior y Master por género.
+  - Los headers dinámicos de disciplina muestran `Anuncio · {disciplina}`.
+- `frontend/src/components/organizador/TablaGrilla.tsx`
+  - El header `AP` fue reemplazado por `Anuncio`.
+  - No se modificó el valor ni el formateo de la marca anunciada.
+
+---
+
+## Documentación Actualizada
+
+- `docs/specs/sp6/US-6.2.2.md`
+  - Estado actualizado a `Done`.
+  - Agregada sección `Fuente de verdad UX`, requerida por `WORKFLOW-DESARROLLO.md` para US frontend.
+- `docs/plans/sp6/US-6.2.2-plan.md`
+  - Plan de Fase 2 creado y actualizado con tareas completadas.
+- `docs/reports/US-6.2.2-report.md`
+  - Reporte final de implementación.
+- `.claude/tracking/US-6.2.2-tracking.json`
+  - Tracking de fases y tareas de la US.
+
+---
+
+## Validación
+
+| Comando | Resultado | Observación |
+|---|---:|---|
+| `npm run build` | OK | TypeScript + Vite + PWA build pasan. |
+| `./node_modules/.bin/eslint src/components/organizador/TablaInscriptos.tsx src/components/organizador/TablaGrilla.tsx` | OK | Los archivos modificados no introducen problemas de lint. |
+| `npm run lint` | Falla | Bloqueado por hallazgo preexistente en `frontend/src/pages/juez/GrillaPage.tsx` y warning en `JuecesPanel.tsx`, fuera de esta US. |
+
+---
+
+## Criterios de Aceptación
+
+- [x] `SENIOR_MASCULINO` se muestra como `Senior M`.
+- [x] `JUNIOR_FEMENINO` se muestra como `Junior F`.
+- [x] Categorías no mapeadas mantienen fallback raw.
+- [x] Headers de inscriptos muestran `Anuncio · DNF`, `Anuncio · STA`, etc.
+- [x] Header de grilla muestra `Anuncio`, no `AP`.
+- [x] Sin cambios en backend ni contratos API.
+
+---
+
+## Notas
+
+Se usó singular `Anuncio` en headers porque cada columna/celda representa un único anuncio por disciplina, aunque algunos hallazgos estén redactados en plural.
+

--- a/docs/specs/sp6/US-6.2.2.md
+++ b/docs/specs/sp6/US-6.2.2.md
@@ -1,6 +1,6 @@
 # US-6.2.2: Inscriptos + Grilla — Categoría Legible + Columna AP → Anuncios
 
-**Estado**: `Pending`  
+**Estado**: `Done`
 **Incremento**: INC-6.2 — Ajustes Organizador  
 **Hallazgos**: UI-ORG-03 · UI-ORG-04  
 **Bounded Context**: `frontend`  
@@ -29,6 +29,13 @@ La columna `Categoria` muestra el valor raw del enum (ej: `SENIOR_MASCULINO`). A
 **Ubicación**: `frontend/src/components/organizador/TablaGrilla.tsx` — línea `<th>AP</th>`
 
 El término interno "AP" (Announced Performance) no es claro para el organizador; debe decir "Anuncio".
+
+## Fuente de verdad UX
+
+- `docs/design/ux/wireframes-organizador.md` — estructura de tablas y lenguaje visual del portal organizador.
+- `docs/design/ux/prototipos/prototipo-organizador.html` — prototipo navegable aprobado para el rol organizador.
+- `docs/plans/sp6/PLAN-SP6.md` — hallazgos UI-ORG-03 y UI-ORG-04 detectados en validación SP5.
+- `frontend/src/components/organizador/TablaInscriptos.tsx` y `TablaGrilla.tsx` — implementación React actual comparada contra los hallazgos.
 
 ---
 

--- a/frontend/src/components/organizador/TablaGrilla.tsx
+++ b/frontend/src/components/organizador/TablaGrilla.tsx
@@ -87,7 +87,7 @@ export function TablaGrilla({ rows, readOnly, isSaving, onReorder }: TablaGrilla
           <tr>
             <th className="px-4 py-3">Posicion</th>
             <th className="px-4 py-3">Atleta</th>
-            <th className="px-4 py-3">AP</th>
+            <th className="px-4 py-3">Anuncio</th>
             <th className="px-4 py-3">Andarivel</th>
             <th className="px-4 py-3">OT</th>
             <th className="px-4 py-3">Estado</th>

--- a/frontend/src/components/organizador/TablaInscriptos.tsx
+++ b/frontend/src/components/organizador/TablaInscriptos.tsx
@@ -6,6 +6,15 @@ function esDisciplinaTiempo(disciplina: string): boolean {
   return ['STA', 'SPE_2X50', 'SPE_4X50', 'SPE_8X50', 'SPE_16X50'].includes(disciplina)
 }
 
+const CATEGORIA_LABELS: Record<string, string> = {
+  SENIOR_MASCULINO: 'Senior M',
+  SENIOR_FEMENINO: 'Senior F',
+  MASTER_MASCULINO: 'Master M',
+  MASTER_FEMENINO: 'Master F',
+  JUNIOR_MASCULINO: 'Junior M',
+  JUNIOR_FEMENINO: 'Junior F',
+}
+
 export interface EstadoAP {
   estado: 'pendiente' | 'declarado' | 'cerrado'
   ap: string | null
@@ -33,6 +42,10 @@ interface TablaInscriptosProps {
 
 function puedeDeclararAp(estado?: EstadoAP): boolean {
   return !estado?.ap?.trim()
+}
+
+function formatCategoria(categoria: string): string {
+  return CATEGORIA_LABELS[categoria] ?? categoria
 }
 
 export function TablaInscriptos({
@@ -95,7 +108,7 @@ export function TablaInscriptos({
                 <th className="px-4 py-3">Inscripcion</th>
                 {disciplinasVisibles.map((disciplina) => (
                   <th key={disciplina} className="px-4 py-3">
-                    {disciplina}
+                    Anuncio · {disciplina}
                   </th>
                 ))}
               </tr>
@@ -105,7 +118,9 @@ export function TablaInscriptos({
                 <tr key={row.inscripcionId}>
                   <td className="px-4 py-3 font-semibold text-white">{row.nombre}</td>
                   <td className="px-4 py-3 text-slate-300">{row.club}</td>
-                  <td className="px-4 py-3 text-slate-300">{row.categoria}</td>
+                  <td className="px-4 py-3 text-slate-300">
+                    {formatCategoria(row.categoria)}
+                  </td>
                   <td className="px-4 py-3 text-slate-300">{row.estadoInscripcion}</td>
                   {disciplinasVisibles.map((disciplina) => {
                     if (!row.disciplinas.includes(disciplina)) {


### PR DESCRIPTION
## Resumen
- Formatea categorias tecnicas en TablaInscriptos como etiquetas legibles.
- Renombra headers de disciplinas en inscriptos a Anuncio · disciplina.
- Renombra columna AP de grilla a Anuncio.
- Agrega Fuente de verdad UX, plan, reporte y tracker cerrado de US-6.2.2.

## Validacion
- npm run build: OK
- ./node_modules/.bin/eslint src/components/organizador/TablaInscriptos.tsx src/components/organizador/TablaGrilla.tsx: OK
- npm run lint global: falla por deuda previa fuera de alcance en GrillaPage.tsx/JuecesPanel.tsx