### PR TITLE
test(uat): F-04 Inscripción Abierta — 6/6 PASS [INC-6.5]

### DIFF
--- a/frontend/src/api/registro.ts
+++ b/frontend/src/api/registro.ts
@@ -55,6 +55,17 @@ export interface AtletaDto {
   brevet: string | null
 }
 
+export interface CrearAtletaPayload {
+  atletaId: string
+  nombre: string
+  apellido: string
+  email: string
+  fechaNacimiento: string
+  categoria: string
+  club: string
+  brevet?: string
+}
+
 export interface InscribirAtletaPayload {
   atletaId: string
   torneoId: string
@@ -149,6 +160,32 @@ export async function fetchAtletaMe(): Promise<AtletaDto> {
     headers: buildHeaders(),
   })
   return parseResponse<AtletaDto>(response)
+}
+
+export async function fetchAtletaMeOrNull(): Promise<AtletaDto | null> {
+  const response = await fetch('/registro/atletas/me', {
+    headers: buildHeaders(),
+  })
+  if (response.status === 404) return null
+  return parseResponse<AtletaDto>(response)
+}
+
+export async function crearAtleta(payload: CrearAtletaPayload): Promise<{ atleta_id: string }> {
+  const response = await fetch('/registro/atletas', {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify({
+      atleta_id: payload.atletaId,
+      nombre: payload.nombre,
+      apellido: payload.apellido,
+      email: payload.email,
+      fecha_nacimiento: payload.fechaNacimiento,
+      categoria: payload.categoria,
+      club: payload.club,
+      brevet: payload.brevet ?? null,
+    }),
+  })
+  return parseResponse<{ atleta_id: string }>(response)
 }
 
 export async function fetchAtleta(atletaId: string): Promise<AtletaDto> {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -24,6 +24,11 @@ export function LoginPage() {
   const [password, setPassword] = useState('')
   const login = useAuthStore((s) => s.login)
   const rol = useAuthStore((s) => s.rol)
+  const [redirectTarget] = useState<string | null>(() => {
+    const redirect = sessionStorage.getItem('redirectAfterLogin')
+    if (redirect) sessionStorage.removeItem('redirectAfterLogin')
+    return redirect
+  })
 
   const mutation = useMutation({
     mutationFn: () => loginApi(email, password),
@@ -35,10 +40,8 @@ export function LoginPage() {
   const resetDone = searchParams.get('reset') === '1'
 
   if (rol) {
-    const redirect = sessionStorage.getItem('redirectAfterLogin')
-    sessionStorage.removeItem('redirectAfterLogin')
-    if (redirect && esDestinoCompatible(redirect, rol)) {
-      return <Navigate to={redirect} replace />
+    if (redirectTarget && esDestinoCompatible(redirectTarget, rol)) {
+      return <Navigate to={redirectTarget} replace />
     }
     return <Navigate to={portalPorRol(rol)} replace />
   }

--- a/frontend/src/pages/PublicTorneosPage.tsx
+++ b/frontend/src/pages/PublicTorneosPage.tsx
@@ -102,23 +102,33 @@ function TorneoCard({ torneo }: { torneo: TorneoDto }) {
       </div>
 
       {(disciplinaNames.length > 0 || categorias.length > 0) && (
-        <div className="mt-3 flex flex-wrap gap-1.5">
-          {disciplinaNames.map((d) => (
-            <span
-              key={d}
-              className="rounded-full border border-sky-700/40 bg-sky-900/30 px-2.5 py-0.5 text-xs font-semibold text-sky-300"
-            >
-              {d}
-            </span>
-          ))}
-          {categorias.map((c) => (
-            <span
-              key={c}
-              className="rounded-full border border-slate-600/40 bg-slate-800/60 px-2.5 py-0.5 text-xs font-semibold text-slate-300"
-            >
-              {c}
-            </span>
-          ))}
+        <div className="mt-3 space-y-2">
+          {disciplinaNames.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs text-slate-500 mr-0.5">Disciplinas</span>
+              {disciplinaNames.map((d) => (
+                <span
+                  key={d}
+                  className="rounded-full border border-sky-700/40 bg-sky-900/30 px-2.5 py-0.5 text-xs font-semibold text-sky-300"
+                >
+                  {d}
+                </span>
+              ))}
+            </div>
+          )}
+          {categorias.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs text-slate-500 mr-0.5">Categorías</span>
+              {categorias.map((c) => (
+                <span
+                  key={c}
+                  className="rounded-full border border-slate-600/40 bg-slate-800/60 px-2.5 py-0.5 text-xs font-semibold text-slate-300"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/atleta/AtletaDeclararAPPage.tsx
+++ b/frontend/src/pages/atleta/AtletaDeclararAPPage.tsx
@@ -50,7 +50,7 @@ function getApError(error: unknown): string {
 export function AtletaDeclararAPPage() {
   const { torneoId, disciplina } = useParams<{ torneoId: string; disciplina: string }>()
   const navigate = useNavigate()
-  const [valorAp, setValorAp] = useState('')
+  const [valorAp, setValorAp] = useState<string | null>(null)
   const query = useQuery({
     queryKey: ['atleta-ap-context', torneoId, disciplina],
     queryFn: () => loadApContext(torneoId ?? '', disciplina ?? ''),
@@ -79,7 +79,7 @@ export function AtletaDeclararAPPage() {
   const currentAp = query.data?.apActual ?? ''
   const currentApDisplay =
     currentAp && esDisciplinaTiempo(disciplina ?? '') ? secondsToApInput(currentAp) : currentAp
-  const valorApValue = valorAp || currentApDisplay
+  const valorApValue = valorAp ?? currentApDisplay
   const apBloqueado = query.data ? query.data.torneo.estado !== 'INSCRIPCION_ABIERTA' : true
   const puedeGuardar = isApInputValido(valorApValue, disciplina ?? '')
 

--- a/frontend/src/pages/atleta/AtletaInscripcionPage.tsx
+++ b/frontend/src/pages/atleta/AtletaInscripcionPage.tsx
@@ -3,7 +3,8 @@ import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { fetchTorneo, listarDisciplinasTorneo } from '../../api/torneo'
 import {
-  fetchAtletaMe,
+  crearAtleta,
+  fetchAtletaMeOrNull,
   guardarApInscripcion,
   inscribirAtleta,
   subirAptoMedico,
@@ -36,6 +37,8 @@ export function AtletaInscripcionPage() {
   const { torneoId } = useParams<{ torneoId: string }>()
   const atletaId = useAuthStore((state) => state.userId)
   const email = useAuthStore((state) => state.email)
+  const authNombre = useAuthStore((state) => state.nombre)
+  const authApellido = useAuthStore((state) => state.apellido)
   const navigate = useNavigate()
   const [step, setStep] = useState<WizardStep>(1)
   const [nombreCompleto, setNombreCompleto] = useState('')
@@ -45,6 +48,7 @@ export function AtletaInscripcionPage() {
   const [documentoNumero, setDocumentoNumero] = useState('')
   const [telefono, setTelefono] = useState('')
   const [categoria, setCategoria] = useState('')
+  const [club, setClub] = useState('')
   const [brevet, setBrevet] = useState('')
   const [disciplinasSeleccionadas, setDisciplinasSeleccionadas] = useState<string[]>([])
   const [apPorDisciplina, setApPorDisciplina] = useState<Record<string, string>>({})
@@ -59,7 +63,7 @@ export function AtletaInscripcionPage() {
       const [torneo, disciplinas, atleta] = await Promise.all([
         fetchTorneo(torneoId ?? ''),
         listarDisciplinasTorneo(torneoId ?? ''),
-        fetchAtletaMe(),
+        fetchAtletaMeOrNull(),
       ])
       return { torneo, disciplinas, atleta }
     },
@@ -68,10 +72,25 @@ export function AtletaInscripcionPage() {
 
   const mutation = useMutation({
     mutationFn: async () => {
-      const registroAtletaId = query.data?.atleta.atleta_id
-      if (!registroAtletaId || !torneoId) {
+      if (!atletaId || !torneoId) {
         throw new Error('No se pudo identificar al atleta o torneo para inscribirse.')
       }
+
+      let registroAtletaId = query.data?.atleta?.atleta_id
+      if (!registroAtletaId) {
+        const created = await crearAtleta({
+          atletaId,
+          nombre: authNombre ?? nombreCompletoValue.split(' ')[0] ?? '',
+          apellido: authApellido ?? nombreCompletoValue.split(' ').slice(1).join(' ') ?? '',
+          email: email ?? '',
+          fechaNacimiento: fechaNacimientoValue,
+          categoria: categoriaValue,
+          club: club || atleta?.club || '',
+          brevet: brevetValue || undefined,
+        })
+        registroAtletaId = created.atleta_id
+      }
+
       const { inscripcion_id: inscripcionId } = await inscribirAtleta({
         atletaId: registroAtletaId,
         torneoId,
@@ -135,7 +154,7 @@ export function AtletaInscripcionPage() {
   })
 
   const atleta = query.data?.atleta
-  const nombreCompletoValue = nombreCompleto || (atleta ? `${atleta.nombre} ${atleta.apellido}`.trim() : '')
+  const nombreCompletoValue = nombreCompleto || (atleta ? `${atleta.nombre} ${atleta.apellido}`.trim() : `${authNombre ?? ''} ${authApellido ?? ''}`.trim())
   const fechaNacimientoValue = fechaNacimiento || atleta?.fecha_nacimiento || ''
   const categoriaValue = categoria || atleta?.categoria || ''
   const brevetValue = brevet || atleta?.brevet || ''
@@ -363,7 +382,22 @@ export function AtletaInscripcionPage() {
               </div>
               <label className="block text-sm text-slate-300">
                 Categoría *
-                {categoriaValue === 'MASTER_MASCULINO' || categoriaValue === 'MASTER_FEMENINO' ? (
+                {!categoriaValue ? (
+                  <select
+                    value={categoria.replace(/_MASCULINO|_FEMENINO/, '')}
+                    onChange={(event) => {
+                      const base = event.target.value
+                      const suffix = genero === 'F' ? '_FEMENINO' : '_MASCULINO'
+                      setCategoria(base ? `${base}${suffix}` : '')
+                    }}
+                    className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                  >
+                    <option value="">— Seleccioná tu categoría —</option>
+                    <option value="JUNIOR">Junior</option>
+                    <option value="SENIOR">Senior</option>
+                    <option value="MASTER">Master</option>
+                  </select>
+                ) : categoriaValue === 'MASTER_MASCULINO' || categoriaValue === 'MASTER_FEMENINO' ? (
                   <select
                     value={categoria || categoriaValue}
                     onChange={(event) => setCategoria(event.target.value)}
@@ -381,6 +415,15 @@ export function AtletaInscripcionPage() {
                     className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-400"
                   />
                 )}
+              </label>
+              <label className="block text-sm text-slate-300">
+                Club
+                <input
+                  value={club || atleta?.club || ''}
+                  onChange={(event) => setClub(event.target.value)}
+                  placeholder="Nombre del club (opcional)"
+                  className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
+                />
               </label>
               <label className="block text-sm text-slate-300">
                 Nº Brevet FAAS

--- a/frontend/src/pages/atleta/AtletaTorneoDetallePage.tsx
+++ b/frontend/src/pages/atleta/AtletaTorneoDetallePage.tsx
@@ -1,20 +1,19 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
-import { fetchTorneo, listarDisciplinasTorneo } from '../../api/torneo'
+import { fetchTorneo } from '../../api/torneo'
 import { fetchAtletaMe, listarInscripcionesDeAtleta } from '../../api/registro'
 import { AtletaShell } from '../../components/atleta/AtletaShell'
 import { formatDisciplina, formatFecha, getEstadoTorneoLabel } from './portalData'
 
 async function loadTorneoDetalle(torneoId: string) {
-  const [torneo, disciplinas, atleta] = await Promise.all([
+  const [torneo, atleta] = await Promise.all([
     fetchTorneo(torneoId),
-    listarDisciplinasTorneo(torneoId),
     fetchAtletaMe(),
   ])
   const inscripciones = await listarInscripcionesDeAtleta(atleta.atleta_id)
   const inscripcion = inscripciones.find((item) => item.torneo_id === torneoId) ?? null
 
-  return { torneo, disciplinas, inscripcion }
+  return { torneo, inscripcion }
 }
 
 export function AtletaTorneoDetallePage() {
@@ -65,25 +64,6 @@ export function AtletaTorneoDetallePage() {
                 <dd className="mt-1">{query.data.torneo.descripcion || 'Sin descripción pública.'}</dd>
               </div>
             </dl>
-          </section>
-
-          <section className="rounded-[1.75rem] border border-slate-800 bg-slate-900 p-5">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
-              Disciplinas disponibles
-            </p>
-            <div className="mt-4 space-y-3">
-              {query.data.disciplinas.map((disciplina) => (
-                <div
-                  key={disciplina.disciplina}
-                  className="rounded-3xl border border-slate-800 bg-slate-950/70 p-4"
-                >
-                  <p className="text-sm font-semibold text-white">{formatDisciplina(disciplina.disciplina)}</p>
-                  <p className="mt-1 text-sm text-slate-400">
-                    Juez asignado: {disciplina.juez_id ? 'Sí' : 'Pendiente'}
-                  </p>
-                </div>
-              ))}
-            </div>
           </section>
 
           {query.data.inscripcion ? (

--- a/quality/reports/uat/SP6/F-04-inscripcion-abierta/escenarios.md
+++ b/quality/reports/uat/SP6/F-04-inscripcion-abierta/escenarios.md
@@ -1,0 +1,24 @@
+# Escenarios — Fase F-04: Inscripción Abierta
+
+## Criterio de Entrada
+
+- [x] F-03 cerrada: Seed-B ejecutado · 31 atletas inscriptos con APs correctas
+- [x] Torneo en estado `INSCRIPCION_ABIERTA`
+
+## Escenarios
+
+| ID | Actor | Dispositivo | Acción | Resultado esperado | Resultado real | Estado | Hallazgo |
+|----|-------|-------------|--------|--------------------|----------------|--------|----------|
+| F04-S01 | Organizador | Desktop | Verificar que el torneo ya está en `INSCRIPCION_ABIERTA` (abierto por Seed-B) | Estado `INSCRIPCION_ABIERTA` visible en panel del organizador | Estado "Inscripción Abierta" confirmado | ✅ PASS | — |
+| F04-S02 | Portal (visitante) | Desktop | Acceder a `/portalapnea` y verificar torneo | Torneo muestra estado "Inscripción abierta" · chips de disciplinas/categorías visibles | Torneo visible · badge correcto · chips presentes | ✅ PASS | M-04-01 |
+| F04-S03 | Visitante | Desktop | Clic en "Inscribirse" sin estar logueado | Redirige a login · post-login regresa al formulario de inscripción | Redirigió a login · post-login llegó al formulario (fix H-04-02) | ✅ PASS | H-04-02 |
+| F04-S03b | Visitante nuevo | Desktop | Registrar cuenta nueva y completar inscripción al torneo | Cuenta creada · perfil atleta generado en primer wizard · inscripción confirmada | Flujo completo OK tras fixes H-04-03/04/05 · email falló (M-04-02) | ✅ PASS | H-04-03 H-04-04 H-04-05 |
+| F04-S04 | Atleta (Guadalupe Fardi) | Móvil | Editar AP en DYN desde portal atleta | AP editable · nuevo valor guardado · visible en Mis Inscripciones | AP editada correctamente tras fix H-04-01 | ✅ PASS | H-04-01 |
+| F04-S05 | Organizador | Desktop | Ver lista inscriptos DYN · verificar Guadalupe Fardi | Categoría "JUNIOR" legible · AP en metros | Aparece · categoría y AP correctos | ✅ PASS | — |
+
+## Criterio de Salida
+
+- [x] F04-S01: torneo verificado en `INSCRIPCION_ABIERTA`
+- [x] Todos los escenarios 🔴 (S01..S04) en PASS
+- [x] Guadalupe Fardi aparece en inscriptos DYN con AP declarada
+- [x] Verificación cruzada organizador confirma la inscripción de Guadalupe Fardi

--- a/quality/reports/uat/SP6/F-04-inscripcion-abierta/hallazgos.md
+++ b/quality/reports/uat/SP6/F-04-inscripcion-abierta/hallazgos.md
@@ -1,0 +1,18 @@
+# Hallazgos — Fase F-04: Inscripción Abierta
+
+## Defectos
+
+| ID | Escenario | Descripción | Severidad | Pasos para reproducir | Estado | Fix |
+|----|-----------|-------------|-----------|----------------------|--------|-----|
+| H-04-01 | F04-S04 | Campo AP editable no permitía borrar el primer dígito al editar (useState `''` con `\|\|` en lugar de `null` con `??`) | 🔴 | 1. Ir a "Editar AP" en Mis Inscripciones 2. Intentar borrar primer dígito | Resuelto | `AtletaDeclararAPPage.tsx`: `useState<string\|null>(null)` + `??` |
+| H-04-02 | F04-S03 | Post-login no redirigía al formulario de inscripción (React StrictMode consumía sessionStorage dos veces en el render) | 🔴 | 1. Click "Inscribirse" sin login 2. Hacer login 3. Llega a portal atleta en vez del formulario | Resuelto | `LoginPage.tsx`: lazy `useState` para capturar redirect una sola vez al montar |
+| H-04-03 | F04-S03b | Formulario de inscripción fallaba para usuarios auto-registrados sin perfil de atleta en BC Registro | 🔴 | 1. Registrar nuevo usuario via `/registro` 2. Intentar inscribirse en un torneo | Resuelto | `AtletaInscripcionPage.tsx`: `fetchAtletaMeOrNull()` + `crearAtleta()` en mutation si perfil no existe |
+| H-04-04 | F04-S03b | Formulario de inscripción sin selector de categoría para usuarios nuevos (campo read-only con valor vacío) | 🔴 | 1. Nuevo usuario sin perfil 2. Paso 2 del wizard — categoría vacía sin opción de selección | Resuelto | `AtletaInscripcionPage.tsx`: selector Junior/Senior/Master cuando `categoriaValue` es vacío; género del paso 1 compone el código completo |
+| H-04-05 | F04-S03b | Formulario de inscripción sin campo Club para usuarios nuevos | 🟡 | 1. Nuevo usuario — paso 2 del wizard sin campo club | Resuelto | `AtletaInscripcionPage.tsx`: campo Club agregado en paso 2 |
+
+## Mejoras (fuera de scope UAT)
+
+| ID | Origen | Descripción | Prioridad sugerida |
+|----|--------|-------------|-------------------|
+| M-04-01 | F04-S02 | Chips de disciplinas y categorías en portal público sin separación visual por tipo | Baja |
+| M-04-02 | F04-S03b | Notificaciones email fallan para destinatarios externos — `onboarding@resend.dev` solo permite enviar a `vvalotto@gmail.com` · pipeline P10 funciona correctamente · requiere dominio verificado en Resend para producción | Alta |

--- a/quality/reports/uat/SP6/F-04-inscripcion-abierta/reporte_f04.md
+++ b/quality/reports/uat/SP6/F-04-inscripcion-abierta/reporte_f04.md
@@ -1,0 +1,48 @@
+# Reporte Fase F-04: Inscripción Abierta
+
+**Fecha de ejecución:** 2026-05-12  
+**Ejecutor:** Victor Valotto  
+**Dispositivos usados:** Desktop (organizador, portal público) · Móvil (atleta)
+
+## Métricas
+
+| Métrica | Valor |
+|---------|-------|
+| Escenarios ejecutados | 6 (S01, S02, S03, S03b, S04, S05) |
+| PASS | 6 |
+| FAIL | 0 |
+| SKIP | 0 |
+| Hallazgos 🔴 | 4 (4 resueltos) |
+| Hallazgos 🟡 | 1 (1 resuelto) |
+| Observaciones 🟡 sin resolver | 1 (M-04-02 — dominio Resend) |
+| Mejoras visuales aplicadas | 2 (chips separados, disciplinas disponibles eliminadas) |
+
+## Resumen
+
+La fase validó el ciclo completo de inscripción: portal público, redirect post-login, wizard de inscripción para atletas existentes y nuevos. Se detectaron y resolvieron 4 defectos bloqueantes: edición de AP que no permitía borrar el primer dígito (bug `||` vs `??`), redirect post-login roto en React StrictMode (sessionStorage consumido dos veces), formulario de inscripción que fallaba para usuarios auto-registrados sin perfil en BC Registro, y selector de categoría ausente para usuarios nuevos. Las notificaciones email funcionan a nivel de pipeline (P10 dispara correctamente) pero Resend bloquea envíos a emails externos con el dominio de prueba — requiere dominio verificado para producción.
+
+## Hallazgos resueltos
+
+| ID | Severidad | Descripción | Fix |
+|----|-----------|-------------|-----|
+| H-04-01 | 🔴 | AP no permitía borrar primer dígito al editar | `AtletaDeclararAPPage.tsx`: `useState<string\|null>(null)` + `??` |
+| H-04-02 | 🔴 | Post-login no redirigía al formulario (StrictMode) | `LoginPage.tsx`: lazy `useState` para redirect, captura una sola vez al montar |
+| H-04-03 | 🔴 | Formulario fallaba para usuarios sin perfil de atleta | `AtletaInscripcionPage.tsx`: `fetchAtletaMeOrNull()` + `crearAtleta()` en mutation |
+| H-04-04 | 🔴 | Sin selector de categoría para usuarios nuevos | `AtletaInscripcionPage.tsx`: selector Junior/Senior/Master compuesto con género |
+| H-04-05 | 🟡 | Sin campo Club para usuarios nuevos | `AtletaInscripcionPage.tsx`: campo Club en paso 2 |
+
+## Observaciones diferidas
+
+| ID | Descripción | Acción sugerida |
+|----|-------------|-----------------|
+| M-04-02 | Notificaciones email: `onboarding@resend.dev` solo permite enviar a `vvalotto@gmail.com` · pipeline P10 funciona | Verificar dominio en resend.com/domains antes de producción |
+
+## Criterio de Salida
+
+- [x] F04-S01: torneo en `INSCRIPCION_ABIERTA` confirmado
+- [x] Todos los escenarios 🔴 en PASS
+- [x] Guadalupe Fardi inscripta en DYN con AP declarada
+- [x] Verificación cruzada organizador: categoría y AP correctos
+- [x] 0 hallazgos 🔴 sin resolver
+
+## Estado: ✅ FASE CERRADA


### PR DESCRIPTION
## UAT F-04 — Inscripción Abierta

Fase del ciclo de vida: `INSCRIPCION_ABIERTA`

## Escenarios

| ID | Actor | Estado |
|----|-------|--------|
| F04-S01 | Organizador — verificar estado torneo | ✅ PASS |
| F04-S02 | Visitante — portal público muestra torneo | ✅ PASS |
| F04-S03 | Visitante — redirect post-login al formulario | ✅ PASS |
| F04-S03b | Usuario nuevo — registro + inscripción completa | ✅ PASS |
| F04-S04 | Atleta (Guadalupe Fardi) — editar AP en DYN | ✅ PASS |
| F04-S05 | Organizador — verificación cruzada inscripción | ✅ PASS |

## Hallazgos resueltos

- 🔴 H-04-01: edición AP bloqueaba borrar primer dígito (`||` → `??`)
- 🔴 H-04-02: redirect post-login roto en React StrictMode (lazy `useState`)
- 🔴 H-04-03: wizard inscripción fallaba para usuarios sin perfil de atleta en BC Registro
- 🔴 H-04-04: selector de categoría ausente para usuarios nuevos
- 🟡 H-04-05: campo Club ausente en wizard para usuario nuevo

## Mejoras aplicadas

- Portal público: chips disciplinas/categorías en regiones separadas
- Detalle torneo (portal atleta): eliminada sección "Disciplinas disponibles"

## Observación diferida

- M-04-02 🟡: `onboarding@resend.dev` bloquea envíos a emails externos — pipeline P10 funciona, requiere dominio verificado en Resend para producción

🤖 Generated with [Claude Code](https://claude.com/claude-code)