### PR TITLE
US-6.3.1: Ajustar inicio atleta

### DIFF
--- a/.claude/tracking/US-6.3.1-tracking.json
+++ b/.claude/tracking/US-6.3.1-tracking.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "us_id": "US-6.3.1",
+    "us_title": "Inicio atleta ajustes visuales",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-07T20:27:35.528641+00:00",
+    "completed_at": "2026-05-07T20:34:18.688714+00:00",
+    "total_elapsed_seconds": 403,
+    "effective_seconds": 403,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-07T20:27:39.493167+00:00",
+      "completed_at": "2026-05-07T20:28:08.718159+00:00",
+      "elapsed_seconds": 29,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación de Plan de Implementación",
+      "started_at": "2026-05-07T20:28:13.479780+00:00",
+      "completed_at": "2026-05-07T20:28:51.164151+00:00",
+      "elapsed_seconds": 37,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-07T20:29:24.024906+00:00",
+      "completed_at": "2026-05-07T20:30:01.037714+00:00",
+      "elapsed_seconds": 37,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-05-07T20:30:07.469147+00:00",
+      "completed_at": "2026-05-07T20:30:10.559141+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-05-07T20:30:13.998085+00:00",
+      "completed_at": "2026-05-07T20:30:17.170998+00:00",
+      "elapsed_seconds": 3,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-07T20:30:20.353507+00:00",
+      "completed_at": "2026-05-07T20:31:39.596348+00:00",
+      "elapsed_seconds": 79,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-07T20:31:46.099914+00:00",
+      "completed_at": "2026-05-07T20:32:33.331001+00:00",
+      "elapsed_seconds": 47,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-07T20:33:39.843933+00:00",
+      "completed_at": "2026-05-07T20:34:15.444148+00:00",
+      "elapsed_seconds": 35,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 8,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/plans/sp6/US-6.3.1-plan.md
+++ b/docs/plans/sp6/US-6.3.1-plan.md
@@ -1,0 +1,101 @@
+# Plan de Implementación — US-6.3.1
+
+**US:** Inicio Atleta — "En línea" en Header + Sin "Hola" + Torneos en Curso Ordenados
+**Incremento:** INC-6.3 — Ajustes Atleta
+**Producto:** frontend
+**Patrón:** React/Vite frontend
+**Estimación total:** 55 min
+**Estado:** ✅ COMPLETADO
+**Fecha completado:** 2026-05-07
+**BDD:** No aplica por decisión operativa para US solo frontend; se valida con build/lint y revisión UI.
+
+---
+
+## Alcance
+
+Implementar tres ajustes visuales y de ordenamiento en el portal atleta:
+
+- Agregar indicador estático "En línea" junto a "AtaraxiaDive" en el header.
+- Eliminar el saludo redundante "Hola" en la página de inicio.
+- Ordenar las disciplinas dentro de cada tarjeta de torneo activo según OT.
+
+No hay cambios de backend, contratos HTTP ni persistencia.
+
+---
+
+## Componentes a Modificar
+
+### 1. Header atleta
+
+- [x] `frontend/src/components/atleta/AtletaShell.tsx` (10 min)
+  - Agregar punto verde y texto "En línea" junto al badge "AtaraxiaDive".
+  - Mantener compatibilidad con `showBack` y `actions`.
+  - Verificar que el layout no colapse en ancho móvil `max-w-[430px]`.
+
+### 2. Inicio atleta
+
+- [x] `frontend/src/pages/atleta/AtletaHomePage.tsx` (25 min)
+  - Eliminar el `<p>Hola</p>` redundante.
+  - Agregar helper local de ordenamiento para entries por OT:
+    - OT futuro primero, ascendente.
+    - Sin OT después de futuras.
+    - OT pasado al final, ascendente.
+  - Aplicar el orden solo a la lista interna de disciplinas de cada torneo.
+  - Mantener el orden actual entre torneos.
+
+### 3. Evidencia de BDD omitido
+
+- [x] `docs/reports/US-6.3.1-bdd-waiver.md` (5 min)
+  - Registrar que Fase 1 y Fase 6 se omiten por tratarse de cambio solo frontend.
+  - Mapear criterios de aceptación a verificación por build/lint y revisión UI/manual.
+
+### 4. Validación
+
+- [x] `npm run build` en `frontend/` (10 min)
+- [x] `npm run lint` en `frontend/` (5 min)
+
+---
+
+## Métricas de Validación
+
+| Gate | Resultado |
+|---|---|
+| `npm run build` | ✅ pasa |
+| `npm run lint` | ✅ pasa |
+| BDD | Waiver por frontend puro |
+
+---
+
+## Criterios de Aceptación Cubiertos
+
+| Criterio | Implementación | Validación |
+|---|---|---|
+| Header muestra "En línea" con punto verde | `AtletaShell.tsx` | Revisión UI/manual + build |
+| No aparece "Hola" antes del nombre | `AtletaHomePage.tsx` | Revisión UI/manual + build |
+| OT futuro más próximo aparece primero | helper de ordenamiento | Revisión de código + build |
+| OT pasado aparece al final | helper de ordenamiento | Revisión de código + build |
+| Sin OT va antes de realizadas | helper de ordenamiento | Revisión de código + build |
+
+---
+
+## Riesgos y Mitigaciones
+
+- **Riesgo:** Comparar fechas inválidas puede producir orden inestable.
+  **Mitigación:** Clasificar entradas sin OT parseable como "sin OT".
+
+- **Riesgo:** El indicador de conexión compite con el botón `Salir` en móvil.
+  **Mitigación:** Mantener el indicador dentro del bloque de marca y `actions` como `shrink-0`.
+
+---
+
+## Definition of Done
+
+- [x] Cambios implementados en los dos archivos frontend previstos.
+- [x] Waiver BDD persistido en `docs/reports/`.
+- [x] `npm run build` pasa.
+- [x] `npm run lint` pasa o se documenta bloqueo preexistente.
+- [ ] Reporte final persistido en `docs/reports/US-6.3.1-report.md` antes del commit.
+
+---
+
+*Generado: 2026-05-07 — Fase 2 /implement-us US-6.3.1*

--- a/docs/reports/US-6.3.1-bdd-waiver.md
+++ b/docs/reports/US-6.3.1-bdd-waiver.md
@@ -1,0 +1,39 @@
+# Waiver BDD — US-6.3.1
+
+**US:** Inicio Atleta — "En línea" en Header + Sin "Hola" + Torneos en Curso Ordenados
+**Incremento:** INC-6.3 — Ajustes Atleta
+**Producto:** frontend
+**Fecha:** 2026-05-07
+
+---
+
+## Decisión
+
+Las Fases 1 y 6 de BDD se omiten para `US-6.3.1` porque la historia modifica solo
+presentación y ordenamiento local en `frontend/`, sin cambios de backend, contratos HTTP,
+persistencia ni reglas de dominio.
+
+La validación se reemplaza por:
+
+- `npm run build`
+- `npm run lint`
+- revisión UI/manual del portal atleta
+
+---
+
+## Mapeo de Criterios
+
+| Criterio de aceptación | Evidencia esperada |
+|---|---|
+| Header muestra "En línea" con punto verde | `AtletaShell.tsx` + revisión UI |
+| No aparece "Hola" antes del nombre | `AtletaHomePage.tsx` + revisión UI |
+| OT futuro más próximo aparece primero | helper `sortDisciplinasPorOt` |
+| OT pasado aparece al final | helper `sortDisciplinasPorOt` |
+| Sin OT va antes de realizadas | helper `sortDisciplinasPorOt` |
+
+---
+
+## Alcance del Waiver
+
+Este waiver aplica solo a `US-6.3.1`. Si una US de INC-6.3 toca `src/` o endpoints
+backend, debe volver al flujo formal con escenarios BDD/HTTP cuando corresponda.

--- a/docs/reports/US-6.3.1-report.md
+++ b/docs/reports/US-6.3.1-report.md
@@ -1,0 +1,73 @@
+# Reporte de Implementación — US-6.3.1
+
+**US:** Inicio Atleta — "En línea" en Header + Sin "Hola" + Torneos en Curso Ordenados
+**Incremento:** INC-6.3 — Ajustes Atleta
+**Producto:** frontend
+**Branch:** `feature-US-6.3.1-ajustes-inicio-atleta`
+**Fecha:** 2026-05-07
+**Estado:** Implementada, pendiente de PR
+
+---
+
+## Resumen
+
+`US-6.3.1` ajusta la pantalla inicial del atleta sin tocar backend ni contratos HTTP.
+La implementación agrega estado visual de conexión en el shell, elimina el saludo
+redundante de la home y ordena las disciplinas de cada torneo activo según OT.
+
+---
+
+## Cambios Implementados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/components/atleta/AtletaShell.tsx` | Agregado indicador estático "En línea" con punto verde junto a "AtaraxiaDive". |
+| `frontend/src/pages/atleta/AtletaHomePage.tsx` | Eliminado "Hola"; agregado ordenamiento local de disciplinas por OT dentro de cada torneo. |
+| `docs/plans/sp6/US-6.3.1-plan.md` | Plan generado y marcado como completado. |
+| `docs/reports/US-6.3.1-bdd-waiver.md` | Waiver BDD por US frontend-only. |
+| `docs/traceability/matrix.md` | Registrado INC-6.3 y evidencia de tests para `US-6.3.1`. |
+
+---
+
+## Criterios de Aceptación
+
+| Criterio | Estado | Evidencia |
+|---|---|---|
+| Header muestra "En línea" con punto verde | ✅ Cumplido | `AtletaShell.tsx` |
+| No aparece "Hola" antes del nombre | ✅ Cumplido | `AtletaHomePage.tsx` |
+| Disciplinas con OT futuro se ordenan ascendente | ✅ Cumplido | `sortDisciplinasPorOt` |
+| Disciplinas ya realizadas aparecen al final | ✅ Cumplido | `sortDisciplinasPorOt` |
+| Disciplinas sin OT van antes de realizadas | ✅ Cumplido | `sortDisciplinasPorOt` |
+
+---
+
+## Validación
+
+| Gate | Resultado |
+|---|---|
+| `npm run build` (`frontend/`) | ✅ Pasa |
+| `npm run lint` (`frontend/`) | ✅ Pasa |
+| BDD | Waiver formal por frontend puro |
+
+El build emitió únicamente la advertencia existente de chunk mayor a 500 kB de Vite.
+
+---
+
+## Notas
+
+- El indicador "En línea" es visual y estático, según la spec.
+- El orden entre torneos no cambia; solo se ordena la lista interna de disciplinas de cada tarjeta.
+- El working tree contiene cambios no relacionados en `.work/formacion/`; no forman parte de esta US.
+
+---
+
+## Artefactos
+
+- Spec: `docs/specs/sp6/US-6.3.1.md`
+- Plan: `docs/plans/sp6/US-6.3.1-plan.md`
+- Waiver BDD: `docs/reports/US-6.3.1-bdd-waiver.md`
+- Tracking: `.claude/tracking/US-6.3.1-tracking.json`
+
+---
+
+*Generado por Fase 9 `/implement-us` — US-6.3.1*

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -581,7 +581,18 @@ alcance vigente de SP5 salvo que se reabra explícitamente el scope.
 
 ---
 
-## 31. Trazabilidad: Discrepancias → US → Documentos a actualizar
+## 31. US-IEDD SP6 INC-6.3 — Ajustes Atleta
+
+> Estado al 2026-05-07: INC-6.3 iniciado. `US-6.3.1` implementada en branch, pendiente de PR.
+> Quality gates `US-6.3.1`: frontend-only · `npm run build` ✅ · `npm run lint` ✅ · BDD waiver.
+
+| US | Inc. | Contenido principal | Estado |
+|----|------|---------------------|--------|
+| US-6.3.1 | 6.3 | Inicio atleta: indicador "En línea", sin saludo redundante "Hola" y disciplinas de torneos activos ordenadas por OT · `AtletaShell.tsx` + `AtletaHomePage.tsx` | ✅ Implementada (pendiente PR) |
+
+---
+
+## 32. Trazabilidad: Discrepancias → US → Documentos a actualizar
 
 Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 2025".
 
@@ -600,7 +611,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 
 ---
 
-## 32. Cobertura Total
+## 33. Cobertura Total
 
 | Área | Total RFs | Definidos | Pendientes | Fuera de alcance v1 |
 |------|:---------:|:---------:|:----------:|:-------------------:|
@@ -620,7 +631,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 
 ---
 
-## 33. US → Tests
+## 34. US → Tests
 
 | US-IEDD | Suite de tests | Estado |
 |---------|---------------|--------|
@@ -715,10 +726,11 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 | US-6.2.4 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #151) |
 | US-6.2.5 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #152) |
 | US-6.2.6 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Done (PR #153) |
+| US-6.3.1 | frontend (build + eslint) · BDD waiver — frontend puro | ✅ Implementada (pendiente PR) |
 
 ---
 
-## 34. US → ADR
+## 35. US → ADR
 
 | US-IEDD | ADR relacionado | Relación |
 |---------|----------------|---------|
@@ -733,6 +745,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 
 ---
 
+*v1.37 — 2026-05-07: INC-6.3 iniciado · §31 nuevo · US-6.3.1 implementada pendiente PR · US→Tests actualizado*
 *v1.36 — 2026-05-07: INC-6.2 cerrado · §30 nuevo (6/6 US ✅ PRs #148–#153) · DesignReviewer 0 CRITICAL · §§ renumerados 31..34 · US→Tests US-6.2.x · header actualizado*
 *v1.35 — 2026-05-04: US-6.1.5 ✅ (PR #147) · §29 5/5 completo · US→Tests actualizados*
 *v1.34 — 2026-05-04: US-6.1.4 ✅ (PR #146) · §29 y US→Tests actualizados*

--- a/frontend/src/components/atleta/AtletaShell.tsx
+++ b/frontend/src/components/atleta/AtletaShell.tsx
@@ -52,6 +52,10 @@ export function AtletaShell({
                 <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-400">
                   AtaraxiaDive
                 </p>
+                <span className="flex items-center gap-1 text-xs font-semibold text-emerald-400">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                  En línea
+                </span>
               </div>
               <h1 className="mt-2 text-xl font-semibold text-white">{title}</h1>
               {subtitle ? <p className="mt-1 text-sm text-slate-400">{subtitle}</p> : null}

--- a/frontend/src/pages/atleta/AtletaHomePage.tsx
+++ b/frontend/src/pages/atleta/AtletaHomePage.tsx
@@ -11,7 +11,36 @@ import {
   formatHora,
   getEstadoTorneoLabel,
   loadAtletaPortalSnapshot,
+  type AtletaPortalEntry,
 } from './portalData'
+
+function getOtTimestamp(entry: AtletaPortalEntry): number | null {
+  if (!entry.ot) return null
+  const timestamp = new Date(entry.ot).getTime()
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
+function sortDisciplinasPorOt(entries: AtletaPortalEntry[], now = new Date()): AtletaPortalEntry[] {
+  const nowTimestamp = now.getTime()
+
+  return [...entries].sort((left, right) => {
+    const leftTimestamp = getOtTimestamp(left)
+    const rightTimestamp = getOtTimestamp(right)
+    const leftFuture = leftTimestamp !== null && leftTimestamp > nowTimestamp
+    const rightFuture = rightTimestamp !== null && rightTimestamp > nowTimestamp
+    const leftPast = leftTimestamp !== null && leftTimestamp <= nowTimestamp
+    const rightPast = rightTimestamp !== null && rightTimestamp <= nowTimestamp
+
+    if (leftFuture && rightFuture) return leftTimestamp - rightTimestamp
+    if (leftFuture) return -1
+    if (rightFuture) return 1
+    if (!leftPast && !rightPast) return 0
+    if (!leftPast) return -1
+    if (!rightPast) return 1
+    if (leftTimestamp !== null && rightTimestamp !== null) return leftTimestamp - rightTimestamp
+    return 0
+  })
+}
 
 export function AtletaHomePage() {
   const atletaId = useAuthStore((state) => state.userId)
@@ -31,8 +60,10 @@ export function AtletaHomePage() {
         entry.torneo.torneo_id,
         {
           torneo: entry.torneo,
-          disciplinas: (query.data?.entries ?? []).filter(
-            (candidate) => candidate.torneo.torneo_id === entry.torneo.torneo_id,
+          disciplinas: sortDisciplinasPorOt(
+            (query.data?.entries ?? []).filter(
+              (candidate) => candidate.torneo.torneo_id === entry.torneo.torneo_id,
+            ),
           ),
         },
       ]),
@@ -68,9 +99,6 @@ export function AtletaHomePage() {
       {query.data ? (
         <div className="space-y-4">
           <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5 shadow-[0_30px_60px_-40px_rgba(56,189,248,0.5)]">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
-              Hola
-            </p>
             <h2 className="mt-2 text-2xl font-semibold text-white">
               {buildNombreCorto(query.data.atleta)}
             </h2>


### PR DESCRIPTION
## Resumen
- Agrega indicador estático En línea en el header del portal atleta.
- Elimina el saludo redundante Hola en inicio.
- Ordena disciplinas de torneos activos por OT dentro de cada tarjeta.

## Validación
- npm run build
- npm run lint
- BDD waiver por frontend puro: docs/reports/US-6.3.1-bdd-waiver.md

## Artefactos
- docs/plans/sp6/US-6.3.1-plan.md
- docs/reports/US-6.3.1-report.md
- docs/traceability/matrix.md