### PR TITLE
test(uat): F-08 Flujos de Excepción — 8/8 PASS [INC-6.5]

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -199,7 +199,20 @@
       "Bash(xargs cat *)",
       "Bash(npx --prefix /Users/victor/PycharmProjects/ataraxiadive/frontend eslint src/components/juez/AtletaCard.tsx src/pages/juez/PerformanceFlowPage.tsx)",
       "Bash(npx --prefix frontend eslint frontend/src/components/juez/AtletaCard.tsx frontend/src/pages/juez/PerformanceFlowPage.tsx)",
-      "Bash(echo \"PID: $!\")"
+      "Bash(echo \"PID: $!\")",
+      "Bash(.venv/bin/python3 .claude/tracking/tracker_cli.py end-phase 3)",
+      "Bash(.venv/bin/python3 .claude/tracking/tracker_cli.py start-phase 4 \"Tests Unitarios\")",
+      "Bash(/Users/victor/PycharmProjects/ataraxiadive/.venv/bin/python3 *)",
+      "Bash(.venv/bin/python3 .claude/tracking/tracker_cli.py end-phase 4)",
+      "Bash(.venv/bin/python3 .claude/tracking/tracker_cli.py start-phase 5 \"Tests Integración\")",
+      "Bash(.venv/bin/python3 .claude/tracking/tracker_cli.py end-phase 5)",
+      "Bash(.venv/bin/python3 *)",
+      "Bash(lsof -iTCP -sTCP:LISTEN)",
+      "Bash(kill 4469)",
+      "Bash(mkdir -p /Users/victor/PycharmProjects/ataraxiadive/quality/reports/uat/SP6/F-02-creacion-torneo)",
+      "Bash(mkdir -p /Users/victor/PycharmProjects/ataraxiadive/quality/reports/uat/SP6/F-03-seed-b)",
+      "Bash(git reset *)",
+      "Bash(git worktree *)"
     ]
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,7 +51,8 @@ function GlobalHealthCheck() {
   if (
     location.pathname.startsWith('/organizador') ||
     location.pathname.startsWith('/juez') ||
-    location.pathname.startsWith('/portalapnea')
+    location.pathname.startsWith('/portalapnea') ||
+    location.pathname.startsWith('/atleta')
   ) {
     return null
   }

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -55,6 +55,7 @@ export interface GrillaAtletaDto {
   estado: EstadoPerformance
   tarjeta_asignada: string | null
   juez_id: string | null
+  motivo_dq: string | null
 }
 
 export interface PerformanceActualDto {

--- a/frontend/src/api/competencia.ts
+++ b/frontend/src/api/competencia.ts
@@ -56,6 +56,7 @@ export interface GrillaAtletaDto {
   tarjeta_asignada: string | null
   juez_id: string | null
   motivo_dq: string | null
+  penalizaciones: string[]
 }
 
 export interface PerformanceActualDto {

--- a/frontend/src/api/resultados.ts
+++ b/frontend/src/api/resultados.ts
@@ -7,6 +7,7 @@ export interface RankingEntradaDto {
   es_dns: boolean
   en_podio: boolean
   puntos: string | null
+  motivo_dq: string | null
 }
 
 export interface RankingCategoriaDto {

--- a/frontend/src/api/resultados.ts
+++ b/frontend/src/api/resultados.ts
@@ -9,6 +9,7 @@ export interface RankingEntradaDto {
   puntos: string | null
   motivo_dq: string | null
   penalizaciones: string[]
+  rp_medido: string | null
 }
 
 export interface RankingCategoriaDto {

--- a/frontend/src/api/resultados.ts
+++ b/frontend/src/api/resultados.ts
@@ -8,6 +8,7 @@ export interface RankingEntradaDto {
   en_podio: boolean
   puntos: string | null
   motivo_dq: string | null
+  penalizaciones: string[]
 }
 
 export interface RankingCategoriaDto {

--- a/frontend/src/components/atleta/AtletaShell.tsx
+++ b/frontend/src/components/atleta/AtletaShell.tsx
@@ -38,8 +38,8 @@ export function AtletaShell({
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <div className="mx-auto flex min-h-screen w-full max-w-[430px] flex-col border-x border-slate-800 bg-slate-950">
-        <header className="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/95 px-4 py-3 backdrop-blur">
-          <div className="flex items-start justify-between gap-3">
+        <header className="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/95 backdrop-blur">
+          <div className="flex items-start justify-between gap-3 px-4 pt-3 pb-0">
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
                 {showBack ? (
@@ -73,27 +73,29 @@ export function AtletaShell({
               </button>
             </div>
           </div>
+
+          <nav className="mt-3 grid grid-cols-4 border-t border-slate-800">
+            {TABS.map((tab) => {
+              const active = isTabActive(location.pathname, tab.to)
+              return (
+                <Link
+                  key={tab.to}
+                  to={tab.to}
+                  className={[
+                    'flex h-10 items-center justify-center text-center text-xs font-semibold transition-colors',
+                    active
+                      ? 'border-b-2 border-sky-400 text-sky-300'
+                      : 'border-b-2 border-transparent text-slate-400',
+                  ].join(' ')}
+                >
+                  {tab.label}
+                </Link>
+              )
+            })}
+          </nav>
         </header>
 
-        <main className="flex-1 px-4 py-4 pb-24">{children}</main>
-
-        <nav className="sticky bottom-0 z-20 grid h-14 grid-cols-4 border-t border-slate-800 bg-slate-900/95 backdrop-blur">
-          {TABS.map((tab) => {
-            const active = isTabActive(location.pathname, tab.to)
-            return (
-              <Link
-                key={tab.to}
-                to={tab.to}
-                className={[
-                  'flex items-center justify-center text-center text-xs font-semibold transition-colors',
-                  active ? 'text-sky-300' : 'text-slate-400',
-                ].join(' ')}
-              >
-                {tab.label}
-              </Link>
-            )
-          })}
-        </nav>
+        <main className="flex-1 px-4 py-4">{children}</main>
       </div>
     </div>
   )

--- a/frontend/src/components/atleta/AtletaShell.tsx
+++ b/frontend/src/components/atleta/AtletaShell.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
+import useAuthStore from '../../stores/useAuthStore'
 
 interface AtletaShellProps {
   title: string
@@ -32,13 +33,14 @@ export function AtletaShell({
 }: AtletaShellProps) {
   const location = useLocation()
   const navigate = useNavigate()
+  const logout = useAuthStore((state) => state.logout)
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <div className="mx-auto flex min-h-screen w-full max-w-[430px] flex-col border-x border-slate-800 bg-slate-950">
         <header className="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/95 px-4 py-3 backdrop-blur">
           <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
                 {showBack ? (
                   <button
@@ -60,7 +62,16 @@ export function AtletaShell({
               <h1 className="mt-2 text-xl font-semibold text-white">{title}</h1>
               {subtitle ? <p className="mt-1 text-sm text-slate-400">{subtitle}</p> : null}
             </div>
-            {actions ? <div className="shrink-0">{actions}</div> : null}
+            <div className="flex shrink-0 items-start gap-2">
+              {actions ? <div>{actions}</div> : null}
+              <button
+                type="button"
+                onClick={logout}
+                className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-400 hover:border-slate-500 hover:text-slate-200"
+              >
+                Salir
+              </button>
+            </div>
           </div>
         </header>
 

--- a/frontend/src/components/organizador/FilaResultado.tsx
+++ b/frontend/src/components/organizador/FilaResultado.tsx
@@ -16,6 +16,7 @@ export interface FilaResultadoData {
   tarjeta: string | null
   motivo_dq: string | null
   penalizaciones: string[]
+  rp_medido: string | null
 }
 
 interface FilaResultadoProps {
@@ -77,6 +78,16 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
     ? 'px-3 py-3 text-center font-mono font-semibold text-red-400'
     : 'px-3 py-3 text-center font-mono font-semibold text-white'
 
+  const rpBreakdown = (() => {
+    if (!fila.rp_medido || !fila.rp || fila.penalizaciones.length === 0) return null
+    const medido = parseFloat(fila.rp_medido)
+    const final = parseFloat(fila.rp)
+    const diff = Math.round((medido - final) * 100) / 100
+    if (diff <= 0) return null
+    const unidad = fila.unidad ?? 'Metros'
+    return `(${formatMarca(fila.rp_medido, unidad)} − ${diff}m)`
+  })()
+
   return (
     <tr className="border-b border-slate-800 text-sm transition hover:bg-slate-800/60">
       <td className="px-3 py-3 text-center font-mono text-xs text-slate-400">
@@ -89,7 +100,12 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
       <td className="px-3 py-3 text-center font-mono text-slate-300">{fila.ap}</td>
       <td className="px-3 py-3 text-center font-mono text-xs text-slate-400">{fila.ot}</td>
       <td className="px-3 py-3 text-center text-slate-400">{fila.linea}</td>
-      <td className={rpClass}>{rpDisplay}</td>
+      <td className={rpClass}>
+        {rpDisplay}
+        {rpBreakdown ? (
+          <p className="mt-0.5 text-xs font-normal text-slate-400">{rpBreakdown}</p>
+        ) : null}
+      </td>
       <td className="px-3 py-3 text-center">
         <ChipTarjeta tarjeta={fila.tarjeta} />
         {fila.motivo_dq ? (

--- a/frontend/src/components/organizador/FilaResultado.tsx
+++ b/frontend/src/components/organizador/FilaResultado.tsx
@@ -1,3 +1,4 @@
+import { DQ_REASON_LABELS } from '../../constants/tarjeta'
 import { formatMarca } from '../../utils/marca'
 
 export interface FilaResultadoData {
@@ -13,6 +14,7 @@ export interface FilaResultadoData {
   rp: string | null
   unidad: string | null
   tarjeta: string | null
+  motivo_dq: string | null
 }
 
 interface FilaResultadoProps {
@@ -85,6 +87,11 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
       <td className="px-3 py-3 text-center font-mono font-semibold text-white">{rpDisplay}</td>
       <td className="px-3 py-3 text-center">
         <ChipTarjeta tarjeta={fila.tarjeta} />
+        {fila.motivo_dq ? (
+          <p className="mt-1 text-xs text-red-300">
+            {DQ_REASON_LABELS[fila.motivo_dq] ?? fila.motivo_dq}
+          </p>
+        ) : null}
       </td>
     </tr>
   )

--- a/frontend/src/components/organizador/FilaResultado.tsx
+++ b/frontend/src/components/organizador/FilaResultado.tsx
@@ -70,7 +70,11 @@ function ChipTarjeta({ tarjeta }: { tarjeta: string | null }) {
 }
 
 export function FilaResultado({ fila }: FilaResultadoProps) {
+  const isRoja = fila.tarjeta === 'Roja' || fila.tarjeta === 'ROJA'
   const rpDisplay = fila.rp ? formatMarca(fila.rp, fila.unidad ?? 'Metros') : '—'
+  const rpClass = isRoja
+    ? 'px-3 py-3 text-center font-mono font-semibold text-red-400'
+    : 'px-3 py-3 text-center font-mono font-semibold text-white'
 
   return (
     <tr className="border-b border-slate-800 text-sm transition hover:bg-slate-800/60">
@@ -84,7 +88,7 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
       <td className="px-3 py-3 text-center font-mono text-slate-300">{fila.ap}</td>
       <td className="px-3 py-3 text-center font-mono text-xs text-slate-400">{fila.ot}</td>
       <td className="px-3 py-3 text-center text-slate-400">{fila.linea}</td>
-      <td className="px-3 py-3 text-center font-mono font-semibold text-white">{rpDisplay}</td>
+      <td className={rpClass}>{rpDisplay}</td>
       <td className="px-3 py-3 text-center">
         <ChipTarjeta tarjeta={fila.tarjeta} />
         {fila.motivo_dq ? (

--- a/frontend/src/components/organizador/FilaResultado.tsx
+++ b/frontend/src/components/organizador/FilaResultado.tsx
@@ -1,4 +1,4 @@
-import { DQ_REASON_LABELS } from '../../constants/tarjeta'
+import { DQ_REASON_LABELS, PENALTY_LABELS } from '../../constants/tarjeta'
 import { formatMarca } from '../../utils/marca'
 
 export interface FilaResultadoData {
@@ -15,6 +15,7 @@ export interface FilaResultadoData {
   unidad: string | null
   tarjeta: string | null
   motivo_dq: string | null
+  penalizaciones: string[]
 }
 
 interface FilaResultadoProps {
@@ -95,6 +96,15 @@ export function FilaResultado({ fila }: FilaResultadoProps) {
           <p className="mt-1 text-xs text-red-300">
             {DQ_REASON_LABELS[fila.motivo_dq] ?? fila.motivo_dq}
           </p>
+        ) : null}
+        {fila.penalizaciones.length > 0 ? (
+          <ul className="mt-1 space-y-0.5">
+            {fila.penalizaciones.map((p) => (
+              <li key={p} className="text-xs text-amber-300">
+                {PENALTY_LABELS[p] ?? p}
+              </li>
+            ))}
+          </ul>
         ) : null}
       </td>
     </tr>

--- a/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
+++ b/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
@@ -36,7 +36,7 @@ export function TablaDisciplinaResultados({
   const filas = useMemo<FilaResultadoData[]>(() => {
     const rankingPorAtleta = new Map<
       string,
-      { rp: string | null; unidad: string | null; tarjeta: string | null; categoria: string }
+      { rp: string | null; unidad: string | null; tarjeta: string | null; categoria: string; motivo_dq: string | null }
     >()
 
     if (ranking) {
@@ -47,6 +47,7 @@ export function TablaDisciplinaResultados({
             unidad: entrada.unidad,
             tarjeta: entrada.es_dns ? 'DNS' : (entrada.tarjeta ?? null),
             categoria: grupo.categoria,
+            motivo_dq: entrada.motivo_dq ?? null,
           })
         }
       }
@@ -80,6 +81,7 @@ export function TablaDisciplinaResultados({
           rp: rankData?.rp ?? null,
           unidad: rankData?.unidad ?? atleta.unidad,
           tarjeta: rankData?.tarjeta ?? null,
+          motivo_dq: rankData?.motivo_dq ?? null,
         }
       })
   }, [grilla, ranking, inscriptos])

--- a/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
+++ b/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
@@ -78,7 +78,7 @@ export function TablaDisciplinaResultados({
           categoria_corta: derivarCategoriaCorta(categoriaRaw),
           club: inscriptoData?.club ?? '',
           ap: formatMarca(atleta.ap_declarado, atleta.unidad),
-          ot: new Date(atleta.ot_programado).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+          ot: new Date(atleta.ot_programado).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }),
           linea: formatearAndarivel(atleta.andarivel),
           rp: rankData?.rp ?? null,
           unidad: rankData?.unidad ?? atleta.unidad,

--- a/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
+++ b/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
@@ -36,7 +36,7 @@ export function TablaDisciplinaResultados({
   const filas = useMemo<FilaResultadoData[]>(() => {
     const rankingPorAtleta = new Map<
       string,
-      { rp: string | null; unidad: string | null; tarjeta: string | null; categoria: string; motivo_dq: string | null }
+      { rp: string | null; unidad: string | null; tarjeta: string | null; categoria: string; motivo_dq: string | null; penalizaciones: string[] }
     >()
 
     if (ranking) {
@@ -48,6 +48,7 @@ export function TablaDisciplinaResultados({
             tarjeta: entrada.es_dns ? 'DNS' : (entrada.tarjeta ?? null),
             categoria: grupo.categoria,
             motivo_dq: entrada.motivo_dq ?? null,
+            penalizaciones: entrada.penalizaciones ?? [],
           })
         }
       }
@@ -82,6 +83,7 @@ export function TablaDisciplinaResultados({
           unidad: rankData?.unidad ?? atleta.unidad,
           tarjeta: rankData?.tarjeta ?? null,
           motivo_dq: rankData?.motivo_dq ?? null,
+          penalizaciones: rankData?.penalizaciones ?? [],
         }
       })
   }, [grilla, ranking, inscriptos])

--- a/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
+++ b/frontend/src/components/organizador/TablaDisciplinaResultados.tsx
@@ -36,7 +36,7 @@ export function TablaDisciplinaResultados({
   const filas = useMemo<FilaResultadoData[]>(() => {
     const rankingPorAtleta = new Map<
       string,
-      { rp: string | null; unidad: string | null; tarjeta: string | null; categoria: string; motivo_dq: string | null; penalizaciones: string[] }
+      { rp: string | null; unidad: string | null; tarjeta: string | null; categoria: string; motivo_dq: string | null; penalizaciones: string[]; rp_medido: string | null }
     >()
 
     if (ranking) {
@@ -49,6 +49,7 @@ export function TablaDisciplinaResultados({
             categoria: grupo.categoria,
             motivo_dq: entrada.motivo_dq ?? null,
             penalizaciones: entrada.penalizaciones ?? [],
+            rp_medido: entrada.rp_medido ?? null,
           })
         }
       }
@@ -84,6 +85,7 @@ export function TablaDisciplinaResultados({
           tarjeta: rankData?.tarjeta ?? null,
           motivo_dq: rankData?.motivo_dq ?? null,
           penalizaciones: rankData?.penalizaciones ?? [],
+          rp_medido: rankData?.rp_medido ?? null,
         }
       })
   }, [grilla, ranking, inscriptos])

--- a/frontend/src/constants/tarjeta.ts
+++ b/frontend/src/constants/tarjeta.ts
@@ -23,5 +23,14 @@ export const PENALTY_LABELS: Record<string, string> = {
   PATADA_DELFIN_BIALETAS: 'Patada delfín con bialetas',
 }
 
+export const DQ_REASON_LABELS: Record<string, string> = {
+  BKO_SUPERFICIE: 'Blackout',
+  BKO_SUBACUATICO: 'Blackout subacuático',
+  PROTOCOLO_SUPERFICIE: 'No protocolo superficie',
+  INFRACCION_TECNICA_DQ: 'Infracción técnica',
+  NO_INICIO_EN_VENTANA: 'No inicio en ventana',
+  SALIDA_EN_FALSO: 'Salida en falso',
+}
+
 export type DqReason = (typeof DQ_REASONS)[number]
 export type PenaltyType = (typeof PENALTY_TYPES)[number]

--- a/frontend/src/constants/tarjeta.ts
+++ b/frontend/src/constants/tarjeta.ts
@@ -32,5 +32,13 @@ export const DQ_REASON_LABELS: Record<string, string> = {
   SALIDA_EN_FALSO: 'Salida en falso',
 }
 
+export const TARJETA_LABELS: Record<string, string> = {
+  Blanca: 'Blanca',
+  BlancaConPenalizaciones: 'Blanca con penalizaciones',
+  Amarilla: 'En revisión',
+  Roja: 'Roja',
+  Dns: 'DNS',
+}
+
 export type DqReason = (typeof DQ_REASONS)[number]
 export type PenaltyType = (typeof PENALTY_TYPES)[number]

--- a/frontend/src/pages/PublicTorneoDetallePage.tsx
+++ b/frontend/src/pages/PublicTorneoDetallePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { DQ_REASON_LABELS } from '../constants/tarjeta'
+import { DQ_REASON_LABELS, PENALTY_LABELS } from '../constants/tarjeta'
 import { formatMarca } from '../utils/marca'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
@@ -107,6 +107,15 @@ function AtletaRow({ entry }: { entry: GrillaAtletaDto }) {
           <p className="mt-0.5 text-red-400">
             {DQ_REASON_LABELS[entry.motivo_dq] ?? entry.motivo_dq}
           </p>
+        ) : null}
+        {entry.penalizaciones?.length > 0 ? (
+          <ul className="mt-0.5 space-y-0.5">
+            {entry.penalizaciones.map((p: string) => (
+              <li key={p} className="text-amber-300">
+                {PENALTY_LABELS[p] ?? p}
+              </li>
+            ))}
+          </ul>
         ) : null}
       </td>
     </tr>

--- a/frontend/src/pages/PublicTorneoDetallePage.tsx
+++ b/frontend/src/pages/PublicTorneoDetallePage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { DQ_REASON_LABELS } from '../constants/tarjeta'
 import { formatMarca } from '../utils/marca'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
@@ -98,8 +99,15 @@ function AtletaRow({ entry }: { entry: GrillaAtletaDto }) {
       <td className="py-2 pr-3 text-center text-xs text-slate-400">{formatAp(entry.ap_declarado, entry.unidad)}</td>
       <td className="py-2 pr-3 text-center text-xs text-slate-400">{formatHora(entry.ot_programado)}</td>
       <td className="py-2 pr-3 text-center text-xs font-medium text-slate-300">{formatRp(entry.performance, entry.unidad)}</td>
-      <td className={`py-2 text-center text-xs ${entry.estado === 'DNS' ? 'text-slate-500' : tarjetaClases(entry.tarjeta_asignada)}`}>
-        {entry.estado === 'DNS' ? 'DNS' : entry.tarjeta_asignada ?? '—'}
+      <td className="py-2 text-center text-xs">
+        <span className={entry.estado === 'DNS' ? 'text-slate-500' : tarjetaClases(entry.tarjeta_asignada)}>
+          {entry.estado === 'DNS' ? 'DNS' : entry.tarjeta_asignada ?? '—'}
+        </span>
+        {entry.motivo_dq ? (
+          <p className="mt-0.5 text-red-400">
+            {DQ_REASON_LABELS[entry.motivo_dq] ?? entry.motivo_dq}
+          </p>
+        ) : null}
       </td>
     </tr>
   )

--- a/frontend/src/pages/PublicTorneoDetallePage.tsx
+++ b/frontend/src/pages/PublicTorneoDetallePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { DQ_REASON_LABELS, PENALTY_LABELS } from '../constants/tarjeta'
+import { DQ_REASON_LABELS, PENALTY_LABELS, TARJETA_LABELS } from '../constants/tarjeta'
 import { formatMarca } from '../utils/marca'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
@@ -101,7 +101,7 @@ function AtletaRow({ entry }: { entry: GrillaAtletaDto }) {
       <td className="py-2 pr-3 text-center text-xs font-medium text-slate-300">{formatRp(entry.performance, entry.unidad)}</td>
       <td className="py-2 text-center text-xs">
         <span className={entry.estado === 'DNS' ? 'text-slate-500' : tarjetaClases(entry.tarjeta_asignada)}>
-          {entry.estado === 'DNS' ? 'DNS' : entry.tarjeta_asignada ?? '—'}
+          {entry.estado === 'DNS' ? 'DNS' : (entry.tarjeta_asignada ? (TARJETA_LABELS[entry.tarjeta_asignada] ?? entry.tarjeta_asignada) : '—')}
         </span>
         {entry.motivo_dq ? (
           <p className="mt-0.5 text-red-400">

--- a/frontend/src/pages/atleta/AtletaHomePage.tsx
+++ b/frontend/src/pages/atleta/AtletaHomePage.tsx
@@ -44,7 +44,6 @@ function sortDisciplinasPorOt(entries: AtletaPortalEntry[], now = new Date()): A
 
 export function AtletaHomePage() {
   const atletaId = useAuthStore((state) => state.userId)
-  const logout = useAuthStore((state) => state.logout)
   const query = useQuery({
     queryKey: ['atleta-portal-home', atletaId],
     queryFn: () => loadAtletaPortalSnapshot(),
@@ -74,15 +73,6 @@ export function AtletaHomePage() {
     <AtletaShell
       title="Portal del atleta"
       subtitle="Tus próximos torneos, anuncios y estado de participación."
-      actions={
-        <button
-          type="button"
-          onClick={logout}
-          className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-200"
-        >
-          Salir
-        </button>
-      }
     >
       {query.isLoading ? (
         <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-300">

--- a/frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx
+++ b/frontend/src/pages/atleta/AtletaMisInscripcionesPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import useAuthStore from '../../stores/useAuthStore'
@@ -8,7 +9,83 @@ import {
   formatFecha,
   formatHora,
   loadAtletaPortalSnapshot,
+  type AtletaPortalEntry,
 } from './portalData'
+
+interface GrupoEnCursoProps {
+  torneoNombre: string
+  entries: AtletaPortalEntry[]
+}
+
+function GrupoEnCurso({ torneoNombre, entries }: GrupoEnCursoProps) {
+  const [tabIdx, setTabIdx] = useState(0)
+  const entry = entries[tabIdx] ?? entries[0]
+
+  return (
+    <div className="rounded-3xl border border-slate-800 bg-slate-900 overflow-hidden">
+      <div className="px-4 pt-4">
+        <p className="text-sm font-semibold text-white">{torneoNombre}</p>
+      </div>
+
+      <div className="mt-3 flex border-b border-slate-800">
+        {entries.map((e, i) => (
+          <button
+            key={e.disciplina}
+            type="button"
+            onClick={() => setTabIdx(i)}
+            className={[
+              'flex-1 py-2 text-xs font-semibold transition-colors',
+              i === tabIdx
+                ? 'border-b-2 border-sky-400 text-sky-300'
+                : 'border-b-2 border-transparent text-slate-400',
+            ].join(' ')}
+          >
+            {formatDisciplina(e.disciplina)}
+          </button>
+        ))}
+      </div>
+
+      <div className="p-4">
+        <dl className="grid grid-cols-2 gap-3 text-sm text-slate-300">
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+            <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">AP</dt>
+            <dd className="mt-1 font-semibold text-white">
+              {formatAp(entry.ap, entry.unidad)}
+            </dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+            <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">OT</dt>
+            <dd className="mt-1 font-semibold text-white">
+              {entry.ot ? formatHora(entry.ot) : 'Pendiente'}
+            </dd>
+          </div>
+        </dl>
+        <p className="mt-3 text-sm text-slate-400">
+          Andarivel {entry.andarivel ?? '—'} · Posición {entry.posicion ?? '—'}
+        </p>
+        {entry.competenciaId ? (
+          <Link
+            to={`/atleta/grilla/${entry.competenciaId}?disciplina=${encodeURIComponent(entry.disciplina)}`}
+            className="mt-4 flex min-h-10 items-center justify-center rounded-2xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-sm font-semibold text-sky-200"
+          >
+            Ver grilla
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function groupByTorneoId(entries: AtletaPortalEntry[]) {
+  const map = new Map<string, { nombre: string; entries: AtletaPortalEntry[] }>()
+  for (const entry of entries) {
+    const id = entry.torneo.torneo_id
+    const current = map.get(id) ?? { nombre: entry.torneo.nombre, entries: [] }
+    current.entries.push(entry)
+    map.set(id, current)
+  }
+  return Array.from(map.values())
+}
 
 export function AtletaMisInscripcionesPage() {
   const atletaId = useAuthStore((state) => state.userId)
@@ -22,8 +99,10 @@ export function AtletaMisInscripcionesPage() {
   const noIniciados = (query.data?.entries ?? []).filter((entry) =>
     NO_INICIADOS.includes(entry.torneo.estado),
   )
-  const enCurso = (query.data?.entries ?? []).filter(
-    (entry) => !NO_INICIADOS.includes(entry.torneo.estado),
+  const enCursoGrupos = groupByTorneoId(
+    (query.data?.entries ?? []).filter(
+      (entry) => !NO_INICIADOS.includes(entry.torneo.estado),
+    ),
   )
 
   return (
@@ -47,54 +126,17 @@ export function AtletaMisInscripcionesPage() {
               En ejecución
             </p>
             <div className="mt-3 space-y-3">
-              {enCurso.length === 0 ? (
+              {enCursoGrupos.length === 0 ? (
                 <div className="rounded-3xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-400">
                   No hay disciplinas en ejecución para tus inscripciones activas.
                 </div>
               ) : null}
-
-              {enCurso.map((entry) => (
-                <div
-                  key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
-                  className="rounded-3xl border border-slate-800 bg-slate-900 p-4"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-semibold text-white">{entry.torneo.nombre}</p>
-                      <p className="mt-1 text-xs uppercase tracking-[0.18em] text-sky-300">
-                        {formatDisciplina(entry.disciplina)}
-                      </p>
-                    </div>
-                    <span className="rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold text-slate-200">
-                      AP cerrado
-                    </span>
-                  </div>
-                  <dl className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
-                    <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
-                      <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">AP</dt>
-                      <dd className="mt-1 font-semibold text-white">
-                        {formatAp(entry.ap, entry.unidad)}
-                      </dd>
-                    </div>
-                    <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
-                      <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">OT</dt>
-                      <dd className="mt-1 font-semibold text-white">
-                        {entry.ot ? formatHora(entry.ot) : 'Pendiente'}
-                      </dd>
-                    </div>
-                  </dl>
-                  <p className="mt-3 text-sm text-slate-400">
-                    Andarivel {entry.andarivel ?? '—'} · Posición {entry.posicion ?? '—'}
-                  </p>
-                  {entry.competenciaId ? (
-                    <Link
-                      to={`/atleta/grilla/${entry.competenciaId}?disciplina=${encodeURIComponent(entry.disciplina)}`}
-                      className="mt-4 flex min-h-10 items-center justify-center rounded-2xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-sm font-semibold text-sky-200"
-                    >
-                      Ver grilla
-                    </Link>
-                  ) : null}
-                </div>
+              {enCursoGrupos.map((grupo) => (
+                <GrupoEnCurso
+                  key={grupo.entries[0].torneo.torneo_id}
+                  torneoNombre={grupo.nombre}
+                  entries={grupo.entries}
+                />
               ))}
             </div>
           </section>

--- a/frontend/src/pages/atleta/AtletaResultadosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaResultadosPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { AtletaShell } from '../../components/atleta/AtletaShell'
 import { DisciplinaPendienteCard } from '../../components/atleta/DisciplinaPendienteCard'
@@ -101,6 +102,112 @@ function groupByTorneo(resultados: ResultadoEntry[]): Array<{
   return Array.from(groups.values())
 }
 
+interface GrupoResultadosProps {
+  grupo: ReturnType<typeof groupByTorneo>[number]
+  atletaId: string
+  nombresPorCompetencia: Map<string, Map<string, string>>
+  overallPorTorneo: Map<string, import('../../api/resultados').OverallDto | null>
+}
+
+function GrupoResultados({ grupo, atletaId, nombresPorCompetencia, overallPorTorneo }: GrupoResultadosProps) {
+  const [tabIdx, setTabIdx] = useState(0)
+  const { entry, miResultado, ranking } = grupo.resultados[tabIdx] ?? grupo.resultados[0]
+
+  const overall = overallPorTorneo.get(grupo.torneoId) ?? null
+  const categoriaAtleta =
+    grupo.resultados
+      .map(({ ranking: r }) => findMiCategoriaEntradas(r, atletaId)?.categoria)
+      .find(Boolean) ?? ''
+  const categoriaLabel = formatCategoria(categoriaAtleta)
+  const nombresParaOverall = (() => {
+    const mapa = new Map<string, string>()
+    grupo.resultados.forEach(({ entry: e }) => {
+      if (!e.competenciaId) return
+      nombresPorCompetencia.get(e.competenciaId)?.forEach((nombre, id) => mapa.set(id, nombre))
+    })
+    return mapa
+  })()
+
+  const nombresPorId = entry.competenciaId
+    ? (nombresPorCompetencia.get(entry.competenciaId) ?? new Map())
+    : new Map<string, string>()
+  const miCategoria = findMiCategoriaEntradas(ranking, atletaId)
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">Torneo</p>
+        <h2 className="mt-1 text-lg font-semibold text-white">{grupo.torneoNombre}</h2>
+      </div>
+
+      {grupo.resultados.length > 1 ? (
+        <div className="flex rounded-2xl border border-slate-800 bg-slate-900 overflow-hidden">
+          {grupo.resultados.map(({ entry: e }, i) => (
+            <button
+              key={e.disciplina}
+              type="button"
+              onClick={() => setTabIdx(i)}
+              className={[
+                'flex-1 py-2 text-xs font-semibold transition-colors border-b-2',
+                i === tabIdx
+                  ? 'border-sky-400 text-sky-300 bg-slate-950/60'
+                  : 'border-transparent text-slate-400',
+              ].join(' ')}
+            >
+              {formatDisciplina(e.disciplina)}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {!miResultado ? (
+        <DisciplinaPendienteCard
+          disciplina={formatDisciplina(entry.disciplina)}
+          ot={entry.ot ? formatHora(entry.ot) : '-'}
+          ap={formatAp(entry.ap, entry.unidad)}
+          andarivel={entry.andarivel}
+        />
+      ) : (
+        <div className="space-y-2">
+          <ResultHero
+            disciplina={formatDisciplina(entry.disciplina)}
+            estado={getEstadoResultado(miResultado)}
+            rp={formatResultado(miResultado)}
+            ap={formatAp(entry.ap, entry.unidad)}
+            diferencia={calcularDiferencia({
+              ap: entry.ap,
+              rp: miResultado.rp,
+              unidad: miResultado.unidad ?? entry.unidad,
+              esDns: miResultado.es_dns,
+            })}
+            enPodio={['PREMIACION', 'CERRADO'].includes(entry.torneo.estado) && miResultado.en_podio}
+          />
+          {miCategoria ? (
+            <RankingCard
+              categoriaLabel={formatCategoria(miCategoria.categoria)}
+              entradas={miCategoria.entradas}
+              unidad={entry.unidad}
+              nombresPorId={nombresPorId}
+              atletaId={atletaId}
+              calculado={ranking?.calculado ?? false}
+            />
+          ) : null}
+        </div>
+      )}
+
+      {['PREMIACION', 'CERRADO'].includes(entry.torneo.estado) ? (
+        <OverallCard
+          overall={overall}
+          atletaId={atletaId}
+          nombresPorId={nombresParaOverall}
+          categoriaAtleta={categoriaAtleta}
+          categoriaLabel={categoriaLabel}
+        />
+      ) : null}
+    </section>
+  )
+}
+
 export function AtletaResultadosPage() {
   const snapshotQuery = useQuery({
     queryKey: ['atleta-resultados-snapshot'],
@@ -188,92 +295,15 @@ export function AtletaResultadosPage() {
 
       {snapshotQuery.data && grupos.length > 0 ? (
         <div className="space-y-8">
-          {grupos.map((grupo) => {
-            const overall = overallPorTorneo.get(grupo.torneoId) ?? null
-            const categoriaAtleta = grupo.resultados
-              .map(({ ranking }) => findMiCategoriaEntradas(ranking, atletaId)?.categoria)
-              .find(Boolean) ?? ''
-            const categoriaLabel = formatCategoria(categoriaAtleta)
-            const nombresParaOverall = (() => {
-              const mapa = new Map<string, string>()
-              grupo.resultados.forEach(({ entry }) => {
-                if (!entry.competenciaId) return
-                const m = nombresPorCompetencia.get(entry.competenciaId)
-                m?.forEach((nombre, id) => mapa.set(id, nombre))
-              })
-              return mapa
-            })()
-
-            return (
-              <section key={grupo.torneoId} className="space-y-3">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-sky-400">
-                    Torneo
-                  </p>
-                  <h2 className="mt-1 text-lg font-semibold text-white">{grupo.torneoNombre}</h2>
-                </div>
-
-                {grupo.resultados.map(({ entry, miResultado, ranking }) => {
-                  const nombresPorId = entry.competenciaId
-                    ? (nombresPorCompetencia.get(entry.competenciaId) ?? new Map())
-                    : new Map<string, string>()
-
-                  const miCategoria = findMiCategoriaEntradas(ranking, atletaId)
-
-                  if (!miResultado) {
-                    return (
-                      <DisciplinaPendienteCard
-                        key={`${entry.torneo.torneo_id}-${entry.disciplina}`}
-                        disciplina={formatDisciplina(entry.disciplina)}
-                        ot={entry.ot ? formatHora(entry.ot) : '-'}
-                        ap={formatAp(entry.ap, entry.unidad)}
-                        andarivel={entry.andarivel}
-                      />
-                    )
-                  }
-
-                  const estado = getEstadoResultado(miResultado)
-                  return (
-                    <div key={`${entry.torneo.torneo_id}-${entry.disciplina}`} className="space-y-2">
-                      <ResultHero
-                        disciplina={formatDisciplina(entry.disciplina)}
-                        estado={estado}
-                        rp={formatResultado(miResultado)}
-                        ap={formatAp(entry.ap, entry.unidad)}
-                        diferencia={calcularDiferencia({
-                          ap: entry.ap,
-                          rp: miResultado.rp,
-                          unidad: miResultado.unidad ?? entry.unidad,
-                          esDns: miResultado.es_dns,
-                        })}
-                        enPodio={['PREMIACION', 'CERRADO'].includes(entry.torneo.estado) && miResultado.en_podio}
-                      />
-                      {miCategoria ? (
-                        <RankingCard
-                          categoriaLabel={formatCategoria(miCategoria.categoria)}
-                          entradas={miCategoria.entradas}
-                          unidad={entry.unidad}
-                          nombresPorId={nombresPorId}
-                          atletaId={atletaId}
-                          calculado={ranking?.calculado ?? false}
-                        />
-                      ) : null}
-                    </div>
-                  )
-                })}
-
-                {['PREMIACION', 'CERRADO'].includes(grupo.resultados[0]?.entry.torneo.estado ?? '') ? (
-                  <OverallCard
-                    overall={overall}
-                    atletaId={atletaId}
-                    nombresPorId={nombresParaOverall}
-                    categoriaAtleta={categoriaAtleta}
-                    categoriaLabel={categoriaLabel}
-                  />
-                ) : null}
-              </section>
-            )
-          })}
+          {grupos.map((grupo) => (
+            <GrupoResultados
+              key={grupo.torneoId}
+              grupo={grupo}
+              atletaId={atletaId}
+              nombresPorCompetencia={nombresPorCompetencia}
+              overallPorTorneo={overallPorTorneo}
+            />
+          ))}
         </div>
       ) : null}
     </AtletaShell>

--- a/frontend/src/pages/atleta/AtletaResultadosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaResultadosPage.tsx
@@ -140,25 +140,23 @@ function GrupoResultados({ grupo, atletaId, nombresPorCompetencia, overallPorTor
         <h2 className="mt-1 text-lg font-semibold text-white">{grupo.torneoNombre}</h2>
       </div>
 
-      {grupo.resultados.length > 1 ? (
-        <div className="flex rounded-2xl border border-slate-800 bg-slate-900 overflow-hidden">
-          {grupo.resultados.map(({ entry: e }, i) => (
-            <button
-              key={e.disciplina}
-              type="button"
-              onClick={() => setTabIdx(i)}
-              className={[
-                'flex-1 py-2 text-xs font-semibold transition-colors border-b-2',
-                i === tabIdx
-                  ? 'border-sky-400 text-sky-300 bg-slate-950/60'
-                  : 'border-transparent text-slate-400',
-              ].join(' ')}
-            >
-              {formatDisciplina(e.disciplina)}
-            </button>
-          ))}
-        </div>
-      ) : null}
+      <div className="flex rounded-2xl border border-slate-800 bg-slate-900 overflow-hidden">
+        {grupo.resultados.map(({ entry: e }, i) => (
+          <button
+            key={e.disciplina}
+            type="button"
+            onClick={() => setTabIdx(i)}
+            className={[
+              'flex-1 py-2 text-xs font-semibold transition-colors border-b-2',
+              i === tabIdx
+                ? 'border-sky-400 text-sky-300 bg-slate-950/60'
+                : 'border-transparent text-slate-400',
+            ].join(' ')}
+          >
+            {formatDisciplina(e.disciplina)}
+          </button>
+        ))}
+      </div>
 
       {!miResultado ? (
         <DisciplinaPendienteCard

--- a/frontend/src/pages/atleta/portalData.ts
+++ b/frontend/src/pages/atleta/portalData.ts
@@ -78,6 +78,7 @@ export function formatHora(fechaIso: string): string {
   return new Intl.DateTimeFormat('es-AR', {
     hour: '2-digit',
     minute: '2-digit',
+    hour12: false,
   }).format(fecha)
 }
 

--- a/quality/reports/uat/SP6/F-08-flujos-excepcion/escenarios.md
+++ b/quality/reports/uat/SP6/F-08-flujos-excepcion/escenarios.md
@@ -37,7 +37,7 @@
 | F08-S05 | Juez 2 (móvil) | iPhone | Cerrar revisión de tarjeta amarilla de Quintana como **blanca** | Performance válida · tarjeta blanca registrada · RP original mantenido | Tarjeta blanca registrada correctamente | ✅ PASS | — |
 | F08-S06 | Organizador | Desktop | Ver resultados DYN · verificar Sebastián Quintana | RP visible · aparece en ranking DYN SENIOR MASC · tarjeta blanca indicada | RP y tarjeta Blanca correctos | ✅ PASS | — |
 | F08-S07 | Juez 2 (móvil) | iPhone | Mauro Almada DYN · ingresar RP=75m · aplicar **1 penalización** al momento de ingreso de marca | Performance válida · RP final = 72m · tarjeta blanca con penalización registrada | RP final = 72m · BlancaConPenalizaciones registrada | ✅ PASS | H-08-02 resuelto |
-| F08-S08 | Organizador | Desktop | Ver resultados DYN · verificar atleta con penalización | RP ajustado (−3m) visible · tarjeta "BlancaConPenalizaciones" o equivalente indicada | | ⬜ PENDIENTE | — |
+| F08-S08 | Organizador | Desktop | Ver resultados DYN · verificar atleta con penalización | RP ajustado (−3m) visible · tarjeta "BlancaConPenalizaciones" o equivalente indicada | 69.00m con desglose "(72m − 3m)" · "Blanca con penalizaciones" | ✅ PASS | H-08-03 resuelto |
 
 ---
 
@@ -52,9 +52,9 @@
 
 ## Criterio de Salida
 
-- [ ] Todos los escenarios 🔴 en PASS
-- [ ] BKO genera tarjeta roja automática con MotivoDQ = BKO_SUPERFICIE (MUX-04 verificado)
-- [ ] Pantalla post-BKO muestra color rojo (MUX-05 verificado)
-- [ ] Tarjeta amarilla cierra correctamente como Blanca (revisión solo admite Blanca o Roja)
-- [ ] BlancaConPenalizaciones registrada correctamente en flujo normal de ingreso de RP con penalización
-- [ ] Sistema listo para F-09 (resultados completos y premiación)
+- [x] Todos los escenarios en PASS (8/8)
+- [x] BKO genera tarjeta roja automática con MotivoDQ = BKO_SUPERFICIE (MUX-04 verificado)
+- [x] Pantalla post-BKO muestra color rojo (MUX-05 verificado)
+- [x] Tarjeta amarilla cierra correctamente como Blanca (revisión solo admite Blanca o Roja)
+- [x] BlancaConPenalizaciones registrada correctamente en flujo normal de ingreso de RP con penalización
+- [x] Sistema listo para F-09 (resultados completos y premiación)

--- a/quality/reports/uat/SP6/F-08-flujos-excepcion/escenarios.md
+++ b/quality/reports/uat/SP6/F-08-flujos-excepcion/escenarios.md
@@ -18,11 +18,11 @@
 
 | Atleta | Disciplina | Andarivel | Juez | AP | Escenario |
 |--------|-----------|:---------:|------|-----|-----------|
-| Sebastián Quintana | DNF | 1 | Juez 1 | 25m | BKO (F08-S01/S02/S03) |
-| Ignacio Saslavsky | DYN | 2 | Juez 2 | 60m | Tarjeta amarilla → blanca con penalización (F08-S04/S05/S06) |
+| Ezequiel Cuchiarelli | DNF | 1 | Juez 1 | 25m | BKO (F08-S01/S02/S03) |
+| Sebastián Quintana | DYN | — | Juez 2 | — | Tarjeta amarilla → blanca con penalización (F08-S04/S05/S06) |
 
-> **Nota:** Quintana y Fardi ya tienen resultados en DNF (Fardi: 41.05m blanca). Quintana está en andarivel 1 → Juez 1.
-> Saslavsky (DYN, andarivel 2) → Juez 2. Una penalización de 1 infracción descuenta 3m → RP final = RP − 3m.
+> **Nota:** Cuchiarelli ya tiene DNS en DBF (F-07) pero no en DNF — válido para BKO.
+> Saslavsky no estaba en la lista de DYN del juez — se usa Quintana. Una penalización de 1 infracción descuenta 3m → RP final = RP − 3m.
 
 ---
 
@@ -30,12 +30,14 @@
 
 | ID | Actor | Dispositivo | Acción | Resultado esperado | Resultado real | Estado | Hallazgo |
 |----|-------|-------------|--------|--------------------|----------------|--------|----------|
-| F08-S01 | Juez 1 (móvil) | iPhone | Abrir grilla DNF · seleccionar Sebastián Quintana (andarivel 1) · avanzar al paso de ingreso · marcar BKO con botón "Confirmar BKO" | Botón "Confirmar BKO" **habilitado** (MUX-04 resuelto) · al confirmar: performance queda con tarjeta **roja** automática · MotivoDQ = `BKO_SUPERFICIE` | | ⬜ PENDIENTE | — |
-| F08-S02 | Juez 1 (móvil) | iPhone | Verificar pantalla de resultado post-BKO | Pantalla de completado muestra color **rojo** (no verde) · mensaje indica DQ/BKO | | ⬜ PENDIENTE | — |
-| F08-S03 | Organizador | Desktop | Ver grilla DNF · verificar fila de Sebastián Quintana | Tarjeta roja visible · DQ con motivo `BKO_SUPERFICIE` en la columna correspondiente | | ⬜ PENDIENTE | — |
-| F08-S04 | Juez 2 (móvil) | iPhone | Abrir grilla DYN · seleccionar Ignacio Saslavsky (andarivel 2) · ingresar RP = 54m · asignar **tarjeta amarilla** | Performance queda en estado "revisión" · la fila del atleta muestra estado pendiente de revisión en la grilla del juez | | ⬜ PENDIENTE | — |
-| F08-S05 | Juez 2 (móvil) | iPhone | Cerrar revisión de tarjeta amarilla de Saslavsky como **blanca con penalización** · ingresar 1 penalización (3m de deducción) | Performance válida · RP final = 54 − 3 = **51m** · tarjeta blanca con penalización registrada | | ⬜ PENDIENTE | — |
-| F08-S06 | Organizador | Desktop | Ver resultados DYN · verificar Ignacio Saslavsky | RP = 51m visible · aparece en ranking DYN SENIOR MASC · tarjeta blanca con penalización indicada | | ⬜ PENDIENTE | — |
+| F08-S01 | Juez 1 (móvil) | iPhone | Abrir grilla DNF · seleccionar Ezequiel Cuchiarelli (andarivel 1) · avanzar al paso de ingreso · marcar BKO con botón "Confirmar BKO" | Botón "Confirmar BKO" **habilitado** (MUX-04 resuelto) · al confirmar: performance queda con tarjeta **roja** automática · MotivoDQ = `BKO_SUPERFICIE` | Botón habilitado · tarjeta roja · pide confirmación de distancia recorrida antes del BKO | ✅ PASS | — |
+| F08-S02 | Juez 1 (móvil) | iPhone | Verificar pantalla de resultado post-BKO | Pantalla de completado muestra color **rojo** (no verde) · mensaje indica DQ/BKO | Pantalla roja correcta | ✅ PASS | — |
+| F08-S03 | Organizador | Desktop | Ver grilla DNF · verificar fila de Ezequiel Cuchiarelli | Tarjeta roja visible · DQ con motivo `BKO_SUPERFICIE` en la columna correspondiente | Tarjeta roja · RP en rojo · motivo "Blackout" visible | ✅ PASS | H-08-01 resuelto |
+| F08-S04 | Juez 2 (móvil) | iPhone | Abrir grilla DYN · seleccionar Sebastián Quintana · ingresar RP · asignar **tarjeta amarilla** | Performance queda en estado "revisión" · la fila del atleta muestra estado pendiente de revisión en la grilla del juez | Estado "revisión" visible en grilla organizador y portal público | ✅ PASS | — |
+| F08-S05 | Juez 2 (móvil) | iPhone | Cerrar revisión de tarjeta amarilla de Quintana como **blanca** | Performance válida · tarjeta blanca registrada · RP original mantenido | Tarjeta blanca registrada correctamente | ✅ PASS | — |
+| F08-S06 | Organizador | Desktop | Ver resultados DYN · verificar Sebastián Quintana | RP visible · aparece en ranking DYN SENIOR MASC · tarjeta blanca indicada | RP y tarjeta Blanca correctos | ✅ PASS | — |
+| F08-S07 | Juez 2 (móvil) | iPhone | Mauro Almada DYN · ingresar RP=75m · aplicar **1 penalización** al momento de ingreso de marca | Performance válida · RP final = 72m · tarjeta blanca con penalización registrada | RP final = 72m · BlancaConPenalizaciones registrada | ✅ PASS | H-08-02 resuelto |
+| F08-S08 | Organizador | Desktop | Ver resultados DYN · verificar atleta con penalización | RP ajustado (−3m) visible · tarjeta "BlancaConPenalizaciones" o equivalente indicada | | ⬜ PENDIENTE | — |
 
 ---
 
@@ -53,5 +55,6 @@
 - [ ] Todos los escenarios 🔴 en PASS
 - [ ] BKO genera tarjeta roja automática con MotivoDQ = BKO_SUPERFICIE (MUX-04 verificado)
 - [ ] Pantalla post-BKO muestra color rojo (MUX-05 verificado)
-- [ ] Tarjeta amarilla cierra correctamente como blanca con penalización con RP ajustado
+- [ ] Tarjeta amarilla cierra correctamente como Blanca (revisión solo admite Blanca o Roja)
+- [ ] BlancaConPenalizaciones registrada correctamente en flujo normal de ingreso de RP con penalización
 - [ ] Sistema listo para F-09 (resultados completos y premiación)

--- a/quality/reports/uat/SP6/F-08-flujos-excepcion/escenarios.md
+++ b/quality/reports/uat/SP6/F-08-flujos-excepcion/escenarios.md
@@ -1,0 +1,57 @@
+# Escenarios — Fase F-08: Flujos de Excepción
+
+**Fecha de apertura:** 2026-05-13  
+**Branch:** `uat/INC-6.5/F-08-flujos-excepcion`
+
+---
+
+## Criterio de Entrada
+
+- [x] F-07 cerrada con 10/10 PASS (PR #175 mergeado a develop)
+- [x] 6 performances manuales registradas correctamente en el sistema
+- [x] Torneo en estado `EJECUCION`
+- [x] Jueces logueados y con asignaciones activas
+
+---
+
+## Atletas del Escenario
+
+| Atleta | Disciplina | Andarivel | Juez | AP | Escenario |
+|--------|-----------|:---------:|------|-----|-----------|
+| Sebastián Quintana | DNF | 1 | Juez 1 | 25m | BKO (F08-S01/S02/S03) |
+| Ignacio Saslavsky | DYN | 2 | Juez 2 | 60m | Tarjeta amarilla → blanca con penalización (F08-S04/S05/S06) |
+
+> **Nota:** Quintana y Fardi ya tienen resultados en DNF (Fardi: 41.05m blanca). Quintana está en andarivel 1 → Juez 1.
+> Saslavsky (DYN, andarivel 2) → Juez 2. Una penalización de 1 infracción descuenta 3m → RP final = RP − 3m.
+
+---
+
+## Escenarios
+
+| ID | Actor | Dispositivo | Acción | Resultado esperado | Resultado real | Estado | Hallazgo |
+|----|-------|-------------|--------|--------------------|----------------|--------|----------|
+| F08-S01 | Juez 1 (móvil) | iPhone | Abrir grilla DNF · seleccionar Sebastián Quintana (andarivel 1) · avanzar al paso de ingreso · marcar BKO con botón "Confirmar BKO" | Botón "Confirmar BKO" **habilitado** (MUX-04 resuelto) · al confirmar: performance queda con tarjeta **roja** automática · MotivoDQ = `BKO_SUPERFICIE` | | ⬜ PENDIENTE | — |
+| F08-S02 | Juez 1 (móvil) | iPhone | Verificar pantalla de resultado post-BKO | Pantalla de completado muestra color **rojo** (no verde) · mensaje indica DQ/BKO | | ⬜ PENDIENTE | — |
+| F08-S03 | Organizador | Desktop | Ver grilla DNF · verificar fila de Sebastián Quintana | Tarjeta roja visible · DQ con motivo `BKO_SUPERFICIE` en la columna correspondiente | | ⬜ PENDIENTE | — |
+| F08-S04 | Juez 2 (móvil) | iPhone | Abrir grilla DYN · seleccionar Ignacio Saslavsky (andarivel 2) · ingresar RP = 54m · asignar **tarjeta amarilla** | Performance queda en estado "revisión" · la fila del atleta muestra estado pendiente de revisión en la grilla del juez | | ⬜ PENDIENTE | — |
+| F08-S05 | Juez 2 (móvil) | iPhone | Cerrar revisión de tarjeta amarilla de Saslavsky como **blanca con penalización** · ingresar 1 penalización (3m de deducción) | Performance válida · RP final = 54 − 3 = **51m** · tarjeta blanca con penalización registrada | | ⬜ PENDIENTE | — |
+| F08-S06 | Organizador | Desktop | Ver resultados DYN · verificar Ignacio Saslavsky | RP = 51m visible · aparece en ranking DYN SENIOR MASC · tarjeta blanca con penalización indicada | | ⬜ PENDIENTE | — |
+
+---
+
+## Verificación Cruzada
+
+| Punto | Actor | Qué verificar |
+|-------|-------|---------------|
+| Post F08-S01 | Portal (visitante) | Si la UI pública expone estado de ejecución, verificar que no hay errores al consultar DNF |
+| Post F08-S05 | Organizador | RP ajustado de Saslavsky visible (51m) · ranking actualizado |
+
+---
+
+## Criterio de Salida
+
+- [ ] Todos los escenarios 🔴 en PASS
+- [ ] BKO genera tarjeta roja automática con MotivoDQ = BKO_SUPERFICIE (MUX-04 verificado)
+- [ ] Pantalla post-BKO muestra color rojo (MUX-05 verificado)
+- [ ] Tarjeta amarilla cierra correctamente como blanca con penalización con RP ajustado
+- [ ] Sistema listo para F-09 (resultados completos y premiación)

--- a/quality/reports/uat/SP6/F-08-flujos-excepcion/hallazgos.md
+++ b/quality/reports/uat/SP6/F-08-flujos-excepcion/hallazgos.md
@@ -4,7 +4,9 @@
 
 | ID | Escenario | Descripción | Severidad | Pasos para reproducir | Estado | Fix |
 |----|-----------|-------------|-----------|----------------------|--------|-----|
-| — | — | Sin hallazgos aún | — | — | — | — |
+| H-08-01 | F08-S03 | Grilla organizador y portal público: (a) falta motivo DQ en texto legible · (b) RP no visible para tarjeta roja · (c) motivo_dq no serializado en router | 🟡 | 1. Registrar BKO · 2. Ver resultados como organizador/portal — motivo y RP ausentes | Resuelto | `eba8e42` + `77b01be` + `ace40df` — motivo_dq en ranking provisional, DTO, router competencia/resultados; RP preservado; FilaResultado y AtletaRow muestran texto legible |
+
+| H-08-02 | F08-S07 | Columna tarjeta en resultados (organizador y portal público) no muestra penalizaciones en lenguaje natural — solo muestra "BlancaConPenalizaciones" como texto crudo o "BLANCA" sin detalle | 🟡 | 1. Registrar performance con BlancaConPenalizaciones · 2. Ver resultados como organizador o portal — sin detalle de infracciones | Resuelto | `b85bf8b` — penalizaciones fluyen desde TarjetaAsignada/grilla, FilaResultado y AtletaRow muestran cada infracción en ámbar |
 
 ## Mejoras (fuera de scope UAT)
 

--- a/quality/reports/uat/SP6/F-08-flujos-excepcion/hallazgos.md
+++ b/quality/reports/uat/SP6/F-08-flujos-excepcion/hallazgos.md
@@ -7,9 +7,12 @@
 | H-08-01 | F08-S03 | Grilla organizador y portal público: (a) falta motivo DQ en texto legible · (b) RP no visible para tarjeta roja · (c) motivo_dq no serializado en router | 🟡 | 1. Registrar BKO · 2. Ver resultados como organizador/portal — motivo y RP ausentes | Resuelto | `eba8e42` + `77b01be` + `ace40df` — motivo_dq en ranking provisional, DTO, router competencia/resultados; RP preservado; FilaResultado y AtletaRow muestran texto legible |
 
 | H-08-02 | F08-S07 | Columna tarjeta en resultados (organizador y portal público) no muestra penalizaciones en lenguaje natural — solo muestra "BlancaConPenalizaciones" como texto crudo o "BLANCA" sin detalle | 🟡 | 1. Registrar performance con BlancaConPenalizaciones · 2. Ver resultados como organizador o portal — sin detalle de infracciones | Resuelto | `b85bf8b` — penalizaciones fluyen desde TarjetaAsignada/grilla, FilaResultado y AtletaRow muestran cada infracción en ámbar |
+| H-08-03 | F08-S08 | Panel organizador muestra RP final (69m) sin indicar que hubo deducción — no queda claro que la marca original era 72m | 🟡 | 1. Registrar BlancaConPenalizaciones con RP=75m y 1 penalización · 2. Ver resultados — solo se ve 72m sin contexto | Resuelto | `795fd38` — rp_medido propagado por todo el pipeline; FilaResultado muestra desglose "(72m − 3m)" debajo del RP final |
 
 ## Mejoras (fuera de scope UAT)
 
-| ID | Origen | Descripción | Prioridad sugerida |
-|----|--------|-------------|-------------------|
-| — | — | Sin mejoras aún | — |
+| ID | Origen | Descripción | Estado |
+|----|--------|-------------|--------|
+| M-08-01 | Sesión F-08 portal atleta | Badge "Backend online" flotante se pisaba con botón Salir · menú de navegación en pie de página dificultaba acceso | Resuelto — `0f4f811` + `0f257e1`: badge excluido del portal atleta; nav movida a la cabecera sticky |
+| M-08-02 | Sesión F-08 portal atleta | Disciplinas de "En ejecución" y "Mis resultados" se mostraban apiladas — sin posibilidad de navegar entre ellas | Resuelto — `4117cc6` + `8ffa799`: pestañas de disciplina en ambas secciones |
+| M-08-03 | Sesión F-08 portal atleta | Formato de hora en 12h (AM/PM) en portal atleta y tabla organizador | Resuelto — `3583d82`: `hour12: false` en `formatHora` y `toLocaleTimeString` |

--- a/quality/reports/uat/SP6/F-08-flujos-excepcion/hallazgos.md
+++ b/quality/reports/uat/SP6/F-08-flujos-excepcion/hallazgos.md
@@ -1,0 +1,13 @@
+# Hallazgos — Fase F-08: Flujos de Excepción
+
+## Defectos
+
+| ID | Escenario | Descripción | Severidad | Pasos para reproducir | Estado | Fix |
+|----|-----------|-------------|-----------|----------------------|--------|-----|
+| — | — | Sin hallazgos aún | — | — | — | — |
+
+## Mejoras (fuera de scope UAT)
+
+| ID | Origen | Descripción | Prioridad sugerida |
+|----|--------|-------------|-------------------|
+| — | — | Sin mejoras aún | — |

--- a/quality/reports/uat/SP6/F-08-flujos-excepcion/reporte_f08.md
+++ b/quality/reports/uat/SP6/F-08-flujos-excepcion/reporte_f08.md
@@ -1,0 +1,83 @@
+# Reporte de Cierre — Fase F-08: Flujos de Excepción
+
+**Fecha de cierre:** 2026-05-13  
+**Branch:** `uat/INC-6.5/F-08-flujos-excepcion`  
+**Resultado:** ✅ 8/8 PASS
+
+---
+
+## Resumen Ejecutivo
+
+F-08 validó los flujos de excepción del sistema: BKO con tarjeta roja automática, revisión de tarjeta amarilla y registro de BlancaConPenalizaciones. Todos los escenarios pasaron. Se identificaron y resolvieron 3 defectos (H-08-01/02/03) y 3 mejoras de UX en el portal atleta (M-08-01/02/03).
+
+---
+
+## Resultados por Escenario
+
+| ID | Descripción | Estado |
+|----|-------------|--------|
+| F08-S01 | BKO de Cuchiarelli en DNF — botón habilitado, tarjeta roja automática | ✅ PASS |
+| F08-S02 | Pantalla post-BKO en rojo | ✅ PASS |
+| F08-S03 | Grilla organizador: tarjeta roja + motivo "Blackout" visible | ✅ PASS |
+| F08-S04 | Quintana DYN — tarjeta amarilla registrada, estado revisión visible | ✅ PASS |
+| F08-S05 | Cierre de revisión como Blanca (no admite BlancaConPenalizaciones desde revisión) | ✅ PASS |
+| F08-S06 | Resultado DYN Quintana visible con tarjeta Blanca | ✅ PASS |
+| F08-S07 | Almada DYN — BlancaConPenalizaciones con 1 penalización (75m → 72m) | ✅ PASS |
+| F08-S08 | Desglose de penalización visible en panel organizador: 69.00m + "(72m − 3m)" | ✅ PASS |
+
+---
+
+## Defectos Encontrados y Resueltos
+
+| ID | Descripción | Fix |
+|----|-------------|-----|
+| H-08-01 | Motivo DQ y RP ausentes en grilla organizador y portal público para tarjeta roja | `eba8e42` + `77b01be` + `ace40df` |
+| H-08-02 | Penalizaciones no se mostraban en lenguaje natural (texto crudo) | `b85bf8b` + `4cf2832` |
+| H-08-03 | Desglose de marca original vs. deducción no visible en panel organizador | `795fd38` |
+
+---
+
+## Corrección de Dominio Identificada
+
+Durante F08-S05 se verificó que **la revisión de una tarjeta amarilla solo puede cerrarse como Blanca o Roja** — no como BlancaConPenalizaciones. BlancaConPenalizaciones es un estado que se registra al momento del ingreso de la marca, no como resultado de una revisión. El escenario original estaba mal planteado y fue corregido en los artefactos.
+
+---
+
+## Mejoras de UX Resueltas (Portal Atleta)
+
+| ID | Descripción | Fix |
+|----|-------------|-----|
+| M-08-01 | Badge flotante pisaba botón Salir · nav al pie era inaccesible | `0f4f811` + `0f257e1` |
+| M-08-02 | Disciplinas apiladas en "En ejecución" y "Mis resultados" | `4117cc6` + `8ffa799` |
+| M-08-03 | Formato de hora en 12h (AM/PM) | `3583d82` |
+
+---
+
+## Commits de la Fase
+
+```
+90d53ab test(uat): actualizar artefactos F-08
+3583d82 fix(frontend): formato de hora en 24h
+8ffa799 fix(frontend): tabs en Mis Resultados con una sola disciplina
+4117cc6 feat(frontend): disciplinas por pestañas en Mis Inscripciones y Mis Resultados
+0f257e1 fix(frontend): nav del portal atleta a cabecera
+0f4f811 fix(frontend): botón Salir al header del AtletaShell
+795fd38 fix(frontend): desglose rp_medido en panel organizador [H-08-03]
+4cf2832 fix(frontend): tarjeta en portal público en palabras separadas [H-08-02]
+b85bf8b fix(resultados): penalizaciones en lenguaje natural [H-08-02]
+ace40df fix(competencia): motivo DQ en grilla pública [H-08-01]
+77b01be fix(resultados): serializar motivo_dq y RP en tarjeta roja [H-08-01]
+eba8e42 fix(resultados): motivo DQ en grilla organizador [H-08-01]
+793c263 test(uat): apertura F-08
+```
+
+---
+
+## Criterio de Salida — Verificado
+
+- [x] 8/8 escenarios PASS
+- [x] BKO genera tarjeta roja automática con MotivoDQ = BKO_SUPERFICIE
+- [x] Pantalla post-BKO en rojo
+- [x] Tarjeta amarilla cierra como Blanca (dominio verificado)
+- [x] BlancaConPenalizaciones registrada correctamente al ingresar RP
+- [x] Sistema listo para F-09

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -1243,6 +1243,7 @@ async def get_grilla(
                 "estado": e.estado,
                 "tarjeta_asignada": e.tarjeta_asignada,
                 "juez_id": e.juez_id,
+                "motivo_dq": e.motivo_dq,
             }
             for e in entradas
         ],

--- a/src/competencia/api/router.py
+++ b/src/competencia/api/router.py
@@ -1244,6 +1244,7 @@ async def get_grilla(
                 "tarjeta_asignada": e.tarjeta_asignada,
                 "juez_id": e.juez_id,
                 "motivo_dq": e.motivo_dq,
+                "penalizaciones": list(e.penalizaciones),
             }
             for e in entradas
         ],

--- a/src/competencia/application/queries/obtener_grilla.py
+++ b/src/competencia/application/queries/obtener_grilla.py
@@ -36,6 +36,7 @@ class EntradaGrillaDTO:
     tarjeta_asignada: str | None
     juez_id: str | None
     motivo_dq: str | None = None
+    penalizaciones: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)  # pylint: disable=too-few-public-methods
@@ -85,6 +86,7 @@ class ObtenerGrillaHandler:
                 tarjeta_asignada=performance.tarjeta_asignada,
                 juez_id=e.juez_id,
                 motivo_dq=performance.motivo_dq,
+                penalizaciones=performance.penalizaciones,
             )
             for e in competencia.grilla
             for performance in [
@@ -120,6 +122,7 @@ class ObtenerGrillaHandler:
             estado=performance.estado.value if performance.estado else "",
             tarjeta_asignada=performance.tarjeta.value if performance.tarjeta else None,
             motivo_dq=performance.motivo_dq.value if performance.motivo_dq else None,
+            penalizaciones=tuple(p.tipo.value for p in performance.penalizaciones),
         )
 
 
@@ -132,3 +135,4 @@ class _PerformanceProjection:
     estado: str
     tarjeta_asignada: str | None
     motivo_dq: str | None = None
+    penalizaciones: tuple[str, ...] = ()

--- a/src/competencia/application/queries/obtener_grilla.py
+++ b/src/competencia/application/queries/obtener_grilla.py
@@ -35,6 +35,7 @@ class EntradaGrillaDTO:
     estado: str
     tarjeta_asignada: str | None
     juez_id: str | None
+    motivo_dq: str | None = None
 
 
 @dataclass(frozen=True)  # pylint: disable=too-few-public-methods
@@ -83,6 +84,7 @@ class ObtenerGrillaHandler:
                 estado=performance.estado,
                 tarjeta_asignada=performance.tarjeta_asignada,
                 juez_id=e.juez_id,
+                motivo_dq=performance.motivo_dq,
             )
             for e in competencia.grilla
             for performance in [
@@ -117,6 +119,7 @@ class ObtenerGrillaHandler:
             performance=str(performance.rp) if performance.rp is not None else None,
             estado=performance.estado.value if performance.estado else "",
             tarjeta_asignada=performance.tarjeta.value if performance.tarjeta else None,
+            motivo_dq=performance.motivo_dq.value if performance.motivo_dq else None,
         )
 
 
@@ -128,3 +131,4 @@ class _PerformanceProjection:
     performance: str | None
     estado: str
     tarjeta_asignada: str | None
+    motivo_dq: str | None = None

--- a/src/resultados/api/router.py
+++ b/src/resultados/api/router.py
@@ -196,6 +196,7 @@ async def get_ranking(
                             "puntos": e.puntos,
                             "motivo_dq": e.motivo_dq,
                             "penalizaciones": list(e.penalizaciones),
+                            "rp_medido": e.rp_medido,
                         }
                         for e in grupo.entradas
                     ],

--- a/src/resultados/api/router.py
+++ b/src/resultados/api/router.py
@@ -194,6 +194,7 @@ async def get_ranking(
                             "es_dns": e.es_dns,
                             "en_podio": e.en_podio,
                             "puntos": e.puntos,
+                            "motivo_dq": e.motivo_dq,
                         }
                         for e in grupo.entradas
                     ],

--- a/src/resultados/api/router.py
+++ b/src/resultados/api/router.py
@@ -195,6 +195,7 @@ async def get_ranking(
                             "en_podio": e.en_podio,
                             "puntos": e.puntos,
                             "motivo_dq": e.motivo_dq,
+                            "penalizaciones": list(e.penalizaciones),
                         }
                         for e in grupo.entradas
                     ],

--- a/src/resultados/application/queries/obtener_ranking.py
+++ b/src/resultados/application/queries/obtener_ranking.py
@@ -54,6 +54,7 @@ class RankingEntradaDTO:
     puntos: str = "0.00"
     motivo_dq: str | None = None
     penalizaciones: tuple[str, ...] = ()
+    rp_medido: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/resultados/application/queries/obtener_ranking.py
+++ b/src/resultados/application/queries/obtener_ranking.py
@@ -52,6 +52,7 @@ class RankingEntradaDTO:
     es_dns: bool
     en_podio: bool
     puntos: str = "0.00"
+    motivo_dq: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/resultados/application/queries/obtener_ranking.py
+++ b/src/resultados/application/queries/obtener_ranking.py
@@ -53,6 +53,7 @@ class RankingEntradaDTO:
     en_podio: bool
     puntos: str = "0.00"
     motivo_dq: str | None = None
+    penalizaciones: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/resultados/application/queries/obtener_ranking_provisional.py
+++ b/src/resultados/application/queries/obtener_ranking_provisional.py
@@ -88,6 +88,7 @@ def _extraer_estado_provisional(
         "rp": None,
         "unidad": None,
         "tarjeta": None,
+        "motivo_dq": None,
         "es_dns": False,
         "tiene_rp": False,
     }
@@ -123,9 +124,17 @@ def _aplicar(estado: dict, event_type: str, payload: dict) -> None:
         estado["tiene_rp"] = True
     elif event_type == "TarjetaAsignada":
         estado["tarjeta"] = payload.get("tipo")
+        estado["motivo_dq"] = payload.get("motivo_dq_codigo")
         rp_final = payload.get("rp_penalizado") or payload.get("rp_medido")
         if rp_final is not None:
             estado["rp"] = str(Decimal(str(rp_final)))
+    elif event_type == "RevisionResuelta":
+        estado["tarjeta"] = payload.get("tipo")
+        estado["motivo_dq"] = payload.get("motivo_dq_codigo")
+        rp_final = payload.get("rp_penalizado") or payload.get("rp_medido")
+        if rp_final is not None:
+            estado["rp"] = str(Decimal(str(rp_final)))
+        estado["tiene_rp"] = rp_final is not None or estado["tiene_rp"]
     elif event_type == "DNSRegistrado":
         estado["es_dns"] = True
         estado["atleta_id"] = payload.get("participante_id")
@@ -172,6 +181,7 @@ def _rankear_categoria(estados: list[dict]) -> list[RankingEntradaDTO]:
                 es_dns=False,
                 en_podio=pos <= 3,
                 puntos="0.00",
+                motivo_dq=e.get("motivo_dq"),
             )
         )
         posicion = len(entradas) + 1
@@ -187,6 +197,7 @@ def _rankear_categoria(estados: list[dict]) -> list[RankingEntradaDTO]:
                 es_dns=e["es_dns"],
                 en_podio=False,
                 puntos="0.00",
+                motivo_dq=e.get("motivo_dq"),
             )
         )
         posicion += 1

--- a/src/resultados/application/queries/obtener_ranking_provisional.py
+++ b/src/resultados/application/queries/obtener_ranking_provisional.py
@@ -86,6 +86,7 @@ def _extraer_estado_provisional(
         "atleta_id": None,
         "disciplina": None,
         "rp": None,
+        "rp_medido": None,
         "unidad": None,
         "tarjeta": None,
         "motivo_dq": None,
@@ -127,16 +128,22 @@ def _aplicar(estado: dict, event_type: str, payload: dict) -> None:
         estado["tarjeta"] = payload.get("tipo")
         estado["motivo_dq"] = payload.get("motivo_dq_codigo")
         estado["penalizaciones"] = [p["tipo"] for p in payload.get("penalizaciones", [])]
-        rp_final = payload.get("rp_penalizado") or payload.get("rp_medido")
+        rp_medido = payload.get("rp_medido")
+        rp_final = payload.get("rp_penalizado") or rp_medido
         if rp_final is not None:
             estado["rp"] = str(Decimal(str(rp_final)))
+        if rp_medido is not None:
+            estado["rp_medido"] = str(Decimal(str(rp_medido)))
     elif event_type == "RevisionResuelta":
         estado["tarjeta"] = payload.get("tipo")
         estado["motivo_dq"] = payload.get("motivo_dq_codigo")
         estado["penalizaciones"] = [p["tipo"] for p in payload.get("penalizaciones", [])]
-        rp_final = payload.get("rp_penalizado") or payload.get("rp_medido")
+        rp_medido = payload.get("rp_medido")
+        rp_final = payload.get("rp_penalizado") or rp_medido
         if rp_final is not None:
             estado["rp"] = str(Decimal(str(rp_final)))
+        if rp_medido is not None:
+            estado["rp_medido"] = str(Decimal(str(rp_medido)))
         estado["tiene_rp"] = rp_final is not None or estado["tiene_rp"]
     elif event_type == "DNSRegistrado":
         estado["es_dns"] = True
@@ -186,6 +193,7 @@ def _rankear_categoria(estados: list[dict]) -> list[RankingEntradaDTO]:
                 puntos="0.00",
                 motivo_dq=e.get("motivo_dq"),
                 penalizaciones=tuple(e.get("penalizaciones", [])),
+                rp_medido=e.get("rp_medido"),
             )
         )
         posicion = len(entradas) + 1
@@ -203,6 +211,7 @@ def _rankear_categoria(estados: list[dict]) -> list[RankingEntradaDTO]:
                 puntos="0.00",
                 motivo_dq=e.get("motivo_dq"),
                 penalizaciones=tuple(e.get("penalizaciones", [])),
+                rp_medido=e.get("rp_medido"),
             )
         )
         posicion += 1

--- a/src/resultados/application/queries/obtener_ranking_provisional.py
+++ b/src/resultados/application/queries/obtener_ranking_provisional.py
@@ -191,8 +191,8 @@ def _rankear_categoria(estados: list[dict]) -> list[RankingEntradaDTO]:
             RankingEntradaDTO(
                 posicion=posicion,
                 atleta_id=e["atleta_id"],
-                rp=None,
-                unidad=None,
+                rp=e["rp"],
+                unidad=e["unidad"],
                 tarjeta=e["tarjeta"],
                 es_dns=e["es_dns"],
                 en_podio=False,

--- a/src/resultados/application/queries/obtener_ranking_provisional.py
+++ b/src/resultados/application/queries/obtener_ranking_provisional.py
@@ -89,6 +89,7 @@ def _extraer_estado_provisional(
         "unidad": None,
         "tarjeta": None,
         "motivo_dq": None,
+        "penalizaciones": [],
         "es_dns": False,
         "tiene_rp": False,
     }
@@ -125,12 +126,14 @@ def _aplicar(estado: dict, event_type: str, payload: dict) -> None:
     elif event_type == "TarjetaAsignada":
         estado["tarjeta"] = payload.get("tipo")
         estado["motivo_dq"] = payload.get("motivo_dq_codigo")
+        estado["penalizaciones"] = [p["tipo"] for p in payload.get("penalizaciones", [])]
         rp_final = payload.get("rp_penalizado") or payload.get("rp_medido")
         if rp_final is not None:
             estado["rp"] = str(Decimal(str(rp_final)))
     elif event_type == "RevisionResuelta":
         estado["tarjeta"] = payload.get("tipo")
         estado["motivo_dq"] = payload.get("motivo_dq_codigo")
+        estado["penalizaciones"] = [p["tipo"] for p in payload.get("penalizaciones", [])]
         rp_final = payload.get("rp_penalizado") or payload.get("rp_medido")
         if rp_final is not None:
             estado["rp"] = str(Decimal(str(rp_final)))
@@ -182,6 +185,7 @@ def _rankear_categoria(estados: list[dict]) -> list[RankingEntradaDTO]:
                 en_podio=pos <= 3,
                 puntos="0.00",
                 motivo_dq=e.get("motivo_dq"),
+                penalizaciones=tuple(e.get("penalizaciones", [])),
             )
         )
         posicion = len(entradas) + 1
@@ -198,6 +202,7 @@ def _rankear_categoria(estados: list[dict]) -> list[RankingEntradaDTO]:
                 en_podio=False,
                 puntos="0.00",
                 motivo_dq=e.get("motivo_dq"),
+                penalizaciones=tuple(e.get("penalizaciones", [])),
             )
         )
         posicion += 1

--- a/tests/uat/sp6/seed_ba2025_inscripciones.py
+++ b/tests/uat/sp6/seed_ba2025_inscripciones.py
@@ -123,7 +123,9 @@ def main() -> None:
         estado = resp.json().get("estado")
         if estado != "INSCRIPCION_ABIERTA":
             print(f"\n✗ El torneo está en estado '{estado}' — debe estar en INSCRIPCION_ABIERTA.")
-            print("  Abrí las inscripciones desde el portal del organizador (F-04-S01) antes de correr Seed-B.")
+            print(
+                "  Abrí las inscripciones desde el portal del organizador (F-04-S01) antes de correr Seed-B."
+            )
             sys.exit(1)
         log(f"✓ estado: {estado}")
         print()
@@ -157,9 +159,7 @@ def main() -> None:
             )
             if resp.status_code == 409 and "ya está inscripto" in resp.text:
                 # Obtener inscripcion existente
-                resp2 = client.get(
-                    f"/registro/atletas/{atleta_id}/inscripciones", headers=headers
-                )
+                resp2 = client.get(f"/registro/atletas/{atleta_id}/inscripciones", headers=headers)
                 if resp2.status_code != 200:
                     log(f"✗ no se pudo recuperar inscripcion para {nombre}")
                     err += 1

--- a/tests/uat/sp6/seed_ba2025_usuarios.py
+++ b/tests/uat/sp6/seed_ba2025_usuarios.py
@@ -126,9 +126,7 @@ def limpiar_entorno_uat() -> None:
 
     # Identidad: eliminar todos los usuarios no-admin de dominios de prueba
     with sqlite3.connect(IDENTIDAD_DB) as con:
-        rows = con.execute(
-            "SELECT email FROM usuarios WHERE rol != 'ADMIN'"
-        ).fetchall()
+        rows = con.execute("SELECT email FROM usuarios WHERE rol != 'ADMIN'").fetchall()
         if rows:
             emails = [r[0] for r in rows]
             placeholders = ",".join("?" * len(emails))
@@ -164,7 +162,13 @@ def assert_ok(resp: httpx.Response, context: str) -> dict:
 def crear_usuario(client: httpx.Client, email: str, nombre: str, apellido: str, rol: str) -> str:
     resp = client.post(
         "/auth/registro",
-        json={"email": email, "password": PASSWORD, "rol": rol, "nombre": nombre, "apellido": apellido},
+        json={
+            "email": email,
+            "password": PASSWORD,
+            "rol": rol,
+            "nombre": nombre,
+            "apellido": apellido,
+        },
     )
     assert_ok(resp, f"registro {email}")
     resp = client.post("/auth/login", json={"email": email, "password": PASSWORD})


### PR DESCRIPTION
## Resumen

Cierre de la fase F-08 del UAT INC-6.5 — Flujos de Excepción.

- 8/8 escenarios PASS
- BKO con tarjeta roja automática y MotivoDQ verificado
- Revisión de tarjeta amarilla cierra como Blanca (corrección de dominio documentada)
- BlancaConPenalizaciones registrada al ingresar la marca (flujo normal)

## Defectos resueltos

| ID | Descripción | Fix |
|----|-------------|-----|
| H-08-01 | Motivo DQ y RP ausentes en grilla organizador y portal público para tarjeta roja | `eba8e42` + `77b01be` + `ace40df` |
| H-08-02 | Penalizaciones no se mostraban en lenguaje natural | `b85bf8b` + `4cf2832` |
| H-08-03 | Desglose de marca original vs. deducción no visible en panel organizador | `795fd38` |

## Mejoras UX resueltas (portal atleta)

| ID | Descripción |
|----|-------------|
| M-08-01 | Badge flotante pisaba botón Salir · nav movida a cabecera sticky |
| M-08-02 | Disciplinas por pestañas en "En ejecución" y "Mis resultados" |
| M-08-03 | Formato de hora en 24h |

## Archivos modificados

- `src/resultados/` — motivo_dq, penalizaciones y rp_medido en pipeline de ranking provisional
- `src/competencia/` — motivo_dq y penalizaciones en grilla pública
- `frontend/src/components/atleta/AtletaShell.tsx` — nav en cabecera, logout siempre visible
- `frontend/src/components/organizador/FilaResultado.tsx` — desglose rp_medido
- `frontend/src/pages/atleta/` — tabs de disciplina, formato de hora 24h
- `frontend/src/constants/tarjeta.ts` — DQ_REASON_LABELS, TARJETA_LABELS, PENALTY_LABELS
- `quality/reports/uat/SP6/F-08-flujos-excepcion/` — escenarios, hallazgos, reporte de cierre

🤖 Generated with [Claude Code](https://claude.com/claude-code)