### PR TITLE
test(uat): F-03 Seed-B — 3/3 PASS + hallazgos resueltos [INC-6.5]

### DIFF
--- a/frontend/src/components/organizador/EstadoAPBadge.tsx
+++ b/frontend/src/components/organizador/EstadoAPBadge.tsx
@@ -32,7 +32,7 @@ export function EstadoAPBadge({ estado, ap, unidad }: EstadoAPBadgeProps) {
 
   return (
     <span className="inline-flex min-h-8 items-center rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-200">
-      {apLabel ? `AP declarado · ${apLabel}` : 'AP declarado'}
+      {apLabel ?? 'AP declarado'}
     </span>
   )
 }

--- a/frontend/src/components/organizador/TablaInscriptos.tsx
+++ b/frontend/src/components/organizador/TablaInscriptos.tsx
@@ -102,12 +102,12 @@ export function TablaInscriptos({
           <table className="min-w-full divide-y divide-slate-700 text-left text-sm">
             <thead className="bg-slate-950/80 text-xs font-semibold uppercase text-slate-400">
               <tr>
-                <th className="px-4 py-3">Atleta</th>
-                <th className="px-4 py-3">Club</th>
-                <th className="px-4 py-3">Categoria</th>
-                <th className="px-4 py-3">Inscripcion</th>
+                <th className="px-4 py-3 text-center">Atleta</th>
+                <th className="px-4 py-3 text-center">Club</th>
+                <th className="px-4 py-3 text-center">Categoria</th>
+                <th className="px-4 py-3 text-center">Inscripcion</th>
                 {disciplinasVisibles.map((disciplina) => (
-                  <th key={disciplina} className="px-4 py-3">
+                  <th key={disciplina} className="px-4 py-3 text-center">
                     Anuncio · {disciplina}
                   </th>
                 ))}
@@ -118,14 +118,14 @@ export function TablaInscriptos({
                 <tr key={row.inscripcionId}>
                   <td className="px-4 py-3 font-semibold text-white">{row.nombre}</td>
                   <td className="px-4 py-3 text-slate-300">{row.club}</td>
-                  <td className="px-4 py-3 text-slate-300">
+                  <td className="px-4 py-3 text-center text-slate-300">
                     {formatCategoria(row.categoria)}
                   </td>
-                  <td className="px-4 py-3 text-slate-300">{row.estadoInscripcion}</td>
+                  <td className="px-4 py-3 text-center text-slate-300">{row.estadoInscripcion}</td>
                   {disciplinasVisibles.map((disciplina) => {
                     if (!row.disciplinas.includes(disciplina)) {
                       return (
-                        <td key={disciplina} className="px-4 py-3 text-slate-500">
+                        <td key={disciplina} className="px-4 py-3 text-center text-slate-500">
                           No inscripto
                         </td>
                       )
@@ -135,8 +135,8 @@ export function TablaInscriptos({
                     const draft = drafts[cellKey] ?? estado?.ap ?? ''
                     const editableCell = editable && puedeDeclararAp(estado)
                     return (
-                      <td key={disciplina} className="px-4 py-3">
-                        <div className="space-y-2">
+                      <td key={disciplina} className="px-4 py-3 text-center">
+                        <div className="flex flex-col items-center space-y-2">
                           <EstadoAPBadge
                             estado={estado?.estado ?? 'pendiente'}
                             ap={estado?.ap}

--- a/frontend/src/pages/PublicTorneosPage.tsx
+++ b/frontend/src/pages/PublicTorneosPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
-import { fetchTorneos, type EstadoTorneo, type TorneoDto } from '../api/torneo'
+import { fetchTorneos, listarDisciplinasTorneo, type EstadoTorneo, type TorneoDto } from '../api/torneo'
 import { formatFecha } from './atleta/portalData'
 import { useNavigateWithRedirect } from '../hooks/useNavigateWithRedirect'
 import useAuthStore from '../stores/useAuthStore'
@@ -59,12 +59,27 @@ function accionPorEstado(torneo: TorneoDto, rol: string | null): Accion | null {
   }
 }
 
+const CATEGORIA_LABELS: Record<string, string> = {
+  JUNIOR: 'Junior',
+  SENIOR: 'Senior',
+  MASTER: 'Master',
+}
+
 function TorneoCard({ torneo }: { torneo: TorneoDto }) {
   const navigateWithRedirect = useNavigateWithRedirect()
   const navigate = useNavigate()
   const rol = useAuthStore((s) => s.rol)
   const badge = ESTADO_BADGE[torneo.estado]
   const accion = accionPorEstado(torneo, rol)
+
+  const { data: disciplinas } = useQuery({
+    queryKey: ['disciplinas-torneo-public', torneo.torneo_id],
+    queryFn: () => listarDisciplinasTorneo(torneo.torneo_id),
+    staleTime: 60_000,
+  })
+
+  const disciplinaNames = disciplinas?.map((d) => d.disciplina) ?? []
+  const categorias = torneo.grupos_etarios.map((g) => CATEGORIA_LABELS[g] ?? g)
 
   return (
     <div className="rounded-3xl border border-slate-800 bg-slate-900 p-5">
@@ -85,6 +100,27 @@ function TorneoCard({ torneo }: { torneo: TorneoDto }) {
           {badge.label}
         </span>
       </div>
+
+      {(disciplinaNames.length > 0 || categorias.length > 0) && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {disciplinaNames.map((d) => (
+            <span
+              key={d}
+              className="rounded-full border border-sky-700/40 bg-sky-900/30 px-2.5 py-0.5 text-xs font-semibold text-sky-300"
+            >
+              {d}
+            </span>
+          ))}
+          {categorias.map((c) => (
+            <span
+              key={c}
+              className="rounded-full border border-slate-600/40 bg-slate-800/60 px-2.5 py-0.5 text-xs font-semibold text-slate-300"
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
 
       {accion ? (
         <div className="mt-4">

--- a/quality/reports/uat/SP6/F-03-seed-b/escenarios.md
+++ b/quality/reports/uat/SP6/F-03-seed-b/escenarios.md
@@ -2,27 +2,28 @@
 
 ## Criterio de Entrada
 
-- [ ] F-02 completada: torneo creado · `torneo_id` anotado
-- [ ] `uat_ba2025_usuarios_ids.json` existe en `quality/reports/uat/SP6/`
+- [x] F-02 completada: torneo creado · `torneo_id` anotado
+- [x] Organizador abrió inscripciones desde la UI (F-04-S01) → torneo en `INSCRIPCION_ABIERTA`
+- [x] `uat_ba2025_usuarios_ids.json` existe en `quality/reports/uat/SP6/`
 
 ## Comando
 
 ```bash
-# Seed-B abre inscripciones, carga 31 atletas y deja el torneo en INSCRIPCION_ABIERTA
-uv run python tests/uat/sp6/seed_ba2025_inscripciones.py --torneo-id <torneo_id_de_F02>
+# Seed-B carga 31 atletas con APs — requiere torneo en INSCRIPCION_ABIERTA
+uv run python tests/uat/sp6/seed_ba2025_inscripciones.py --torneo-id cedbbe83-a87a-4a81-9d80-68de6f6f5405
 ```
 
 ## Escenarios de verificación
 
 | ID | Actor | Dispositivo | Acción | Resultado esperado | Resultado real | Estado | Hallazgo |
 |----|-------|-------------|--------|--------------------|----------------|--------|----------|
-| F03-S01 | Organizador | Desktop | Ver lista de inscriptos en DBF | Atletas con disciplina DBF · columna "ANUNCIO" con AP en metros · categoría legible | — | ⬜ PENDIENTE | — |
-| F03-S02 | Organizador | Desktop | Verificar atleta Víctor Valotto en STA | AP visible en formato mm:ss en columna ANUNCIO | — | ⬜ PENDIENTE | — |
-| F03-S03 | Atleta (Víctor Valotto) | Móvil | Login → ver inscripciones propias | Sus disciplinas con AP declarada | — | ⬜ PENDIENTE | — |
+| F03-S01 | Organizador | Desktop | Ver lista de inscriptos en DBF | Atletas con disciplina DBF · columna "ANUNCIO" con AP en metros · categoría legible | 31 atletas visibles · APs correctas · categorías legibles · 2 hallazgos visuales corregidos | ✅ PASS | H-03-01 · H-03-02 |
+| F03-S02 | Organizador | Desktop | Verificar atleta Víctor Valotto en STA | AP visible en formato mm:ss en columna ANUNCIO | Se muestra `3:15` correctamente | ✅ PASS | — |
+| F03-S03 | Atleta (Víctor Valotto) | Móvil | Login → ver inscripciones propias | Sus disciplinas con AP declarada | Disciplinas e inscripciones visibles con APs declaradas | ✅ PASS | — |
 
 ## Criterio de Salida
 
-- [ ] Seed-B completado sin errores
-- [ ] 31 atletas visibles en la lista de inscriptos
-- [ ] APs correctas en cada disciplina
-- [ ] Estado del torneo: `INSCRIPCION_ABIERTA` (Seed-B lo abre internamente)
+- [x] Seed-B completado sin errores
+- [x] 31 atletas visibles en la lista de inscriptos
+- [x] APs correctas en cada disciplina
+- [x] Estado del torneo: `INSCRIPCION_ABIERTA` (abierto por el organizador en F-04-S01)

--- a/quality/reports/uat/SP6/F-03-seed-b/hallazgos.md
+++ b/quality/reports/uat/SP6/F-03-seed-b/hallazgos.md
@@ -1,0 +1,16 @@
+# Hallazgos — Fase F-03: Volcado de Datos (Seed-B)
+
+## Defectos
+
+| ID | Escenario | Descripción | Severidad | Pasos para reproducir | Estado | Fix |
+|----|-----------|-------------|-----------|----------------------|--------|-----|
+| H-03-02 | F03-S01 | Cabeceras de la tabla de inscriptos sin centrar | ⚪ | Ver lista de inscriptos · cabeceras alineadas a la izquierda | ✅ Resuelto | `text-center` agregado a todos los `<th>` en `TablaInscriptos.tsx` |
+| H-03-01 | F03-S01 | El badge mostraba "AP declarado · 52.40m" — el prefijo "AP declarado ·" es redundante cuando el valor está presente | 🟡 | Ver lista de inscriptos con AP declarada · columna ANUNCIO muestra el texto completo | ✅ Resuelto | `EstadoAPBadge.tsx`: cuando hay valor solo muestra el valor, sin prefijo |
+
+## Mejoras (fuera de scope UAT)
+
+| ID | Origen | Descripción | Prioridad sugerida |
+|----|--------|-------------|-------------------|
+| H-03-03 | F03 observación | Portal público no mostraba disciplinas ni categorías del torneo en las tarjetas | 🟡 Media |
+
+**Fix H-03-03:** `PublicTorneosPage.tsx` — `TorneoCard` usa `useQuery` para obtener disciplinas por torneo y muestra chips de disciplinas (sky) y categorías (slate) cuando están disponibles.

--- a/quality/reports/uat/SP6/F-03-seed-b/reporte_f03.md
+++ b/quality/reports/uat/SP6/F-03-seed-b/reporte_f03.md
@@ -1,0 +1,39 @@
+# Reporte Fase F-03: Volcado de Datos (Seed-B)
+
+**Fecha de ejecución:** 2026-05-11  
+**Ejecutor:** Victor Valotto  
+**Dispositivos usados:** Desktop · Móvil
+
+## Métricas
+
+| Métrica | Valor |
+|---------|-------|
+| Escenarios ejecutados | 3 |
+| PASS | 3 |
+| FAIL | 0 |
+| SKIP | 0 |
+| Hallazgos 🔴 | 0 |
+| Hallazgos 🟡 | 1 (H-03-01) |
+| Hallazgos ⚪ | 1 (H-03-02) |
+| Mejoras registradas | 1 (H-03-03) |
+
+## Resumen
+
+Seed-B ejecutado con éxito: 31 atletas cargados con APs correctas en todas las disciplinas. Se detectaron y corrigieron 2 defectos visuales en `TablaInscriptos` (badge redundante, cabeceras sin centrar) y se aplicó una mejora en el portal público para mostrar disciplinas y categorías en las tarjetas de torneos. Todos los escenarios cerraron en PASS.
+
+## Hallazgos resueltos
+
+| ID | Severidad | Descripción | Fix |
+|----|-----------|-------------|-----|
+| H-03-01 | 🟡 Minor | Badge mostraba prefijo "AP declarado ·" redundante cuando había valor | `EstadoAPBadge.tsx`: solo muestra el valor cuando existe |
+| H-03-02 | ⚪ Cosmético | Cabeceras de tabla sin centrar | `TablaInscriptos.tsx`: `text-center` en todos los `<th>` |
+| H-03-03 | 🟡 Mejora | Portal público sin disciplinas ni categorías en tarjetas | `PublicTorneosPage.tsx`: chips via `useQuery` por torneo |
+
+## Criterio de Salida
+
+- [x] Seed-B ejecutado sin errores
+- [x] 31 atletas visibles en lista de inscriptos
+- [x] APs correctas por disciplina (metros y mm:ss)
+- [x] Estado del torneo: `INSCRIPCION_ABIERTA`
+
+## Estado: ✅ CERRADA

--- a/tests/uat/sp6/seed_ba2025_inscripciones.py
+++ b/tests/uat/sp6/seed_ba2025_inscripciones.py
@@ -114,16 +114,18 @@ def main() -> None:
 
     with httpx.Client(base_url=BASE, timeout=30) as client:
 
-        # ── 1. Abrir inscripciones ─────────────────────────────────────────────
-        print("▸ Abriendo inscripciones del torneo")
+        # ── 1. Verificar que el torneo está en INSCRIPCION_ABIERTA ────────────
+        print("▸ Verificando estado del torneo")
         org_token = login(client, f"organizador{EMAIL_DOMAIN}")
         org_h = {"Authorization": f"Bearer {org_token}"}
-        resp = client.put(f"/torneos/{torneo_id}/abrir-inscripcion", headers=org_h)
-        if resp.status_code == 409:
-            log("inscripciones ya abiertas (OK)")
-        else:
-            assert_ok(resp, "abrir-inscripcion")
-            log("✓ inscripciones abiertas")
+        resp = client.get(f"/torneos/{torneo_id}")
+        assert_ok(resp, "obtener torneo")
+        estado = resp.json().get("estado")
+        if estado != "INSCRIPCION_ABIERTA":
+            print(f"\n✗ El torneo está en estado '{estado}' — debe estar en INSCRIPCION_ABIERTA.")
+            print("  Abrí las inscripciones desde el portal del organizador (F-04-S01) antes de correr Seed-B.")
+            sys.exit(1)
+        log(f"✓ estado: {estado}")
         print()
 
         # ── 2. Inscribir atletas y declarar APs ───────────────────────────────


### PR DESCRIPTION
## Resumen

- F-03 UAT INC-6.5: volcado de datos Seed-B completado
- 31 atletas cargados con APs correctas en todas las disciplinas (DBF, DNF, DYN, SPE_2X50, STA)
- 3/3 escenarios PASS

## Hallazgos resueltos

| ID | Severidad | Descripción | Archivo |
|----|-----------|-------------|---------|
| H-03-01 | 🟡 Minor | Badge AP mostraba prefijo "AP declarado ·" redundante | `EstadoAPBadge.tsx` |
| H-03-02 | ⚪ Cosmético | Cabeceras de tabla inscriptos sin centrar | `TablaInscriptos.tsx` |
| H-03-03 | 🟡 Mejora | Portal público sin disciplinas ni categorías en tarjetas de torneo | `PublicTorneosPage.tsx` |

## Artefactos UAT

- `quality/reports/uat/SP6/F-03-seed-b/escenarios.md` — 3/3 PASS
- `quality/reports/uat/SP6/F-03-seed-b/hallazgos.md` — 3 hallazgos resueltos
- `quality/reports/uat/SP6/F-03-seed-b/reporte_f03.md` — cerrado

🤖 Generated with [Claude Code](https://claude.com/claude-code)