### PR TITLE
feat(frontend): limpiar tabla de resultados [US-6.2.3]

### DIFF
--- a/.claude/tracking/US-6.2.3-tracking.json
+++ b/.claude/tracking/US-6.2.3-tracking.json
@@ -1,0 +1,169 @@
+{
+  "metadata": {
+    "us_id": "US-6.2.3",
+    "us_title": "Resultados - quitar FAAS, andarivel numerico y AP como Anuncio",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-05T12:39:03.435653+00:00",
+    "completed_at": "2026-05-05T12:50:11.959394+00:00",
+    "total_elapsed_seconds": 668,
+    "effective_seconds": 668,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-05T12:39:10.470081+00:00",
+      "completed_at": "2026-05-05T12:39:42.523351+00:00",
+      "elapsed_seconds": 32,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación de Plan de Implementación",
+      "started_at": "2026-05-05T12:39:49.858381+00:00",
+      "completed_at": "2026-05-05T12:40:25.744382+00:00",
+      "elapsed_seconds": 35,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-05T12:40:56.535229+00:00",
+      "completed_at": "2026-05-05T12:42:51.345160+00:00",
+      "elapsed_seconds": 114,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Actualizar tabla resultados",
+          "task_type": "frontend",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-05T12:41:03.141898+00:00",
+          "completed_at": "2026-05-05T12:41:22.214659+00:00",
+          "elapsed_seconds": 19,
+          "actual_minutes": 0.32,
+          "variance_minutes": -14.68,
+          "file_created": "frontend/src/components/organizador/TablaDisciplinaResultados.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Actualizar fila resultado",
+          "task_type": "frontend",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-05T12:41:30.659656+00:00",
+          "completed_at": "2026-05-05T12:41:55.082167+00:00",
+          "elapsed_seconds": 24,
+          "actual_minutes": 0.4,
+          "variance_minutes": -4.6,
+          "file_created": "frontend/src/components/organizador/FilaResultado.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Actualizar copy resultados",
+          "task_type": "frontend",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-05T12:42:01.893945+00:00",
+          "completed_at": "2026-05-05T12:42:13.963718+00:00",
+          "elapsed_seconds": 12,
+          "actual_minutes": 0.2,
+          "variance_minutes": -4.8,
+          "file_created": "frontend/src/pages/organizador/ResultadosPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_004",
+          "task_name": "Actualizar fuente UX en spec",
+          "task_type": "docs",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-05T12:42:24.854828+00:00",
+          "completed_at": "2026-05-05T12:42:44.951426+00:00",
+          "elapsed_seconds": 20,
+          "actual_minutes": 0.33,
+          "variance_minutes": -4.67,
+          "file_created": "docs/specs/sp6/US-6.2.3.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-05-05T12:43:16.038916+00:00",
+      "completed_at": "2026-05-05T12:44:09.708389+00:00",
+      "elapsed_seconds": 53,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-05-05T12:44:54.338603+00:00",
+      "completed_at": "2026-05-05T12:45:00.062666+00:00",
+      "elapsed_seconds": 5,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-05T12:45:05.768509+00:00",
+      "completed_at": "2026-05-05T12:48:05.060481+00:00",
+      "elapsed_seconds": 179,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-05T12:48:12.455574+00:00",
+      "completed_at": "2026-05-05T12:48:55.580652+00:00",
+      "elapsed_seconds": 43,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-05T12:49:20.018021+00:00",
+      "completed_at": "2026-05-05T12:50:03.195022+00:00",
+      "elapsed_seconds": 43,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 4,
+    "completed_tasks": 4,
+    "total_phases": 8,
+    "estimated_total_minutes": 30.0,
+    "actual_total_minutes": 1.25,
+    "variance_minutes": -28.75,
+    "variance_percent": -95.83
+  }
+}

--- a/docs/plans/sp6/US-6.2.3-plan.md
+++ b/docs/plans/sp6/US-6.2.3-plan.md
@@ -1,0 +1,113 @@
+# Plan de Implementación — US-6.2.3
+
+**US:** US-6.2.3 — Resultados: quitar PTS FAAS + andarivel numérico + AP como Anuncio  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature/US-6.2.3-resultados-anuncio-andarivel`  
+**Estimación:** 40 min  
+**Estado:** Completado  
+**Fecha implementación:** 2026-05-05  
+
+---
+
+## Contexto Validado
+
+- Spec fuente: `docs/specs/sp6/US-6.2.3.md`
+- Hallazgo fuente: `docs/plans/sp6/PLAN-SP6.md` — UI-ORG-05
+- Fuente UX consultada:
+  - `docs/design/ux/wireframes-organizador.md`
+  - `docs/design/ux/prototipos/prototipo-organizador.html`
+  - `docs/design/ux/README.md`
+- Componentes afectados:
+  - `frontend/src/components/organizador/TablaDisciplinaResultados.tsx`
+  - `frontend/src/components/organizador/FilaResultado.tsx`
+  - `frontend/src/pages/organizador/ResultadosPage.tsx`
+
+La US es frontend puro. Por instrucción operativa del usuario, se omiten Fase 1 y Fase 6 de BDD. La validación se hará con build/lint de frontend y revisión manual del comportamiento.
+
+---
+
+## Hallazgos de Fase 0
+
+- `TablaDisciplinaResultados` tiene helper `formatearLinea` que convierte `1 → A`, `2 → B`.
+- `TablaDisciplinaResultados` renderiza header `AP`.
+- `TablaDisciplinaResultados` renderiza header `Pts FAAS`.
+- La celda de puntos FAAS se renderiza en `FilaResultado`.
+- `ResultadosPage` contiene copy visible: `Tabla de ejecucion ordenada por OT con AP, RP, tarjeta y puntos FAAS.`
+- La spec `US-6.2.3` no incluye el campo obligatorio `## Fuente de verdad UX` definido por `WORKFLOW-DESARROLLO.md` para US que tocan `frontend/`.
+
+---
+
+## Tareas
+
+### 1. Implementación UI — TablaDisciplinaResultados (15 min)
+
+- [x] Reemplazar `formatearLinea` por `formatearAndarivel`.
+- [x] Mostrar andarivel numérico literal.
+- [x] Mostrar `—` si el andarivel es `null`, `undefined` o `0`.
+- [x] Cambiar header `AP` por `Anuncio`.
+- [x] Eliminar header `Pts FAAS`.
+- [x] Mantener el campo `puntos` en DTO/API; no tocar API ni queries.
+
+### 2. Implementación UI — FilaResultado (5 min)
+
+- [x] Eliminar render de celda `puntosDisplay`.
+- [x] Mantener el resto de columnas alineado con la tabla.
+- [x] No modificar `rp`, `tarjeta` ni formato de anuncio.
+
+### 3. Copy de ResultadosPage (5 min)
+
+- [x] Cambiar copy visible para no mencionar `AP` ni `puntos FAAS`.
+- [x] Usar lenguaje de organizador: `Anuncio`, `RP`, `tarjeta` y `andarivel`.
+
+### 4. Ajuste documental mínimo de la spec (5 min)
+
+- [x] Agregar `## Fuente de verdad UX` a `docs/specs/sp6/US-6.2.3.md`.
+- [x] Referenciar wireframes, prototipo, PLAN-SP6 y componentes React comparados.
+
+### 5. Validación frontend (10 min)
+
+- [x] Ejecutar `cd frontend && npm run build`.
+- [x] Ejecutar ESLint focalizado sobre los archivos modificados.
+- [x] Ejecutar `cd frontend && npm run lint` para registrar estado global.
+- [x] Verificar que no se tocaron archivos de backend.
+
+### 6. Cierre de US (5 min)
+
+- [x] Actualizar estado de `US-6.2.3` de `Pending` a `Done` si la validación pasa.
+- [x] Generar `docs/reports/US-6.2.3-report.md`.
+- [x] Cerrar tracker de `US-6.2.3`.
+- [ ] Commit atómico con referencia `[US-6.2.3]`.
+
+---
+
+## Validación Esperada
+
+- La tabla de resultados no muestra columna `Pts FAAS`.
+- El andarivel `1` se muestra como `1`, no `A`.
+- Andarivel faltante o `0` se muestra como `—`.
+- La columna de marca anunciada dice `Anuncio`.
+- El copy visible no menciona puntos FAAS.
+- Sin cambios en backend ni contratos API.
+
+---
+
+## Riesgos
+
+- `GrillaAtletaDto.andarivel` parece tipado como número obligatorio en el frontend, pero la spec pide manejar `null`/`undefined`; el helper aceptará esos casos para robustez sin cambiar tipos de API.
+- `FilaResultadoData.puntos` puede quedar como dato interno no renderizado. Si TypeScript marca dato no usado, se eliminará solo de la fila de presentación, no de DTOs ni queries.
+
+---
+
+## Resultado de Validación
+
+- `npm run build`: OK.
+- `./node_modules/.bin/eslint src/components/organizador/TablaDisciplinaResultados.tsx src/components/organizador/FilaResultado.tsx src/pages/organizador/ResultadosPage.tsx`: OK.
+- `npm run lint`: falla por hallazgo preexistente fuera de alcance en `frontend/src/pages/juez/GrillaPage.tsx` y warning en `frontend/src/components/organizador/JuecesPanel.tsx`.
+
+---
+
+## Lecciones Aprendidas
+
+- La columna FAAS estaba dividida entre header (`TablaDisciplinaResultados`) y celda (`FilaResultado`), por lo que la implementación debía tocar ambos componentes para mantener alineación de columnas.
+- El copy de página también forma parte del criterio de claridad operativa; dejar `puntos FAAS` en texto visible hubiera contradicho el objetivo de la US aunque la tabla estuviera corregida.

--- a/docs/reports/US-6.2.3-report.md
+++ b/docs/reports/US-6.2.3-report.md
@@ -1,0 +1,74 @@
+# Reporte de Implementación — US-6.2.3
+
+**US:** US-6.2.3 — Resultados: quitar PTS FAAS + andarivel numérico + AP como Anuncio  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature/US-6.2.3-resultados-anuncio-andarivel`  
+**Estado:** Completado  
+**Fecha:** 2026-05-05  
+
+---
+
+## Resumen
+
+Se implementó el ajuste UI-ORG-05 para la tabla de resultados del organizador. La vista ya no muestra puntuación FAAS en la tabla de ejecución, el andarivel se presenta como número literal y la columna de marca anunciada usa lenguaje operativo (`Anuncio`) en lugar de la sigla interna `AP`.
+
+La US es frontend puro. Por instrucción operativa, se omitieron las fases BDD y se validó con build/lint de frontend.
+
+---
+
+## Componentes Implementados
+
+- `frontend/src/components/organizador/TablaDisciplinaResultados.tsx`
+  - `formatearLinea` fue reemplazado por `formatearAndarivel`.
+  - El andarivel se muestra como número literal.
+  - Andarivel `null`, `undefined` o `0` se muestra como `—`.
+  - Header `AP` reemplazado por `Anuncio`.
+  - Header `Pts FAAS` eliminado.
+- `frontend/src/components/organizador/FilaResultado.tsx`
+  - Celda de puntos FAAS eliminada.
+  - Columnas restantes mantienen alineación con el header.
+- `frontend/src/pages/organizador/ResultadosPage.tsx`
+  - Copy visible actualizado para no mencionar `AP` ni `puntos FAAS`.
+
+---
+
+## Documentación Actualizada
+
+- `docs/specs/sp6/US-6.2.3.md`
+  - Estado actualizado a `Done`.
+  - Agregada sección `Fuente de verdad UX`, requerida por `WORKFLOW-DESARROLLO.md` para US frontend.
+- `docs/plans/sp6/US-6.2.3-plan.md`
+  - Plan de Fase 2 creado y actualizado con tareas completadas.
+- `docs/reports/US-6.2.3-report.md`
+  - Reporte final de implementación.
+- `.claude/tracking/US-6.2.3-tracking.json`
+  - Tracking de fases y tareas de la US.
+
+---
+
+## Validación
+
+| Comando | Resultado | Observación |
+|---|---:|---|
+| `npm run build` | OK | TypeScript + Vite + PWA build pasan. |
+| `./node_modules/.bin/eslint src/components/organizador/TablaDisciplinaResultados.tsx src/components/organizador/FilaResultado.tsx src/pages/organizador/ResultadosPage.tsx` | OK | Los archivos modificados no introducen problemas de lint. |
+| `npm run lint` | Falla | Bloqueado por hallazgo preexistente en `frontend/src/pages/juez/GrillaPage.tsx` y warning en `JuecesPanel.tsx`, fuera de esta US. |
+
+---
+
+## Criterios de Aceptación
+
+- [x] No existe columna visible `Pts FAAS` en la tabla de resultados.
+- [x] Andarivel `1` se muestra como `1`, no `A`.
+- [x] Andarivel faltante o `0` se muestra como `—`.
+- [x] Header de marca anunciada muestra `Anuncio`.
+- [x] Copy visible no menciona puntos FAAS.
+- [x] Sin cambios en backend ni contratos API.
+
+---
+
+## Notas
+
+El dato de puntos/ranking puede seguir existiendo en DTOs o queries, pero dejó de formar parte de la tabla de ejecución del organizador según el alcance de la US.
+

--- a/docs/specs/sp6/US-6.2.3.md
+++ b/docs/specs/sp6/US-6.2.3.md
@@ -1,6 +1,6 @@
 # US-6.2.3: Resultados — Quitar PTS FAAS + Andarivel Numérico + AP → Anuncio
 
-**Estado**: `Pending`  
+**Estado**: `Done`
 **Incremento**: INC-6.2 — Ajustes Organizador  
 **Hallazgos**: UI-ORG-05  
 **Bounded Context**: `frontend`  
@@ -28,6 +28,13 @@ Hallazgos concretos en el código:
 - Columna AP sin renombrar (aplica igual que UI-ORG-04 en grilla)
 
 El hallazgo "Podios y Overall → mover a página propia" está cubierto por **US-6.2.6**.
+
+## Fuente de verdad UX
+
+- `docs/design/ux/wireframes-organizador.md` — estructura de la vista de resultados y ranking del portal organizador.
+- `docs/design/ux/prototipos/prototipo-organizador.html` — prototipo navegable aprobado para el rol organizador.
+- `docs/plans/sp6/PLAN-SP6.md` — hallazgo UI-ORG-05 detectado en validación SP5.
+- `frontend/src/components/organizador/TablaDisciplinaResultados.tsx`, `FilaResultado.tsx` y `frontend/src/pages/organizador/ResultadosPage.tsx` — implementación React actual comparada contra el hallazgo.
 
 ---
 

--- a/frontend/src/components/organizador/FilaResultado.tsx
+++ b/frontend/src/components/organizador/FilaResultado.tsx
@@ -11,7 +11,6 @@ export interface FilaResultadoData {
   rp: string | null
   unidad: string | null
   tarjeta: string | null
-  puntos: string | null
 }
 
 interface FilaResultadoProps {
@@ -68,7 +67,6 @@ function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
 
 export function FilaResultado({ fila }: FilaResultadoProps) {
   const rpDisplay = fila.rp ? `${fila.rp} ${fila.unidad ?? ''}`.trim() : '—'
-  const puntosDisplay = fila.puntos ?? '—'
 
   return (
     <tr className="border-b border-slate-800 text-sm transition hover:bg-slate-800/60">
@@ -85,9 +83,6 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
       <td className="px-3 py-3 font-mono font-semibold text-white">{rpDisplay}</td>
       <td className="px-3 py-3">
         <ChipTarjeta tarjeta={fila.tarjeta} />
-      </td>
-      <td className="px-3 py-3 text-right font-mono font-bold text-sky-300">
-        {puntosDisplay}
       </td>
     </tr>
   )

--- a/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
+++ b/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
@@ -22,8 +22,9 @@ function derivarCategoriaCorta(categoria: string): string {
   return categoria.split('_')[0] ?? categoria
 }
 
-function formatearLinea(andarivel: number): string {
-  return andarivel === 1 ? 'A' : andarivel === 2 ? 'B' : String(andarivel)
+function formatearAndarivel(andarivel: number | null | undefined): string {
+  if (!andarivel) return '—'
+  return String(andarivel)
 }
 
 export function TablaDisciplinaResultados({
@@ -34,7 +35,7 @@ export function TablaDisciplinaResultados({
   const filas = useMemo<FilaResultadoData[]>(() => {
     const rankingPorAtleta = new Map<
       string,
-      { rp: string | null; unidad: string | null; tarjeta: string | null; puntos: string | null; categoria: string }
+      { rp: string | null; unidad: string | null; tarjeta: string | null; categoria: string }
     >()
 
     if (ranking) {
@@ -44,7 +45,6 @@ export function TablaDisciplinaResultados({
             rp: entrada.rp,
             unidad: entrada.unidad,
             tarjeta: entrada.es_dns ? 'DNS' : (entrada.tarjeta ?? null),
-            puntos: entrada.puntos ?? null,
             categoria: grupo.categoria,
           })
         }
@@ -75,11 +75,10 @@ export function TablaDisciplinaResultados({
           club: inscriptoData?.club ?? '',
           ap: `${atleta.ap_declarado} ${atleta.unidad}`.trim(),
           ot: atleta.ot_programado,
-          linea: formatearLinea(atleta.andarivel),
+          linea: formatearAndarivel(atleta.andarivel),
           rp: rankData?.rp ?? null,
           unidad: rankData?.unidad ?? atleta.unidad,
           tarjeta: rankData?.tarjeta ?? null,
-          puntos: rankData?.puntos ?? null,
         }
       })
   }, [grilla, ranking, inscriptos])
@@ -102,12 +101,11 @@ export function TablaDisciplinaResultados({
             <th className="px-3 py-2 text-center">Gén.</th>
             <th className="px-3 py-2">Categoría</th>
             <th className="px-3 py-2">Club</th>
-            <th className="px-3 py-2">AP</th>
+            <th className="px-3 py-2">Anuncio</th>
             <th className="px-3 py-2">OT</th>
             <th className="px-3 py-2 text-center">Línea</th>
             <th className="px-3 py-2">RP</th>
             <th className="px-3 py-2">Tarjeta</th>
-            <th className="px-3 py-2 text-right">Pts FAAS</th>
           </tr>
         </thead>
         <tbody className="bg-slate-900/40">

--- a/frontend/src/pages/organizador/ResultadosPage.tsx
+++ b/frontend/src/pages/organizador/ResultadosPage.tsx
@@ -367,7 +367,7 @@ function ResultadosTorneo({ torneoId }: ResultadosTorneoProps) {
                   </p>
                   <h2 className="mt-2 text-2xl font-semibold text-white">{disciplinaActiva}</h2>
                   <p className="mt-2 text-sm text-slate-300">
-                    Tabla de ejecucion ordenada por OT con AP, RP, tarjeta y puntos FAAS.
+                    Tabla de ejecucion ordenada por OT con anuncio, RP, tarjeta y andarivel.
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.16em] text-slate-400">


### PR DESCRIPTION
## Resumen
- Quita la columna Pts FAAS de la tabla de resultados del organizador.
- Muestra andarivel numerico literal y guion para faltantes.
- Renombra AP a Anuncio y ajusta copy visible de Resultados.
- Agrega Fuente de verdad UX, plan, reporte y tracker cerrado de US-6.2.3.

## Validacion
- npm run build: OK
- ./node_modules/.bin/eslint src/components/organizador/TablaDisciplinaResultados.tsx src/components/organizador/FilaResultado.tsx src/pages/organizador/ResultadosPage.tsx: OK
- npm run lint global: falla por deuda previa fuera de alcance en GrillaPage.tsx/JuecesPanel.tsx