### PR TITLE
feat(frontend): simplificar panel torneo [US-6.2.4]

### DIFF
--- a/.claude/tracking/US-6.2.4-tracking.json
+++ b/.claude/tracking/US-6.2.4-tracking.json
@@ -1,0 +1,192 @@
+{
+  "metadata": {
+    "us_id": "US-6.2.4",
+    "us_title": "Panel torneo alertas y jueces simplificados",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-05T22:48:38.538419+00:00",
+    "completed_at": "2026-05-05T22:56:50.680463+00:00",
+    "total_elapsed_seconds": 492,
+    "effective_seconds": 492,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-05T22:48:43.679997+00:00",
+      "completed_at": "2026-05-05T22:50:12.392763+00:00",
+      "elapsed_seconds": 88,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Evaluación BDD",
+      "started_at": "2026-05-05T22:50:17.258536+00:00",
+      "completed_at": "2026-05-05T22:50:32.378318+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementación",
+      "started_at": "2026-05-05T22:50:35.573918+00:00",
+      "completed_at": "2026-05-05T22:51:14.172385+00:00",
+      "elapsed_seconds": 38,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-05T22:51:40.444267+00:00",
+      "completed_at": "2026-05-05T22:52:54.427332+00:00",
+      "elapsed_seconds": 73,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Quitar acciones Resolver de alertas",
+          "task_type": "frontend",
+          "estimated_minutes": 8.0,
+          "started_at": "2026-05-05T22:51:43.882373+00:00",
+          "completed_at": "2026-05-05T22:51:56.584211+00:00",
+          "elapsed_seconds": 12,
+          "actual_minutes": 0.2,
+          "variance_minutes": -7.8,
+          "file_created": "frontend/src/pages/organizador/DashboardOperativoPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Simplificar resumen de JuecesPanel",
+          "task_type": "frontend",
+          "estimated_minutes": 8.0,
+          "started_at": "2026-05-05T22:52:00.062386+00:00",
+          "completed_at": "2026-05-05T22:52:23.701497+00:00",
+          "elapsed_seconds": 23,
+          "actual_minutes": 0.38,
+          "variance_minutes": -7.62,
+          "file_created": "frontend/src/components/organizador/JuecesPanel.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Simplificar fila de TablaJueces",
+          "task_type": "frontend",
+          "estimated_minutes": 7.0,
+          "started_at": "2026-05-05T22:52:27.296752+00:00",
+          "completed_at": "2026-05-05T22:52:43.835396+00:00",
+          "elapsed_seconds": 16,
+          "actual_minutes": 0.27,
+          "variance_minutes": -6.73,
+          "file_created": "frontend/src/components/organizador/TablaJueces.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Validación frontend",
+      "started_at": "2026-05-05T22:52:59.170237+00:00",
+      "completed_at": "2026-05-05T22:54:26.070863+00:00",
+      "elapsed_seconds": 86,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_004",
+          "task_name": "Corregir warning focal de hook",
+          "task_type": "frontend",
+          "estimated_minutes": 4.0,
+          "started_at": "2026-05-05T22:53:51.899339+00:00",
+          "completed_at": "2026-05-05T22:53:59.714385+00:00",
+          "elapsed_seconds": 7,
+          "actual_minutes": 0.12,
+          "variance_minutes": -3.88,
+          "file_created": "frontend/src/components/organizador/JuecesPanel.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Integración no aplicable",
+      "started_at": "2026-05-05T22:54:31.812669+00:00",
+      "completed_at": "2026-05-05T22:54:35.113168+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "BDD waiver",
+      "started_at": "2026-05-05T22:54:39.698448+00:00",
+      "completed_at": "2026-05-05T22:54:42.975863+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality gates",
+      "started_at": "2026-05-05T22:54:47.081448+00:00",
+      "completed_at": "2026-05-05T22:55:03.239320+00:00",
+      "elapsed_seconds": 16,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-05T22:55:07.735344+00:00",
+      "completed_at": "2026-05-05T22:55:45.623442+00:00",
+      "elapsed_seconds": 37,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-05T22:56:15.031773+00:00",
+      "completed_at": "2026-05-05T22:56:47.066567+00:00",
+      "elapsed_seconds": 32,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 4,
+    "completed_tasks": 4,
+    "total_phases": 10,
+    "estimated_total_minutes": 27.0,
+    "actual_total_minutes": 0.97,
+    "variance_minutes": -26.03,
+    "variance_percent": -96.42
+  }
+}

--- a/docs/plans/sp6/US-6.2.4-plan.md
+++ b/docs/plans/sp6/US-6.2.4-plan.md
@@ -1,0 +1,110 @@
+# Plan de Implementación — US-6.2.4
+
+**US:** US-6.2.4 — Panel torneo: alertas sin Resolver + jueces simplificados  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature-US-6.2.4-panel-torneo`  
+**Estimación:** 35 min  
+**Estado:** Completado  
+**Fecha plan:** 2026-05-05  
+
+---
+
+## Contexto Validado
+
+- Spec fuente: `docs/specs/sp6/US-6.2.4.md`
+- Hallazgos fuente: `docs/plans/sp6/PLAN-SP6.md` — UI-ORG-02, UI-ORG-06
+- Fuente UX consultada:
+  - `docs/design/ux/wireframes-organizador.md`
+  - `docs/design/ux/prototipos/prototipo-organizador.html`
+- Componentes afectados:
+  - `frontend/src/pages/organizador/DashboardOperativoPage.tsx`
+  - `frontend/src/components/organizador/JuecesPanel.tsx`
+  - `frontend/src/components/organizador/TablaJueces.tsx`
+
+La US es frontend puro. Por evaluación de Fase 1 y regla operativa del usuario,
+se omiten BDD ejecutable y Fase 6. La validación se hará con build/lint de
+frontend y revisión manual del comportamiento.
+
+---
+
+## Hallazgos de Fase 0
+
+- `DashboardOperativoPage` renderiza `Resolver ->` en el encabezado de alertas activas.
+- `DashboardOperativoPage` renderiza `Resolver ->` dentro de cada alerta.
+- `JuecesPanel` renderiza tarjetas `Cobertura operativa` y `Estado de asignación`.
+- `TablaJueces` renderiza texto adicional bajo `JuezSelector` con `Pendiente`, `Guardando...` o el nombre del juez.
+- `TablaJueces` contiene helper `juezLabel` usado solo para ese texto adicional.
+- La spec original no incluía `## Fuente de verdad UX`; se corrigió en Fase 0.
+- La fila de juez vive en `TablaJueces.tsx`, no directamente en `JuecesPanel.tsx`; se corrigió la lista de archivos afectados.
+
+---
+
+## Tareas
+
+### 1. Implementación UI — DashboardOperativoPage (8 min)
+
+- [x] Eliminar el `Link`/acción `Resolver ->` del encabezado de alertas activas.
+- [x] Eliminar el texto `Resolver ->` dentro de cada alerta.
+- [x] Mantener las alertas visibles y navegables si el contenedor ya funciona como `Link`.
+- [x] No modificar cálculo ni fuente de datos de `alertas`.
+
+### 2. Implementación UI — JuecesPanel (8 min)
+
+- [x] Eliminar el bloque de resumen `Cobertura operativa`.
+- [x] Eliminar el bloque de resumen `Estado de asignación`.
+- [x] Mantener header, badge de asignación completa/pendiente, selector de disciplina y tabla.
+- [x] Eliminar variables derivadas que queden sin uso (`sinJuecesAsignados`) si TypeScript/ESLint lo exige.
+- [x] Corregir warning focal de hook envolviendo `disciplinas` en `useMemo`.
+
+### 3. Implementación UI — TablaJueces (7 min)
+
+- [x] Eliminar el texto adicional bajo `JuezSelector`.
+- [x] Mantener el selector habilitado/deshabilitado igual que antes.
+- [x] Mantener feedback de guardado sin reintroducir nombre duplicado; si hace falta feedback, usar `disabled` del selector existente.
+- [x] Eliminar helper `juezLabel` si queda sin uso.
+
+### 4. Validación frontend (8 min)
+
+- [x] Ejecutar `cd frontend && npm run build`.
+- [x] Ejecutar ESLint focalizado sobre:
+  - `src/pages/organizador/DashboardOperativoPage.tsx`
+  - `src/components/organizador/JuecesPanel.tsx`
+  - `src/components/organizador/TablaJueces.tsx`
+- [x] Ejecutar `cd frontend && npm run lint` para registrar estado global.
+- [x] Verificar que no se tocaron archivos de backend.
+
+### 5. Cierre documental (4 min)
+
+- [x] Actualizar estado de `US-6.2.4` de `Pending` a `Done` si la validación pasa.
+- [x] Generar `docs/reports/US-6.2.4-report.md`.
+- [ ] Cerrar tracker de `US-6.2.4`.
+- [ ] Commit atómico con referencia `[US-6.2.4]`.
+
+---
+
+## Validación Esperada
+
+- El panel de alertas no muestra ningún texto visible `Resolver`.
+- Las alertas siguen mostrando atleta, disciplina y descripción.
+- `JuecesPanel` ya no muestra `Cobertura operativa` ni `Estado de asignación`.
+- Cada fila de asignación muestra el `JuezSelector` sin nombre/texto duplicado debajo.
+- La asignación de juez sigue invocando `onAsignar(row, juezId)`.
+- Sin cambios en backend ni contratos API.
+
+---
+
+## Riesgos
+
+- Si se elimina todo feedback textual bajo el selector, durante el guardado el usuario solo verá el selector deshabilitado. Es aceptable para el alcance de la US porque el objetivo explícito es dejar solo el selector.
+- El encabezado de alertas quedará sin CTA global. Esto coincide con el hallazgo: el organizador no resuelve esas alertas desde ese rol.
+
+---
+
+## Resultado de Validación
+
+- `npm run build`: OK.
+- `./node_modules/.bin/eslint src/pages/organizador/DashboardOperativoPage.tsx src/components/organizador/JuecesPanel.tsx src/components/organizador/TablaJueces.tsx`: OK.
+- `npm run lint`: falla por hallazgo preexistente fuera de alcance en `frontend/src/pages/juez/GrillaPage.tsx`.
+- Revisión textual focal: sin `Resolver ->`, `Cobertura operativa`, `Estado de asignación`, `juezLabel`, `Pendiente` ni `Guardando...` visibles en los componentes objetivo.
+- `git diff --check`: OK.

--- a/docs/reports/US-6.2.4-bdd-waiver.md
+++ b/docs/reports/US-6.2.4-bdd-waiver.md
@@ -1,0 +1,36 @@
+# Waiver BDD — US-6.2.4
+## Panel torneo: alertas limpias y jueces simplificados
+
+**Fecha:** `2026-05-05`  
+**Decisión:** `BDD no ejecutable para frontend puro`
+
+## Justificación
+
+`US-6.2.4` modifica exclusivamente presentación React en el portal organizador:
+
+- elimina acciones visibles `Resolver ->` que no corresponden al rol organizador;
+- elimina tarjetas de resumen redundantes del panel de jueces;
+- elimina texto adicional junto al selector de juez.
+
+No introduce reglas de dominio, endpoints, persistencia, contratos API ni comportamiento en `src/`.
+El repositorio no cuenta hoy con harness automatizado de UI React (`vitest`,
+`playwright` o equivalente) ni con steps BDD reutilizables para navegación del
+portal organizador. Crear esa infraestructura en esta US desviaría el alcance
+hacia una plataforma de testing frontend transversal.
+
+## Validación sustitutiva
+
+- `npm run build` en `frontend/`.
+- ESLint focalizado sobre archivos modificados.
+- `npm run lint` global para registrar estado del frontend.
+- Revisión manual de ausencia de textos:
+  - `Resolver ->`
+  - `Cobertura operativa`
+  - `Estado de asignación`
+- Revisión manual de que el selector de juez conserva la asignación.
+
+## Alcance del waiver
+
+- Se omite la creación de `.feature` y steps para esta US.
+- Se omite Fase 6 de validación BDD ejecutable.
+- No exime Fase 2, implementación, validación frontend, documentación ni reporte final.

--- a/docs/reports/US-6.2.4-report.md
+++ b/docs/reports/US-6.2.4-report.md
@@ -1,0 +1,70 @@
+# Reporte de Implementación — US-6.2.4
+
+**US:** US-6.2.4 — Panel torneo: alertas sin Resolver + jueces simplificados  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** frontend  
+**Branch:** `feature-US-6.2.4-panel-torneo`  
+**Fecha:** 2026-05-05  
+
+---
+
+## Resumen
+
+Se simplificó el panel operativo del organizador eliminando acciones visibles que
+no correspondían al rol y quitando información redundante del panel de jueces.
+La asignación de jueces conserva el selector y el flujo de guardado existente.
+
+---
+
+## Cambios Implementados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/pages/organizador/DashboardOperativoPage.tsx` | Eliminado `Resolver ->` del encabezado y de cada alerta activa |
+| `frontend/src/components/organizador/JuecesPanel.tsx` | Eliminadas secciones `Cobertura operativa` y `Estado de asignación`; corregido warning focal de hook |
+| `frontend/src/components/organizador/TablaJueces.tsx` | Eliminado texto adicional bajo `JuezSelector` y helper `juezLabel` |
+| `docs/specs/sp6/US-6.2.4.md` | Agregada fuente UX obligatoria y estado `Done` |
+| `docs/plans/sp6/US-6.2.4-plan.md` | Plan y resultados de validación documentados |
+| `docs/reports/US-6.2.4-bdd-waiver.md` | Waiver BDD por frontend puro sin harness UI automatizado |
+
+---
+
+## BDD
+
+No se generó ni ejecutó BDD para esta US.
+
+Justificación: `US-6.2.4` es frontend puro, no toca `src/`, contratos API,
+persistencia ni reglas de dominio. El repo no tiene harness UI automatizado para
+React. La decisión queda documentada en `docs/reports/US-6.2.4-bdd-waiver.md`.
+
+---
+
+## Validación
+
+| Gate | Resultado |
+|---|---|
+| `cd frontend && npm run build` | OK |
+| ESLint focal sobre archivos modificados | OK |
+| `cd frontend && npm run lint` | Falla por hallazgo preexistente en `frontend/src/pages/juez/GrillaPage.tsx` |
+| Revisión textual focal | OK |
+| `git diff --check` | OK |
+
+La revisión textual focal confirmó ausencia de `Resolver ->`, `Cobertura operativa`,
+`Estado de asignación`, `juezLabel`, `Pendiente` y `Guardando...` en los
+componentes objetivo.
+
+---
+
+## Alcance No Modificado
+
+- No se modificaron endpoints ni contratos API.
+- No se modificaron módulos backend bajo `src/`.
+- No se modificó la lógica de asignación de juez: el selector sigue llamando a
+  `onAsignar(row, juezId)`.
+- No se cerró el hallazgo global preexistente de `GrillaPage.tsx`.
+
+---
+
+## Resultado
+
+`US-6.2.4` queda implementada y validada para el alcance definido.

--- a/docs/specs/sp6/README.md
+++ b/docs/specs/sp6/README.md
@@ -31,7 +31,7 @@ Foco: **corregir UX del portal organizador** — torneos ordenados, columnas ren
 | [US-6.2.1](./US-6.2.1.md) | Inicio: Ordenar Torneos por Fecha + Mostrar Fecha | UI-ORG-01 | Pending |
 | [US-6.2.2](./US-6.2.2.md) | Inscriptos + Grilla: Categoría Legible + AP → Anuncios | UI-ORG-03 · UI-ORG-04 | Pending |
 | [US-6.2.3](./US-6.2.3.md) | Resultados: Quitar PTS FAAS + Andarivel Numérico + AP → Anuncio | UI-ORG-05 | Pending |
-| [US-6.2.4](./US-6.2.4.md) | Panel Torneo: Alertas sin "Resolver" + Jueces sin Texto Nombre | UI-ORG-02 · UI-ORG-06 | Pending |
+| [US-6.2.4](./US-6.2.4.md) | Panel Torneo: Alertas sin "Resolver" + Jueces sin Texto Nombre | UI-ORG-02 · UI-ORG-06 | Done |
 | [US-6.2.5](./US-6.2.5.md) | Nuevo Torneo: Selección Categorías JUNIOR/SENIOR/MASTER | UI-ORG-07 | Pending |
 | [US-6.2.6](./US-6.2.6.md) | Crear Página de Podios | UI-ORG-08 | Pending |
 

--- a/docs/specs/sp6/US-6.2.4.md
+++ b/docs/specs/sp6/US-6.2.4.md
@@ -1,10 +1,10 @@
 # US-6.2.4: Panel Torneo — Alertas sin "Resolver" + Jueces sin Texto Nombre
 
-**Estado**: `Pending`  
+**Estado**: `Done`
 **Incremento**: INC-6.2 — Ajustes Organizador  
 **Hallazgos**: UI-ORG-02 · UI-ORG-06  
 **Bounded Context**: `frontend`  
-**Capas afectadas**: `frontend/pages/organizador/DashboardOperativoPage.tsx`, `frontend/components/organizador/JuecesPanel.tsx`
+**Capas afectadas**: `frontend/pages/organizador/DashboardOperativoPage.tsx`, `frontend/components/organizador/JuecesPanel.tsx`, `frontend/components/organizador/TablaJueces.tsx`
 
 ---
 
@@ -29,6 +29,15 @@ El panel de alertas activas muestra un botón/texto `Resolver →` junto a cada 
 **Ubicación**: `frontend/src/components/organizador/JuecesPanel.tsx`
 
 El panel muestra dos secciones de resumen ("Cobertura Operativa" y "Estado de Asignación") que no aportan valor al organizador en el contexto de validación SP5. Además, en cada fila de la tabla de asignación de juez, se muestra el nombre del juez como texto adicional junto al selector — lo que duplica información ya visible en el selector mismo.
+
+---
+
+## Fuente de verdad UX
+
+- `docs/design/ux/wireframes-organizador.md` — estructura aprobada del portal organizador, incluyendo alertas y flujos de revisión.
+- `docs/design/ux/prototipos/prototipo-organizador.html` — prototipo navegable aprobado para el rol organizador.
+- `docs/plans/sp6/PLAN-SP6.md` — hallazgos UI-ORG-02 y UI-ORG-06 detectados en validación SP5.
+- `frontend/src/pages/organizador/DashboardOperativoPage.tsx`, `frontend/src/components/organizador/JuecesPanel.tsx` y `frontend/src/components/organizador/TablaJueces.tsx` — implementación React actual comparada contra los hallazgos.
 
 ---
 

--- a/frontend/src/components/organizador/JuecesPanel.tsx
+++ b/frontend/src/components/organizador/JuecesPanel.tsx
@@ -76,7 +76,7 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
       })) ?? [],
   })
 
-  const disciplinas = disciplinasQuery.data ?? []
+  const disciplinas = useMemo(() => disciplinasQuery.data ?? [], [disciplinasQuery.data])
   const jueces = useMemo(
     () => (juecesQuery.data ?? []).filter((usuario) => usuario.rol === 'JUEZ' && usuario.activo),
     [juecesQuery.data],
@@ -123,7 +123,6 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
     disciplinasConGrilla === disciplinas.length &&
     totalPerformances > 0 &&
     performancesAsignadas === totalPerformances
-  const sinJuecesAsignados = totalPerformances > 0 && performancesAsignadas === 0
   const hayCompetenciasOperativas = (competenciasQuery.data?.length ?? 0) > 0
   const disciplinasPendientesDeGrilla = useMemo(() => {
     const competenciasPorDisciplina = new Map(
@@ -216,32 +215,6 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
           >
             {todasAsignadas ? 'Asignación completa' : 'Asignación pendiente'}
           </span>
-        </div>
-
-        <div className="mt-6 grid gap-4 md:grid-cols-2">
-          <div className="rounded-[1.5rem] border border-slate-700 bg-slate-950/70 p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-              Cobertura operativa
-            </p>
-            <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
-              {performancesAsignadas}/{totalPerformances || 0}
-            </p>
-            <p className="mt-2 text-sm text-slate-300">
-              performances con juez · {jueces.length} jueces disponibles
-            </p>
-          </div>
-
-          <div className="rounded-[1.5rem] border border-slate-700 bg-slate-950/70 p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-              Estado de asignación
-            </p>
-            <p className="mt-3 text-lg font-semibold text-white">
-              {sinJuecesAsignados ? 'Todavía no hay jueces asignados' : 'Asignaciones en curso'}
-            </p>
-            <p className="mt-2 text-sm text-slate-300">
-              La asignación se hace por performance una vez que la disciplina ya tiene grilla confirmada.
-            </p>
-          </div>
         </div>
 
         {disciplinasPendientesDeGrilla.length > 0 ? (

--- a/frontend/src/components/organizador/TablaJueces.tsx
+++ b/frontend/src/components/organizador/TablaJueces.tsx
@@ -24,13 +24,6 @@ interface TablaJuecesProps {
   onAsignar: (row: FilaJuezPerformance, juezId: string) => void
 }
 
-function juezLabel(jueces: UsuarioDto[], juezId: string | null) {
-  if (!juezId) return 'Sin juez asignado'
-  const juez = jueces.find((item) => item.usuario_id === juezId)
-  if (!juez) return 'Juez no encontrado'
-  return [juez.nombre, juez.apellido].filter(Boolean).join(' ').trim() || juez.email
-}
-
 function formatOt(value: string) {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
@@ -97,21 +90,12 @@ export function TablaJueces({
                     {formatMarca(row.apDeclarado, row.unidad)}
                   </td>
                   <td className="min-w-64 px-4 py-3">
-                    <div className="space-y-2">
-                      <JuezSelector
-                        jueces={jueces}
-                        value={row.juezId}
-                        disabled={saving || jueces.length === 0}
-                        onChange={(juezId) => onAsignar(row, juezId)}
-                      />
-                      <p className="text-xs text-slate-400">
-                        {saving
-                          ? 'Guardando...'
-                          : row.juezId
-                            ? juezLabel(jueces, row.juezId)
-                            : 'Pendiente'}
-                      </p>
-                    </div>
+                    <JuezSelector
+                      jueces={jueces}
+                      value={row.juezId}
+                      disabled={saving || jueces.length === 0}
+                      onChange={(juezId) => onAsignar(row, juezId)}
+                    />
                   </td>
                 </tr>
               )

--- a/frontend/src/pages/organizador/DashboardOperativoPage.tsx
+++ b/frontend/src/pages/organizador/DashboardOperativoPage.tsx
@@ -554,12 +554,6 @@ function DashboardOperativoContent({ torneoId }: { torneoId: string }) {
                     </p>
                     <h3 className="mt-2 text-xl font-semibold text-white">Operacion en revision</h3>
                   </div>
-                  <Link
-                    to={`/organizador/grilla?torneo_id=${torneoId}`}
-                    className="text-sm font-semibold text-sky-300"
-                  >
-                    Resolver →
-                  </Link>
                 </div>
 
                 <div className="mt-4 space-y-3">
@@ -574,7 +568,6 @@ function DashboardOperativoContent({ torneoId }: { torneoId: string }) {
                           {alerta.atleta} · {alerta.disciplina}
                         </p>
                         <p className="mt-2 text-sm text-amber-50/90">{alerta.descripcion}</p>
-                        <p className="mt-3 text-sm font-semibold text-amber-200">Resolver →</p>
                       </Link>
                     ))
                   ) : (


### PR DESCRIPTION
## Resumen
- Quita las acciones visibles "Resolver" del panel de alertas del organizador.
- Elimina resúmenes redundantes del panel de jueces.
- Deja cada fila de jueces con solo el selector y documenta waiver BDD para frontend puro.

## Validación
- cd frontend && npm run build: OK
- ESLint focal sobre DashboardOperativoPage, JuecesPanel y TablaJueces: OK
- npm run lint: falla por hallazgo preexistente fuera de alcance en frontend/src/pages/juez/GrillaPage.tsx
- git diff --check: OK