### PR TITLE
fix(resultados): usar proyección para overall [US-6.4.2]

### DIFF
--- a/.claude/tracking/US-6.4.2-tracking.json
+++ b/.claude/tracking/US-6.4.2-tracking.json
@@ -1,0 +1,165 @@
+{
+  "metadata": {
+    "us_id": "US-6.4.2",
+    "us_title": "Materializar proyección competencias_por_torneo en CalcularOverallHandler",
+    "us_points": 5,
+    "producto": "resultados",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-09T14:38:26.169910+00:00",
+    "completed_at": "2026-05-09T14:48:42.927144+00:00",
+    "total_elapsed_seconds": 616,
+    "effective_seconds": 616,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-09T14:38:30.187796+00:00",
+      "completed_at": "2026-05-09T14:39:12.664390+00:00",
+      "elapsed_seconds": 42,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-05-09T14:39:18.385080+00:00",
+      "completed_at": "2026-05-09T14:39:33.256522+00:00",
+      "elapsed_seconds": 14,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generación del Plan de Implementación",
+      "started_at": "2026-05-09T14:39:38.411514+00:00",
+      "completed_at": "2026-05-09T14:40:34.183598+00:00",
+      "elapsed_seconds": 55,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-09T14:40:55.825371+00:00",
+      "completed_at": "2026-05-09T14:42:54.612545+00:00",
+      "elapsed_seconds": 118,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_3_1",
+          "task_name": "Actualizar handler y composition root",
+          "task_type": "implementation",
+          "estimated_minutes": 50.0,
+          "started_at": "2026-05-09T14:41:09.497392+00:00",
+          "completed_at": "2026-05-09T14:41:36.828378+00:00",
+          "elapsed_seconds": 27,
+          "actual_minutes": 0.45,
+          "variance_minutes": -49.55,
+          "file_created": "src/resultados/application/commands/calcular_overall.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_3_2",
+          "task_name": "Actualizar tests overall",
+          "task_type": "test",
+          "estimated_minutes": 65.0,
+          "started_at": "2026-05-09T14:41:41.142211+00:00",
+          "completed_at": "2026-05-09T14:42:49.907701+00:00",
+          "elapsed_seconds": 68,
+          "actual_minutes": 1.13,
+          "variance_minutes": -63.87,
+          "file_created": "tests/unit/resultados/application/test_calcular_overall_handler.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-05-09T14:42:59.330241+00:00",
+      "completed_at": "2026-05-09T14:43:23.525068+00:00",
+      "elapsed_seconds": 24,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integración",
+      "started_at": "2026-05-09T14:43:32.035156+00:00",
+      "completed_at": "2026-05-09T14:43:46.028595+00:00",
+      "elapsed_seconds": 13,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validación BDD",
+      "started_at": "2026-05-09T14:43:51.984324+00:00",
+      "completed_at": "2026-05-09T14:44:57.037551+00:00",
+      "elapsed_seconds": 65,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-09T14:45:04.164705+00:00",
+      "completed_at": "2026-05-09T14:45:32.609298+00:00",
+      "elapsed_seconds": 28,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-09T14:45:37.146712+00:00",
+      "completed_at": "2026-05-09T14:46:08.731453+00:00",
+      "elapsed_seconds": 31,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-09T14:48:00.887727+00:00",
+      "completed_at": "2026-05-09T14:48:37.748110+00:00",
+      "elapsed_seconds": 36,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 2,
+    "completed_tasks": 2,
+    "total_phases": 10,
+    "estimated_total_minutes": 115.0,
+    "actual_total_minutes": 1.58,
+    "variance_minutes": -113.42,
+    "variance_percent": -98.62
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versionado: [Semantic Versioning](https://semver.org/lang/es/)
 ## [Unreleased]
 
 ### Fixed
+- [US-6.4.2] `CalcularOverallHandler` usa la proyeccion materializada `competencias_por_torneo`
+  - Reemplaza el scan O(n) sobre streams de competencia por `listar_por_torneo(torneo_id)`
+  - Actualiza P-09 en `app.py`, tests y BDD de overall
+  - Agrega cobertura para torneos sin competencias materializadas
 - [US-6.4.1] Eliminado ciclo ADP en `competencia/domain/aggregates`
   - `aggregates/__init__.py` deja de reexportar aggregate roots
   - `Performance` importa helpers de reconstitucion por path directo

--- a/docs/plans/sp6/US-6.4.2-plan.md
+++ b/docs/plans/sp6/US-6.4.2-plan.md
@@ -1,0 +1,151 @@
+# Plan de Implementacion: US-6.4.2 - Materializar proyeccion competencias_por_torneo en CalcularOverallHandler
+
+**Patron:** Hexagonal DDD BC-first
+**Producto:** resultados + competencia
+**Incremento:** INC-6.4 - Deuda Tecnica Sistema
+**Estimacion total:** 2h 00min
+**Estado:** Completado
+**Fecha completado:** 2026-05-09
+
+## Contexto Validado
+
+- La US existe en `docs/specs/sp6/US-6.4.2.md`.
+- `CalcularOverallHandler` en `src/resultados/application/commands/calcular_overall.py`
+  todavia usa `_mapear_competencias_por_torneo()` con
+  `competencia_store.load_all_streams_with_prefix("competencia-")`.
+- `CompetenciasPorTorneoPort` ya existe en
+  `src/competencia/domain/ports/competencias_por_torneo_port.py`.
+- `SQLiteCompetenciasPorTorneo` ya existe, crea indice por `torneo_id` y expone
+  `listar_por_torneo(torneo_id)`.
+- `src/app.py` ya importa `SQLiteCompetenciasPorTorneo`, pero
+  `_calcular_overall_si_corresponde()` sigue instanciando
+  `CalcularOverallHandler(ranking_store, competencia_event_store)`.
+
+## Decisiones de Diseno
+
+- `CalcularOverallHandler` recibira `CompetenciasPorTorneoPort` en lugar de
+  `EventStorePort` de competencia.
+- Se eliminara `_mapear_competencias_por_torneo()` y la constante
+  `_EVENTO_INTERVALO_OT`.
+- El handler filtrara los records de la proyeccion por las disciplinas pedidas.
+- Si la proyeccion no devuelve competencias, el handler retornara `[]` sin persistir
+  `RankingOverallCalculado`; esto evita crear eventos vacios para torneos sin datos
+  materializados y cubre el tercer criterio BDD.
+- La importacion cross-BC de `competencia.domain.ports.CompetenciasPorTorneoPort`
+  se acepta como comunicacion por port. Si DesignReviewer la marca, se documentara en
+  el reporte final.
+
+## Componentes a Modificar
+
+### 1. Handler de resultados
+
+- [x] `src/resultados/application/commands/calcular_overall.py` (35 min)
+  - Importar `CompetenciasPorTorneoPort`.
+  - Cambiar constructor a `ranking_store, competencias_por_torneo`.
+  - Usar `await self._competencias_por_torneo.listar_por_torneo(command.torneo_id)`.
+  - Construir `dict[Disciplina, UUID]` desde records filtrados.
+  - Retornar `[]` si no hay competencias para las disciplinas solicitadas.
+  - Eliminar `_mapear_competencias_por_torneo()` y `_EVENTO_INTERVALO_OT`.
+
+### 2. Composition root
+
+- [x] `src/app.py` (15 min)
+  - Instanciar `SQLiteCompetenciasPorTorneo()` dentro de
+    `_calcular_overall_si_corresponde()`.
+  - Pasar la proyeccion a `CalcularOverallHandler`.
+  - Mantener `competencia_event_store` para las precondiciones P-09 existentes.
+
+### 3. Tests unitarios
+
+- [x] `tests/unit/resultados/application/test_calcular_overall_handler.py` (30 min)
+  - Reemplazar mocks de `competencia_store` por mock de `competencias_por_torneo`.
+  - Agregar test que asegura que no se llama `load_all_streams_with_prefix`.
+  - Cubrir caso sin competencias materializadas: retorna `[]` y no persiste evento.
+
+### 4. Tests de integracion
+
+- [x] `tests/integration/resultados/test_calcular_overall_integration.py` (25 min)
+  - Usar `SQLiteCompetenciasPorTorneo` con DB temporal.
+  - Materializar competencias con `guardar()` en lugar de depender del scan de eventos.
+  - Mantener rankings en `ranking_store`.
+
+### 5. BDD y steps existentes
+
+- [x] `tests/features/US-6.4.2-proyeccion-overall.feature` (10 min)
+  - Escenarios BDD creados.
+- [x] `tests/features/steps/calcular_overall_steps.py` (20 min)
+  - Agregar `SQLiteCompetenciasPorTorneo` al contexto.
+  - Hacer que `_append_competencia()` guarde en la proyeccion.
+  - Instanciar `CalcularOverallHandler(ctx["ranking_store"], ctx["competencias_por_torneo"])`.
+  - Si se automatiza el feature nuevo, registrar `scenarios("../US-6.4.2-proyeccion-overall.feature")`.
+
+### 6. Seeds/UAT que instancian el handler
+
+- [x] `tests/uat/sp3/seed_sp3.py` (10 min)
+  - Actualizar `CalcularOverallHandler(resultados_store, store)` a la nueva firma.
+  - Reutilizar la proyeccion `SQLiteCompetenciasPorTorneo` ya importada en el seed.
+
+### 7. Quality Gates
+
+- [x] Tests unitarios de resultados (10 min)
+  - `.venv/bin/python -m pytest tests/unit/resultados/application/test_calcular_overall_handler.py -q`
+- [x] Tests de integracion de resultados (10 min)
+  - `.venv/bin/python -m pytest tests/integration/resultados/test_calcular_overall_integration.py -q`
+- [x] BDD overall (10 min)
+  - `.venv/bin/python -m pytest tests/features/steps/calcular_overall_steps.py -q`
+- [x] Suite acotada P-09/app si aplica (10 min)
+  - `.venv/bin/python -m pytest tests/unit/test_app_p09.py tests/integration/test_p09_callback_integration.py -q`
+- [x] CodeGuard/DesignReviewer acotados (10 min)
+  - `.venv/bin/codeguard src/resultados/application/commands/calcular_overall.py`
+  - `.venv/bin/designreviewer src/resultados/ --config pyproject.toml`
+
+### 8. Documentacion y Reporte
+
+- [x] Actualizar `CHANGELOG.md` (5 min).
+- [x] Actualizar este plan con resultados de validacion en Fase 8 (5 min).
+- [ ] Generar `docs/reports/US-6.4.2-report.md` en Fase 9 (10 min).
+
+## Resultado de Implementacion
+
+- `CalcularOverallHandler` ahora depende de `CompetenciasPorTorneoPort`.
+- Se elimino el scan de `competencia_store.load_all_streams_with_prefix("competencia-")`.
+- `src/app.py` inyecta `SQLiteCompetenciasPorTorneo` en el handler de P-09.
+- Tests unitarios, integracion, BDD steps y seed UAT SP3 quedaron alineados con la nueva firma.
+- El caso sin competencias materializadas retorna `[]` sin persistir `RankingOverallCalculado`.
+
+## Validacion Ejecutada
+
+- `.venv/bin/python -m pytest tests/unit/resultados/application/test_calcular_overall_handler.py -q`
+  - Resultado: 3 passed.
+- `.venv/bin/python -m pytest tests/unit/resultados/ tests/unit/test_app_p09.py -q`
+  - Resultado: 77 passed.
+- `.venv/bin/python -m pytest tests/integration/resultados/test_calcular_overall_integration.py tests/integration/test_p09_callback_integration.py -q`
+  - Resultado: 3 passed.
+- `.venv/bin/python -m pytest tests/features/steps/calcular_overall_steps.py -q`
+  - Resultado: 8 passed.
+- `.venv/bin/python -m pytest tests/unit/resultados/ tests/integration/resultados/test_calcular_overall_integration.py tests/integration/test_p09_callback_integration.py tests/features/steps/calcular_overall_steps.py -q`
+  - Resultado: 85 passed.
+- `.venv/bin/codeguard src/resultados/application/commands/calcular_overall.py`
+  - Resultado: 0 errores, 0 advertencias.
+- `.venv/bin/designreviewer src/resultados/ --config pyproject.toml`
+  - Resultado: 0 CRITICAL, 40 warnings preexistentes/acotados al BC.
+
+## Lecciones Aprendidas
+
+- La proyeccion ya estaba presente en `app.py`; la deuda estaba en la ultima milla de inyeccion.
+- Los BDD de US-3.5.1 eran buenos tests de regresion para preservar el comportamiento del overall.
+
+## Riesgos
+
+- La capa application de `resultados` importara un port del domain de `competencia`.
+  Es mejor que importar infraestructura o escanear el event store, pero DesignReviewer
+  puede marcarlo como cross-BC. Se validara y documentara.
+- Los tests/steps BDD previos de US-3.5.1 dependen de la firma vieja del handler y
+  deben actualizarse junto con el codigo.
+- La proyeccion debe estar poblada antes de calcular overall; `app.py` ya lo hace en el
+  flujo de `CompetenciaIniciadaHandler`/`guardar()`.
+
+## STOP de Fase 2
+
+No se modifica codigo de `src/` ni tests existentes hasta recibir aprobacion explicita
+de este plan.

--- a/docs/reports/US-6.4.2-report.md
+++ b/docs/reports/US-6.4.2-report.md
@@ -1,0 +1,99 @@
+# Reporte de Implementacion: US-6.4.2
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** US-6.4.2 - Materializar proyeccion `competencias_por_torneo` en CalcularOverallHandler
+- **Incremento:** INC-6.4 - Deuda Tecnica Sistema
+- **Producto:** resultados + competencia
+- **Puntos estimados:** 5
+- **Tiempo estimado:** 2h 00min
+- **Tiempo registrado:** 9 min
+- **Estado:** Completado
+- **Fecha completado:** 2026-05-09
+
+## Componentes Implementados
+
+- `src/resultados/application/commands/calcular_overall.py`
+  - `CalcularOverallHandler` ahora recibe `CompetenciasPorTorneoPort`.
+  - Se elimino `_mapear_competencias_por_torneo()` basado en event store.
+  - El handler consulta `listar_por_torneo(torneo_id)` y filtra por disciplinas pedidas.
+  - Si no hay competencias materializadas, retorna `[]` sin persistir eventos.
+- `src/app.py`
+  - P-09 inyecta `SQLiteCompetenciasPorTorneo` al calcular overall.
+- Tests y BDD
+  - Unitarios actualizados para verificar que no se escanea el event store de competencia.
+  - Integracion actualizada con `SQLiteCompetenciasPorTorneo` real.
+  - BDD de overall extendido con escenarios de US-6.4.2.
+- `tests/uat/sp3/seed_sp3.py`
+  - Seed UAT actualizado a la nueva firma del handler.
+
+## Metricas de Calidad
+
+| Gate | Resultado | Estado |
+|------|-----------|--------|
+| Unitarios resultados + P-09 | 77 passed | OK |
+| Integracion overall + P-09 | 3 passed | OK |
+| BDD overall | 8 passed | OK |
+| Suite acotada combinada | 85 passed | OK |
+| CodeGuard handler | 0 errores, 0 advertencias | OK |
+| DesignReviewer resultados | 0 CRITICAL, 40 warnings | OK con warnings preexistentes |
+
+## Validacion Ejecutada
+
+```bash
+.venv/bin/python -m pytest tests/unit/resultados/application/test_calcular_overall_handler.py -q
+# 3 passed
+
+.venv/bin/python -m pytest tests/unit/resultados/ tests/unit/test_app_p09.py -q
+# 77 passed
+
+.venv/bin/python -m pytest tests/integration/resultados/test_calcular_overall_integration.py tests/integration/test_p09_callback_integration.py -q
+# 3 passed
+
+.venv/bin/python -m pytest tests/features/steps/calcular_overall_steps.py -q
+# 8 passed
+
+.venv/bin/python -m pytest tests/unit/resultados/ tests/integration/resultados/test_calcular_overall_integration.py tests/integration/test_p09_callback_integration.py tests/features/steps/calcular_overall_steps.py -q
+# 85 passed
+
+.venv/bin/codeguard src/resultados/application/commands/calcular_overall.py
+# 0 errores; 0 advertencias
+
+.venv/bin/designreviewer src/resultados/ --config pyproject.toml
+# 0 CRITICAL; 40 warnings
+```
+
+## Criterios de Aceptacion
+
+- [x] `CalcularOverallHandler` no llama a `load_all_streams_with_prefix`.
+- [x] `CalcularOverallHandler` llama a `competencias_por_torneo.listar_por_torneo(torneo_id)`.
+- [x] El resultado del overall se preserva para rankings calculados.
+- [x] Torneo sin competencias materializadas retorna `[]` sin error.
+- [x] P-09 en `app.py` usa la proyeccion existente.
+
+## Riesgos y Observaciones
+
+- `DesignReviewer` no reporto CRITICAL. Los 40 warnings pertenecen al estado actual del BC
+  `resultados` y no bloquean esta US.
+- La capa application de `resultados` importa un port del domain de `competencia`. Es una
+  dependencia cross-BC por port, no por infraestructura, y reemplaza un acoplamiento mas costoso
+  al event store completo.
+- La correcta ejecucion de P-09 depende de que la proyeccion se encuentre poblada antes del
+  calculo overall. Ese flujo ya existe en `app.py`.
+
+## Archivos Creados o Modificados
+
+- `CHANGELOG.md`
+- `docs/plans/sp6/US-6.4.2-plan.md`
+- `docs/reports/US-6.4.2-report.md`
+- `src/app.py`
+- `src/resultados/application/commands/calcular_overall.py`
+- `tests/features/US-6.4.2-proyeccion-overall.feature`
+- `tests/features/steps/calcular_overall_steps.py`
+- `tests/integration/resultados/test_calcular_overall_integration.py`
+- `tests/uat/sp3/seed_sp3.py`
+- `tests/unit/resultados/application/test_calcular_overall_handler.py`
+
+## Proximo Paso
+
+- Continuar con US-6.4.3 cuando se apruebe iniciar la siguiente US del incremento.

--- a/src/app.py
+++ b/src/app.py
@@ -391,7 +391,8 @@ async def _calcular_overall_si_corresponde(
     if not disciplinas:
         return
 
-    overall_handler = CalcularOverallHandler(ranking_store, competencia_event_store)
+    competencias_por_torneo = SQLiteCompetenciasPorTorneo()
+    overall_handler = CalcularOverallHandler(ranking_store, competencias_por_torneo)
     await overall_handler.handle(
         CalcularOverallCommand(
             torneo_id=torneo_id,

--- a/src/resultados/application/commands/calcular_overall.py
+++ b/src/resultados/application/commands/calcular_overall.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
+from competencia.domain.ports.competencias_por_torneo_port import CompetenciasPorTorneoPort
 from resultados.domain.aggregates.ranking_competencia import RankingCompetencia
 from resultados.domain.aggregates.ranking_overall import RankingOverall
 from shared.domain.ports.event_store_port import EventStorePort
 from shared.domain.value_objects.disciplina import Disciplina
-
-_EVENTO_INTERVALO_OT = "IntervaloOTConfigurado"
 
 
 @dataclass(frozen=True)
@@ -24,17 +23,17 @@ class CalcularOverallCommand:
 class CalcularOverallHandler:
     """Handler del comando CalcularOverall.
 
-    Usa el Event Store de Competencia para mapear torneo -> competencia/disciplina
+    Usa la proyeccion materializada para mapear torneo -> competencia/disciplina
     y el Event Store de Resultados para leer los rankings ya calculados por disciplina.
     """
 
     def __init__(
         self,
         ranking_store: EventStorePort,
-        competencia_store: EventStorePort,
+        competencias_por_torneo: CompetenciasPorTorneoPort,
     ) -> None:
         self._ranking_store = ranking_store
-        self._competencia_store = competencia_store
+        self._competencias_por_torneo = competencias_por_torneo
 
     async def handle(self, command: CalcularOverallCommand) -> list:
         """Calcula y persiste el overall del torneo.
@@ -42,9 +41,10 @@ class CalcularOverallHandler:
         Raises:
             DisciplinasNoFinalizadas: si alguna disciplina no tiene ranking calculado.
         """
-        competencias = await _mapear_competencias_por_torneo(
-            self._competencia_store, command.torneo_id, command.disciplinas
-        )
+        competencias = await self._mapear_competencias_por_torneo(command)
+        if not competencias:
+            return []
+
         rankings_por_disciplina = {}
         for disciplina, competencia_id in competencias.items():
             stream_id = f"ranking-{competencia_id}-{disciplina.value}"
@@ -65,31 +65,18 @@ class CalcularOverallHandler:
             )
         return entries
 
-
-async def _mapear_competencias_por_torneo(
-    competencia_store: EventStorePort,
-    torneo_id: UUID,
-    disciplinas: list[Disciplina],
-) -> dict[Disciplina, UUID]:
-    """Obtiene la competencia por disciplina para un torneo dado."""
-    streams = await competencia_store.load_all_streams_with_prefix("competencia-")
-    disciplinas_buscadas = set(disciplinas)
-    mapeo: dict[Disciplina, UUID] = {}
-
-    for events in streams:
-        for event in events:
-            if event["event_type"] != _EVENTO_INTERVALO_OT:
-                continue
-            payload = event["payload"]
-            torneo_raw = payload.get("torneo_id")
-            if torneo_raw != str(torneo_id):
-                continue
-            disciplina = Disciplina(payload["disciplina"])
-            if disciplina not in disciplinas_buscadas:
-                continue
-            mapeo[disciplina] = UUID(payload["competencia_id"])
-            break
-    return mapeo
+    async def _mapear_competencias_por_torneo(
+        self, command: CalcularOverallCommand
+    ) -> dict[Disciplina, UUID]:
+        """Obtiene la competencia por disciplina para un torneo dado desde la proyeccion."""
+        records = await self._competencias_por_torneo.listar_por_torneo(command.torneo_id)
+        disciplinas_buscadas = set(command.disciplinas)
+        mapeo: dict[Disciplina, UUID] = {}
+        for record in records:
+            disciplina = Disciplina(record.disciplina)
+            if disciplina in disciplinas_buscadas:
+                mapeo[disciplina] = record.competencia_id
+        return mapeo
 
 
 def _build_stream_id(torneo_id: UUID) -> str:

--- a/tests/features/US-6.4.2-proyeccion-overall.feature
+++ b/tests/features/US-6.4.2-proyeccion-overall.feature
@@ -1,0 +1,18 @@
+Feature: US-6.4.2 - CalcularOverallHandler usa proyeccion materializada
+
+  Scenario: CalcularOverall no escanea el event store de competencia
+    Given un torneo con competencias registradas en la proyeccion competencias_por_torneo
+    When se ejecuta CalcularOverallCommand para ese torneo
+    Then el handler consulta competencias_por_torneo.listar_por_torneo una sola vez
+    And no llama a load_all_streams_with_prefix sobre el event store de competencia
+
+  Scenario: El resultado del overall se preserva
+    Given un torneo con competencias finalizadas y rankings calculados por disciplina
+    When se ejecuta CalcularOverallCommand usando la proyeccion materializada
+    Then los entries del ranking overall conservan puntajes y posiciones esperadas
+
+  Scenario: Torneo sin competencias materializadas no falla
+    Given un torneo sin competencias registradas en la proyeccion competencias_por_torneo
+    When se ejecuta CalcularOverallCommand para ese torneo
+    Then el handler retorna una lista vacia
+    And no persiste un evento RankingOverallCalculado

--- a/tests/features/steps/calcular_overall_steps.py
+++ b/tests/features/steps/calcular_overall_steps.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
 import aiosqlite
 import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
 
+from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
+    SQLiteCompetenciasPorTorneo,
+)
 from resultados.application.commands.calcular_overall import (
     CalcularOverallCommand,
     CalcularOverallHandler,
@@ -20,6 +24,7 @@ from shared.domain.value_objects.disciplina import Disciplina
 from shared.infrastructure.event_store.sqlite_event_store import SQLiteEventStore
 
 scenarios("../US-3.5.1-ranking-overall.feature")
+scenarios("../US-6.4.2-proyeccion-overall.feature")
 
 CREATE_EVENTS_TABLE = """
     CREATE TABLE events (
@@ -56,6 +61,11 @@ async def _append_competencia(ctx: dict, disciplina: Disciplina) -> UUID:
             "torneo_id": str(ctx["torneo_id"]),
             "occurred_at": "2026-04-02T12:00:00+00:00",
         },
+    )
+    await ctx["competencias_por_torneo"].guardar(
+        competencia_id,
+        disciplina.value,
+        ctx["torneo_id"],
     )
     return competencia_id
 
@@ -103,6 +113,7 @@ def ctx() -> dict:
         return {
             "torneo_id": uuid4(),
             "competencia_store": SQLiteEventStore(competencia_db),
+            "competencias_por_torneo": SQLiteCompetenciasPorTorneo(competencia_db),
             "ranking_store": SQLiteEventStore(resultados_db),
             "athletes": {"A": uuid4(), "B": uuid4(), "C": uuid4()},
             "exc": None,
@@ -200,6 +211,38 @@ def given_torneo_sin_rankings(ctx: dict) -> None:
     asyncio.run(_run())
 
 
+@given("un torneo con competencias registradas en la proyeccion competencias_por_torneo")
+def given_competencias_en_proyeccion(ctx: dict) -> None:
+    async def _run() -> None:
+        competencia_id = await _append_competencia(ctx, Disciplina.STA)
+        ctx["competencia_sta"] = competencia_id
+        await _append_ranking(
+            ctx,
+            competencia_id,
+            Disciplina.STA,
+            [_entry(ctx["athletes"]["A"], 1, "310", "Segundos", "20.00")],
+        )
+        ctx["competencias_por_torneo"].listar_por_torneo = AsyncMock(
+            wraps=ctx["competencias_por_torneo"].listar_por_torneo
+        )
+        ctx["competencia_store"].load_all_streams_with_prefix = AsyncMock()
+
+    asyncio.run(_run())
+
+
+@given("un torneo con competencias finalizadas y rankings calculados por disciplina")
+def given_competencias_finalizadas_con_rankings(ctx: dict) -> None:
+    given_sta_abc(ctx)
+    given_dnf_abc(ctx)
+
+
+@given("un torneo sin competencias registradas en la proyeccion competencias_por_torneo")
+def given_torneo_sin_competencias_materializadas(ctx: dict) -> None:
+    ctx["competencias_por_torneo"].listar_por_torneo = AsyncMock(
+        wraps=ctx["competencias_por_torneo"].listar_por_torneo
+    )
+
+
 @given("rankings del torneo con DNF: A=2, B=1")
 def given_dnf_ab(ctx: dict) -> None:
     async def _run() -> None:
@@ -222,7 +265,10 @@ def given_dnf_ab(ctx: dict) -> None:
 def when_calcula_overall(ctx: dict) -> None:
     async def _run() -> None:
         try:
-            handler = CalcularOverallHandler(ctx["ranking_store"], ctx["competencia_store"])
+            handler = CalcularOverallHandler(
+                ctx["ranking_store"],
+                ctx["competencias_por_torneo"],
+            )
             await handler.handle(
                 CalcularOverallCommand(
                     torneo_id=ctx["torneo_id"],
@@ -240,7 +286,10 @@ def when_calcula_overall(ctx: dict) -> None:
 @when("el sistema calcula el overall solo con STA")
 def when_calcula_overall_solo_sta(ctx: dict) -> None:
     async def _run() -> None:
-        handler = CalcularOverallHandler(ctx["ranking_store"], ctx["competencia_store"])
+        handler = CalcularOverallHandler(
+            ctx["ranking_store"],
+            ctx["competencias_por_torneo"],
+        )
         await handler.handle(
             CalcularOverallCommand(
                 torneo_id=ctx["torneo_id"],
@@ -251,6 +300,61 @@ def when_calcula_overall_solo_sta(ctx: dict) -> None:
         ctx["overall"] = RankingOverall.reconstitute(ctx["torneo_id"], events)
 
     asyncio.run(_run())
+
+
+@when("se ejecuta CalcularOverallCommand para ese torneo")
+def when_ejecuta_calcular_overall_para_torneo(ctx: dict) -> None:
+    async def _run() -> None:
+        handler = CalcularOverallHandler(
+            ctx["ranking_store"],
+            ctx["competencias_por_torneo"],
+        )
+        ctx["entries"] = await handler.handle(
+            CalcularOverallCommand(
+                torneo_id=ctx["torneo_id"],
+                disciplinas=[Disciplina.STA, Disciplina.DNF],
+            )
+        )
+        events = await ctx["ranking_store"].load(f"ranking-overall-{ctx['torneo_id']}")
+        ctx["overall"] = RankingOverall.reconstitute(ctx["torneo_id"], events)
+
+    asyncio.run(_run())
+
+
+@when("se ejecuta CalcularOverallCommand usando la proyeccion materializada")
+def when_ejecuta_calcular_overall_con_proyeccion(ctx: dict) -> None:
+    when_ejecuta_calcular_overall_para_torneo(ctx)
+
+
+@then("el handler consulta competencias_por_torneo.listar_por_torneo una sola vez")
+def then_consulta_proyeccion_una_vez(ctx: dict) -> None:
+    ctx["competencias_por_torneo"].listar_por_torneo.assert_awaited_once_with(ctx["torneo_id"])
+
+
+@then("no llama a load_all_streams_with_prefix sobre el event store de competencia")
+def then_no_escanea_event_store_competencia(ctx: dict) -> None:
+    ctx["competencia_store"].load_all_streams_with_prefix.assert_not_called()
+
+
+@then("los entries del ranking overall conservan puntajes y posiciones esperadas")
+def then_entries_overall_esperados(ctx: dict) -> None:
+    by_id = {entry.atleta_id: entry for entry in ctx["overall"].entries}
+    assert by_id[ctx["athletes"]["A"]].puntos_overall == 30
+    assert by_id[ctx["athletes"]["A"]].posicion == 1
+    assert by_id[ctx["athletes"]["B"]].puntos_overall == 30
+    assert by_id[ctx["athletes"]["B"]].posicion == 1
+    assert by_id[ctx["athletes"]["C"]].puntos_overall == 10
+    assert by_id[ctx["athletes"]["C"]].posicion == 3
+
+
+@then("el handler retorna una lista vacia")
+def then_retorna_lista_vacia(ctx: dict) -> None:
+    assert ctx["entries"] == []
+
+
+@then("no persiste un evento RankingOverallCalculado")
+def then_no_persiste_ranking_overall(ctx: dict) -> None:
+    assert ctx["overall"].entries == []
 
 
 @then(parsers.parse("{atleta} tiene puntaje overall {puntaje:d} y posicion {posicion:d}"))

--- a/tests/integration/resultados/test_calcular_overall_integration.py
+++ b/tests/integration/resultados/test_calcular_overall_integration.py
@@ -9,6 +9,9 @@ from uuid import uuid4
 import aiosqlite
 import pytest
 
+from competencia.infrastructure.repositories.sqlite_competencias_por_torneo import (
+    SQLiteCompetenciasPorTorneo,
+)
 from resultados.application.commands.calcular_overall import (
     CalcularOverallCommand,
     CalcularOverallHandler,
@@ -97,6 +100,7 @@ async def test_calcular_overall_persiste_y_reconstituye() -> None:
 
     competencia_store = SQLiteEventStore(competencia_db)
     ranking_store = SQLiteEventStore(resultados_db)
+    competencias_por_torneo = SQLiteCompetenciasPorTorneo(competencia_db)
 
     torneo_id = uuid4()
     competencia_sta = uuid4()
@@ -107,6 +111,8 @@ async def test_calcular_overall_persiste_y_reconstituye() -> None:
 
     await _append_competencia(competencia_store, competencia_sta, torneo_id, Disciplina.STA)
     await _append_competencia(competencia_store, competencia_dnf, torneo_id, Disciplina.DNF)
+    await competencias_por_torneo.guardar(competencia_sta, Disciplina.STA.value, torneo_id)
+    await competencias_por_torneo.guardar(competencia_dnf, Disciplina.DNF.value, torneo_id)
 
     # Atleta A: STA=100, DNF=80 → overall=180
     # Atleta B: STA=80, DNF=100 → overall=180 (empate)
@@ -132,7 +138,7 @@ async def test_calcular_overall_persiste_y_reconstituye() -> None:
         ],
     )
 
-    handler = CalcularOverallHandler(ranking_store, competencia_store)
+    handler = CalcularOverallHandler(ranking_store, competencias_por_torneo)
     await handler.handle(
         CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA, Disciplina.DNF])
     )
@@ -160,6 +166,7 @@ async def test_calcular_overall_rechaza_si_falta_ranking_de_disciplina() -> None
 
     competencia_store = SQLiteEventStore(competencia_dir + "/comp.db")
     ranking_store = SQLiteEventStore(resultados_dir + "/res.db")
+    competencias_por_torneo = SQLiteCompetenciasPorTorneo(competencia_dir + "/comp.db")
 
     torneo_id = uuid4()
     competencia_sta = uuid4()
@@ -168,6 +175,8 @@ async def test_calcular_overall_rechaza_si_falta_ranking_de_disciplina() -> None
 
     await _append_competencia(competencia_store, competencia_sta, torneo_id, Disciplina.STA)
     await _append_competencia(competencia_store, competencia_dnf, torneo_id, Disciplina.DNF)
+    await competencias_por_torneo.guardar(competencia_sta, Disciplina.STA.value, torneo_id)
+    await competencias_por_torneo.guardar(competencia_dnf, Disciplina.DNF.value, torneo_id)
     await _append_ranking(
         ranking_store,
         competencia_sta,
@@ -176,7 +185,7 @@ async def test_calcular_overall_rechaza_si_falta_ranking_de_disciplina() -> None
     )
     # DNF no tiene ranking calculado
 
-    handler = CalcularOverallHandler(ranking_store, competencia_store)
+    handler = CalcularOverallHandler(ranking_store, competencias_por_torneo)
 
     with pytest.raises(DisciplinasNoFinalizadas):
         await handler.handle(

--- a/tests/uat/sp3/seed_sp3.py
+++ b/tests/uat/sp3/seed_sp3.py
@@ -361,6 +361,7 @@ async def fase2() -> None:
 
     store = SQLiteEventStore(_COMPETENCIA_DB)
     resultados_store = SQLiteEventStore(_RESULTADOS_DB)
+    competencias_por_torneo = SQLiteCompetenciasPorTorneo(_COMPETENCIA_DB)
     estado_adapter = CompetenciaEstadoAdapter(store)
     perf_estado_adapter = PerformancesEstadoAdapter(store)
     descriptor_adapter = DisciplinaDescriptorAdapter()
@@ -383,7 +384,7 @@ async def fase2() -> None:
             torneo = await torneo_repo.find_by_id(torneo_id_cb)
             if torneo is not None:
                 disciplinas = [d for dt in torneo.disciplinas_torneo for d in [dt.disciplina]]
-                await CalcularOverallHandler(resultados_store, store).handle(
+                await CalcularOverallHandler(resultados_store, competencias_por_torneo).handle(
                     CalcularOverallCommand(torneo_id=torneo_id_cb, disciplinas=disciplinas)
                 )
                 print("✓ Overall calculado (P-09)")

--- a/tests/unit/resultados/application/test_calcular_overall_handler.py
+++ b/tests/unit/resultados/application/test_calcular_overall_handler.py
@@ -7,26 +7,13 @@ from uuid import uuid4
 
 import pytest
 
+from competencia.domain.ports.competencias_por_torneo_port import CompetenciaPorTorneoRecord
 from resultados.application.commands.calcular_overall import (
     CalcularOverallCommand,
     CalcularOverallHandler,
 )
 from resultados.domain.exceptions import DisciplinasNoFinalizadas
 from shared.domain.value_objects.disciplina import Disciplina
-
-
-def _competencia_event(competencia_id, torneo_id, disciplina: Disciplina) -> dict:
-    return {
-        "event_type": "IntervaloOTConfigurado",
-        "payload": {
-            "competencia_id": str(competencia_id),
-            "disciplina": disciplina.value,
-            "intervalo_minutos": 3,
-            "configurado_por": "organizador",
-            "torneo_id": str(torneo_id),
-            "occurred_at": "2026-04-02T12:00:00+00:00",
-        },
-    }
 
 
 def _ranking_event(
@@ -71,14 +58,23 @@ async def test_handle_persiste_ranking_overall_calculado() -> None:
     )
     ranking_store.append = AsyncMock()
 
-    competencia_store = AsyncMock()
-    competencia_store.load_all_streams_with_prefix = AsyncMock(
-        return_value=[[_competencia_event(competencia_sta, torneo_id, Disciplina.STA)]]
+    competencias_por_torneo = AsyncMock()
+    competencias_por_torneo.listar_por_torneo = AsyncMock(
+        return_value=[
+            CompetenciaPorTorneoRecord(
+                competencia_id=competencia_sta,
+                disciplina=Disciplina.STA.value,
+                torneo_id=torneo_id,
+            )
+        ]
     )
+    competencia_store = AsyncMock()
 
-    handler = CalcularOverallHandler(ranking_store, competencia_store)
+    handler = CalcularOverallHandler(ranking_store, competencias_por_torneo)
     await handler.handle(CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA]))
 
+    competencias_por_torneo.listar_por_torneo.assert_awaited_once_with(torneo_id)
+    competencia_store.load_all_streams_with_prefix.assert_not_called()
     ranking_store.append.assert_called_once()
     call = ranking_store.append.call_args.kwargs
     assert call["stream_id"] == f"ranking-overall-{torneo_id}"
@@ -95,16 +91,44 @@ async def test_handle_disciplina_sin_ranking_lanza_excepcion() -> None:
     ranking_store.load = AsyncMock(side_effect=[[], []])
     ranking_store.append = AsyncMock()
 
-    competencia_store = AsyncMock()
-    competencia_store.load_all_streams_with_prefix = AsyncMock(
-        return_value=[[_competencia_event(competencia_id, torneo_id, Disciplina.STA)]]
+    competencias_por_torneo = AsyncMock()
+    competencias_por_torneo.listar_por_torneo = AsyncMock(
+        return_value=[
+            CompetenciaPorTorneoRecord(
+                competencia_id=competencia_id,
+                disciplina=Disciplina.STA.value,
+                torneo_id=torneo_id,
+            )
+        ]
     )
 
-    handler = CalcularOverallHandler(ranking_store, competencia_store)
+    handler = CalcularOverallHandler(ranking_store, competencias_por_torneo)
 
     with pytest.raises(DisciplinasNoFinalizadas):
         await handler.handle(
             CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA])
         )
 
+    ranking_store.append.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_torneo_sin_competencias_materializadas_retorna_vacio() -> None:
+    torneo_id = uuid4()
+
+    ranking_store = AsyncMock()
+    ranking_store.load = AsyncMock()
+    ranking_store.append = AsyncMock()
+    competencias_por_torneo = AsyncMock()
+    competencias_por_torneo.listar_por_torneo = AsyncMock(return_value=[])
+
+    handler = CalcularOverallHandler(ranking_store, competencias_por_torneo)
+
+    result = await handler.handle(
+        CalcularOverallCommand(torneo_id=torneo_id, disciplinas=[Disciplina.STA])
+    )
+
+    assert result == []
+    competencias_por_torneo.listar_por_torneo.assert_awaited_once_with(torneo_id)
+    ranking_store.load.assert_not_called()
     ranking_store.append.assert_not_called()


### PR DESCRIPTION
## Resumen
- Cambia CalcularOverallHandler para usar CompetenciasPorTorneoPort
- Reemplaza el scan O(n) sobre streams de competencia por listar_por_torneo(torneo_id)
- Actualiza P-09 en app.py, unitarios, integración, BDD y seed UAT SP3

## Validación
- .venv/bin/python -m pytest tests/unit/resultados/ tests/unit/test_app_p09.py -q -> 77 passed
- .venv/bin/python -m pytest tests/integration/resultados/test_calcular_overall_integration.py tests/integration/test_p09_callback_integration.py -q -> 3 passed
- .venv/bin/python -m pytest tests/features/steps/calcular_overall_steps.py -q -> 8 passed
- .venv/bin/python -m pytest tests/unit/resultados/ tests/integration/resultados/test_calcular_overall_integration.py tests/integration/test_p09_callback_integration.py tests/features/steps/calcular_overall_steps.py -q -> 85 passed
- .venv/bin/codeguard src/resultados/application/commands/calcular_overall.py -> 0 errores, 0 advertencias
- .venv/bin/designreviewer src/resultados/ --config pyproject.toml -> 0 CRITICAL