### PR TITLE
test(uat): F-07 Ejecución Normal de Performances — 10/10 PASS [INC-6.5]

### DIFF
--- a/frontend/src/components/atleta/RankingCard.tsx
+++ b/frontend/src/components/atleta/RankingCard.tsx
@@ -38,7 +38,6 @@ export function RankingCard({
             posicion={entrada.posicion}
             nombre={nombresPorId.get(entrada.atleta_id) ?? entrada.atleta_id.slice(0, 8)}
             rp={formatRp(entrada, unidad)}
-            puntos={entrada.es_dns ? '0' : (entrada.puntos ?? '-')}
             tarjeta={entrada.tarjeta}
             esDns={entrada.es_dns}
             isSelf={entrada.atleta_id === atletaId}

--- a/frontend/src/components/atleta/RankingRow.tsx
+++ b/frontend/src/components/atleta/RankingRow.tsx
@@ -2,13 +2,10 @@ interface RankingRowProps {
   posicion: number
   nombre: string
   rp: string
-  puntos: string
   tarjeta: string | null
   esDns: boolean
   isSelf: boolean
 }
-
-const PODIO_ICONS: Record<number, string> = { 1: '🥇', 2: '🥈', 3: '🥉' }
 
 function ChipTarjeta({ tarjeta, esDns }: { tarjeta: string | null; esDns: boolean }) {
   if (esDns) {
@@ -35,7 +32,7 @@ function ChipTarjeta({ tarjeta, esDns }: { tarjeta: string | null; esDns: boolea
   return null
 }
 
-export function RankingRow({ posicion, nombre, rp, puntos, tarjeta, esDns, isSelf }: RankingRowProps) {
+export function RankingRow({ posicion, nombre, rp, tarjeta, esDns, isSelf }: RankingRowProps) {
   return (
     <div
       className={`flex items-center gap-3 rounded-2xl px-3 py-2.5 ${
@@ -43,7 +40,7 @@ export function RankingRow({ posicion, nombre, rp, puntos, tarjeta, esDns, isSel
       }`}
     >
       <span className="w-6 text-center text-sm font-bold text-slate-400">
-        {PODIO_ICONS[posicion] ?? posicion}
+        {posicion}
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
@@ -57,7 +54,6 @@ export function RankingRow({ posicion, nombre, rp, puntos, tarjeta, esDns, isSel
         <span className="text-xs text-slate-400">{rp}</span>
       </div>
       <div className="flex flex-col items-end gap-1">
-        <span className="text-sm font-semibold text-white">{puntos}</span>
         <ChipTarjeta tarjeta={tarjeta} esDns={esDns} />
       </div>
     </div>

--- a/frontend/src/components/atleta/ResultHero.tsx
+++ b/frontend/src/components/atleta/ResultHero.tsx
@@ -6,7 +6,6 @@ interface ResultHeroProps {
   rp: string
   ap: string
   diferencia: string
-  puntos: string
   enPodio: boolean
 }
 
@@ -23,7 +22,6 @@ export function ResultHero({
   rp,
   ap,
   diferencia,
-  puntos,
   enPodio,
 }: ResultHeroProps) {
   return (
@@ -47,7 +45,7 @@ export function ResultHero({
         </div>
       </div>
 
-      <dl className="mt-5 grid grid-cols-3 gap-3 text-sm">
+      <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
         <div className="rounded-2xl border border-white/10 bg-slate-950/30 p-3">
           <dt className="text-xs uppercase tracking-[0.16em] opacity-70">AP</dt>
           <dd className="mt-1 font-semibold text-white">{ap}</dd>
@@ -55,10 +53,6 @@ export function ResultHero({
         <div className="rounded-2xl border border-white/10 bg-slate-950/30 p-3">
           <dt className="text-xs uppercase tracking-[0.16em] opacity-70">Dif.</dt>
           <dd className="mt-1 font-semibold text-white">{diferencia}</dd>
-        </div>
-        <div className="rounded-2xl border border-white/10 bg-slate-950/30 p-3">
-          <dt className="text-xs uppercase tracking-[0.16em] opacity-70">Puntos</dt>
-          <dd className="mt-1 font-semibold text-white">{puntos}</dd>
         </div>
       </dl>
     </article>

--- a/frontend/src/components/juez/StepTarjeta.tsx
+++ b/frontend/src/components/juez/StepTarjeta.tsx
@@ -60,15 +60,15 @@ export function StepTarjeta({
           const colorClasses =
             card === 'Blanca'
               ? isSelected
-                ? 'border-white bg-white/15 ring-2 ring-white'
-                : 'border-white/30 bg-white/5'
+                ? 'border-white bg-white/30 ring-2 ring-white'
+                : 'border-white/60 bg-white/40'
               : card === 'Roja'
                 ? isSelected
-                  ? 'border-red-300 bg-red-400/15 ring-2 ring-red-300'
-                  : 'border-red-300/30 bg-red-500/5'
+                  ? 'border-red-300 bg-red-400/30 ring-2 ring-red-300'
+                  : 'border-red-400/60 bg-red-500/40'
                 : isSelected
-                  ? 'border-amber-300 bg-amber-400/15 ring-2 ring-amber-300'
-                  : 'border-amber-300/30 bg-amber-400/5'
+                  ? 'border-amber-300 bg-amber-400/30 ring-2 ring-amber-300'
+                  : 'border-amber-400/60 bg-amber-400/40'
           return (
             <button
               key={card}

--- a/frontend/src/components/organizador/FilaResultado.tsx
+++ b/frontend/src/components/organizador/FilaResultado.tsx
@@ -1,3 +1,5 @@
+import { formatMarca } from '../../utils/marca'
+
 export interface FilaResultadoData {
   posicion_ot: number
   atleta_id: string
@@ -66,7 +68,7 @@ function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
 }
 
 export function FilaResultado({ fila }: FilaResultadoProps) {
-  const rpDisplay = fila.rp ? `${fila.rp} ${fila.unidad ?? ''}`.trim() : '—'
+  const rpDisplay = fila.rp ? formatMarca(fila.rp, fila.unidad ?? 'Metros') : '—'
 
   return (
     <tr className="border-b border-slate-800 text-sm transition hover:bg-slate-800/60">
@@ -77,11 +79,11 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
       <td className="px-3 py-3 text-center text-slate-300">{fila.genero}</td>
       <td className="px-3 py-3 text-slate-300">{fila.categoria_corta}</td>
       <td className="px-3 py-3 text-slate-400">{fila.club || '—'}</td>
-      <td className="px-3 py-3 font-mono text-slate-300">{fila.ap}</td>
-      <td className="px-3 py-3 font-mono text-xs text-slate-400">{fila.ot}</td>
+      <td className="px-3 py-3 text-center font-mono text-slate-300">{fila.ap}</td>
+      <td className="px-3 py-3 text-center font-mono text-xs text-slate-400">{fila.ot}</td>
       <td className="px-3 py-3 text-center text-slate-400">{fila.linea}</td>
-      <td className="px-3 py-3 font-mono font-semibold text-white">{rpDisplay}</td>
-      <td className="px-3 py-3">
+      <td className="px-3 py-3 text-center font-mono font-semibold text-white">{rpDisplay}</td>
+      <td className="px-3 py-3 text-center">
         <ChipTarjeta tarjeta={fila.tarjeta} />
       </td>
     </tr>

--- a/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
+++ b/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import type { GrillaAtletaDto } from '../../api/competencia'
 import type { InscriptoDetalleDto } from '../../api/registro'
 import type { RankingCompetenciaDto } from '../../api/resultados'
+import { formatMarca } from '../../utils/marca'
 import { FilaResultado, type FilaResultadoData } from './FilaResultado'
 
 interface TablaDisciplinaResultadosProps {
@@ -73,8 +74,8 @@ export function TablaDisciplinaResultados({
           genero: derivarGenero(categoriaRaw),
           categoria_corta: derivarCategoriaCorta(categoriaRaw),
           club: inscriptoData?.club ?? '',
-          ap: `${atleta.ap_declarado} ${atleta.unidad}`.trim(),
-          ot: atleta.ot_programado,
+          ap: formatMarca(atleta.ap_declarado, atleta.unidad),
+          ot: new Date(atleta.ot_programado).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
           linea: formatearAndarivel(atleta.andarivel),
           rp: rankData?.rp ?? null,
           unidad: rankData?.unidad ?? atleta.unidad,
@@ -101,11 +102,11 @@ export function TablaDisciplinaResultados({
             <th className="px-3 py-2 text-center">Gén.</th>
             <th className="px-3 py-2">Categoría</th>
             <th className="px-3 py-2">Club</th>
-            <th className="px-3 py-2">Anuncio</th>
-            <th className="px-3 py-2">OT</th>
+            <th className="px-3 py-2 text-center">Anuncio</th>
+            <th className="px-3 py-2 text-center">OT</th>
             <th className="px-3 py-2 text-center">Línea</th>
-            <th className="px-3 py-2">RP</th>
-            <th className="px-3 py-2">Tarjeta</th>
+            <th className="px-3 py-2 text-center">Performance</th>
+            <th className="px-3 py-2 text-center">Tarjeta</th>
           </tr>
         </thead>
         <tbody className="bg-slate-900/40">

--- a/frontend/src/pages/PublicTorneoDetallePage.tsx
+++ b/frontend/src/pages/PublicTorneoDetallePage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { formatMarca } from '../utils/marca'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
 import {
@@ -74,7 +75,7 @@ function tarjetaClases(tarjeta: string | null): string {
 
 function formatRp(performance: string | null | undefined, unidad: string): string {
   if (!performance) return '—'
-  return `${performance} ${unidad}`
+  return formatMarca(performance, unidad)
 }
 
 function formatCategoria(cat: string): string {
@@ -97,8 +98,8 @@ function AtletaRow({ entry }: { entry: GrillaAtletaDto }) {
       <td className="py-2 pr-3 text-center text-xs text-slate-400">{formatAp(entry.ap_declarado, entry.unidad)}</td>
       <td className="py-2 pr-3 text-center text-xs text-slate-400">{formatHora(entry.ot_programado)}</td>
       <td className="py-2 pr-3 text-center text-xs font-medium text-slate-300">{formatRp(entry.performance, entry.unidad)}</td>
-      <td className={`py-2 text-center text-xs ${tarjetaClases(entry.tarjeta_asignada)}`}>
-        {entry.tarjeta_asignada ?? '—'}
+      <td className={`py-2 text-center text-xs ${entry.estado === 'DNS' ? 'text-slate-500' : tarjetaClases(entry.tarjeta_asignada)}`}>
+        {entry.estado === 'DNS' ? 'DNS' : entry.tarjeta_asignada ?? '—'}
       </td>
     </tr>
   )
@@ -312,8 +313,10 @@ function TorneoDetalleCard({ torneo, grillas, rankings, noDisponible }: TorneoDe
               {grillaActiva ? <GrillaTabContent grilla={grillaActiva} /> : null}
             </div>
 
-            {/* Podios */}
-            <PodiosSection rankings={rankings} nombrePorId={nombrePorId} />
+            {/* Podios — solo en PREMIACION o CERRADO */}
+            {['PREMIACION', 'CERRADO'].includes(torneo.estado) ? (
+              <PodiosSection rankings={rankings} nombrePorId={nombrePorId} />
+            ) : null}
           </>
         )}
       </div>

--- a/frontend/src/pages/atleta/AtletaResultadosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaResultadosPage.tsx
@@ -246,8 +246,7 @@ export function AtletaResultadosPage() {
                           unidad: miResultado.unidad ?? entry.unidad,
                           esDns: miResultado.es_dns,
                         })}
-                        puntos={miResultado.es_dns ? '-' : (miResultado.puntos ?? '-')}
-                        enPodio={miResultado.en_podio}
+                        enPodio={['PREMIACION', 'CERRADO'].includes(entry.torneo.estado) && miResultado.en_podio}
                       />
                       {miCategoria ? (
                         <RankingCard
@@ -263,13 +262,15 @@ export function AtletaResultadosPage() {
                   )
                 })}
 
-                <OverallCard
-                  overall={overall}
-                  atletaId={atletaId}
-                  nombresPorId={nombresParaOverall}
-                  categoriaAtleta={categoriaAtleta}
-                  categoriaLabel={categoriaLabel}
-                />
+                {['PREMIACION', 'CERRADO'].includes(grupo.resultados[0]?.entry.torneo.estado ?? '') ? (
+                  <OverallCard
+                    overall={overall}
+                    atletaId={atletaId}
+                    nombresPorId={nombresParaOverall}
+                    categoriaAtleta={categoriaAtleta}
+                    categoriaLabel={categoriaLabel}
+                  />
+                ) : null}
               </section>
             )
           })}

--- a/frontend/src/pages/juez/PerformanceFlowPage.tsx
+++ b/frontend/src/pages/juez/PerformanceFlowPage.tsx
@@ -118,16 +118,6 @@ export function PerformanceFlowPage() {
             </button>
           ) : (
             <>
-              <div className="rounded-3xl border border-cyan-400/20 bg-cyan-400/10 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">
-                  Ventana OT activa
-                </p>
-                <p className="mt-2 text-sm text-slate-100">
-                  {flow.isSTA
-                    ? 'Las vias respiratorias del atleta entran en contacto con el agua.'
-                    : 'El atleta comienza su performance dentro de la ventana oficial.'}
-                </p>
-              </div>
               <button
                 type="button"
                 onClick={() => {

--- a/quality/reports/uat/SP6/F-07-ejecucion-normal/escenarios.md
+++ b/quality/reports/uat/SP6/F-07-ejecucion-normal/escenarios.md
@@ -12,26 +12,26 @@
 | Atleta | Disciplina | Andarivel | Juez | AP | RP real | Tarjeta |
 |--------|-----------|:---------:|------|-----|---------|---------|
 | Ezequiel Cuchiarelli | DBF | 1 | Juez 1 | (schedules) | DNS | — |
-| Víctor Valotto | DBF | 2 | Juez 2 | (schedules) | 52.40m | Blanca |
+| Víctor Valotto | DBF | 1 | Juez 1 | (schedules) | 52.40m | Blanca |
 | Guadalupe Fardi | DNF | 1 | Juez 1 | (schedules) | 41.05m | Blanca |
 | Alejandro Alperin | SPE | 2 | Juez 2 | (schedules) | 00:59.00 | Blanca |
-| Víctor Valotto | STA | 2 | Juez 2 | 03:15 | 04:32.98 | Blanca |
-| José Enjuto | STA | 3 | Juez 3 | (schedules) | 06:33.05 | Blanca |
+| Víctor Valotto | STA | 3 | Juez 3 | 03:15 | 04:32.98 | Blanca |
+| José Enjuto | STA | 1 | Juez 1 | (schedules) | 06:33.05 | Blanca |
 
 ## Escenarios
 
 | ID | Actor | Dispositivo | Acción | Resultado esperado | Resultado real | Estado | Hallazgo |
 |----|-------|-------------|--------|--------------------|----------------|--------|----------|
-| F07-S01 | Juez 1 | Móvil | Abrir grilla DBF · ver atletas asignados a andarivel 1 | Primer atleta = mayor prioridad de estado · sin scroll horizontal | — | ⬜ PENDIENTE | — |
-| F07-S02 | Juez 1 | Móvil | Seleccionar Ezequiel Cuchiarelli DBF · marcar DNS | Performance queda como DNS · atleta no aparece en ranking DBF | — | ⬜ PENDIENTE | — |
-| F07-S03 | Juez 2 | Móvil | Seleccionar Víctor Valotto DBF (andarivel 2) · ingresar RP=52.40 · asignar tarjeta blanca | Secuencia correcta: performance → tarjeta → confirmar · pantalla completada en verde | — | ⬜ PENDIENTE | — |
-| F07-S04 | Juez 2 | Móvil | Verificar botones de tarjeta antes de seleccionar | Tarjetas sin color cuando no están seleccionadas · diferenciadas al seleccionar | — | ⬜ PENDIENTE | — |
-| F07-S05 | Juez 1 | Móvil | Seleccionar Guadalupe Fardi DNF (andarivel 1) · ingresar RP=41.05 | Tarjeta blanca · JUNIOR FEM rank 1 DNF | — | ⬜ PENDIENTE | — |
-| F07-S06 | Juez 2 | Móvil | Seleccionar Alejandro Alperin SPE (andarivel 2) · ingresar RP=00:59.00 | Marca en mm:ss · tarjeta blanca | — | ⬜ PENDIENTE | — |
-| F07-S07 | Juez 2 | Móvil | Seleccionar Víctor Valotto STA (andarivel 2) · ingresar RP=04:32.98 | Marca en formato mm:ss · tarjeta blanca | — | ⬜ PENDIENTE | — |
-| F07-S08 | Juez 3 | Móvil | Seleccionar José Enjuto STA (andarivel 3) · ingresar RP=06:33.05 | Tarjeta blanca · pantalla completada en verde | — | ⬜ PENDIENTE | — |
-| F07-S09 | Juez 3 | Móvil | Ver "Mis asignaciones" · verificar que solo aparece STA | Solo STA en su lista · no ve DBF/DNF/DYN/SPE | — | ⬜ PENDIENTE | — |
-| F07-S10 | Juez 1 | Móvil | Verificar keypad RpSelector en pantalla de ingreso de RP | Keypad completamente visible sin scroll horizontal en móvil | — | ⬜ PENDIENTE | — |
+| F07-S01 | Juez 1 | Móvil | Abrir grilla DBF · ver atletas asignados a andarivel 1 | Primer atleta = mayor prioridad de estado · sin scroll horizontal | Cuchiarelli primero · sin scroll horizontal | ✅ PASS | — |
+| F07-S02 | Juez 1 | Móvil | Seleccionar Ezequiel Cuchiarelli DBF · marcar DNS | Performance queda como DNS · atleta no aparece en ranking DBF | DNS registrado · portal mostraba sin estado (H-07-01 resuelto) | ✅ PASS | H-07-01 |
+| F07-S03 | Juez 1 | Móvil | Seleccionar Víctor Valotto DBF (andarivel 1, pos=19) · ingresar RP=52.40 · asignar tarjeta blanca | Secuencia correcta: performance → tarjeta → confirmar · pantalla completada en verde | Secuencia correcta · pantalla verde | ✅ PASS | M-07-01 |
+| F07-S04 | Juez 1 | Móvil | Verificar botones de tarjeta antes de seleccionar | Tarjetas sin color cuando no están seleccionadas · diferenciadas al seleccionar | Tres colores diferenciados sin selección activa | ✅ PASS | — |
+| F07-S05 | Juez 1 | Móvil | Seleccionar Guadalupe Fardi DNF (andarivel 1) · ingresar RP=41.05 | Tarjeta blanca · JUNIOR FEM rank 1 DNF | Correcto · pantalla verde | ✅ PASS | — |
+| F07-S06 | Juez 2 | Móvil | Seleccionar Alejandro Alperin SPE (andarivel 2) · ingresar RP=00:59.00 | Marca en mm:ss · tarjeta blanca | Correcto · portal mostraba segundos crudos (H-07-02 resuelto) | ✅ PASS | H-07-02 |
+| F07-S07 | Juez 3 | Móvil | Seleccionar Víctor Valotto STA (andarivel 3) · ingresar RP=04:32.98 | Marca en formato mm:ss · tarjeta blanca | Correcto · pantalla verde | ✅ PASS | — |
+| F07-S08 | Juez 1 | Móvil | Seleccionar José Enjuto STA (andarivel 1) · ingresar RP=06:33.05 | Tarjeta blanca · pantalla completada en verde | Correcto · M-07-02 resuelto (cartel OT eliminado) | ✅ PASS | M-07-02 |
+| F07-S09 | Juez 3 | Móvil | Ver "Mis asignaciones" · verificar que solo aparece STA | Solo STA en su lista · no ve DBF/DNF/DYN/SPE | Solo STA visible | ✅ PASS | — |
+| F07-S10 | Juez 1 | Móvil | Verificar keypad RpSelector en pantalla de ingreso de RP | Keypad completamente visible sin scroll horizontal en móvil | Keypad visible sin scroll | ✅ PASS | — |
 
 ## Verificación Cruzada
 
@@ -43,9 +43,9 @@
 
 ## Criterio de Salida
 
-- [ ] Todos los escenarios 🔴 en PASS (F07-S01, F07-S02, F07-S03, F07-S07, F07-S08)
-- [ ] 6 performances manuales registradas
-- [ ] Secuencia ingreso RP → tarjeta → confirmar correcta en móvil
-- [ ] Formatos de marca correctos: metros (DBF/DNF/DYN) y mm:ss (STA/SPE)
-- [ ] Verificación cruzada positiva: organizador · portal · atleta ven los resultados
-- [ ] Sistema en estado `EJECUCION` listo para F-08 (flujos de excepción)
+- [x] Todos los escenarios 🔴 en PASS (F07-S01, F07-S02, F07-S03, F07-S07, F07-S08)
+- [x] 6 performances manuales registradas
+- [x] Secuencia ingreso RP → tarjeta → confirmar correcta en móvil
+- [x] Formatos de marca correctos: metros (DBF/DNF/DYN) y mm:ss (STA/SPE)
+- [x] Verificación cruzada positiva: organizador · portal · atleta ven los resultados
+- [x] Sistema en estado `EJECUCION` listo para F-08 (flujos de excepción)

--- a/quality/reports/uat/SP6/F-07-ejecucion-normal/escenarios.md
+++ b/quality/reports/uat/SP6/F-07-ejecucion-normal/escenarios.md
@@ -1,0 +1,51 @@
+# Escenarios — Fase F-07: Ejecución Normal de Performances
+
+## Criterio de Entrada
+
+- [ ] F-06 cerrada: torneo en estado `EJECUCION`
+- [ ] Portal público activo · grilla visible públicamente
+- [ ] Jueces asignados por andarivel en todas las disciplinas
+- [ ] Dataset BA 2025 disponible: schedules.json con APs y results.json con RPs reales
+
+## Atletas del Escenario Manual
+
+| Atleta | Disciplina | Andarivel | Juez | AP | RP real | Tarjeta |
+|--------|-----------|:---------:|------|-----|---------|---------|
+| Ezequiel Cuchiarelli | DBF | 1 | Juez 1 | (schedules) | DNS | — |
+| Víctor Valotto | DBF | 2 | Juez 2 | (schedules) | 52.40m | Blanca |
+| Guadalupe Fardi | DNF | 1 | Juez 1 | (schedules) | 41.05m | Blanca |
+| Alejandro Alperin | SPE | 2 | Juez 2 | (schedules) | 00:59.00 | Blanca |
+| Víctor Valotto | STA | 2 | Juez 2 | 03:15 | 04:32.98 | Blanca |
+| José Enjuto | STA | 3 | Juez 3 | (schedules) | 06:33.05 | Blanca |
+
+## Escenarios
+
+| ID | Actor | Dispositivo | Acción | Resultado esperado | Resultado real | Estado | Hallazgo |
+|----|-------|-------------|--------|--------------------|----------------|--------|----------|
+| F07-S01 | Juez 1 | Móvil | Abrir grilla DBF · ver atletas asignados a andarivel 1 | Primer atleta = mayor prioridad de estado · sin scroll horizontal | — | ⬜ PENDIENTE | — |
+| F07-S02 | Juez 1 | Móvil | Seleccionar Ezequiel Cuchiarelli DBF · marcar DNS | Performance queda como DNS · atleta no aparece en ranking DBF | — | ⬜ PENDIENTE | — |
+| F07-S03 | Juez 2 | Móvil | Seleccionar Víctor Valotto DBF (andarivel 2) · ingresar RP=52.40 · asignar tarjeta blanca | Secuencia correcta: performance → tarjeta → confirmar · pantalla completada en verde | — | ⬜ PENDIENTE | — |
+| F07-S04 | Juez 2 | Móvil | Verificar botones de tarjeta antes de seleccionar | Tarjetas sin color cuando no están seleccionadas · diferenciadas al seleccionar | — | ⬜ PENDIENTE | — |
+| F07-S05 | Juez 1 | Móvil | Seleccionar Guadalupe Fardi DNF (andarivel 1) · ingresar RP=41.05 | Tarjeta blanca · JUNIOR FEM rank 1 DNF | — | ⬜ PENDIENTE | — |
+| F07-S06 | Juez 2 | Móvil | Seleccionar Alejandro Alperin SPE (andarivel 2) · ingresar RP=00:59.00 | Marca en mm:ss · tarjeta blanca | — | ⬜ PENDIENTE | — |
+| F07-S07 | Juez 2 | Móvil | Seleccionar Víctor Valotto STA (andarivel 2) · ingresar RP=04:32.98 | Marca en formato mm:ss · tarjeta blanca | — | ⬜ PENDIENTE | — |
+| F07-S08 | Juez 3 | Móvil | Seleccionar José Enjuto STA (andarivel 3) · ingresar RP=06:33.05 | Tarjeta blanca · pantalla completada en verde | — | ⬜ PENDIENTE | — |
+| F07-S09 | Juez 3 | Móvil | Ver "Mis asignaciones" · verificar que solo aparece STA | Solo STA en su lista · no ve DBF/DNF/DYN/SPE | — | ⬜ PENDIENTE | — |
+| F07-S10 | Juez 1 | Móvil | Verificar keypad RpSelector en pantalla de ingreso de RP | Keypad completamente visible sin scroll horizontal en móvil | — | ⬜ PENDIENTE | — |
+
+## Verificación Cruzada
+
+| Momento | Actor | Qué verificar |
+|---------|-------|---------------|
+| Post F07-S03 | Organizador (desktop) | Resultado de Víctor Valotto visible en grilla DBF con RP y tarjeta |
+| Post F07-S06 | Portal (visitante) | Página pública muestra resultado de José Enjuto en STA (polling 30s) |
+| Post F07-S07 | Atleta Guadalupe Fardi (móvil) | Login → ver resultado propio · RP=41.05 · rank 1 JUNIOR FEM DNF |
+
+## Criterio de Salida
+
+- [ ] Todos los escenarios 🔴 en PASS (F07-S01, F07-S02, F07-S03, F07-S07, F07-S08)
+- [ ] 6 performances manuales registradas
+- [ ] Secuencia ingreso RP → tarjeta → confirmar correcta en móvil
+- [ ] Formatos de marca correctos: metros (DBF/DNF/DYN) y mm:ss (STA/SPE)
+- [ ] Verificación cruzada positiva: organizador · portal · atleta ven los resultados
+- [ ] Sistema en estado `EJECUCION` listo para F-08 (flujos de excepción)

--- a/quality/reports/uat/SP6/F-07-ejecucion-normal/hallazgos.md
+++ b/quality/reports/uat/SP6/F-07-ejecucion-normal/hallazgos.md
@@ -4,10 +4,12 @@
 
 | ID | Escenario | Descripción | Severidad | Pasos para reproducir | Estado | Fix |
 |----|-----------|-------------|-----------|----------------------|--------|-----|
-| — | — | Sin defectos registrados aún | — | — | — | — |
+| H-07-01 | F07-S02 | Portal público muestra a Cuchiarelli en grilla DBF sin estado DNS tras marcarlo en panel juez | 🟡 | 1. Juez 1 marca DNS a Cuchiarelli DBF · 2. Abrir portal público `/portalapnea` → página torneo → tab DBF · 3. Refrescar manualmente · Cuchiarelli aparece sin estado DNS | Resuelto | `AtletaRow`: columna Tarjeta muestra "DNS" cuando `entry.estado === 'DNS'` |
+| H-07-02 | F07-S06 | Portal público muestra RP de SPE en segundos crudos (ej: "59") en lugar de mm:ss (ej: "00:59.00") | 🟡 | 1. Juez 2 registra Alperin SPE RP=00:59.00 · 2. Abrir portal público → tab SPE · resultado muestra "59" | Resuelto | `PublicTorneoDetallePage`: `formatRp` usa `formatMarca` en lugar de valor crudo |
 
 ## Mejoras (fuera de scope UAT)
 
 | ID | Origen | Descripción | Prioridad sugerida |
 |----|--------|-------------|-------------------|
-| — | — | Sin mejoras registradas aún | — |
+| M-07-01 | F07-S03 | Botones de tarjeta (Blanca/Amarilla/Roja) con colores muy tenues en estado no seleccionado — dificultan identificación en móvil · Resuelto: bg opacidad /5→/40 · border /30→/60 en `StepTarjeta.tsx` | Media |
+| M-07-02 | F07-S08 | Cartel "Ventana OT activa" redundante en paso 3 del flujo juez · Resuelto: div cyan eliminado de `PerformanceFlowPage.tsx` | Baja |

--- a/quality/reports/uat/SP6/F-07-ejecucion-normal/hallazgos.md
+++ b/quality/reports/uat/SP6/F-07-ejecucion-normal/hallazgos.md
@@ -1,0 +1,13 @@
+# Hallazgos — Fase F-07: Ejecución Normal de Performances
+
+## Defectos
+
+| ID | Escenario | Descripción | Severidad | Pasos para reproducir | Estado | Fix |
+|----|-----------|-------------|-----------|----------------------|--------|-----|
+| — | — | Sin defectos registrados aún | — | — | — | — |
+
+## Mejoras (fuera de scope UAT)
+
+| ID | Origen | Descripción | Prioridad sugerida |
+|----|--------|-------------|-------------------|
+| — | — | Sin mejoras registradas aún | — |

--- a/quality/reports/uat/SP6/F-07-ejecucion-normal/reporte_f07.md
+++ b/quality/reports/uat/SP6/F-07-ejecucion-normal/reporte_f07.md
@@ -8,23 +8,29 @@
 
 | Métrica | Valor |
 |---------|-------|
-| Escenarios ejecutados | — |
-| PASS | — |
-| FAIL | — |
-| SKIP | — |
-| Hallazgos 🔴 | — |
-| Hallazgos 🟡 | — |
-| Mejoras registradas | — |
+| Escenarios ejecutados | 10 |
+| PASS | 10 |
+| FAIL | 0 |
+| SKIP | 0 |
+| Hallazgos 🔴 | 0 |
+| Hallazgos 🟡 | 2 (2 resueltos) |
+| Mejoras registradas | 2 (2 resueltas) |
 
 ## Resumen
 
-> Pendiente de ejecución.
+6 performances manuales registradas correctamente por los jueces según andarivel asignado. Secuencia ingreso RP → tarjeta → confirmar funcionó correctamente en todos los casos. Formatos de marca correctos: metros para DBF/DNF/DYN y mm:ss para STA/SPE. Verificación cruzada positiva desde organizador, portal público y atleta.
+
+Nota: el plan original tenía los andariveles de Valotto (DBF) y Enjuto/Valotto (STA) incorrectos — se corrigieron contra los datos reales de la grilla durante la ejecución.
+
+Hallazgos resueltos: H-07-01 (portal no mostraba DNS) · H-07-02 (portal mostraba segundos crudos en SPE). Mejoras resueltas: M-07-01 (colores botones tarjeta) · M-07-02 (cartel "Ventana OT activa" eliminado).
+
+Mejoras adicionales aplicadas durante la fase: grilla organizador con formato mm:ss en AP/Performance para STA/SPE · OT en hh:mm · columna "Performance" renombrada · cabeceras y datos centrados · puntos eliminados del portal atleta · podios condicionados a estado PREMIACION/CERRADO.
 
 ## Criterio de Salida
 
-- [ ] Todos los escenarios 🔴 en PASS
-- [ ] 6 performances manuales registradas con formatos correctos
-- [ ] Verificación cruzada positiva (organizador · portal · atleta)
-- [ ] Sistema listo para F-08 (flujos de excepción)
+- [x] Todos los escenarios 🔴 en PASS
+- [x] 6 performances manuales registradas con formatos correctos
+- [x] Verificación cruzada positiva (organizador · portal · atleta)
+- [x] Sistema listo para F-08 (flujos de excepción)
 
-## Estado: ⏳ EN EJECUCIÓN
+## Estado: FASE CERRADA

--- a/quality/reports/uat/SP6/F-07-ejecucion-normal/reporte_f07.md
+++ b/quality/reports/uat/SP6/F-07-ejecucion-normal/reporte_f07.md
@@ -1,0 +1,30 @@
+# Reporte Fase F-07: Ejecución Normal de Performances
+
+**Fecha de ejecución:** 2026-05-13  
+**Ejecutor:** Víctor Valotto  
+**Dispositivos usados:** MacBook (organizador/portal) · iPhone (jueces · atleta)
+
+## Métricas
+
+| Métrica | Valor |
+|---------|-------|
+| Escenarios ejecutados | — |
+| PASS | — |
+| FAIL | — |
+| SKIP | — |
+| Hallazgos 🔴 | — |
+| Hallazgos 🟡 | — |
+| Mejoras registradas | — |
+
+## Resumen
+
+> Pendiente de ejecución.
+
+## Criterio de Salida
+
+- [ ] Todos los escenarios 🔴 en PASS
+- [ ] 6 performances manuales registradas con formatos correctos
+- [ ] Verificación cruzada positiva (organizador · portal · atleta)
+- [ ] Sistema listo para F-08 (flujos de excepción)
+
+## Estado: ⏳ EN EJECUCIÓN


### PR DESCRIPTION
## Resumen

- 10/10 escenarios PASS — flujo completo de ingreso de performances por juez en móvil
- 6 performances manuales registradas (DBF · DNF · SPE · STA) con formatos correctos
- Verificación cruzada positiva: organizador · portal público · atleta

## Hallazgos resueltos

- **H-07-01** 🟡 Portal público no mostraba estado DNS en grilla — `AtletaRow`: columna Tarjeta muestra "DNS" cuando `entry.estado === 'DNS'`
- **H-07-02** 🟡 Portal público mostraba RP de SPE en segundos crudos — `PublicTorneoDetallePage`: `formatRp` usa `formatMarca`

## Mejoras aplicadas

- **M-07-01** Botones de tarjeta (Blanca/Roja/Amarilla) con mayor opacidad en estado no seleccionado — `StepTarjeta.tsx`
- **M-07-02** Cartel "Ventana OT activa" eliminado del paso 3 del flujo juez — `PerformanceFlowPage.tsx`
- Grilla organizador: AP y Performance en mm:ss para STA/SPE · OT en hh:mm · columna renombrada "Performance" · cabeceras centradas
- Portal atleta: puntos eliminados de ResultHero y RankingCard · podios y Overall condicionados a estado PREMIACION/CERRADO · íconos de medalla eliminados del ranking

## Nota

Andariveles del plan corregidos contra datos reales de la grilla (Valotto DBF → andarivel 1/Juez 1; Valotto/Enjuto STA → andariveles 3 y 1 respectivamente).

## Test plan

- [x] F-07 ejecutada completa con dataset BA 2025
- [x] Verificación cruzada: organizador · portal · atleta
- [x] Hallazgos re-verificados en PASS post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)