### PR TITLE
feat(torneo): grupos etarios al crear torneo [US-6.2.5]

### DIFF
--- a/.claude/tracking/US-6.2.5-tracking.json
+++ b/.claude/tracking/US-6.2.5-tracking.json
@@ -1,0 +1,288 @@
+{
+  "metadata": {
+    "us_id": "US-6.2.5",
+    "us_title": "Nuevo torneo con grupos etarios",
+    "us_points": 3,
+    "producto": "torneo",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-06T09:35:24.068171+00:00",
+    "completed_at": "2026-05-06T10:03:18.283814+00:00",
+    "total_elapsed_seconds": 1674,
+    "effective_seconds": 1674,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-06T09:35:34.665189+00:00",
+      "completed_at": "2026-05-06T09:36:56.608804+00:00",
+      "elapsed_seconds": 81,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación BDD",
+      "started_at": "2026-05-06T09:37:23.343345+00:00",
+      "completed_at": "2026-05-06T09:37:52.088178+00:00",
+      "elapsed_seconds": 28,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementación",
+      "started_at": "2026-05-06T09:37:59.683164+00:00",
+      "completed_at": "2026-05-06T09:38:41.215319+00:00",
+      "elapsed_seconds": 41,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-06T09:40:38.685959+00:00",
+      "completed_at": "2026-05-06T09:57:04.712249+00:00",
+      "elapsed_seconds": 986,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_001",
+          "task_name": "Implementar GrupoEtario en dominio",
+          "task_type": "domain",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-06T09:40:52.720449+00:00",
+          "completed_at": "2026-05-06T09:41:21.852378+00:00",
+          "elapsed_seconds": 29,
+          "actual_minutes": 0.48,
+          "variance_minutes": -14.52,
+          "file_created": "src/torneo/domain/value_objects/grupo_etario.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_002",
+          "task_name": "Actualizar API y command torneo",
+          "task_type": "api",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-06T09:41:26.849445+00:00",
+          "completed_at": "2026-05-06T09:41:54.549999+00:00",
+          "elapsed_seconds": 27,
+          "actual_minutes": 0.45,
+          "variance_minutes": -14.55,
+          "file_created": "src/torneo/api/router.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_003",
+          "task_name": "Persistir grupos etarios SQLite",
+          "task_type": "infrastructure",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-06T09:42:00.763935+00:00",
+          "completed_at": "2026-05-06T09:42:28.658842+00:00",
+          "elapsed_seconds": 27,
+          "actual_minutes": 0.45,
+          "variance_minutes": -14.55,
+          "file_created": "src/torneo/infrastructure/repositories/sqlite_torneo_repository.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_004",
+          "task_name": "Implementar selector frontend",
+          "task_type": "frontend",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-06T09:42:47.384281+00:00",
+          "completed_at": "2026-05-06T09:43:38.781209+00:00",
+          "elapsed_seconds": 51,
+          "actual_minutes": 0.85,
+          "variance_minutes": -14.15,
+          "file_created": "frontend/src/pages/organizador/CrearTorneoPage.tsx",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_005",
+          "task_name": "Actualizar tests y BDD",
+          "task_type": "test",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-05-06T09:43:49.456708+00:00",
+          "completed_at": "2026-05-06T09:56:58.606841+00:00",
+          "elapsed_seconds": 789,
+          "actual_minutes": 13.15,
+          "variance_minutes": -11.85,
+          "file_created": "tests/features/steps/grupos_etarios_torneo_steps.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-05-06T09:57:46.750295+00:00",
+      "completed_at": "2026-05-06T09:58:05.272801+00:00",
+      "elapsed_seconds": 18,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_006",
+          "task_name": "Ejecutar tests unitarios torneo",
+          "task_type": "test",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-06T09:57:53.855670+00:00",
+          "completed_at": "2026-05-06T09:57:59.516002+00:00",
+          "elapsed_seconds": 5,
+          "actual_minutes": 0.08,
+          "variance_minutes": -4.92,
+          "file_created": "tests/unit/torneo/domain/test_torneo.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-05-06T09:58:09.566544+00:00",
+      "completed_at": "2026-05-06T09:58:22.783561+00:00",
+      "elapsed_seconds": 13,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_007",
+          "task_name": "Ejecutar tests integración torneo",
+          "task_type": "test",
+          "estimated_minutes": 10.0,
+          "started_at": "2026-05-06T09:58:14.038681+00:00",
+          "completed_at": "2026-05-06T09:58:18.758571+00:00",
+          "elapsed_seconds": 4,
+          "actual_minutes": 0.07,
+          "variance_minutes": -9.93,
+          "file_created": "tests/integration/torneo/test_grupos_etarios_api.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-05-06T09:58:27.567029+00:00",
+      "completed_at": "2026-05-06T09:58:44.709670+00:00",
+      "elapsed_seconds": 17,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_008",
+          "task_name": "Ejecutar BDD US-6.2.5",
+          "task_type": "test",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-06T09:58:32.885244+00:00",
+          "completed_at": "2026-05-06T09:58:38.648154+00:00",
+          "elapsed_seconds": 5,
+          "actual_minutes": 0.08,
+          "variance_minutes": -4.92,
+          "file_created": "tests/features/steps/grupos_etarios_torneo_steps.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-06T09:58:49.033461+00:00",
+      "completed_at": "2026-05-06T09:59:07.999155+00:00",
+      "elapsed_seconds": 18,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_009",
+          "task_name": "Ejecutar build lint y diff check",
+          "task_type": "quality",
+          "estimated_minutes": 10.0,
+          "started_at": "2026-05-06T09:58:54.261782+00:00",
+          "completed_at": "2026-05-06T09:59:03.662805+00:00",
+          "elapsed_seconds": 9,
+          "actual_minutes": 0.15,
+          "variance_minutes": -9.85,
+          "file_created": "frontend/src/pages/organizador/CrearTorneoPage.tsx",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-06T09:59:21.532077+00:00",
+      "completed_at": "2026-05-06T10:02:00.233314+00:00",
+      "elapsed_seconds": 158,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_010",
+          "task_name": "Actualizar documentación US",
+          "task_type": "documentation",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-06T09:59:30.001778+00:00",
+          "completed_at": "2026-05-06T10:01:53.189051+00:00",
+          "elapsed_seconds": 143,
+          "actual_minutes": 2.38,
+          "variance_minutes": -2.62,
+          "file_created": "docs/specs/sp6/US-6.2.5.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-06T10:02:38.343675+00:00",
+      "completed_at": "2026-05-06T10:03:14.735153+00:00",
+      "elapsed_seconds": 36,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_011",
+          "task_name": "Generar reporte final",
+          "task_type": "documentation",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-06T10:02:43.773829+00:00",
+          "completed_at": "2026-05-06T10:03:08.292895+00:00",
+          "elapsed_seconds": 24,
+          "actual_minutes": 0.4,
+          "variance_minutes": -4.6,
+          "file_created": "docs/reports/US-6.2.5-report.md",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 11,
+    "completed_tasks": 11,
+    "total_phases": 10,
+    "estimated_total_minutes": 125.0,
+    "actual_total_minutes": 18.55,
+    "variance_minutes": -106.45,
+    "variance_percent": -85.16
+  }
+}

--- a/docs/plans/sp6/US-6.2.5-plan.md
+++ b/docs/plans/sp6/US-6.2.5-plan.md
@@ -1,0 +1,135 @@
+# Plan de Implementación — US-6.2.5
+
+**US:** US-6.2.5 — Nuevo torneo: selección de grupos etarios  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** torneo + frontend  
+**Branch:** `feature-US-6.2.5-grupos-etarios`  
+**Estimación:** 85 min  
+**Estado:** Implementado — pendiente de Fase 9  
+**Fecha plan:** 2026-05-06  
+
+---
+
+## Contexto Validado
+
+- Spec fuente: `docs/specs/sp6/US-6.2.5.md`
+- Hallazgo fuente: `docs/plans/sp6/PLAN-SP6.md` — UI-ORG-07
+- Fuente UX consultada:
+  - `docs/design/ux/wireframes-organizador.md`
+  - `docs/design/ux/prototipos/prototipo-organizador.html`
+- Feature BDD creada:
+  - `tests/features/US-6.2.5-grupos-etarios-torneo.feature`
+- Componentes afectados:
+  - `src/torneo/domain/value_objects/`
+  - `src/torneo/domain/aggregates/torneo.py`
+  - `src/torneo/application/commands/crear_torneo.py`
+  - `src/torneo/api/router.py`
+  - `src/torneo/infrastructure/repositories/sqlite_torneo_repository.py`
+  - `frontend/src/api/torneo.ts`
+  - `frontend/src/pages/organizador/CrearTorneoPage.tsx`
+
+---
+
+## Decisiones Técnicas
+
+- Crear `GrupoEtario` en `torneo/domain/value_objects/` en vez de importar `Categoria` desde `registro`. Esto evita acoplamiento directo entre bounded contexts.
+- Persistir `grupos_etarios` como JSON text en SQLite, igual que `disciplinas_torneo`.
+- Default retrocompatible: torneos existentes migran con `["SENIOR"]`.
+- El campo será requerido en `CrearTorneoRequest`; payload omitido, vacío o inválido retorna 422.
+- `GET /torneos` y `GET /torneos/{id}` retornan `grupos_etarios`.
+- La UI inicia con `SENIOR` seleccionado y bloquea submit si el usuario deselecciona todo.
+
+---
+
+## Tareas
+
+### 1. Dominio torneo — GrupoEtario (15 min)
+
+- [x] Crear `src/torneo/domain/value_objects/grupo_etario.py` como `StrEnum` con `JUNIOR`, `SENIOR`, `MASTER`.
+- [x] Agregar `grupos_etarios: frozenset[GrupoEtario]` a `Torneo` con default `SENIOR`.
+- [x] Validar que la colección no esté vacía.
+- [x] Mantener orden determinístico para persistencia/respuesta.
+
+### 2. Application/API torneo (15 min)
+
+- [x] Agregar `grupos_etarios` a `CrearTorneoCommand`.
+- [x] Pasar los grupos al aggregate en `CrearTorneoHandler`.
+- [x] Agregar `grupos_etarios: list[GrupoEtario]` a `CrearTorneoRequest`.
+- [x] Agregar `grupos_etarios` a `TorneoResponse.from_torneo`.
+- [x] Verificar 422 automático para omitido, vacío e inválido.
+
+### 3. Persistencia SQLite (15 min)
+
+- [x] Agregar columna `grupos_etarios TEXT NOT NULL DEFAULT '["SENIOR"]'` al create table.
+- [x] Agregar migración idempotente `ALTER TABLE`.
+- [x] Serializar/deserializar `grupos_etarios`.
+- [x] Mantener compatibilidad con DBs existentes.
+
+### 4. Frontend (15 min)
+
+- [x] Agregar tipos `GrupoEtario` y `grupos_etarios` a DTO/payload en `frontend/src/api/torneo.ts`.
+- [x] Agregar estado local `gruposSeleccionados` con default `['SENIOR']`.
+- [x] Renderizar tres toggles `JUNIOR`, `SENIOR`, `MASTER` solo en alta de torneo.
+- [x] Validar al menos un grupo seleccionado.
+- [x] Incluir `grupos_etarios` en `crearTorneo(buildPayload())`.
+
+### 5. Tests y BDD (15 min)
+
+- [x] Agregar tests unitarios de dominio para default, selección múltiple y lista vacía.
+- [x] Agregar tests de handler para persistir grupos.
+- [x] Agregar tests de repositorio para migración/persistencia.
+- [x] Agregar test API para POST/GET y rechazos 422.
+- [x] Implementar steps BDD para `US-6.2.5-grupos-etarios-torneo.feature`.
+- [x] Ejecutar BDD focal de US-6.2.5.
+
+### 6. Validación frontend/backend (10 min)
+
+- [x] Ejecutar tests focales de torneo.
+- [x] Ejecutar `cd frontend && npm run build`.
+- [x] Ejecutar ESLint focal sobre `CrearTorneoPage.tsx` y `api/torneo.ts`.
+- [x] Ejecutar `cd frontend && npm run lint` para registrar estado global.
+- [x] Ejecutar `git diff --check`.
+
+### 7. Cierre documental (5 min)
+
+- [x] Actualizar estado de `docs/specs/sp6/US-6.2.5.md` a `Done`.
+- [x] Actualizar `docs/specs/sp6/README.md`.
+- [ ] Generar `docs/reports/US-6.2.5-report.md`.
+- [ ] Cerrar tracker.
+- [ ] Commit atómico con referencia `[US-6.2.5]`.
+
+---
+
+## Validación Esperada
+
+- `POST /torneos` con `grupos_etarios=["JUNIOR","MASTER"]` crea torneo.
+- `GET /torneos/{id}` retorna `["JUNIOR","MASTER"]`.
+- `POST /torneos` sin `grupos_etarios` retorna 422.
+- `POST /torneos` con `grupos_etarios=[]` retorna 422.
+- `POST /torneos` con valor inválido retorna 422.
+- La UI muestra toggles de grupos etarios y default `SENIOR`.
+- El submit queda bloqueado si no hay grupos.
+
+---
+
+## Riesgos
+
+- Tests existentes que crean torneos vía API sin `grupos_etarios` deberán actualizarse, porque la US exige que el campo sea requerido.
+- Tests o fixtures que instancian `Torneo` directamente no deberían romperse por el default `SENIOR`.
+- El lint global frontend conserva un error preexistente en `frontend/src/pages/juez/GrillaPage.tsx`; se registrará si persiste.
+
+---
+
+## Resultado de Validación
+
+| Gate | Resultado |
+|---|---|
+| `./.venv/bin/pytest tests/unit/torneo/domain/test_torneo.py tests/unit/torneo/application/test_crear_torneo.py tests/integration/torneo/test_sqlite_torneo_repository.py tests/integration/torneo/test_grupos_etarios_api.py tests/features/steps/grupos_etarios_torneo_steps.py` | OK — 41 passed |
+| Regresión backend afectada (`identidad`, `torneo`, E2E US-3.3.2, BDD torneo API) | OK — 49 passed |
+| `cd frontend && npm run build` | OK |
+| `cd frontend && npm run lint` | OK |
+| `git diff --check` | OK |
+
+Notas:
+- Se actualizó `frontend/src/pages/juez/GrillaPage.tsx` para corregir una dependencia faltante de `useMemo` que bloqueaba `npm run lint`.
+- Se actualizaron helpers E2E de US-3.3.2 para usar el contrato vigente de `PerformancesAPAdapter` con proyección `competencias_por_torneo` e inscripciones como fuente de AP.

--- a/docs/reports/US-6.2.5-report.md
+++ b/docs/reports/US-6.2.5-report.md
@@ -1,0 +1,87 @@
+# Reporte de Implementación — US-6.2.5
+
+**US:** US-6.2.5 — Nuevo torneo: selección de grupos etarios  
+**Incremento:** INC-6.2 — Ajustes Organizador  
+**Producto:** torneo + frontend  
+**Branch:** `feature-US-6.2.5-grupos-etarios`  
+**Fecha:** 2026-05-06  
+
+---
+
+## Resumen
+
+Se agregó selección de grupos etarios al alta de torneo. El organizador puede
+seleccionar `JUNIOR`, `SENIOR` y/o `MASTER`; `SENIOR` queda seleccionado por
+defecto. El backend valida, persiste y expone los grupos en las respuestas de
+torneo.
+
+---
+
+## Cambios Implementados
+
+| Archivo | Cambio |
+|---|---|
+| `src/torneo/domain/value_objects/grupo_etario.py` | Nuevo value object `GrupoEtario` con orden determinístico |
+| `src/torneo/domain/aggregates/torneo.py` | Agregado `grupos_etarios` con default `SENIOR` y validación no vacía |
+| `src/torneo/application/commands/crear_torneo.py` | `CrearTorneoCommand` recibe y pasa grupos etarios al aggregate |
+| `src/torneo/api/router.py` | `POST /torneos` valida `grupos_etarios`; responses incluyen el campo |
+| `src/torneo/infrastructure/repositories/sqlite_torneo_repository.py` | Nueva columna SQLite con migración idempotente y serialización JSON |
+| `frontend/src/api/torneo.ts` | Tipos `GrupoEtario`, DTO y payload de creación actualizados |
+| `frontend/src/pages/organizador/CrearTorneoPage.tsx` | Toggles de grupos etarios, default `SENIOR`, validación y payload |
+| `tests/features/US-6.2.5-grupos-etarios-torneo.feature` | BDD de persistencia y rechazos 422 |
+| `tests/features/steps/grupos_etarios_torneo_steps.py` | Steps BDD ejecutables para la US |
+| `tests/integration/torneo/test_grupos_etarios_api.py` | Cobertura API POST/GET y validación |
+| `docs/specs/sp6/US-6.2.5.md` | Estado `Done` y resultado de implementación |
+| `docs/plans/sp6/US-6.2.5-plan.md` | Plan actualizado con checklist y validación real |
+
+---
+
+## BDD
+
+Se generó y ejecutó BDD porque la US toca backend, API y persistencia.
+
+Feature:
+- `tests/features/US-6.2.5-grupos-etarios-torneo.feature`
+
+Scenarios cubiertos:
+- Crear torneo persiste `JUNIOR` y `MASTER`.
+- Payload sin `grupos_etarios` retorna 422.
+- Payload con lista vacía retorna 422.
+- Payload con grupo inválido retorna 422.
+
+---
+
+## Validación
+
+| Gate | Resultado |
+|---|---|
+| Tests focales torneo + BDD US-6.2.5 | OK — 41 passed |
+| Regresión backend afectada | OK — 49 passed |
+| `cd frontend && npm run build` | OK |
+| `cd frontend && npm run lint` | OK |
+| `git diff --check` | OK |
+
+---
+
+## Ajustes de Compatibilidad
+
+- Tests y seeds existentes que crean torneos ahora envían `grupos_etarios`.
+- DBs SQLite existentes migran con default `["SENIOR"]`.
+- Se corrigió una dependencia faltante en `frontend/src/pages/juez/GrillaPage.tsx`
+  que bloqueaba el lint global.
+- Se actualizaron helpers E2E de US-3.3.2 para usar el contrato vigente de
+  `PerformancesAPAdapter`.
+
+---
+
+## Alcance No Modificado
+
+- No se filtran inscripciones por grupo etario.
+- No se modifican rankings ni podios.
+- No se acopla `torneo` al enum `Categoria` del bounded context `registro`.
+
+---
+
+## Resultado
+
+`US-6.2.5` queda implementada, documentada y validada para el alcance definido.

--- a/docs/specs/sp6/README.md
+++ b/docs/specs/sp6/README.md
@@ -32,7 +32,7 @@ Foco: **corregir UX del portal organizador** — torneos ordenados, columnas ren
 | [US-6.2.2](./US-6.2.2.md) | Inscriptos + Grilla: Categoría Legible + AP → Anuncios | UI-ORG-03 · UI-ORG-04 | Pending |
 | [US-6.2.3](./US-6.2.3.md) | Resultados: Quitar PTS FAAS + Andarivel Numérico + AP → Anuncio | UI-ORG-05 | Pending |
 | [US-6.2.4](./US-6.2.4.md) | Panel Torneo: Alertas sin "Resolver" + Jueces sin Texto Nombre | UI-ORG-02 · UI-ORG-06 | Done |
-| [US-6.2.5](./US-6.2.5.md) | Nuevo Torneo: Selección Categorías JUNIOR/SENIOR/MASTER | UI-ORG-07 | Pending |
+| [US-6.2.5](./US-6.2.5.md) | Nuevo Torneo: Selección Categorías JUNIOR/SENIOR/MASTER | UI-ORG-07 | Done |
 | [US-6.2.6](./US-6.2.6.md) | Crear Página de Podios | UI-ORG-08 | Pending |
 
 ### Criterios de Cierre INC-6.2

--- a/docs/specs/sp6/US-6.2.5.md
+++ b/docs/specs/sp6/US-6.2.5.md
@@ -1,6 +1,6 @@
-# US-6.2.5: Nuevo Torneo — Selección de Categorías JUNIOR/SENIOR/MASTER
+# US-6.2.5: Nuevo Torneo — Selección de Grupos Etarios JUNIOR/SENIOR/MASTER
 
-**Estado**: `Pending`  
+**Estado**: `Done`
 **Incremento**: INC-6.2 — Ajustes Organizador  
 **Hallazgos**: UI-ORG-07  
 **Bounded Context**: `torneo` · `frontend`  
@@ -23,6 +23,15 @@ para **que el sistema sepa desde el inicio qué categorías habilitar en inscrip
 **Ubicación**: `frontend/src/pages/organizador/CrearTorneoPage.tsx`
 
 El formulario de creación no tiene campo para categorías. Los seis valores posibles del enum `Categoria` son combinaciones de grupo etario (JUNIOR, SENIOR, MASTER) y género (MASCULINO, FEMENINO). Para el organizador tiene más sentido seleccionar los **grupos** (JUNIOR, SENIOR, MASTER) — el género resulta del registro del atleta.
+
+---
+
+## Fuente de verdad UX
+
+- `docs/design/ux/wireframes-organizador.md` — estructura aprobada del portal organizador y criterios visuales del formulario de torneo.
+- `docs/design/ux/prototipos/prototipo-organizador.html` — prototipo navegable aprobado para el rol organizador.
+- `docs/plans/sp6/PLAN-SP6.md` — hallazgo UI-ORG-07 detectado en validación SP5.
+- `frontend/src/pages/organizador/CrearTorneoPage.tsx` — implementación React actual comparada contra el hallazgo.
 
 ---
 
@@ -102,7 +111,7 @@ Feature: US-6.2.5 — Selección de categorías en nuevo torneo
 ## Notas de implementación
 
 - La integración con inscripción/rankings (validar que el atleta pertenece a un grupo habilitado) está **fuera de scope** de esta US — solo persistir el dato
-- Evaluar si `grupos_etarios` va en la entidad `Torneo` del dominio o solo en el DTO de la API; dado que es informativo y sin lógica de dominio en este incremento, puede ir solo en el modelo de infraestructura/API
+- `grupos_etarios` quedó modelado en el dominio `Torneo` con value object propio `GrupoEtario` para evitar acoplamiento directo con `registro.domain.value_objects.Categoria`
 - Migración SQLite: agregar columna `grupos_etarios TEXT NOT NULL DEFAULT '["SENIOR"]'`
 
 ---
@@ -113,6 +122,16 @@ Feature: US-6.2.5 — Selección de categorías en nuevo torneo
 - Página: `frontend/src/pages/organizador/CrearTorneoPage.tsx`
 - Enum: `src/registro/domain/value_objects/categoria.py`
 - Router torneo: `src/torneo/api/router.py`
+
+---
+
+## Resultado de implementación
+
+- `POST /torneos` requiere `grupos_etarios` y valida `JUNIOR`, `SENIOR`, `MASTER`.
+- `GET /torneos` y `GET /torneos/{id}` retornan `grupos_etarios` en orden determinístico.
+- La persistencia SQLite migra torneos existentes con default `["SENIOR"]`.
+- La pantalla de alta de torneo muestra toggles para los tres grupos etarios con `SENIOR` seleccionado por defecto.
+- La validación impide enviar el formulario sin al menos un grupo etario.
 
 ---
 

--- a/frontend/src/api/torneo.ts
+++ b/frontend/src/api/torneo.ts
@@ -25,6 +25,7 @@ export interface TorneoDto {
     tipo: string
   }
   estado: EstadoTorneo
+  grupos_etarios: GrupoEtario[]
 }
 
 type TorneoApiDto = Omit<TorneoDto, 'estado'> & {
@@ -63,6 +64,8 @@ export type DisciplinaCodigo =
   | 'SPE_8X50'
   | 'SPE_16X50'
 
+export type GrupoEtario = 'JUNIOR' | 'SENIOR' | 'MASTER'
+
 export interface CrearTorneoPayload {
   nombre: string
   descripcion: string
@@ -77,6 +80,7 @@ export interface CrearTorneoPayload {
     nombre: string
     tipo: string
   }
+  grupos_etarios: GrupoEtario[]
 }
 
 export interface CrearTorneoResponse {

--- a/frontend/src/pages/juez/GrillaPage.tsx
+++ b/frontend/src/pages/juez/GrillaPage.tsx
@@ -119,7 +119,7 @@ export function GrillaPage() {
     const grilla = Array.from(grillaMap.values())
     const first = grilla.find((atleta) => atleta.estado === 'AnunciadaAP')
     return first?.performance_id ?? null
-  }, [precargaQuery.payload?.grilla, queueData])
+  }, [juezId, precargaQuery.payload?.grilla, queueData])
 
   const grillaOrdenada = useMemo(() => {
     const grillaBase = (precargaQuery.payload?.grilla ?? []).filter(

--- a/frontend/src/pages/organizador/CrearTorneoPage.tsx
+++ b/frontend/src/pages/organizador/CrearTorneoPage.tsx
@@ -9,6 +9,7 @@ import {
   listarDisciplinasTorneo,
   type CrearTorneoPayload,
   type DisciplinaCodigo,
+  type GrupoEtario,
 } from '../../api/torneo'
 import { DisciplinaSelector } from '../../components/organizador/DisciplinaSelector'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
@@ -25,7 +26,9 @@ interface FormState {
   entidadTipo: string
 }
 
-type FormErrors = Partial<Record<keyof FormState | 'disciplinas' | 'general', string>>
+type FormErrors = Partial<Record<keyof FormState | 'disciplinas' | 'gruposEtarios' | 'general', string>>
+
+const GRUPOS_ETARIOS: GrupoEtario[] = ['JUNIOR', 'SENIOR', 'MASTER']
 
 const INITIAL_FORM: FormState = {
   nombre: '',
@@ -60,6 +63,7 @@ export function CrearTorneoPage() {
   const isEditingDisciplinas = Boolean(torneoId)
   const [form, setForm] = useState<FormState>(INITIAL_FORM)
   const [disciplinas, setDisciplinas] = useState<DisciplinaCodigo[]>([])
+  const [gruposEtarios, setGruposEtarios] = useState<GrupoEtario[]>(['SENIOR'])
   const [errors, setErrors] = useState<FormErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isLoading, setIsLoading] = useState(isEditingDisciplinas)
@@ -131,6 +135,9 @@ export function CrearTorneoPage() {
     if (disciplinas.length === 0) {
       nextErrors.disciplinas = 'Selecciona al menos una disciplina'
     }
+    if (!isEditingDisciplinas && gruposEtarios.length === 0) {
+      nextErrors.gruposEtarios = 'Selecciona al menos un grupo etario'
+    }
     return nextErrors
   }
 
@@ -149,7 +156,17 @@ export function CrearTorneoPage() {
         nombre: form.entidadNombre.trim(),
         tipo: form.entidadTipo.trim(),
       },
+      grupos_etarios: gruposEtarios,
     }
+  }
+
+  function toggleGrupoEtario(grupo: GrupoEtario) {
+    setGruposEtarios((current) =>
+      current.includes(grupo)
+        ? current.filter((item) => item !== grupo)
+        : GRUPOS_ETARIOS.filter((item) => item === grupo || current.includes(item)),
+    )
+    setErrors((current) => ({ ...current, gruposEtarios: undefined, general: undefined }))
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -345,6 +362,36 @@ export function CrearTorneoPage() {
         </div>
 
         <div className="mt-6">
+          {!isEditingDisciplinas ? (
+            <fieldset className="mb-6">
+              <legend className="text-sm font-semibold text-slate-100">Grupos etarios</legend>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {GRUPOS_ETARIOS.map((grupo) => {
+                  const selected = gruposEtarios.includes(grupo)
+                  return (
+                    <button
+                      key={grupo}
+                      type="button"
+                      onClick={() => toggleGrupoEtario(grupo)}
+                      className={[
+                        'rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] transition',
+                        selected
+                          ? 'border-sky-400 bg-sky-400/10 text-sky-300'
+                          : 'border-slate-700 bg-slate-950 text-slate-300 hover:border-slate-500',
+                      ].join(' ')}
+                      aria-pressed={selected}
+                    >
+                      {grupo}
+                    </button>
+                  )
+                })}
+              </div>
+              {errors.gruposEtarios ? (
+                <p className="mt-2 text-sm text-red-300">{errors.gruposEtarios}</p>
+              ) : null}
+            </fieldset>
+          ) : null}
+
           <DisciplinaSelector
             value={disciplinas}
             onChange={(nextValue) => {
@@ -364,7 +411,12 @@ export function CrearTorneoPage() {
           </Link>
           <button
             type="submit"
-            disabled={isSubmitting || isLoading || Boolean(errors.general)}
+            disabled={
+              isSubmitting ||
+              isLoading ||
+              Boolean(errors.general) ||
+              (!isEditingDisciplinas && gruposEtarios.length === 0)
+            }
             className="rounded-full bg-sky-500 px-5 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
           >
             {isSubmitting

--- a/src/torneo/api/router.py
+++ b/src/torneo/api/router.py
@@ -37,6 +37,7 @@ from torneo.application.queries.obtener_torneo import (
 )
 from torneo.domain.aggregates.torneo import Torneo
 from torneo.domain.exceptions import AsignacionNoPermitida, DisciplinaNoEnTorneo, DisciplinaObsoleta
+from torneo.domain.value_objects.grupo_etario import GrupoEtario, ordenar_grupos_etarios
 from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
 
 router = APIRouter(prefix="/torneos", tags=["torneos"])
@@ -94,6 +95,7 @@ class CrearTorneoRequest(BaseModel):
     fecha_fin: date
     sede: SedeSchema
     entidad_organizadora: EntidadOrganizadoraSchema
+    grupos_etarios: list[GrupoEtario]
 
     @field_validator("nombre")
     @classmethod
@@ -108,6 +110,13 @@ class CrearTorneoRequest(BaseModel):
             raise ValueError("fecha_fin debe ser mayor o igual a fecha_inicio")
         return self
 
+    @field_validator("grupos_etarios")
+    @classmethod
+    def grupos_etarios_no_vacio(cls, v: list[GrupoEtario]) -> list[GrupoEtario]:
+        if not v:
+            raise ValueError("Debe seleccionar al menos un grupo etario")
+        return v
+
 
 class TorneoResponse(BaseModel):
     torneo_id: UUID
@@ -118,6 +127,7 @@ class TorneoResponse(BaseModel):
     sede: SedeSchema
     entidad_organizadora: EntidadOrganizadoraSchema
     estado: str
+    grupos_etarios: list[GrupoEtario]
 
     @classmethod
     def from_torneo(cls, torneo: Torneo) -> TorneoResponse:
@@ -137,6 +147,7 @@ class TorneoResponse(BaseModel):
                 tipo=torneo.entidad_organizadora.tipo,
             ),
             estado=torneo.estado.value,
+            grupos_etarios=ordenar_grupos_etarios(torneo.grupos_etarios),
         )
 
 
@@ -165,6 +176,7 @@ async def crear_torneo(body: CrearTorneoRequest, _: OrganizadorDep) -> JSONRespo
             sede_pais=body.sede.pais,
             entidad_nombre=body.entidad_organizadora.nombre,
             entidad_tipo=body.entidad_organizadora.tipo,
+            grupos_etarios=frozenset(body.grupos_etarios),
         )
     )
     return JSONResponse(status_code=201, content={"torneo_id": str(torneo_id)})

--- a/src/torneo/application/commands/crear_torneo.py
+++ b/src/torneo/application/commands/crear_torneo.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from torneo.domain.aggregates.torneo import Torneo
 from torneo.domain.ports.torneo_repository_port import TorneoRepositoryPort
 from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 from torneo.domain.value_objects.sede import Sede
 
 
@@ -21,6 +22,7 @@ class CrearTorneoCommand:
     sede_pais: str
     entidad_nombre: str
     entidad_tipo: str
+    grupos_etarios: frozenset[GrupoEtario]
 
 
 class CrearTorneoHandler:
@@ -37,6 +39,7 @@ class CrearTorneoHandler:
             entidad_organizadora=EntidadOrganizadora(
                 nombre=cmd.entidad_nombre, tipo=cmd.entidad_tipo
             ),
+            grupos_etarios=cmd.grupos_etarios,
         )
         await self._repo.save(torneo)
         return torneo.torneo_id

--- a/src/torneo/domain/aggregates/torneo.py
+++ b/src/torneo/domain/aggregates/torneo.py
@@ -15,6 +15,7 @@ from torneo.domain.exceptions import (
 from torneo.domain.value_objects.disciplina_torneo import DisciplinaTorneo
 from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
 from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 from torneo.domain.value_objects.sede import Sede
 from torneo.domain.value_objects.tipo_reglamento import TipoReglamento
 
@@ -50,10 +51,14 @@ class Torneo:
     estado: EstadoTorneo = EstadoTorneo.CREADO
     disciplinas_torneo: list[DisciplinaTorneo] = field(default_factory=list)
     tipo_reglamento: TipoReglamento = TipoReglamento.FAAS
+    grupos_etarios: frozenset[GrupoEtario] = field(
+        default_factory=lambda: frozenset({GrupoEtario.SENIOR})
+    )
 
     def __post_init__(self) -> None:
         self._validar_nombre()
         self._validar_fechas()
+        self._validar_grupos_etarios()
 
     def _transicionar(self, nuevo_estado: EstadoTorneo) -> None:
         self._validar_transicion(nuevo_estado)
@@ -135,3 +140,7 @@ class Torneo:
             raise DisciplinaObsoleta(
                 "Disciplina.SPE es legacy y no puede configurarse en torneos nuevos"
             )
+
+    def _validar_grupos_etarios(self) -> None:
+        if not self.grupos_etarios:
+            raise ValueError("Debe seleccionar al menos un grupo etario")

--- a/src/torneo/domain/value_objects/grupo_etario.py
+++ b/src/torneo/domain/value_objects/grupo_etario.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class GrupoEtario(StrEnum):
+    JUNIOR = "JUNIOR"
+    SENIOR = "SENIOR"
+    MASTER = "MASTER"
+
+
+ORDEN_GRUPOS_ETARIOS: tuple[GrupoEtario, ...] = (
+    GrupoEtario.JUNIOR,
+    GrupoEtario.SENIOR,
+    GrupoEtario.MASTER,
+)
+
+
+def ordenar_grupos_etarios(grupos: frozenset[GrupoEtario]) -> list[GrupoEtario]:
+    return [grupo for grupo in ORDEN_GRUPOS_ETARIOS if grupo in grupos]

--- a/src/torneo/infrastructure/repositories/sqlite_torneo_repository.py
+++ b/src/torneo/infrastructure/repositories/sqlite_torneo_repository.py
@@ -12,6 +12,7 @@ from torneo.domain.ports.torneo_repository_port import TorneoRepositoryPort
 from torneo.domain.value_objects.disciplina_torneo import DisciplinaTorneo
 from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
 from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+from torneo.domain.value_objects.grupo_etario import GrupoEtario, ordenar_grupos_etarios
 from torneo.domain.value_objects.sede import Sede
 from torneo.domain.value_objects.tipo_reglamento import TipoReglamento
 
@@ -26,7 +27,8 @@ CREATE TABLE IF NOT EXISTS torneos (
     entidad            TEXT NOT NULL,
     estado             TEXT NOT NULL,
     disciplinas_torneo TEXT NOT NULL DEFAULT '[]',
-    tipo_reglamento    TEXT NOT NULL DEFAULT 'FAAS'
+    tipo_reglamento    TEXT NOT NULL DEFAULT 'FAAS',
+    grupos_etarios     TEXT NOT NULL DEFAULT '["SENIOR"]'
 )
 """
 
@@ -38,6 +40,10 @@ _ADD_TIPO_REGLAMENTO_COLUMN = """
 ALTER TABLE torneos ADD COLUMN tipo_reglamento TEXT NOT NULL DEFAULT 'FAAS'
 """
 
+_ADD_GRUPOS_ETARIOS_COLUMN = """
+ALTER TABLE torneos ADD COLUMN grupos_etarios TEXT NOT NULL DEFAULT '["SENIOR"]'
+"""
+
 
 class SQLiteTorneoRepository(TorneoRepositoryPort):
     def __init__(self, db_path: str | None = None) -> None:
@@ -45,7 +51,11 @@ class SQLiteTorneoRepository(TorneoRepositoryPort):
 
     async def _ensure_table(self, conn: aiosqlite.Connection) -> None:
         await conn.execute(_CREATE_TABLE)
-        for migration in (_ADD_DISCIPLINAS_COLUMN, _ADD_TIPO_REGLAMENTO_COLUMN):
+        for migration in (
+            _ADD_DISCIPLINAS_COLUMN,
+            _ADD_TIPO_REGLAMENTO_COLUMN,
+            _ADD_GRUPOS_ETARIOS_COLUMN,
+        ):
             try:
                 await conn.execute(migration)
             except Exception:
@@ -59,8 +69,9 @@ class SQLiteTorneoRepository(TorneoRepositoryPort):
                 """
                 INSERT OR REPLACE INTO torneos
                     (torneo_id, nombre, descripcion, fecha_inicio, fecha_fin,
-                     sede, entidad, estado, disciplinas_torneo, tipo_reglamento)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     sede, entidad, estado, disciplinas_torneo, tipo_reglamento,
+                     grupos_etarios)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._torneo_to_row(torneo),
             )
@@ -98,11 +109,12 @@ class SQLiteTorneoRepository(TorneoRepositoryPort):
             estado=EstadoTorneo(row["estado"]),
             disciplinas_torneo=self._deserialize_disciplinas(row["disciplinas_torneo"]),
             tipo_reglamento=TipoReglamento(row["tipo_reglamento"] or "FAAS"),
+            grupos_etarios=self._deserialize_grupos_etarios(row["grupos_etarios"]),
         )
 
     def _torneo_to_row(
         self, torneo: Torneo
-    ) -> tuple[str, str, str, str, str, str, str, str, str, str]:
+    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str]:
         return (
             str(torneo.torneo_id),
             torneo.nombre,
@@ -114,6 +126,7 @@ class SQLiteTorneoRepository(TorneoRepositoryPort):
             torneo.estado.value,
             self._serialize_disciplinas(torneo.disciplinas_torneo),
             torneo.tipo_reglamento.value,
+            self._serialize_grupos_etarios(torneo.grupos_etarios),
         )
 
     @staticmethod
@@ -140,6 +153,10 @@ class SQLiteTorneoRepository(TorneoRepositoryPort):
         return json.dumps([disciplina.to_dict() for disciplina in disciplinas])
 
     @staticmethod
+    def _serialize_grupos_etarios(grupos: frozenset[GrupoEtario]) -> str:
+        return json.dumps([grupo.value for grupo in ordenar_grupos_etarios(grupos)])
+
+    @staticmethod
     def _deserialize_sede(raw: str) -> Sede:
         return Sede(**json.loads(raw))
 
@@ -151,3 +168,8 @@ class SQLiteTorneoRepository(TorneoRepositoryPort):
     def _deserialize_disciplinas(raw: str) -> list[DisciplinaTorneo]:
         disciplinas_raw = json.loads(raw) if raw else []
         return [DisciplinaTorneo.from_dict(disciplina) for disciplina in disciplinas_raw]
+
+    @staticmethod
+    def _deserialize_grupos_etarios(raw: str) -> frozenset[GrupoEtario]:
+        grupos_raw = json.loads(raw) if raw else ["SENIOR"]
+        return frozenset(GrupoEtario(grupo) for grupo in grupos_raw)

--- a/tests/features/US-6.2.5-grupos-etarios-torneo.feature
+++ b/tests/features/US-6.2.5-grupos-etarios-torneo.feature
@@ -1,0 +1,25 @@
+Feature: US-6.2.5 - Grupos etarios al crear torneo
+
+  Background:
+    Given la base de datos de torneos está limpia para grupos etarios
+
+  Scenario: crear torneo persiste grupos etarios seleccionados
+    Given un payload de torneo con grupos etarios JUNIOR y MASTER
+    When POST /torneos con el payload de grupos etarios
+    Then la respuesta de creacion es 201 con torneo_id
+    And GET /torneos/{torneo_id} retorna grupos_etarios JUNIOR y MASTER
+
+  Scenario: payload sin grupos_etarios es rechazado
+    Given un payload de torneo sin grupos_etarios
+    When POST /torneos con el payload de grupos etarios
+    Then la respuesta de grupos etarios es 422
+
+  Scenario: payload con grupos_etarios vacio es rechazado
+    Given un payload de torneo con grupos_etarios vacio
+    When POST /torneos con el payload de grupos etarios
+    Then la respuesta de grupos etarios es 422
+
+  Scenario: payload con grupo etario invalido es rechazado
+    Given un payload de torneo con grupo etario INVALIDO
+    When POST /torneos con el payload de grupos etarios
+    Then la respuesta de grupos etarios es 422

--- a/tests/features/steps/grupos_etarios_torneo_steps.py
+++ b/tests/features/steps/grupos_etarios_torneo_steps.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest_bdd import given, scenarios, then, when
+
+from identidad.api.dependencies import get_current_user
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.api.router import router
+
+scenarios("../US-6.2.5-grupos-etarios-torneo.feature")
+
+
+@pytest.fixture
+def context(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setenv("TORNEO_DB_PATH", str(tmp_path / "torneo.db"))
+    return {}
+
+
+@pytest.fixture
+def client(context: dict[str, Any]) -> Iterator[TestClient]:
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "test-user",
+        "email": "test@test.com",
+        "rol": "ORGANIZADOR",
+    }
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "nombre": "Copa Grupos BDD 2026",
+        "descripcion": "Torneo BDD con grupos etarios",
+        "fecha_inicio": "2026-06-01",
+        "fecha_fin": "2026-06-03",
+        "sede": {"nombre": "Piscina", "ciudad": "BA", "pais": "AR"},
+        "entidad_organizadora": {"nombre": "AIDA", "tipo": "FEDERACION"},
+        "grupos_etarios": ["JUNIOR", "MASTER"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+@given("la base de datos de torneos esta limpia para grupos etarios")
+@given("la base de datos de torneos está limpia para grupos etarios")
+def base_limpia(context: dict[str, Any]) -> None:
+    pass
+
+
+@given("un payload de torneo con grupos etarios JUNIOR y MASTER")
+def payload_junior_master(context: dict[str, Any]) -> None:
+    context["payload"] = _payload()
+
+
+@given("un payload de torneo sin grupos_etarios")
+def payload_sin_grupos(context: dict[str, Any]) -> None:
+    payload = _payload()
+    del payload["grupos_etarios"]
+    context["payload"] = payload
+
+
+@given("un payload de torneo con grupos_etarios vacio")
+@given("un payload de torneo con grupos_etarios vacío")
+def payload_grupos_vacio(context: dict[str, Any]) -> None:
+    context["payload"] = _payload(grupos_etarios=[])
+
+
+@given("un payload de torneo con grupo etario INVALIDO")
+def payload_grupo_invalido(context: dict[str, Any]) -> None:
+    context["payload"] = _payload(grupos_etarios=["INVALIDO"])
+
+
+@when("POST /torneos con el payload de grupos etarios")
+def post_torneos(client: TestClient, context: dict[str, Any]) -> None:
+    context["response"] = client.post("/torneos", json=context["payload"])
+
+
+@then("la respuesta de creacion es 201 con torneo_id")
+@then("la respuesta de creación es 201 con torneo_id")
+def respuesta_201(context: dict[str, Any]) -> None:
+    assert context["response"].status_code == 201
+    context["torneo_id"] = context["response"].json()["torneo_id"]
+
+
+@then("GET /torneos/{torneo_id} retorna grupos_etarios JUNIOR y MASTER")
+def get_retorna_grupos(client: TestClient, context: dict[str, Any]) -> None:
+    response = client.get(f"/torneos/{context['torneo_id']}")
+
+    assert response.status_code == 200
+    assert response.json()["grupos_etarios"] == ["JUNIOR", "MASTER"]
+
+
+@then("la respuesta de grupos etarios es 422")
+def respuesta_422(context: dict[str, Any]) -> None:
+    assert context["response"].status_code == 422

--- a/tests/features/steps/test_US_3_3_2_steps.py
+++ b/tests/features/steps/test_US_3_3_2_steps.py
@@ -52,6 +52,9 @@ from competencia.infrastructure.repositories.disciplina_descriptor_adapter impor
 from competencia.infrastructure.repositories.performances_ap_adapter import (
     PerformancesAPAdapter,
 )
+from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
+    SQLiteCompetenciasPorTorneo,
+)
 from registro.application.commands.inscribir_atleta import (
     InscribirAtletaCommand,
     InscribirAtletaHandler,
@@ -75,6 +78,7 @@ from torneo.application.commands.transicionar_torneo import (
     AbrirInscripcionHandler,
     TransicionarTorneoCommand,
 )
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 from torneo.infrastructure.repositories.sqlite_torneo_repository import (
     SQLiteTorneoRepository,
 )
@@ -122,6 +126,7 @@ def ctx(tmp_path: Any) -> dict[str, Any]:
         "inscripcion_repo": SQLiteInscripcionRepository(db_path=registro_db),
         "torneo_consulta": SQLiteTorneoConsulta(db_path=torneo_db),
         "event_store": SQLiteEventStore(db_path=competencia_db),
+        "competencias_por_torneo": SQLiteCompetenciasPorTorneo(db_path=competencia_db),
         "torneo_id": None,
         "atleta_id": None,
         "atleta_con_ap": None,
@@ -163,6 +168,7 @@ async def _crear_torneo_abierto(torneo_repo) -> UUID:
         sede_pais="Argentina",
         entidad_nombre="FADA",
         entidad_tipo="FEDERACION",
+        grupos_etarios=frozenset({GrupoEtario.SENIOR}),
     )
     torneo_id = await CrearTorneoHandler(torneo_repo).handle(cmd)
     await AbrirInscripcionHandler(torneo_repo).handle(TransicionarTorneoCommand(torneo_id))
@@ -202,7 +208,19 @@ async def _registrar_e_inscribir(
     return atleta_id
 
 
-async def _ap(event_store, competencia_id: UUID, atleta_id: UUID, valor: int) -> None:
+async def _ap(
+    event_store,
+    inscripcion_repo,
+    torneo_id: UUID,
+    competencia_id: UUID,
+    atleta_id: UUID,
+    valor: int,
+) -> None:
+    inscripcion = await inscripcion_repo.find_by_atleta_y_torneo(atleta_id, torneo_id)
+    assert inscripcion is not None
+    inscripcion.declarar_ap(SharedDisciplina.STA, Decimal(valor))
+    await inscripcion_repo.save(inscripcion)
+
     estado_adapter = CompetenciaEstadoAdapter(event_store)
     descriptor_adapter = DisciplinaDescriptorAdapter()
     await RegistrarAPHandler(event_store, estado_adapter, descriptor_adapter).handle(
@@ -216,8 +234,13 @@ async def _ap(event_store, competencia_id: UUID, atleta_id: UUID, valor: int) ->
     )
 
 
-async def _generar_y_confirmar(event_store, competencia_id: UUID) -> list:
-    ap_adapter = PerformancesAPAdapter(event_store)
+async def _generar_y_confirmar(
+    event_store,
+    competencias_por_torneo,
+    inscripcion_repo,
+    competencia_id: UUID,
+) -> list:
+    ap_adapter = PerformancesAPAdapter(event_store, competencias_por_torneo, inscripcion_repo)
     descriptor_adapter = DisciplinaDescriptorAdapter()
     await GenerarGrillaHandler(event_store, ap_adapter, descriptor_adapter).handle(
         GenerarGrillaCommand(
@@ -261,7 +284,9 @@ def competencia_configurada(ctx: dict[str, Any]) -> None:
     competencia_id = uuid4()
 
     async def _cfg():
-        await ConfigurarIntervaloOTHandler(ctx["event_store"]).handle(
+        await ConfigurarIntervaloOTHandler(
+            ctx["event_store"], ctx["competencias_por_torneo"]
+        ).handle(
             ConfigurarIntervaloOTCommand(
                 competencia_id=competencia_id,
                 disciplina=Disciplina.STA,
@@ -326,18 +351,52 @@ def tres_atletas_con_aps(ctx: dict[str, Any]) -> None:
 
 @when("el atleta registra su AP en la competencia")
 def atleta_registra_ap(ctx: dict[str, Any]) -> None:
-    _run(_ap(ctx["event_store"], ctx["competencia_id"], ctx["atleta_id"], 360))
+    _run(
+        _ap(
+            ctx["event_store"],
+            ctx["inscripcion_repo"],
+            ctx["torneo_id"],
+            ctx["competencia_id"],
+            ctx["atleta_id"],
+            360,
+        )
+    )
 
 
 @when("se genera y confirma la grilla")
 def generar_confirmar_grilla(ctx: dict[str, Any]) -> None:
     # Registrar AP del atleta_con_ap si aplica (escenario 2)
     if ctx.get("atleta_con_ap"):
-        _run(_ap(ctx["event_store"], ctx["competencia_id"], ctx["atleta_con_ap"], 300))
+        _run(
+            _ap(
+                ctx["event_store"],
+                ctx["inscripcion_repo"],
+                ctx["torneo_id"],
+                ctx["competencia_id"],
+                ctx["atleta_con_ap"],
+                300,
+            )
+        )
     # Registrar APs de atletas_y_aps si aplica (escenario 3)
     for atleta_id, ap in ctx.get("atletas_y_aps", []):
-        _run(_ap(ctx["event_store"], ctx["competencia_id"], atleta_id, ap))
-    grilla = _run(_generar_y_confirmar(ctx["event_store"], ctx["competencia_id"]))
+        _run(
+            _ap(
+                ctx["event_store"],
+                ctx["inscripcion_repo"],
+                ctx["torneo_id"],
+                ctx["competencia_id"],
+                atleta_id,
+                ap,
+            )
+        )
+    grilla = _run(
+        _generar_y_confirmar(
+            ctx["event_store"],
+            ctx["competencias_por_torneo"],
+            ctx["inscripcion_repo"],
+            ctx["competencia_id"],
+        )
+    )
     ctx["grilla"] = grilla
 
 

--- a/tests/features/steps/test_US_3_4_2_steps.py
+++ b/tests/features/steps/test_US_3_4_2_steps.py
@@ -133,6 +133,7 @@ _TORNEO_PAYLOAD = {
     "fecha_fin": "2026-06-03",
     "sede": {"nombre": "Piscina", "ciudad": "CABA", "pais": "Argentina"},
     "entidad_organizadora": {"nombre": "FAADS", "tipo": "federacion"},
+    "grupos_etarios": ["SENIOR"],
 }
 
 

--- a/tests/features/steps/torneo_api_steps.py
+++ b/tests/features/steps/torneo_api_steps.py
@@ -49,6 +49,7 @@ def _payload(**overrides: Any) -> dict[str, Any]:
         "fecha_fin": "2026-06-03",
         "sede": {"nombre": "Piscina Municipal", "ciudad": "Buenos Aires", "pais": "Argentina"},
         "entidad_organizadora": {"nombre": "AIDA Argentina", "tipo": "FEDERACION"},
+        "grupos_etarios": ["SENIOR"],
     }
     base.update(overrides)
     return base

--- a/tests/integration/e2e/test_flujo_torneo_competencia.py
+++ b/tests/integration/e2e/test_flujo_torneo_competencia.py
@@ -57,6 +57,9 @@ from competencia.infrastructure.repositories.disciplina_descriptor_adapter impor
 from competencia.infrastructure.repositories.performances_ap_adapter import (
     PerformancesAPAdapter,
 )
+from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
+    SQLiteCompetenciasPorTorneo,
+)
 from registro.application.commands.inscribir_atleta import (
     InscribirAtletaCommand,
     InscribirAtletaHandler,
@@ -79,6 +82,7 @@ from torneo.application.commands.transicionar_torneo import (
     AbrirInscripcionHandler,
     TransicionarTorneoCommand,
 )
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 from torneo.infrastructure.repositories.sqlite_torneo_repository import (
     SQLiteTorneoRepository,
 )
@@ -121,6 +125,7 @@ async def infra(tmp_path):
     inscripcion_repo = SQLiteInscripcionRepository(db_path=registro_db)
     torneo_consulta = SQLiteTorneoConsulta(db_path=torneo_db)
     event_store = SQLiteEventStore(db_path=competencia_db)
+    competencias_por_torneo = SQLiteCompetenciasPorTorneo(db_path=competencia_db)
 
     return {
         "torneo_repo": torneo_repo,
@@ -128,6 +133,7 @@ async def infra(tmp_path):
         "inscripcion_repo": inscripcion_repo,
         "torneo_consulta": torneo_consulta,
         "event_store": event_store,
+        "competencias_por_torneo": competencias_por_torneo,
     }
 
 
@@ -143,6 +149,7 @@ async def _crear_torneo_abierto(torneo_repo) -> UUID:
         sede_pais="Argentina",
         entidad_nombre="FADA",
         entidad_tipo="FEDERACION",
+        grupos_etarios=frozenset({GrupoEtario.SENIOR}),
     )
     torneo_id = await CrearTorneoHandler(torneo_repo).handle(cmd)
     await AbrirInscripcionHandler(torneo_repo).handle(TransicionarTorneoCommand(torneo_id))
@@ -175,10 +182,10 @@ async def _registrar_e_inscribir(
     return atleta_id
 
 
-async def _configurar_competencia(event_store, torneo_id: UUID) -> UUID:
+async def _configurar_competencia(event_store, competencias_por_torneo, torneo_id: UUID) -> UUID:
     """Configura una competencia STA con torneo_id. Retorna competencia_id."""
     competencia_id = uuid4()
-    await ConfigurarIntervaloOTHandler(event_store).handle(
+    await ConfigurarIntervaloOTHandler(event_store, competencias_por_torneo).handle(
         ConfigurarIntervaloOTCommand(
             competencia_id=competencia_id,
             disciplina=Disciplina.STA,
@@ -190,8 +197,20 @@ async def _configurar_competencia(event_store, torneo_id: UUID) -> UUID:
     return competencia_id
 
 
-async def _registrar_ap(event_store, competencia_id: UUID, atleta_id: UUID, valor: int) -> None:
+async def _registrar_ap(
+    event_store,
+    inscripcion_repo,
+    competencia_id: UUID,
+    torneo_id: UUID,
+    atleta_id: UUID,
+    valor: int,
+) -> None:
     """Registra AP para un atleta en la competencia."""
+    inscripcion = await inscripcion_repo.find_by_atleta_y_torneo(atleta_id, torneo_id)
+    assert inscripcion is not None
+    inscripcion.declarar_ap(SharedDisciplina.STA, Decimal(valor))
+    await inscripcion_repo.save(inscripcion)
+
     estado_adapter = CompetenciaEstadoAdapter(event_store)
     descriptor_adapter = DisciplinaDescriptorAdapter()
     await RegistrarAPHandler(event_store, estado_adapter, descriptor_adapter).handle(
@@ -205,9 +224,14 @@ async def _registrar_ap(event_store, competencia_id: UUID, atleta_id: UUID, valo
     )
 
 
-async def _generar_y_confirmar_grilla(event_store, competencia_id: UUID) -> None:
+async def _generar_y_confirmar_grilla(
+    event_store,
+    competencias_por_torneo,
+    inscripcion_repo,
+    competencia_id: UUID,
+) -> None:
     """Genera y confirma la grilla de la competencia."""
-    ap_adapter = PerformancesAPAdapter(event_store)
+    ap_adapter = PerformancesAPAdapter(event_store, competencias_por_torneo, inscripcion_repo)
     descriptor_adapter = DisciplinaDescriptorAdapter()
 
     ot_inicio = datetime(2026, 9, 10, 9, 0, 0, tzinfo=timezone.utc)
@@ -239,11 +263,25 @@ async def test_flujo_completo_inscripcion_ap_grilla(infra):
         infra["torneo_consulta"],
         torneo_id,
     )
-    competencia_id = await _configurar_competencia(infra["event_store"], torneo_id)
+    competencia_id = await _configurar_competencia(
+        infra["event_store"], infra["competencias_por_torneo"], torneo_id
+    )
 
     # AP y grilla (participante_id = atleta_id — INV-E2E-01)
-    await _registrar_ap(infra["event_store"], competencia_id, atleta_id, 360)
-    await _generar_y_confirmar_grilla(infra["event_store"], competencia_id)
+    await _registrar_ap(
+        infra["event_store"],
+        infra["inscripcion_repo"],
+        competencia_id,
+        torneo_id,
+        atleta_id,
+        360,
+    )
+    await _generar_y_confirmar_grilla(
+        infra["event_store"],
+        infra["competencias_por_torneo"],
+        infra["inscripcion_repo"],
+        competencia_id,
+    )
 
     # Verificar grilla (INV-E2E-03)
     grilla = await ObtenerGrillaHandler(infra["event_store"]).handle(
@@ -288,9 +326,23 @@ async def test_atleta_sin_ap_no_aparece_en_grilla(infra):
         )
     )
 
-    competencia_id = await _configurar_competencia(infra["event_store"], torneo_id)
-    await _registrar_ap(infra["event_store"], competencia_id, atleta_con_ap, 300)
-    await _generar_y_confirmar_grilla(infra["event_store"], competencia_id)
+    competencia_id = await _configurar_competencia(
+        infra["event_store"], infra["competencias_por_torneo"], torneo_id
+    )
+    await _registrar_ap(
+        infra["event_store"],
+        infra["inscripcion_repo"],
+        competencia_id,
+        torneo_id,
+        atleta_con_ap,
+        300,
+    )
+    await _generar_y_confirmar_grilla(
+        infra["event_store"],
+        infra["competencias_por_torneo"],
+        infra["inscripcion_repo"],
+        competencia_id,
+    )
 
     grilla = await ObtenerGrillaHandler(infra["event_store"]).handle(
         ObtenerGrillaQuery(competencia_id=competencia_id, disciplina=Disciplina.STA)
@@ -303,7 +355,9 @@ async def test_atleta_sin_ap_no_aparece_en_grilla(infra):
 async def test_multiples_atletas_ordenados_por_ap_ascendente(infra):
     """RF-PR-05: STA — menor AP primero (240s → 300s → 360s)."""
     torneo_id = await _crear_torneo_abierto(infra["torneo_repo"])
-    competencia_id = await _configurar_competencia(infra["event_store"], torneo_id)
+    competencia_id = await _configurar_competencia(
+        infra["event_store"], infra["competencias_por_torneo"], torneo_id
+    )
 
     atletas_y_aps = [(uuid4(), ap) for ap in [360, 300, 240]]
 
@@ -326,9 +380,21 @@ async def test_multiples_atletas_ordenados_por_ap_ascendente(infra):
                 disciplinas=frozenset({SharedDisciplina.STA}),
             )
         )
-        await _registrar_ap(infra["event_store"], competencia_id, atleta_id, ap_segundos)
+        await _registrar_ap(
+            infra["event_store"],
+            infra["inscripcion_repo"],
+            competencia_id,
+            torneo_id,
+            atleta_id,
+            ap_segundos,
+        )
 
-    await _generar_y_confirmar_grilla(infra["event_store"], competencia_id)
+    await _generar_y_confirmar_grilla(
+        infra["event_store"],
+        infra["competencias_por_torneo"],
+        infra["inscripcion_repo"],
+        competencia_id,
+    )
 
     grilla = await ObtenerGrillaHandler(infra["event_store"]).handle(
         ObtenerGrillaQuery(competencia_id=competencia_id, disciplina=Disciplina.STA)

--- a/tests/integration/torneo/test_cierre_inscripcion_precondition.py
+++ b/tests/integration/torneo/test_cierre_inscripcion_precondition.py
@@ -54,6 +54,7 @@ def _crear_torneo_con_disciplina(client: TestClient) -> UUID:
             "fecha_fin": "2026-06-03",
             "sede": {"nombre": "Piscina", "ciudad": "BA", "pais": "AR"},
             "entidad_organizadora": {"nombre": "AIDA", "tipo": "FEDERACION"},
+            "grupos_etarios": ["SENIOR"],
         },
     )
     torneo_id = UUID(response.json()["torneo_id"])

--- a/tests/integration/torneo/test_disciplinas_torneo_api.py
+++ b/tests/integration/torneo/test_disciplinas_torneo_api.py
@@ -56,6 +56,7 @@ def client_con_torneo() -> tuple[TestClient, Torneo]:
             "fecha_fin": "2026-06-03",
             "sede": {"nombre": "Piscina", "ciudad": "CABA", "pais": "Argentina"},
             "entidad_organizadora": {"nombre": "FAADS", "tipo": "federacion"},
+            "grupos_etarios": ["SENIOR"],
         },
     )
     assert resp.status_code == 201
@@ -98,6 +99,7 @@ def _crear_torneo(client: TestClient) -> str:
             "fecha_fin": "2026-06-03",
             "sede": {"nombre": "Piscina", "ciudad": "CABA", "pais": "Argentina"},
             "entidad_organizadora": {"nombre": "FAADS", "tipo": "federacion"},
+            "grupos_etarios": ["SENIOR"],
         },
     )
     assert resp.status_code == 201

--- a/tests/integration/torneo/test_ejecucion_precondicion.py
+++ b/tests/integration/torneo/test_ejecucion_precondicion.py
@@ -60,6 +60,7 @@ def _crear_torneo_en_preparacion(client: TestClient) -> UUID:
             "fecha_fin": "2026-06-03",
             "sede": {"nombre": "Piscina", "ciudad": "BA", "pais": "AR"},
             "entidad_organizadora": {"nombre": "AIDA", "tipo": "FEDERACION"},
+            "grupos_etarios": ["SENIOR"],
         },
     )
     assert response.status_code == 201

--- a/tests/integration/torneo/test_grupos_etarios_api.py
+++ b/tests/integration/torneo/test_grupos_etarios_api.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from identidad.api.dependencies import get_current_user
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.api.router import router
+
+
+@pytest.fixture
+def client(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("TORNEO_DB_PATH", str(tmp_path / "torneo.db"))
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "test-user",
+        "email": "test@test.com",
+        "rol": "ORGANIZADOR",
+    }
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "nombre": "Copa Grupos 2026",
+        "descripcion": "Torneo con grupos etarios",
+        "fecha_inicio": "2026-06-01",
+        "fecha_fin": "2026-06-03",
+        "sede": {"nombre": "Piscina", "ciudad": "BA", "pais": "AR"},
+        "entidad_organizadora": {"nombre": "AIDA", "tipo": "FEDERACION"},
+        "grupos_etarios": ["JUNIOR", "MASTER"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_crear_torneo_persiste_grupos_etarios(client: TestClient) -> None:
+    response = client.post("/torneos", json=_payload())
+
+    assert response.status_code == 201
+    torneo_id = response.json()["torneo_id"]
+
+    get_response = client.get(f"/torneos/{torneo_id}")
+
+    assert get_response.status_code == 200
+    assert get_response.json()["grupos_etarios"] == ["JUNIOR", "MASTER"]
+
+
+def test_crear_torneo_sin_grupos_etarios_retorna_422(client: TestClient) -> None:
+    payload = _payload()
+    del payload["grupos_etarios"]
+
+    response = client.post("/torneos", json=payload)
+
+    assert response.status_code == 422
+
+
+def test_crear_torneo_con_grupos_etarios_vacio_retorna_422(client: TestClient) -> None:
+    response = client.post("/torneos", json=_payload(grupos_etarios=[]))
+
+    assert response.status_code == 422
+
+
+def test_crear_torneo_con_grupo_etario_invalido_retorna_422(client: TestClient) -> None:
+    response = client.post("/torneos", json=_payload(grupos_etarios=["INVALIDO"]))
+
+    assert response.status_code == 422

--- a/tests/integration/torneo/test_premiacion_precondicion.py
+++ b/tests/integration/torneo/test_premiacion_precondicion.py
@@ -51,6 +51,7 @@ def _crear_torneo_en_ejecucion(client: TestClient) -> UUID:
             "fecha_fin": "2026-06-03",
             "sede": {"nombre": "Piscina", "ciudad": "BA", "pais": "AR"},
             "entidad_organizadora": {"nombre": "AIDA", "tipo": "FEDERACION"},
+            "grupos_etarios": ["SENIOR"],
         },
     )
     assert response.status_code == 201

--- a/tests/integration/torneo/test_sqlite_torneo_repository.py
+++ b/tests/integration/torneo/test_sqlite_torneo_repository.py
@@ -8,6 +8,7 @@ import pytest
 from torneo.domain.aggregates.torneo import Torneo
 from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
 from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 from torneo.domain.value_objects.sede import Sede
 from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
 
@@ -47,6 +48,7 @@ async def test_save_y_find_by_id(repo: SQLiteTorneoRepository) -> None:
     assert resultado.sede.ciudad == "Buenos Aires"
     assert resultado.entidad_organizadora.tipo == "FEDERACION"
     assert resultado.estado == EstadoTorneo.CREADO
+    assert resultado.grupos_etarios == frozenset({GrupoEtario.SENIOR})
 
 
 @pytest.mark.asyncio
@@ -90,3 +92,12 @@ async def test_round_trip_completo(repo: SQLiteTorneoRepository) -> None:
     assert loaded.sede.nombre == "Piscina Municipal"
     assert loaded.sede.pais == "Argentina"
     assert loaded.entidad_organizadora.nombre == "AIDA Argentina"
+
+
+@pytest.mark.asyncio
+async def test_persiste_y_recupera_grupos_etarios(repo: SQLiteTorneoRepository) -> None:
+    torneo = _torneo(grupos_etarios=frozenset({GrupoEtario.JUNIOR, GrupoEtario.MASTER}))
+    await repo.save(torneo)
+    loaded = await repo.find_by_id(torneo.torneo_id)
+    assert loaded is not None
+    assert loaded.grupos_etarios == frozenset({GrupoEtario.JUNIOR, GrupoEtario.MASTER})

--- a/tests/uat/sp3/seed_sp3.py
+++ b/tests/uat/sp3/seed_sp3.py
@@ -130,6 +130,7 @@ from torneo.application.commands.asignar_disciplinas import (
     AsignarDisciplinasHandler,
 )
 from torneo.application.commands.crear_torneo import CrearTorneoCommand, CrearTorneoHandler
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 from torneo.application.commands.transicionar_torneo import (
     AbrirInscripcionHandler,
     TransicionarTorneoCommand,
@@ -206,6 +207,7 @@ async def fase1() -> None:
             sede_pais="Argentina",
             entidad_nombre="AIDA Argentina",
             entidad_tipo="Federación",
+            grupos_etarios=frozenset({GrupoEtario.SENIOR}),
         )
     )
     print(f"✓ Torneo creado: {torneo_id}")

--- a/tests/uat/sp4/seed_sp4.py
+++ b/tests/uat/sp4/seed_sp4.py
@@ -208,6 +208,7 @@ def main() -> None:
                 "fecha_fin": "2025-12-01",
                 "sede": {"nombre": "Pileta UAT", "ciudad": "Buenos Aires", "pais": "Argentina"},
                 "entidad_organizadora": {"nombre": "AIDA Argentina", "tipo": "Federación"},
+                "grupos_etarios": ["SENIOR"],
             },
             headers=org_h,
         )

--- a/tests/uat/sp6/seed_sp6.py
+++ b/tests/uat/sp6/seed_sp6.py
@@ -225,6 +225,7 @@ def main() -> None:
                         "pais": "Argentina",
                     },
                     "entidad_organizadora": {"nombre": "AIDA Argentina", "tipo": "Federación"},
+                    "grupos_etarios": ["SENIOR"],
                 },
                 headers=org_h,
             ),

--- a/tests/unit/identidad/api/test_dependencies.py
+++ b/tests/unit/identidad/api/test_dependencies.py
@@ -101,6 +101,7 @@ class TestOrganizadorDep:
                 "fecha_fin": "2026-06-03",
                 "sede": {"nombre": "P", "ciudad": "C", "pais": "AR"},
                 "entidad_organizadora": {"nombre": "E", "tipo": "club"},
+                "grupos_etarios": ["SENIOR"],
             },
         )
         assert resp.status_code == 201
@@ -125,6 +126,7 @@ class TestOrganizadorDep:
                 "fecha_fin": "2026-06-03",
                 "sede": {"nombre": "P", "ciudad": "C", "pais": "AR"},
                 "entidad_organizadora": {"nombre": "E", "tipo": "club"},
+                "grupos_etarios": ["SENIOR"],
             },
         )
         assert resp.status_code == 403

--- a/tests/unit/torneo/application/test_crear_torneo.py
+++ b/tests/unit/torneo/application/test_crear_torneo.py
@@ -9,6 +9,7 @@ import pytest
 from torneo.application.commands.crear_torneo import CrearTorneoCommand, CrearTorneoHandler
 from torneo.domain.aggregates.torneo import Torneo
 from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 
 
 def _cmd(**overrides: object) -> CrearTorneoCommand:
@@ -22,6 +23,7 @@ def _cmd(**overrides: object) -> CrearTorneoCommand:
         sede_pais="Argentina",
         entidad_nombre="AIDA Argentina",
         entidad_tipo="FEDERACION",
+        grupos_etarios=frozenset({GrupoEtario.SENIOR}),
     )
     defaults.update(overrides)
     return CrearTorneoCommand(**defaults)  # type: ignore[arg-type]
@@ -44,6 +46,15 @@ async def test_crear_torneo_persiste_con_estado_creado() -> None:
     torneo: Torneo = repo.save.call_args[0][0]
     assert torneo.estado == EstadoTorneo.CREADO
     assert torneo.nombre == "Torneo Test"
+
+
+@pytest.mark.asyncio
+async def test_crear_torneo_persiste_grupos_etarios() -> None:
+    repo = AsyncMock()
+    handler = CrearTorneoHandler(repo)
+    await handler.handle(_cmd(grupos_etarios=frozenset({GrupoEtario.JUNIOR, GrupoEtario.MASTER})))
+    torneo: Torneo = repo.save.call_args[0][0]
+    assert torneo.grupos_etarios == frozenset({GrupoEtario.JUNIOR, GrupoEtario.MASTER})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/torneo/domain/test_torneo.py
+++ b/tests/unit/torneo/domain/test_torneo.py
@@ -7,6 +7,7 @@ from torneo.domain.aggregates.torneo import Torneo
 from torneo.domain.exceptions import TorneoCerrado, TransicionEstadoInvalida
 from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
 from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
 from torneo.domain.value_objects.sede import Sede
 
 
@@ -115,6 +116,37 @@ class TestCreacion:
             entidad_organizadora=entidad,
         )
         assert t.estado == EstadoTorneo.CREADO
+
+    def test_grupo_etario_default_es_senior(self, torneo: Torneo) -> None:
+        assert torneo.grupos_etarios == frozenset({GrupoEtario.SENIOR})
+
+    def test_grupos_etarios_multiples_son_validos(
+        self, sede: Sede, entidad: EntidadOrganizadora
+    ) -> None:
+        t = Torneo(
+            nombre="Test",
+            descripcion="",
+            fecha_inicio=date(2026, 6, 1),
+            fecha_fin=date(2026, 6, 1),
+            sede=sede,
+            entidad_organizadora=entidad,
+            grupos_etarios=frozenset({GrupoEtario.JUNIOR, GrupoEtario.MASTER}),
+        )
+        assert t.grupos_etarios == frozenset({GrupoEtario.JUNIOR, GrupoEtario.MASTER})
+
+    def test_grupos_etarios_vacio_lanza_error(
+        self, sede: Sede, entidad: EntidadOrganizadora
+    ) -> None:
+        with pytest.raises(ValueError, match="grupo etario"):
+            Torneo(
+                nombre="Test",
+                descripcion="",
+                fecha_inicio=date(2026, 6, 1),
+                fecha_fin=date(2026, 6, 1),
+                sede=sede,
+                entidad_organizadora=entidad,
+                grupos_etarios=frozenset(),
+            )
 
 
 class TestTransiciones:


### PR DESCRIPTION
## Resumen
- agrega GrupoEtario al dominio de torneo y lo persiste en SQLite con migración default SENIOR
- requiere y valida grupos_etarios en POST /torneos, y lo expone en GET /torneos
- agrega selector de grupos etarios en el alta de torneo con SENIOR por defecto
- agrega BDD y tests API/unit/integration para US-6.2.5

## Validación
- ./.venv/bin/pytest tests/unit/torneo/domain/test_torneo.py tests/unit/torneo/application/test_crear_torneo.py tests/integration/torneo/test_sqlite_torneo_repository.py tests/integration/torneo/test_grupos_etarios_api.py tests/features/steps/grupos_etarios_torneo_steps.py
- ./.venv/bin/pytest tests/unit/identidad/api/test_dependencies.py tests/integration/torneo/test_disciplinas_torneo_api.py tests/integration/torneo/test_cierre_inscripcion_precondition.py tests/integration/torneo/test_ejecucion_precondicion.py tests/integration/torneo/test_premiacion_precondicion.py tests/integration/e2e/test_flujo_torneo_competencia.py tests/features/steps/test_US_3_3_2_steps.py tests/features/steps/test_US_3_4_2_steps.py tests/features/steps/torneo_api_steps.py
- cd frontend && npm run build
- cd frontend && npm run lint
- git diff --check