### PR TITLE
US-6.4.5: refactor registro repository

### DIFF
--- a/.claude/tracking/US-6.4.5-tracking.json
+++ b/.claude/tracking/US-6.4.5-tracking.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {
+    "us_id": "US-6.4.5",
+    "us_title": "Refactoring DeclararAPInscripcionHandler + SQLiteInscripcionRepository",
+    "us_points": 6,
+    "producto": "registro",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-09T23:34:27.971314+00:00",
+    "completed_at": "2026-05-10T00:39:01.694136+00:00",
+    "total_elapsed_seconds": 3873,
+    "effective_seconds": 3873,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de contexto",
+      "started_at": "2026-05-09T23:34:30.920229+00:00",
+      "completed_at": "2026-05-09T23:35:13.892743+00:00",
+      "elapsed_seconds": 42,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Escenarios BDD",
+      "started_at": "2026-05-09T23:35:17.054974+00:00",
+      "completed_at": "2026-05-09T23:35:32.628510+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de implementacion",
+      "started_at": "2026-05-09T23:35:36.316428+00:00",
+      "completed_at": "2026-05-09T23:36:27.741662+00:00",
+      "elapsed_seconds": 51,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementacion",
+      "started_at": "2026-05-09T23:36:54.063620+00:00",
+      "completed_at": "2026-05-09T23:38:06.254424+00:00",
+      "elapsed_seconds": 72,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests unitarios",
+      "started_at": "2026-05-09T23:38:10.705254+00:00",
+      "completed_at": "2026-05-09T23:38:18.167327+00:00",
+      "elapsed_seconds": 7,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de integracion",
+      "started_at": "2026-05-09T23:38:21.326448+00:00",
+      "completed_at": "2026-05-09T23:38:34.776520+00:00",
+      "elapsed_seconds": 13,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validacion BDD",
+      "started_at": "2026-05-09T23:38:38.857059+00:00",
+      "completed_at": "2026-05-09T23:38:46.098194+00:00",
+      "elapsed_seconds": 7,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality gates",
+      "started_at": "2026-05-09T23:38:49.409632+00:00",
+      "completed_at": "2026-05-09T23:40:30.500109+00:00",
+      "elapsed_seconds": 101,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentacion",
+      "started_at": "2026-05-09T23:40:35.968939+00:00",
+      "completed_at": "2026-05-09T23:41:54.250133+00:00",
+      "elapsed_seconds": 78,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte final",
+      "started_at": "2026-05-10T00:38:01.645279+00:00",
+      "completed_at": "2026-05-10T00:38:58.340460+00:00",
+      "elapsed_seconds": 56,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 10,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versionado: [Semantic Versioning](https://semver.org/lang/es/)
 ## [Unreleased]
 
 ### Fixed
+- [US-6.4.5] `SQLiteInscripcionRepository` delega reconstitucion en `Inscripcion`
+  - Agrega `Inscripcion.from_row()` para reconstruir datos planos persistidos
+  - Elimina DR-07 del repositorio en DesignReviewer
+  - Documenta DR-06 como falso positivo de coordination handler
 - [US-6.4.4] `AlgoritmoPuntajeFAAS` queda como dispatcher explícito
   - Extrae cálculo FAAS de distancia y tiempo a funciones de módulo
   - Elimina el hallazgo LCOM DR-02 en DesignReviewer

--- a/docs/plans/sp6/PLAN-SP6.md
+++ b/docs/plans/sp6/PLAN-SP6.md
@@ -102,8 +102,8 @@ más la deuda técnica pendiente de quality gates.
 | ARCH-03 | `resultados_competencia_adapter.py` | Import cross-BC directo — decisión pendiente: ¿ACL aceptable o violación? | Media | notas .work |
 | DR-01 | `RankingCompetencia` | LCOM 2/1 — mezcla lógica ranking + acumulación overall → candidato SRP | Media | DR INC-5.6 |
 | DR-02 | `AlgoritmoPuntajeFAAS` | LCOM 2/1 + C=11 — dos paths cálculo → dispatch por TipoDisciplina | Media | DR INC-5.6 + CG |
-| DR-06 | `DeclararAPInscripcionHandler` | FeatureEnvy 4/2 — lógica AP debería estar en aggregate `Inscripcion` | Media | DR SP-ADJ-09 |
-| DR-07 | `SQLiteInscripcionRepository` | FeatureEnvy 7/2 + FanOut 9/7 — query ensambla múltiples entidades | Media | DR SP-ADJ-09 |
+| DR-06 | `DeclararAPInscripcionHandler` | FeatureEnvy 4/2 — no aplicable: coordination handler load → domain method → save | Media | US-6.4.5 |
+| DR-07 | `SQLiteInscripcionRepository` | Resuelto: reconstitucion delegada a `Inscripcion.from_row()` y helpers de serializacion fuera del metodo `save()` | Media | US-6.4.5 |
 | CG-01/03/04/05 | varios | E501 (4 líneas) + `import os` huérfano — resolubles con `black` | Baja | CodeGuard |
 | QG-01 | DesignReviewer | Evaluar reducción `max_cbo`/`max_wmc` post-SP6 | Baja | memory |
 

--- a/docs/plans/sp6/US-6.4.5-plan.md
+++ b/docs/plans/sp6/US-6.4.5-plan.md
@@ -1,0 +1,153 @@
+# Plan de Implementacion: US-6.4.5 - Refactor registro DesignReviewer
+
+**Patron:** Hexagonal DDD BC-first  
+**Producto:** registro  
+**Incremento:** INC-6.4 - Deuda Tecnica Sistema  
+**Estimacion total:** 2h 30min  
+**Estado:** Completado
+
+## Contexto Validado
+
+- La US existe en `docs/specs/sp6/US-6.4.5.md`.
+- El BC afectado es `registro`.
+- El handler existe en `src/registro/application/commands/declarar_ap_inscripcion.py`.
+- El repositorio existe en
+  `src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py`.
+- El aggregate existe en `src/registro/domain/aggregates/inscripcion.py`.
+- Tests existentes relevantes:
+  - `tests/unit/registro/test_inscripcion.py`
+  - `tests/integration/registro/test_sqlite_inscripcion_repository.py`
+- DesignReviewer reproduce los hallazgos iniciales:
+  - `DeclararAPInscripcionHandler`: FeatureEnvy `4/2`.
+  - `SQLiteInscripcionRepository`: FanOut `9/7`, FeatureEnvy `7/0` y `9/2`,
+    LongMethod `40/20`.
+
+## Diagnostico DR-06
+
+`DeclararAPInscripcionHandler` implementa el patron esperado de application layer:
+
+1. carga el aggregate desde el puerto de repositorio;
+2. valida ausencia con excepcion de dominio;
+3. delega la regla de negocio en `inscripcion.declarar_ap()`;
+4. persiste el aggregate.
+
+No hay condiciones, calculos ni validaciones de negocio propias del handler. Por lo tanto, DR-06 se
+trata como falso positivo estructural del analyzer para coordination handlers. El codigo del handler
+no se modificara salvo que durante tests aparezca evidencia contraria.
+
+## Decisiones de Diseno
+
+- Mantener el handler sin cambios funcionales.
+- Agregar `Inscripcion.from_row(data: Mapping[str, Any]) -> Inscripcion` como factory de
+  reconstitucion desde datos planos.
+- Mover el parsing de `disciplinas`, `ap_por_disciplina`, fechas e IDs al aggregate.
+- Reducir `SQLiteInscripcionRepository._row_to_inscripcion()` a conversion de `aiosqlite.Row` a
+  `dict` + llamada a `Inscripcion.from_row()`.
+- El repositorio debe dejar de importar `APDeclarado`, `Disciplina`, `UnidadMedida`, `Decimal`,
+  `datetime` y `UUID` si ya no los usa directamente.
+- Mantener `EstadoInscripcion` en el repositorio si se sigue usando para query de activas.
+- Extraer serializacion de `save()` a helpers de modulo para eliminar LongMethod y FeatureEnvy
+  remanentes en el repositorio.
+- No cambiar esquema SQLite ni formato JSON persistido.
+
+## Componentes a Modificar
+
+### 1. Aggregate `Inscripcion`
+
+- [x] `src/registro/domain/aggregates/inscripcion.py` (35 min)
+  - Importar dependencias necesarias para reconstitucion (`json`, `Any`, `Mapping`,
+    `Decimal`, `UnidadMedida`).
+  - Agregar `from_row()` tipado.
+  - Encapsular reconstruccion de `ap_por_disciplina`.
+  - Preservar adjuntos opcionales.
+
+### 2. Repositorio SQLite
+
+- [x] `src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py` (25 min)
+  - Simplificar `_row_to_inscripcion(row)` a `Inscripcion.from_row(_row_to_dict(row))`.
+  - Agregar helper privado `_row_to_dict()` si `dict(row)` no es robusto con `aiosqlite.Row`.
+  - Eliminar imports huerfanos.
+
+### 3. Tests Unitarios
+
+- [x] `tests/unit/registro/test_inscripcion.py` (25 min)
+  - Agregar test de `Inscripcion.from_row()` con disciplinas, AP, estado, fecha y adjuntos.
+  - Agregar test de `from_row()` con `ap_por_disciplina` vacio.
+
+### 4. Tests de Integracion
+
+- [x] `tests/integration/registro/test_sqlite_inscripcion_repository.py` (20 min)
+  - Agregar/ajustar test para round-trip con AP declarado.
+  - Mantener test de adjuntos.
+  - Mantener test legacy sin adjuntos.
+
+### 5. BDD
+
+- [x] `tests/features/US-6.4.5-refactor-registro-designreviewer.feature` (10 min)
+  - Escenarios creados en Fase 1.
+- [x] Validar escenarios por correspondencia con tests/gates (10 min)
+  - No crear steps nuevos salvo que exista patron BDD automatizado aplicable.
+
+### 6. Quality Gates
+
+- [x] Unitarios de registro (10 min)
+  - `.venv/bin/python -m pytest tests/unit/registro -q`
+- [x] Integracion de registro (10 min)
+  - `.venv/bin/python -m pytest tests/integration/registro -q`
+- [x] Regresion registro (10 min)
+  - `.venv/bin/python -m pytest tests/unit/registro tests/integration/registro -q`
+- [x] DesignReviewer acotado (10 min)
+  - `.venv/bin/designreviewer src/registro/application/commands/declarar_ap_inscripcion.py src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py --config pyproject.toml`
+  - Criterio: DR-07 no aparece en `SQLiteInscripcionRepository`; DR-06 puede quedar documentado
+    como falso positivo si el analyzer lo sigue reportando.
+- [x] CodeGuard acotado (10 min)
+  - `.venv/bin/codeguard src/registro/domain/aggregates/inscripcion.py src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py`
+- [x] Formato/lint acotado (10 min)
+  - `.venv/bin/ruff check <archivos Python tocados>`
+  - `.venv/bin/black --check <archivos Python tocados>`
+  - `.venv/bin/isort --check-only <archivos Python tocados>`
+
+### 7. Documentacion y Cierre
+
+- [x] Documentar DR-06 como falso positivo/no aplicable de coordination handler (10 min).
+- [x] Actualizar `CHANGELOG.md` (5 min).
+- [x] Actualizar `docs/specs/sp6/US-6.4.5.md` a `Done` si los gates pasan (5 min).
+- [x] Actualizar `docs/traceability/matrix.md` (5 min).
+- [x] Generar `docs/reports/US-6.4.5-report.md` (15 min).
+- [x] Actualizar este plan con resultados de validacion (5 min).
+
+## Resultados de Validacion
+
+- `.venv/bin/python -m pytest tests/unit/registro/test_inscripcion.py tests/integration/registro/test_sqlite_inscripcion_repository.py -q`
+  - `23 passed`
+- `.venv/bin/python -m pytest tests/unit/registro -q`
+  - `42 passed`
+- `.venv/bin/python -m pytest tests/integration/registro -q`
+  - `25 passed`
+- `.venv/bin/python -m pytest tests/unit/registro tests/integration/registro -q`
+  - `67 passed`
+- `.venv/bin/designreviewer src/registro/application/commands/declarar_ap_inscripcion.py src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py --config pyproject.toml`
+  - `SQLiteInscripcionRepository`: sin DR-07, sin FanOut, sin LongMethod.
+  - `DeclararAPInscripcionHandler`: conserva FeatureEnvy `4/2`, documentado como falso
+    positivo estructural de coordination handler.
+- `.venv/bin/codeguard src/registro/domain/aggregates/inscripcion.py src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py`
+  - `0 errores`, `0 advertencias`, `6 informativos`
+- `.venv/bin/ruff check <archivos Python tocados>`
+  - `All checks passed`
+- `.venv/bin/black --check <archivos Python tocados>`
+  - `4 files would be left unchanged`
+- `.venv/bin/isort --check-only <archivos Python tocados>`
+  - OK
+
+## Riesgos
+
+- Mover parsing al aggregate puede aumentar fan-out del aggregate. Es aceptable si reduce el
+  repositorio y no introduce imports fuera de `registro/domain` o `shared/domain`.
+- DesignReviewer puede seguir reportando DR-06 por el patron normal de handler. Se documentara como
+  falso positivo si no hay logica de negocio movible.
+- La corrida amplia de `registro` puede exponer warnings preexistentes fuera del alcance. Se
+  registraran sin reformateos masivos.
+
+## STOP de Fase 2
+
+No se modifica codigo de `src/` ni tests existentes hasta recibir aprobacion explicita de este plan.

--- a/docs/reports/US-6.4.5-report.md
+++ b/docs/reports/US-6.4.5-report.md
@@ -1,0 +1,67 @@
+# Reporte Final: US-6.4.5 - Refactor registro DesignReviewer
+
+**Fecha:** 2026-05-09  
+**Incremento:** INC-6.4 - Deuda Tecnica Sistema  
+**Producto / BC:** registro  
+**Estado:** Completada
+
+## Resumen
+
+Se resolvio DR-07 en `SQLiteInscripcionRepository` moviendo la reconstitucion de
+`Inscripcion` a `Inscripcion.from_row()` y extrayendo helpers de serializacion/esquema fuera de
+metodos largos del repositorio.
+
+DR-06 en `DeclararAPInscripcionHandler` se investigo y quedo documentado como falso positivo
+estructural: el handler solo coordina carga, metodo de dominio y persistencia.
+
+## Cambios Implementados
+
+- `src/registro/domain/aggregates/inscripcion.py`
+  - Agrega `Inscripcion.from_row(data)` para reconstituir desde datos planos.
+  - Encapsula parsing de `disciplinas`, `ap_por_disciplina`, IDs, fecha, estado y adjuntos.
+- `src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py`
+  - `_row_to_inscripcion()` delega en `Inscripcion.from_row(_row_to_dict(row))`.
+  - `save()` usa `_UPSERT_INSCRIPCION` y `_inscripcion_to_values()`.
+  - `_ensure_schema()` y `_ensure_table()` quedan como helpers de modulo.
+  - El repositorio deja de importar `APDeclarado`, `Disciplina`, `UnidadMedida`, `Decimal` y
+    `datetime`.
+- `tests/unit/registro/test_inscripcion.py`
+  - Cobertura de `from_row()` con AP, estado, fecha, disciplinas y adjuntos.
+  - Cobertura de `from_row()` con AP vacio.
+- `tests/integration/registro/test_sqlite_inscripcion_repository.py`
+  - Round-trip SQLite de AP por disciplina.
+- Documentacion actualizada en `CHANGELOG.md`, spec, trazabilidad y plan SP6.
+
+## Evidencia de Validacion
+
+| Gate | Resultado |
+| --- | --- |
+| `pytest tests/unit/registro/test_inscripcion.py tests/integration/registro/test_sqlite_inscripcion_repository.py -q` | `23 passed` |
+| `pytest tests/unit/registro -q` | `42 passed` |
+| `pytest tests/integration/registro -q` | `25 passed` |
+| `pytest tests/unit/registro tests/integration/registro -q` | `67 passed` |
+| `designreviewer declarar_ap_inscripcion.py sqlite_inscripcion_repository.py` | DR-07 eliminado; solo queda DR-06 documentado |
+| `codeguard inscripcion.py sqlite_inscripcion_repository.py` | `0 errores`, `0 advertencias`, `6 informativos` |
+| `ruff check <archivos Python tocados>` | OK |
+| `black --check <archivos Python tocados>` | OK |
+| `isort --check-only <archivos Python tocados>` | OK |
+
+## Criterios de Aceptacion
+
+- DR-06 investigado: no hay logica de negocio en el handler; se documenta como no aplicable.
+- `SQLiteInscripcionRepository` usa `Inscripcion.from_row()` para reconstitucion.
+- El repositorio no importa `APDeclarado`, `Disciplina` ni `UnidadMedida` directamente.
+- La reconstitucion preserva adjuntos y AP por disciplina.
+- La suite de `registro` pasa completa.
+
+## Observaciones
+
+- DesignReviewer conserva una advertencia en `DeclararAPInscripcionHandler` por FeatureEnvy `4/2`.
+  La decision de esta US es no refactorizar ese handler porque responde al patron normal de
+  coordination handler en application layer.
+- El refactor no cambia esquema SQLite ni formato JSON persistido.
+- Persisten warnings de tests por `datetime.utcnow()` preexistente, fuera del alcance de esta US.
+
+## Siguiente Paso
+
+Preparar commit y PR de `feature/US-6.4.5-refactor-registro` hacia `develop`.

--- a/docs/specs/sp6/US-6.4.5.md
+++ b/docs/specs/sp6/US-6.4.5.md
@@ -1,6 +1,6 @@
 # US-6.4.5: Refactoring `DeclararAPInscripcionHandler` + `SQLiteInscripcionRepository`
 
-**Estado**: `Pending`
+**Estado**: `Done`
 **Incremento**: INC-6.4 — Deuda Técnica Sistema
 **Hallazgos**: DR-06 · DR-07
 **Bounded Context**: `registro`

--- a/docs/traceability/matrix.md
+++ b/docs/traceability/matrix.md
@@ -597,7 +597,7 @@ alcance vigente de SP5 salvo que se reabra explícitamente el scope.
 
 ## 32. US-IEDD SP6 INC-6.4 — Deuda Técnica Sistema
 
-> Estado al 2026-05-09: INC-6.4 ⏳ **en definición**. 2/6 US · specs generadas.
+> Estado al 2026-05-09: INC-6.4 ⏳ **en definición**. 3/6 US · specs generadas.
 > Foco: resolver hallazgos DesignReviewer + correcciones arquitectónicas críticas.
 
 | US | Inc. | Contenido principal | Estado |
@@ -606,7 +606,7 @@ alcance vigente de SP5 salvo que se reabra explícitamente el scope.
 | US-6.4.2 | 6.4 | Materializar proyección `competencias_por_torneo` en `CalcularOverallHandler` — eliminar O(n) scan · ARCH-01 | ⏳ Pending |
 | US-6.4.3 | 6.4 | Corregir D-05: `resultados/api` y `competencia/api` importan infra cross-BC + reducir `registro` D↑ · ARCH-02 + AA-03 | ✅ Done |
 | US-6.4.4 | 6.4 | Refactoring `AlgoritmoPuntajeFAAS` dispatch explícito + correcciones CodeGuard (E501, import huérfano) · DR-02 + CG | ✅ Done |
-| US-6.4.5 | 6.4 | Refactoring `DeclararAPInscripcionHandler` (investigar DR-06) + `SQLiteInscripcionRepository.from_row()` · DR-06 + DR-07 | ⏳ Pending |
+| US-6.4.5 | 6.4 | Refactoring `DeclararAPInscripcionHandler` (DR-06 no aplicable) + `SQLiteInscripcionRepository.from_row()` · DR-06 + DR-07 | ✅ Done |
 | US-6.4.6 | 6.4 | Cierre decisión ARCH-03 (ACL aceptable) + SRP `RankingCompetencia` (investigar DR-01) + monitoreo `identidad`/`shared` · BL-006 | ⏳ Pending |
 
 ---
@@ -765,6 +765,7 @@ Hallazgos del análisis HITO-17 sobre dataset real "Apnea Indoor Buenos Aires 20
 
 ---
 
+*v1.43 — 2026-05-09: US-6.4.5 completada · SQLiteInscripcionRepository sin DR-07 · DR-06 documentado como coordination handler*
 *v1.42 — 2026-05-09: US-6.4.4 completada · AlgoritmoPuntajeFAAS thin dispatcher · DesignReviewer 0 issues componente*
 *v1.41 — 2026-05-09: US-6.4.3 completada · routers sin imports cross-BC de infraestructura · D(registro) 0.59→0.57 · reporte generado*
 *v1.40 — 2026-05-09: INC-6.4 iniciado · §32 nuevo (6 US specs generadas) · §33..35 renumerados · header actualizado*

--- a/src/registro/domain/aggregates/inscripcion.py
+++ b/src/registro/domain/aggregates/inscripcion.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any, Mapping
 from uuid import UUID, uuid4
 
 from registro.domain.exceptions import DisciplinaNoInscripta, PlazoCancelacionVencido
 from registro.domain.value_objects.ap_declarado import APDeclarado
 from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
 from shared.domain.value_objects.disciplina import Disciplina
+from shared.domain.value_objects.unidad_medida import UnidadMedida
 
 
 @dataclass
@@ -22,6 +25,21 @@ class Inscripcion:
     ap_por_disciplina: dict[Disciplina, APDeclarado] = field(default_factory=dict)
     apto_medico_path: str | None = None
     constancia_pago_path: str | None = None
+
+    @classmethod
+    def from_row(cls, data: Mapping[str, Any]) -> Inscripcion:
+        """Reconstituye una inscripcion desde datos planos persistidos."""
+        return cls(
+            inscripcion_id=UUID(data["inscripcion_id"]),
+            atleta_id=UUID(data["atleta_id"]),
+            torneo_id=UUID(data["torneo_id"]),
+            disciplinas=frozenset(Disciplina(d) for d in json.loads(data["disciplinas"])),
+            estado=EstadoInscripcion(data["estado"]),
+            fecha_inscripcion=datetime.fromisoformat(data["fecha_inscripcion"]),
+            ap_por_disciplina=_parse_ap_por_disciplina(data.get("ap_por_disciplina")),
+            apto_medico_path=data.get("apto_medico_path"),
+            constancia_pago_path=data.get("constancia_pago_path"),
+        )
 
     def cancelar(self, fecha_actual: date, fecha_inicio_torneo: date) -> None:
         """INV-I-03: solo cancela si fecha_actual < fecha_inicio_torneo."""
@@ -53,3 +71,13 @@ class Inscripcion:
         if not path or not path.strip():
             raise ValueError("path no puede ser vacío")
         self.constancia_pago_path = path
+
+
+def _parse_ap_por_disciplina(raw: Any) -> dict[Disciplina, APDeclarado]:
+    return {
+        Disciplina(disciplina): APDeclarado(
+            valor=Decimal(payload["valor"]),
+            unidad=UnidadMedida(payload["unidad"]),
+        )
+        for disciplina, payload in json.loads(raw or "{}").items()
+    }

--- a/src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py
+++ b/src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py
@@ -2,18 +2,13 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime
-from decimal import Decimal
 from uuid import UUID
 
 import aiosqlite
 
 from registro.domain.aggregates.inscripcion import Inscripcion
 from registro.domain.ports.inscripcion_repository_port import InscripcionRepositoryPort
-from registro.domain.value_objects.ap_declarado import APDeclarado
 from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
-from shared.domain.value_objects.disciplina import Disciplina
-from shared.domain.value_objects.unidad_medida import UnidadMedida
 
 _CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS inscripciones (
@@ -35,62 +30,17 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
         self._db_path = db_path or os.getenv("REGISTRO_DB_PATH", "data/registro.db")
 
     async def _ensure_table(self, conn: aiosqlite.Connection) -> None:
-        await conn.execute(_CREATE_TABLE)
-        await conn.commit()
+        await _ensure_table(conn)
 
     async def _ensure_schema(self, conn: aiosqlite.Connection) -> None:
-        await conn.execute(_CREATE_TABLE)
-        conn.row_factory = aiosqlite.Row
-        async with conn.execute("PRAGMA table_info(inscripciones)") as cursor:
-            columns = [row["name"] for row in await cursor.fetchall()]
-        if "ap_por_disciplina" not in columns:
-            await conn.execute(
-                "ALTER TABLE inscripciones ADD COLUMN ap_por_disciplina TEXT NOT NULL DEFAULT '{}'"
-            )
-        if "apto_medico_path" not in columns:
-            await conn.execute("ALTER TABLE inscripciones ADD COLUMN apto_medico_path TEXT")
-        if "constancia_pago_path" not in columns:
-            await conn.execute("ALTER TABLE inscripciones ADD COLUMN constancia_pago_path TEXT")
-        await conn.commit()
+        await _ensure_schema(conn)
 
     async def save(self, inscripcion: Inscripcion) -> None:
         async with aiosqlite.connect(self._db_path) as conn:
             await self._ensure_schema(conn)
             await conn.execute(
-                """
-                INSERT OR REPLACE INTO inscripciones
-                    (
-                        inscripcion_id,
-                        atleta_id,
-                        torneo_id,
-                        disciplinas,
-                        ap_por_disciplina,
-                        estado,
-                        fecha_inscripcion,
-                        apto_medico_path,
-                        constancia_pago_path
-                    )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    str(inscripcion.inscripcion_id),
-                    str(inscripcion.atleta_id),
-                    str(inscripcion.torneo_id),
-                    json.dumps([d.value for d in inscripcion.disciplinas]),
-                    json.dumps(
-                        {
-                            disciplina.value: {
-                                "valor": str(ap.valor),
-                                "unidad": ap.unidad.value,
-                            }
-                            for disciplina, ap in inscripcion.ap_por_disciplina.items()
-                        }
-                    ),
-                    inscripcion.estado.value,
-                    inscripcion.fecha_inscripcion.isoformat(),
-                    inscripcion.apto_medico_path,
-                    inscripcion.constancia_pago_path,
-                ),
+                _UPSERT_INSCRIPCION,
+                _inscripcion_to_values(inscripcion),
             )
             await conn.commit()
 
@@ -157,20 +107,68 @@ class SQLiteInscripcionRepository(InscripcionRepositoryPort):
                 return [self._row_to_inscripcion(row) for row in rows]
 
     def _row_to_inscripcion(self, row: aiosqlite.Row) -> Inscripcion:
-        return Inscripcion(
-            inscripcion_id=UUID(row["inscripcion_id"]),
-            atleta_id=UUID(row["atleta_id"]),
-            torneo_id=UUID(row["torneo_id"]),
-            disciplinas=frozenset(Disciplina(d) for d in json.loads(row["disciplinas"])),
-            estado=EstadoInscripcion(row["estado"]),
-            fecha_inscripcion=datetime.fromisoformat(row["fecha_inscripcion"]),
-            ap_por_disciplina={
-                Disciplina(disciplina): APDeclarado(
-                    valor=Decimal(payload["valor"]),
-                    unidad=UnidadMedida(payload["unidad"]),
-                )
-                for disciplina, payload in json.loads(row["ap_por_disciplina"] or "{}").items()
-            },
-            apto_medico_path=row["apto_medico_path"],
-            constancia_pago_path=row["constancia_pago_path"],
+        return Inscripcion.from_row(_row_to_dict(row))
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict[str, object]:
+    return {key: row[key] for key in row.keys()}
+
+
+_UPSERT_INSCRIPCION = """
+INSERT OR REPLACE INTO inscripciones
+    (
+        inscripcion_id,
+        atleta_id,
+        torneo_id,
+        disciplinas,
+        ap_por_disciplina,
+        estado,
+        fecha_inscripcion,
+        apto_medico_path,
+        constancia_pago_path
+    )
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+async def _ensure_table(conn: aiosqlite.Connection) -> None:
+    await conn.execute(_CREATE_TABLE)
+    await conn.commit()
+
+
+async def _ensure_schema(conn: aiosqlite.Connection) -> None:
+    await conn.execute(_CREATE_TABLE)
+    conn.row_factory = aiosqlite.Row
+    async with conn.execute("PRAGMA table_info(inscripciones)") as cursor:
+        columns = [row["name"] for row in await cursor.fetchall()]
+    if "ap_por_disciplina" not in columns:
+        await conn.execute(
+            "ALTER TABLE inscripciones ADD COLUMN ap_por_disciplina TEXT NOT NULL DEFAULT '{}'"
         )
+    if "apto_medico_path" not in columns:
+        await conn.execute("ALTER TABLE inscripciones ADD COLUMN apto_medico_path TEXT")
+    if "constancia_pago_path" not in columns:
+        await conn.execute("ALTER TABLE inscripciones ADD COLUMN constancia_pago_path TEXT")
+    await conn.commit()
+
+
+def _inscripcion_to_values(inscripcion: Inscripcion) -> tuple[object, ...]:
+    return (
+        str(inscripcion.inscripcion_id),
+        str(inscripcion.atleta_id),
+        str(inscripcion.torneo_id),
+        json.dumps([d.value for d in inscripcion.disciplinas]),
+        json.dumps(
+            {
+                disciplina.value: {
+                    "valor": str(ap.valor),
+                    "unidad": ap.unidad.value,
+                }
+                for disciplina, ap in inscripcion.ap_por_disciplina.items()
+            }
+        ),
+        inscripcion.estado.value,
+        inscripcion.fecha_inscripcion.isoformat(),
+        inscripcion.apto_medico_path,
+        inscripcion.constancia_pago_path,
+    )

--- a/tests/features/US-6.4.5-refactor-registro-designreviewer.feature
+++ b/tests/features/US-6.4.5-refactor-registro-designreviewer.feature
@@ -1,0 +1,35 @@
+Feature: US-6.4.5 - DesignReviewer sin DR-06/DR-07 en registro
+
+  Background:
+    Given el bounded context registro existe
+    And la especificacion US-6.4.5 esta aprobada
+
+  Scenario: DR-06 se investiga como coordination handler
+    Given DeclararAPInscripcionHandler solo ejecuta load, domain method y save
+    When se revisa la responsabilidad del handler
+    Then DR-06 queda documentado como falso positivo estructural
+    And el handler no incorpora logica de dominio nueva
+
+  Scenario: SQLiteInscripcionRepository delega reconstitucion al aggregate
+    Given una fila SQLite de inscripcion con disciplinas y AP declarados
+    When el repositorio reconstruye la inscripcion
+    Then llama a Inscripcion.from_row con los datos planos de la fila
+    And el repositorio no importa APDeclarado, Disciplina ni UnidadMedida
+
+  Scenario: La reconstitucion preserva adjuntos
+    Given una inscripcion persistida con apto medico y constancia de pago
+    When se consulta por id desde SQLiteInscripcionRepository
+    Then la inscripcion retornada conserva apto_medico_path
+    And la inscripcion retornada conserva constancia_pago_path
+
+  Scenario: La reconstitucion preserva AP por disciplina
+    Given una inscripcion persistida con AP declarado para una disciplina
+    When se consulta por id desde SQLiteInscripcionRepository
+    Then la inscripcion retornada conserva el valor AP
+    And la inscripcion retornada conserva la unidad AP
+
+  Scenario: Quality gates de registro pasan
+    Given los cambios de US-6.4.5 aplicados
+    When se ejecutan tests unitarios e integracion de registro
+    Then todos los tests pasan
+    And DesignReviewer no reporta DR-07 en SQLiteInscripcionRepository

--- a/tests/integration/registro/test_sqlite_inscripcion_repository.py
+++ b/tests/integration/registro/test_sqlite_inscripcion_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from uuid import uuid4
 
 import aiosqlite
@@ -12,6 +13,7 @@ from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
     SQLiteInscripcionRepository,
 )
 from shared.domain.value_objects.disciplina import Disciplina
+from shared.domain.value_objects.unidad_medida import UnidadMedida
 
 
 @pytest_asyncio.fixture
@@ -97,6 +99,22 @@ async def test_disciplinas_persisten_correctamente(repo):
 
 
 @pytest.mark.asyncio
+async def test_ap_por_disciplina_persiste_correctamente(repo):
+    ins = _inscripcion()
+    ins.declarar_ap(Disciplina.STA, Decimal("120"))
+    ins.declarar_ap(Disciplina.DNF, Decimal("75"))
+
+    await repo.save(ins)
+
+    found = await repo.find_by_id(ins.inscripcion_id)
+    assert found is not None
+    assert found.ap_por_disciplina[Disciplina.STA].valor == Decimal("120")
+    assert found.ap_por_disciplina[Disciplina.STA].unidad == UnidadMedida.Segundos
+    assert found.ap_por_disciplina[Disciplina.DNF].valor == Decimal("75")
+    assert found.ap_por_disciplina[Disciplina.DNF].unidad == UnidadMedida.Metros
+
+
+@pytest.mark.asyncio
 async def test_adjuntos_persisten_correctamente(repo):
     ins = _inscripcion()
     ins.adjuntar_apto_medico("data/adjuntos/ins/apto_medico.pdf")
@@ -118,8 +136,7 @@ async def test_migracion_legacy_sin_adjuntos_usa_none(tmp_path):
     torneo_id = uuid4()
 
     async with aiosqlite.connect(db_path) as conn:
-        await conn.execute(
-            """
+        await conn.execute("""
             CREATE TABLE inscripciones (
                 inscripcion_id    TEXT PRIMARY KEY,
                 atleta_id         TEXT NOT NULL,
@@ -129,8 +146,7 @@ async def test_migracion_legacy_sin_adjuntos_usa_none(tmp_path):
                 estado            TEXT NOT NULL,
                 fecha_inscripcion TEXT NOT NULL
             )
-            """
-        )
+            """)
         await conn.execute(
             """
             INSERT INTO inscripciones (

--- a/tests/unit/registro/test_inscripcion.py
+++ b/tests/unit/registro/test_inscripcion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from decimal import Decimal
 from uuid import uuid4
 
 import pytest
@@ -9,6 +10,7 @@ from registro.domain.aggregates.inscripcion import Inscripcion
 from registro.domain.exceptions import PlazoCancelacionVencido
 from registro.domain.value_objects.estado_inscripcion import EstadoInscripcion
 from shared.domain.value_objects.disciplina import Disciplina
+from shared.domain.value_objects.unidad_medida import UnidadMedida
 
 
 def _inscripcion(**kwargs) -> Inscripcion:
@@ -86,3 +88,59 @@ def test_adjuntar_constancia_pago_rechaza_path_vacio():
     ins = _inscripcion()
     with pytest.raises(ValueError, match="path no puede ser vacío"):
         ins.adjuntar_constancia_pago("")
+
+
+def test_from_row_reconstituye_inscripcion_con_ap_y_adjuntos():
+    inscripcion_id = uuid4()
+    atleta_id = uuid4()
+    torneo_id = uuid4()
+
+    ins = Inscripcion.from_row(
+        {
+            "inscripcion_id": str(inscripcion_id),
+            "atleta_id": str(atleta_id),
+            "torneo_id": str(torneo_id),
+            "disciplinas": '["STA", "DNF"]',
+            "estado": "ACTIVA",
+            "fecha_inscripcion": "2026-05-09T12:30:00",
+            "ap_por_disciplina": (
+                '{"STA": {"valor": "120", "unidad": "Segundos"}, '
+                '"DNF": {"valor": "75", "unidad": "Metros"}}'
+            ),
+            "apto_medico_path": "data/adjuntos/ins/apto.pdf",
+            "constancia_pago_path": "data/adjuntos/ins/pago.pdf",
+        }
+    )
+
+    assert ins.inscripcion_id == inscripcion_id
+    assert ins.atleta_id == atleta_id
+    assert ins.torneo_id == torneo_id
+    assert ins.disciplinas == frozenset({Disciplina.STA, Disciplina.DNF})
+    assert ins.estado == EstadoInscripcion.ACTIVA
+    assert ins.fecha_inscripcion == datetime(2026, 5, 9, 12, 30)
+    assert ins.ap_por_disciplina[Disciplina.STA].valor == Decimal("120")
+    assert ins.ap_por_disciplina[Disciplina.STA].unidad == UnidadMedida.Segundos
+    assert ins.ap_por_disciplina[Disciplina.DNF].valor == Decimal("75")
+    assert ins.ap_por_disciplina[Disciplina.DNF].unidad == UnidadMedida.Metros
+    assert ins.apto_medico_path == "data/adjuntos/ins/apto.pdf"
+    assert ins.constancia_pago_path == "data/adjuntos/ins/pago.pdf"
+
+
+def test_from_row_reconstituye_ap_vacio():
+    ins = Inscripcion.from_row(
+        {
+            "inscripcion_id": str(uuid4()),
+            "atleta_id": str(uuid4()),
+            "torneo_id": str(uuid4()),
+            "disciplinas": '["STA"]',
+            "estado": "ACTIVA",
+            "fecha_inscripcion": "2026-05-09T12:30:00",
+            "ap_por_disciplina": "{}",
+            "apto_medico_path": None,
+            "constancia_pago_path": None,
+        }
+    )
+
+    assert ins.ap_por_disciplina == {}
+    assert ins.apto_medico_path is None
+    assert ins.constancia_pago_path is None


### PR DESCRIPTION
## Resumen
- Agrega Inscripcion.from_row() para reconstituir inscripciones desde datos planos persistidos.
- Simplifica SQLiteInscripcionRepository delegando reconstitucion y extrayendo helpers de esquema/serializacion.
- Documenta DR-06 como falso positivo de coordination handler y resuelve DR-07 del repositorio.
- Actualiza BDD, plan, reporte, changelog, spec y trazabilidad de US-6.4.5.

## Validacion
- pytest tests/unit/registro/test_inscripcion.py tests/integration/registro/test_sqlite_inscripcion_repository.py -q: 23 passed
- pytest tests/unit/registro tests/integration/registro -q: 67 passed
- designreviewer src/registro/application/commands/declarar_ap_inscripcion.py src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py --config pyproject.toml: DR-07 eliminado; queda DR-06 documentado
- codeguard src/registro/domain/aggregates/inscripcion.py src/registro/infrastructure/repositories/sqlite_inscripcion_repository.py: 0 errores, 0 advertencias, 6 informativos
- ruff/black/isort sobre archivos Python tocados: OK

## Notas
- DesignReviewer conserva FeatureEnvy 4/2 en DeclararAPInscripcionHandler; se documenta como no aplicable porque el handler solo coordina load -> domain method -> save.