### PR TITLE
US-6.6.1 Endpoint publico de torneos

### DIFF
--- a/.claude/tracking/US-6.6.1-tracking.json
+++ b/.claude/tracking/US-6.6.1-tracking.json
@@ -1,0 +1,178 @@
+{
+  "metadata": {
+    "us_id": "US-6.6.1",
+    "us_title": "Endpoint publico GET api torneos",
+    "us_points": 2,
+    "producto": "torneo",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-10T13:31:23.955132+00:00",
+    "completed_at": "2026-05-10T13:40:01.942687+00:00",
+    "total_elapsed_seconds": 517,
+    "effective_seconds": 517,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validacion de Contexto",
+      "started_at": "2026-05-10T13:31:27.083535+00:00",
+      "completed_at": "2026-05-10T13:32:12.287389+00:00",
+      "elapsed_seconds": 45,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generacion de Escenarios BDD",
+      "started_at": "2026-05-10T13:32:16.644142+00:00",
+      "completed_at": "2026-05-10T13:32:37.131767+00:00",
+      "elapsed_seconds": 20,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Generacion de Plan de Implementacion",
+      "started_at": "2026-05-10T13:33:04.736706+00:00",
+      "completed_at": "2026-05-10T13:33:31.575411+00:00",
+      "elapsed_seconds": 26,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementacion",
+      "started_at": "2026-05-10T13:34:47.096919+00:00",
+      "completed_at": "2026-05-10T13:36:17.580108+00:00",
+      "elapsed_seconds": 90,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "task_3_1",
+          "task_name": "Filtrar cancelados en router",
+          "task_type": "api",
+          "estimated_minutes": 10.0,
+          "started_at": "2026-05-10T13:34:50.688924+00:00",
+          "completed_at": "2026-05-10T13:35:00.786450+00:00",
+          "elapsed_seconds": 10,
+          "actual_minutes": 0.17,
+          "variance_minutes": -9.83,
+          "file_created": "src/torneo/api/router.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_3_2",
+          "task_name": "Tests integracion endpoint publico",
+          "task_type": "tests",
+          "estimated_minutes": 25.0,
+          "started_at": "2026-05-10T13:35:04.790447+00:00",
+          "completed_at": "2026-05-10T13:35:35.131745+00:00",
+          "elapsed_seconds": 30,
+          "actual_minutes": 0.5,
+          "variance_minutes": -24.5,
+          "file_created": "tests/integration/torneo/test_torneos_publicos_api.py",
+          "status": "completed"
+        },
+        {
+          "task_id": "task_3_3",
+          "task_name": "Steps BDD endpoint publico",
+          "task_type": "tests",
+          "estimated_minutes": 20.0,
+          "started_at": "2026-05-10T13:35:38.563424+00:00",
+          "completed_at": "2026-05-10T13:36:14.379805+00:00",
+          "elapsed_seconds": 35,
+          "actual_minutes": 0.58,
+          "variance_minutes": -19.42,
+          "file_created": "tests/features/steps/torneos_publicos_steps.py",
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 4,
+      "phase_name": "Tests Unitarios",
+      "started_at": "2026-05-10T13:36:23.209570+00:00",
+      "completed_at": "2026-05-10T13:36:41.045943+00:00",
+      "elapsed_seconds": 17,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 5,
+      "phase_name": "Tests de Integracion",
+      "started_at": "2026-05-10T13:36:45.044195+00:00",
+      "completed_at": "2026-05-10T13:36:56.306455+00:00",
+      "elapsed_seconds": 11,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 6,
+      "phase_name": "Validacion BDD",
+      "started_at": "2026-05-10T13:37:00.168722+00:00",
+      "completed_at": "2026-05-10T13:37:21.073791+00:00",
+      "elapsed_seconds": 20,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-10T13:37:24.862856+00:00",
+      "completed_at": "2026-05-10T13:38:12.876270+00:00",
+      "elapsed_seconds": 48,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentacion",
+      "started_at": "2026-05-10T13:38:17.033488+00:00",
+      "completed_at": "2026-05-10T13:38:47.508130+00:00",
+      "elapsed_seconds": 30,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": false,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-10T13:39:24.945507+00:00",
+      "completed_at": "2026-05-10T13:39:58.396119+00:00",
+      "elapsed_seconds": 33,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 10,
+    "estimated_total_minutes": 55.0,
+    "actual_total_minutes": 1.25,
+    "variance_minutes": -53.75,
+    "variance_percent": -97.73
+  }
+}

--- a/docs/plans/sp6/US-6.6.1-fase0.md
+++ b/docs/plans/sp6/US-6.6.1-fase0.md
@@ -1,0 +1,45 @@
+# US-6.6.1 - Fase 0: Validacion de Contexto
+
+## Historia de Usuario
+
+- **ID:** US-6.6.1
+- **Titulo:** Endpoint publico `GET /api/torneos`
+- **Producto / BC:** torneo
+- **Puntos:** 2
+- **Incremento:** INC-6.6 - Portal Publico
+
+## Validacion de Arquitectura
+
+- **Patron:** Hexagonal DDD BC-first.
+- **BC verificado:** `src/torneo/`.
+- **Capas existentes:** `domain/`, `application/`, `infrastructure/`, `api/`.
+- **Documentacion base encontrada:**
+  - `docs/adr/ADR-005-bounded-contexts-ddd-estrategico.md`
+  - `docs/adr/ADR-006-estructura-bc-first.md`
+  - `docs/design/architecture.md`
+  - `docs/design/domain-model.md`
+  - `docs/contexto/ATARAXIADIVE-CONTEXT.md`
+
+## Validacion Tecnica Inicial
+
+- `src/torneo/api/router.py` expone `@router.get("", response_model=list[TorneoResponse])`.
+- `listar_torneos()` no recibe `OrganizadorDep`, `RequireAuth` ni `Depends(get_current_user)`.
+- `src/app.py` no define middleware global de autenticacion.
+- `TorneoResponse` incluye los campos requeridos por el portal publico:
+  `torneo_id`, `nombre`, `descripcion`, `fecha_inicio`, `fecha_fin`, `sede`, `estado`.
+- `EstadoTorneo` incluye `CANCELADO`, por lo que el filtro puede implementarse en API sin tocar dominio.
+
+## Quality Gates
+
+- `CLAUDE.md` existe y documenta workflow, arquitectura y quality gates.
+- `pyproject.toml` configura pytest, coverage, CodeGuard y DesignReviewer.
+- Existen suites `tests/unit/torneo/`, `tests/integration/torneo/` y `tests/features/`.
+
+## Riesgos
+
+- El endpoint existente `GET /torneos` tambien es consumido por frontend organizador. La US acepta mantener el mismo contrato y aplicar filtro de `CANCELADO` en la lista publica.
+- La ruta publica real se publica como `/api/torneos` si el entorno monta el backend bajo prefijo `/api`; en FastAPI el router mantiene `prefix="/torneos"`.
+
+## Resultado
+
+Contexto validado. La implementacion puede avanzar con un cambio minimo en API y tests de integracion/BDD enfocados en contrato publico y exclusion de torneos cancelados.

--- a/docs/plans/sp6/US-6.6.1-plan.md
+++ b/docs/plans/sp6/US-6.6.1-plan.md
@@ -1,0 +1,85 @@
+# Plan de Implementacion: US-6.6.1 - Endpoint publico GET /api/torneos
+
+**Patron:** Hexagonal DDD BC-first  
+**Producto / BC:** torneo  
+**Incremento:** INC-6.6 - Portal Publico  
+**Estimacion total:** 1h 20m  
+**Estado:** Implementacion completada - pendiente reporte final  
+**Fecha implementacion:** 2026-05-10
+
+## Objetivo
+
+Exponer la lista publica de torneos sin autenticacion, manteniendo el contrato actual y excluyendo torneos en estado `CANCELADO`.
+
+## Componentes a Modificar
+
+### 1. API Router Torneo
+
+- [x] `src/torneo/api/router.py` (10 min)
+  - Mantener `listar_torneos()` sin dependencias de autenticacion.
+  - Filtrar `EstadoTorneo.CANCELADO` antes de serializar la respuesta.
+  - Importar `EstadoTorneo` si hace falta para evitar comparar strings sueltos.
+
+### 2. Tests de Integracion HTTP
+
+- [x] `tests/integration/torneo/test_torneos_publicos_api.py` (25 min)
+  - Verificar `GET /torneos` sin `Authorization` retorna 200.
+  - Verificar que torneos `CANCELADO` no aparecen.
+  - Verificar campos requeridos por portal publico.
+  - Verificar que llamada con override de organizador mantiene mismo contrato.
+
+### 3. BDD
+
+- [x] `tests/features/steps/torneos_publicos_steps.py` (20 min)
+  - Implementar steps para `US-6.6.1-endpoint-publico-torneos.feature`.
+  - Usar `TestClient` con DB temporal.
+  - Crear torneos mediante API y transiciones para llegar a estados requeridos.
+
+### 4. Validacion
+
+- [x] Ejecutar tests de integracion de torneo enfocados (5 min)
+  - `pytest tests/integration/torneo/test_torneos_publicos_api.py`
+- [x] Ejecutar BDD de la US (5 min)
+  - `pytest tests/features/steps/torneos_publicos_steps.py`
+- [x] Ejecutar regresion acotada de router torneo (5 min)
+  - `pytest tests/integration/torneo/test_grupos_etarios_api.py tests/integration/torneo/test_disciplinas_torneo_api.py`
+- [x] Ejecutar quality gate de BC (10 min)
+  - `codeguard src/torneo --config pyproject.toml` o comando equivalente disponible.
+
+## Invariantes
+
+- No agregar auth al endpoint `GET /torneos`.
+- No modificar contrato de `TorneoResponse`.
+- No tocar dominio ni repositorio para este filtro.
+- No afectar endpoints privados con `OrganizadorDep`.
+
+## Riesgos y Mitigaciones
+
+- **Riesgo:** El filtro de cancelados afecte el panel organizador si consume el mismo endpoint.
+  - **Mitigacion:** La spec acepta el mismo endpoint filtrado; validar contrato estable y documentar alcance.
+- **Riesgo:** Diferencia entre `/api/torneos` documentado y `/torneos` interno FastAPI.
+  - **Mitigacion:** Tests internos usan `/torneos`; el proxy/frontend podra montarlo bajo `/api`.
+
+## Artefactos Esperados
+
+- `src/torneo/api/router.py`
+- `tests/integration/torneo/test_torneos_publicos_api.py`
+- `tests/features/steps/torneos_publicos_steps.py`
+- `quality/reports/codeguard/US-6.6.1-quality.txt`
+- `docs/reports/US-6.6.1-report.md` (pendiente Fase 9)
+
+## Evidencia de Validacion
+
+- `.venv/bin/python -m pytest tests/integration/torneo/test_torneos_publicos_api.py` -> 4 passed.
+- `.venv/bin/python -m pytest tests/integration/torneo/test_torneos_publicos_api.py tests/integration/torneo/test_grupos_etarios_api.py tests/integration/torneo/test_disciplinas_torneo_api.py` -> 20 passed.
+- `.venv/bin/python -m pytest tests/features/steps/torneos_publicos_steps.py` -> 4 passed.
+- `.venv/bin/codeguard src/torneo --config pyproject.toml` -> 0 errores, 0 advertencias.
+
+## Documentacion Arquitectonica
+
+No requiere ADR ni actualizacion de arquitectura: no se agregaron componentes ni integraciones nuevas. El cambio mantiene el router existente y acota el contrato publico de listado para excluir `CANCELADO`.
+
+## Lecciones Aprendidas
+
+- El endpoint ya era publico por firma y ausencia de middleware global; la US se resolvio como hardening contractual.
+- Los escenarios BDD necesitaron normalizacion de conectores en espanol (`y`/`e`) para listas de estados.

--- a/docs/reports/US-6.6.1-report.md
+++ b/docs/reports/US-6.6.1-report.md
@@ -1,0 +1,59 @@
+# Reporte de Implementacion: US-6.6.1
+
+## Resumen Ejecutivo
+
+- **Historia de Usuario:** US-6.6.1 - Endpoint publico `GET /api/torneos`
+- **Incremento:** INC-6.6 - Portal Publico
+- **Producto / BC:** torneo
+- **Puntos estimados:** 2
+- **Estado:** COMPLETADO
+- **Fecha completado:** 2026-05-10
+
+## Componentes Implementados
+
+- `src/torneo/api/router.py`
+  - `GET /torneos` se mantiene sin dependencia de autenticacion.
+  - La respuesta excluye torneos con `EstadoTorneo.CANCELADO`.
+  - `TorneoResponse` mantiene el contrato existente.
+
+## Tests Implementados
+
+- `tests/integration/torneo/test_torneos_publicos_api.py`
+  - 4 tests HTTP para acceso publico, exclusion de cancelados, contrato del portal y compatibilidad con llamada autenticada.
+- `tests/features/US-6.6.1-endpoint-publico-torneos.feature`
+  - 4 escenarios BDD aprobados.
+- `tests/features/steps/torneos_publicos_steps.py`
+  - Steps ejecutables con `TestClient` y base SQLite temporal.
+
+## Validacion Ejecutada
+
+| Comando | Resultado |
+|---|---|
+| `.venv/bin/python -m pytest tests/integration/torneo/test_torneos_publicos_api.py` | 4 passed |
+| `.venv/bin/python -m pytest tests/integration/torneo/test_torneos_publicos_api.py tests/integration/torneo/test_grupos_etarios_api.py tests/integration/torneo/test_disciplinas_torneo_api.py` | 20 passed |
+| `.venv/bin/python -m pytest tests/features/steps/torneos_publicos_steps.py` | 4 passed |
+| `.venv/bin/codeguard src/torneo --config pyproject.toml` | 0 errores, 0 advertencias |
+
+## Criterios de Aceptacion
+
+- [x] Visitante puede listar torneos sin `Authorization`.
+- [x] Torneos `CANCELADO` no aparecen en la lista publica.
+- [x] Cada torneo expone `torneo_id`, `nombre`, `fecha_inicio`, `fecha_fin`, `sede`, `estado` y `descripcion`.
+- [x] La llamada con auth mantiene el mismo contrato que la llamada publica.
+
+## Archivos Creados o Modificados
+
+- `src/torneo/api/router.py`
+- `tests/integration/torneo/test_torneos_publicos_api.py`
+- `tests/features/US-6.6.1-endpoint-publico-torneos.feature`
+- `tests/features/steps/torneos_publicos_steps.py`
+- `docs/plans/sp6/US-6.6.1-fase0.md`
+- `docs/plans/sp6/US-6.6.1-plan.md`
+- `quality/reports/codeguard/US-6.6.1-quality.txt`
+- `docs/reports/US-6.6.1-report.md`
+
+## Notas
+
+- No se agrego middleware ni excepcion de auth porque `src/app.py` no tiene autenticacion global y el endpoint ya era publico por firma.
+- No se actualizo arquitectura ni ADR: el cambio es un ajuste contractual menor en un endpoint existente.
+- El prefijo `/api` queda como responsabilidad del despliegue/proxy/frontend; en FastAPI el router se prueba como `/torneos`.

--- a/quality/reports/codeguard/US-6.6.1-quality.txt
+++ b/quality/reports/codeguard/US-6.6.1-quality.txt
@@ -1,0 +1,16 @@
+US-6.6.1 - Quality Gate
+
+Comando:
+.venv/bin/codeguard src/torneo --config pyproject.toml
+
+Resultado:
+- Archivos analizados: 30
+- Checks ejecutados: 6
+- Resultados totales: 90
+- Errores: 0
+- Advertencias: 0
+- Informativos: 90
+
+Notas:
+- `src/torneo/api/router.py` queda PEP8 compliant, sin security issues y con complejidad bajo umbral.
+- CodeGuard reporta un informativo preexistente B110 en `src/torneo/infrastructure/repositories/sqlite_torneo_repository.py`; no es error ni advertencia y no pertenece al cambio de US-6.6.1.

--- a/src/torneo/api/router.py
+++ b/src/torneo/api/router.py
@@ -186,7 +186,11 @@ async def crear_torneo(body: CrearTorneoRequest, _: OrganizadorDep) -> JSONRespo
 async def listar_torneos() -> list[TorneoResponse]:
     handler = ListarTorneosHandler(_repo())
     torneos = await handler.handle(ListarTorneosQuery())
-    return [TorneoResponse.from_torneo(t) for t in torneos]
+    return [
+        TorneoResponse.from_torneo(torneo)
+        for torneo in torneos
+        if torneo.estado.value != "CANCELADO"
+    ]
 
 
 @router.get("/{torneo_id}", response_model=TorneoResponse)

--- a/tests/features/US-6.6.1-endpoint-publico-torneos.feature
+++ b/tests/features/US-6.6.1-endpoint-publico-torneos.feature
@@ -1,0 +1,29 @@
+Feature: US-6.6.1 - Endpoint publico GET /api/torneos
+
+  Background:
+    Given la base de datos de torneos publicos esta limpia
+
+  Scenario: Visitante lista torneos sin token
+    Given existe un torneo publico con estado CREADO
+    When un visitante hace GET /torneos sin Authorization header
+    Then la respuesta publica de torneos es 200 OK
+    And el body es una lista de torneos
+
+  Scenario: Torneos cancelados no aparecen en la lista publica
+    Given existe un torneo publico con estado CREADO
+    And existe un torneo publico con estado CANCELADO
+    When un visitante hace GET /torneos sin Authorization header
+    Then la respuesta publica de torneos es 200 OK
+    And la lista publica no contiene torneos con estado CANCELADO
+
+  Scenario: Respuesta incluye los campos del portal
+    Given existen torneos publicos con estados CREADO, INSCRIPCION_ABIERTA y EJECUCION
+    When un visitante hace GET /torneos sin Authorization header
+    Then cada torneo publico incluye torneo_id, nombre, descripcion, fecha_inicio, fecha_fin, sede y estado
+
+  Scenario: Endpoint con auth mantiene el mismo contrato
+    Given existen torneos publicos con estados CREADO e INSCRIPCION_ABIERTA
+    When un visitante hace GET /torneos sin Authorization header
+    And un organizador autenticado hace GET /torneos
+    Then ambas respuestas publicas tienen status 200
+    And ambas respuestas publicas tienen el mismo contrato de torneo

--- a/tests/features/steps/torneos_publicos_steps.py
+++ b/tests/features/steps/torneos_publicos_steps.py
@@ -1,0 +1,158 @@
+"""Step definitions BDD — US-6.6.1: endpoint publico de torneos."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from identidad.api.dependencies import get_current_user
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.api.router import router
+
+scenarios("../US-6.6.1-endpoint-publico-torneos.feature")
+
+
+@pytest.fixture
+def context(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setenv("TORNEO_DB_PATH", str(tmp_path / "torneo.db"))
+    return {"created_ids": {}}
+
+
+@pytest.fixture
+def client(context: dict[str, Any]) -> Iterator[TestClient]:
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _organizador_override() -> dict[str, str]:
+    return {
+        "sub": "test-user",
+        "email": "test@test.com",
+        "rol": "ORGANIZADOR",
+    }
+
+
+def _payload(nombre: str) -> dict[str, object]:
+    return {
+        "nombre": nombre,
+        "descripcion": "Torneo para portal publico",
+        "fecha_inicio": "2026-06-01",
+        "fecha_fin": "2026-06-03",
+        "sede": {"nombre": "Piscina Municipal", "ciudad": "Buenos Aires", "pais": "Argentina"},
+        "entidad_organizadora": {"nombre": "AIDA Argentina", "tipo": "FEDERACION"},
+        "grupos_etarios": ["SENIOR"],
+    }
+
+
+def _with_organizador(client: TestClient) -> None:
+    client.app.dependency_overrides[get_current_user] = _organizador_override
+
+
+def _clear_auth(client: TestClient) -> None:
+    client.app.dependency_overrides.clear()
+
+
+def _crear_torneo(client: TestClient, context: dict[str, Any], estado: str) -> str:
+    nombre = f"Torneo {estado} {len(context['created_ids']) + 1}"
+    _with_organizador(client)
+    response = client.post("/torneos", json=_payload(nombre))
+    assert response.status_code == 201
+    torneo_id = str(response.json()["torneo_id"])
+
+    if estado == "INSCRIPCION_ABIERTA":
+        assert client.put(f"/torneos/{torneo_id}/abrir-inscripcion").status_code == 200
+    elif estado == "EJECUCION":
+        assert client.put(f"/torneos/{torneo_id}/abrir-inscripcion").status_code == 200
+        assert client.put(f"/torneos/{torneo_id}/cerrar-inscripcion").status_code == 200
+        assert client.put(f"/torneos/{torneo_id}/iniciar-ejecucion").status_code == 200
+    elif estado == "CANCELADO":
+        assert client.put(f"/torneos/{torneo_id}/cancelar").status_code == 200
+    elif estado != "CREADO":
+        raise AssertionError(f"Estado no soportado por el escenario: {estado}")
+
+    _clear_auth(client)
+    context["created_ids"].setdefault(estado, []).append(torneo_id)
+    return torneo_id
+
+
+def _parse_estados(estados: str) -> list[str]:
+    normalizados = estados.replace(" e ", ", ").replace(" y ", ", ")
+    return [item.strip() for item in normalizados.split(",") if item.strip()]
+
+
+@given("la base de datos de torneos publicos esta limpia")
+def base_limpia(context: dict[str, Any]) -> None:
+    context["created_ids"] = {}
+
+
+@given(parsers.parse("existe un torneo publico con estado {estado}"))
+def existe_torneo_estado(client: TestClient, context: dict[str, Any], estado: str) -> None:
+    _crear_torneo(client, context, estado)
+
+
+@given(parsers.parse("existen torneos publicos con estados {estados}"))
+def existen_torneos_estados(client: TestClient, context: dict[str, Any], estados: str) -> None:
+    for estado in _parse_estados(estados):
+        _crear_torneo(client, context, estado)
+
+
+@when("un visitante hace GET /torneos sin Authorization header")
+def visitante_get_torneos(client: TestClient, context: dict[str, Any]) -> None:
+    _clear_auth(client)
+    context["public_response"] = client.get("/torneos")
+
+
+@when("un organizador autenticado hace GET /torneos")
+def organizador_get_torneos(client: TestClient, context: dict[str, Any]) -> None:
+    _with_organizador(client)
+    context["auth_response"] = client.get("/torneos", headers={"Authorization": "Bearer fake"})
+    _clear_auth(client)
+
+
+@then("la respuesta publica de torneos es 200 OK")
+def respuesta_publica_200(context: dict[str, Any]) -> None:
+    assert context["public_response"].status_code == 200
+
+
+@then("el body es una lista de torneos")
+def body_lista(context: dict[str, Any]) -> None:
+    assert isinstance(context["public_response"].json(), list)
+
+
+@then("la lista publica no contiene torneos con estado CANCELADO")
+def lista_sin_cancelados(context: dict[str, Any]) -> None:
+    torneos = context["public_response"].json()
+    ids = {torneo["torneo_id"] for torneo in torneos}
+    cancelados = set(context["created_ids"].get("CANCELADO", []))
+    assert cancelados.isdisjoint(ids)
+    assert all(torneo["estado"] != "CANCELADO" for torneo in torneos)
+
+
+@then(
+    "cada torneo publico incluye torneo_id, nombre, descripcion, fecha_inicio, "
+    "fecha_fin, sede y estado"
+)
+def contrato_portal(context: dict[str, Any]) -> None:
+    required = {"torneo_id", "nombre", "descripcion", "fecha_inicio", "fecha_fin", "sede", "estado"}
+    for torneo in context["public_response"].json():
+        assert required.issubset(torneo)
+        assert {"ciudad", "pais"}.issubset(torneo["sede"])
+
+
+@then("ambas respuestas publicas tienen status 200")
+def ambas_200(context: dict[str, Any]) -> None:
+    assert context["public_response"].status_code == 200
+    assert context["auth_response"].status_code == 200
+
+
+@then("ambas respuestas publicas tienen el mismo contrato de torneo")
+def mismo_contrato(context: dict[str, Any]) -> None:
+    assert context["public_response"].json() == context["auth_response"].json()

--- a/tests/integration/torneo/test_torneos_publicos_api.py
+++ b/tests/integration/torneo/test_torneos_publicos_api.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from identidad.api.dependencies import get_current_user
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.api.router import router
+
+
+@pytest.fixture
+def app_client(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("TORNEO_DB_PATH", str(tmp_path / "torneo.db"))
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _payload(nombre: str = "Open Publico 2026") -> dict[str, object]:
+    return {
+        "nombre": nombre,
+        "descripcion": "Torneo visible para el portal publico",
+        "fecha_inicio": "2026-06-01",
+        "fecha_fin": "2026-06-03",
+        "sede": {"nombre": "Piscina Municipal", "ciudad": "Buenos Aires", "pais": "Argentina"},
+        "entidad_organizadora": {"nombre": "AIDA Argentina", "tipo": "FEDERACION"},
+        "grupos_etarios": ["SENIOR"],
+    }
+
+
+def _organizador_override() -> dict[str, str]:
+    return {
+        "sub": "test-user",
+        "email": "test@test.com",
+        "rol": "ORGANIZADOR",
+    }
+
+
+def _crear_torneo(client: TestClient, nombre: str) -> str:
+    client.app.dependency_overrides[get_current_user] = _organizador_override
+    response = client.post("/torneos", json=_payload(nombre))
+    client.app.dependency_overrides.clear()
+    assert response.status_code == 201
+    return str(response.json()["torneo_id"])
+
+
+def _cancelar_torneo(client: TestClient, torneo_id: str) -> None:
+    client.app.dependency_overrides[get_current_user] = _organizador_override
+    response = client.put(f"/torneos/{torneo_id}/cancelar")
+    client.app.dependency_overrides.clear()
+    assert response.status_code == 200
+
+
+def _abrir_inscripcion(client: TestClient, torneo_id: str) -> None:
+    client.app.dependency_overrides[get_current_user] = _organizador_override
+    response = client.put(f"/torneos/{torneo_id}/abrir-inscripcion")
+    client.app.dependency_overrides.clear()
+    assert response.status_code == 200
+
+
+def _torneo_fields(torneo: dict[str, Any]) -> set[str]:
+    return {
+        "torneo_id",
+        "nombre",
+        "descripcion",
+        "fecha_inicio",
+        "fecha_fin",
+        "sede",
+        "estado",
+    }.intersection(torneo)
+
+
+def test_get_torneos_es_publico_sin_authorization(app_client: TestClient) -> None:
+    _crear_torneo(app_client, "Torneo sin token")
+
+    response = app_client.get("/torneos")
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+    assert len(response.json()) == 1
+
+
+def test_get_torneos_excluye_cancelados(app_client: TestClient) -> None:
+    visible_id = _crear_torneo(app_client, "Torneo visible")
+    cancelado_id = _crear_torneo(app_client, "Torneo cancelado")
+    _cancelar_torneo(app_client, cancelado_id)
+
+    response = app_client.get("/torneos")
+
+    assert response.status_code == 200
+    ids = {torneo["torneo_id"] for torneo in response.json()}
+    estados = {torneo["estado"] for torneo in response.json()}
+    assert visible_id in ids
+    assert cancelado_id not in ids
+    assert "CANCELADO" not in estados
+
+
+def test_get_torneos_incluye_campos_del_portal(app_client: TestClient) -> None:
+    creado_id = _crear_torneo(app_client, "Torneo creado")
+    abierto_id = _crear_torneo(app_client, "Torneo abierto")
+    _abrir_inscripcion(app_client, abierto_id)
+
+    response = app_client.get("/torneos")
+
+    assert response.status_code == 200
+    torneos = response.json()
+    assert {torneo["torneo_id"] for torneo in torneos} == {creado_id, abierto_id}
+    required = {"torneo_id", "nombre", "descripcion", "fecha_inicio", "fecha_fin", "sede", "estado"}
+    for torneo in torneos:
+        assert _torneo_fields(torneo) == required
+        assert {"ciudad", "pais"}.issubset(torneo["sede"])
+
+
+def test_get_torneos_con_auth_mantiene_contrato_publico(app_client: TestClient) -> None:
+    _crear_torneo(app_client, "Torneo creado")
+    abierto_id = _crear_torneo(app_client, "Torneo abierto")
+    _abrir_inscripcion(app_client, abierto_id)
+
+    public_response = app_client.get("/torneos")
+    app_client.app.dependency_overrides[get_current_user] = _organizador_override
+    auth_response = app_client.get("/torneos", headers={"Authorization": "Bearer fake-token"})
+    app_client.app.dependency_overrides.clear()
+
+    assert public_response.status_code == 200
+    assert auth_response.status_code == 200
+    assert public_response.json() == auth_response.json()


### PR DESCRIPTION
## Resumen
- Mantiene GET /torneos publico sin dependencia de autenticacion
- Excluye torneos CANCELADO de la lista publica
- Agrega cobertura HTTP y BDD para contrato del portal publico

## Validacion
- .venv/bin/python -m pytest tests/integration/torneo/test_torneos_publicos_api.py
- .venv/bin/python -m pytest tests/integration/torneo/test_torneos_publicos_api.py tests/integration/torneo/test_grupos_etarios_api.py tests/integration/torneo/test_disciplinas_torneo_api.py
- .venv/bin/python -m pytest tests/features/steps/torneos_publicos_steps.py
- .venv/bin/codeguard src/torneo --config pyproject.toml