### PR TITLE
feat(torneo): US-ADJ-10.1 — Edición completa del torneo

### DIFF
--- a/.claude/tracking/US-ADJ-10.1-tracking.json
+++ b/.claude/tracking/US-ADJ-10.1-tracking.json
@@ -1,0 +1,6 @@
+{
+  "us_id": "US-ADJ-10.1",
+  "started_at": "2026-05-15T08:29:44.610142",
+  "phases": [],
+  "status": "in_progress"
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -248,6 +248,14 @@ function App() {
           }
         />
         <Route
+          path="/organizador/torneos/:torneoId/editar"
+          element={
+            <RequireRole role="organizador">
+              <CrearTorneoPage />
+            </RequireRole>
+          }
+        />
+        <Route
           path="/organizador/usuarios"
           element={
             <RequireRole role="organizador">

--- a/frontend/src/api/torneo.ts
+++ b/frontend/src/api/torneo.ts
@@ -183,6 +183,32 @@ export async function fetchTorneo(torneoId: string): Promise<TorneoDto> {
   return normalizarTorneo(torneo)
 }
 
+export interface ActualizarTorneoPayload {
+  nombre: string
+  descripcion: string
+  fecha_inicio: string
+  fecha_fin: string
+  sede: {
+    nombre: string
+    ciudad: string
+    pais: string
+  }
+  grupos_etarios: GrupoEtario[]
+}
+
+export async function actualizarTorneo(
+  torneoId: string,
+  payload: ActualizarTorneoPayload,
+): Promise<void> {
+  const response = await fetch(`/torneos/${torneoId}`, {
+    method: 'PUT',
+    headers: buildHeaders(),
+    body: JSON.stringify(payload),
+  })
+
+  await parseResponse<{ ok: boolean }>(response)
+}
+
 export async function crearTorneo(payload: CrearTorneoPayload): Promise<CrearTorneoResponse> {
   const response = await fetch('/torneos', {
     method: 'POST',

--- a/frontend/src/pages/organizador/CrearTorneoPage.tsx
+++ b/frontend/src/pages/organizador/CrearTorneoPage.tsx
@@ -3,10 +3,12 @@ import type { FormEvent } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import {
   ApiError,
+  actualizarTorneo,
   asignarDisciplinas,
   crearTorneo,
   fetchTorneo,
   listarDisciplinasTorneo,
+  type ActualizarTorneoPayload,
   type CrearTorneoPayload,
   type DisciplinaCodigo,
   type GrupoEtario,
@@ -42,13 +44,16 @@ const INITIAL_FORM: FormState = {
   entidadTipo: '',
 }
 
-function inputClass(hasError: boolean): string {
+function inputClass(hasError: boolean, disabled = false): string {
   return [
     'mt-2 w-full rounded-lg border bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition placeholder:text-slate-500',
+    disabled ? 'cursor-not-allowed opacity-50' : '',
     hasError
       ? 'border-red-500/60 focus:border-red-400'
       : 'border-slate-700 focus:border-sky-400',
-  ].join(' ')
+  ]
+    .filter(Boolean)
+    .join(' ')
 }
 
 function getErrorMessage(error: unknown): string {
@@ -57,16 +62,28 @@ function getErrorMessage(error: unknown): string {
   return 'No se pudo completar la operacion'
 }
 
+type PageMode = 'crear' | 'editar-disciplinas' | 'editar-torneo'
+
+function detectMode(pathname: string, torneoId: string | undefined): PageMode {
+  if (!torneoId) return 'crear'
+  if (pathname.endsWith('/editar')) return 'editar-torneo'
+  return 'editar-disciplinas'
+}
+
 export function CrearTorneoPage() {
   const navigate = useNavigate()
   const { torneoId } = useParams<{ torneoId: string }>()
-  const isEditingDisciplinas = Boolean(torneoId)
+  const mode = detectMode(window.location.pathname, torneoId)
+  const isEditing = mode !== 'crear'
+  const isEditingDisciplinas = mode === 'editar-disciplinas'
+  const isEditingTorneo = mode === 'editar-torneo'
+
   const [form, setForm] = useState<FormState>(INITIAL_FORM)
   const [disciplinas, setDisciplinas] = useState<DisciplinaCodigo[]>([])
   const [gruposEtarios, setGruposEtarios] = useState<GrupoEtario[]>(['JUNIOR', 'SENIOR', 'MASTER'])
   const [errors, setErrors] = useState<FormErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isLoading, setIsLoading] = useState(isEditingDisciplinas)
+  const [isLoading, setIsLoading] = useState(isEditing)
   const [torneoCreadoSinDisciplinas, setTorneoCreadoSinDisciplinas] = useState<string | null>(null)
 
   useEffect(() => {
@@ -96,12 +113,22 @@ export function CrearTorneoPage() {
           entidadNombre: torneo.entidad_organizadora.nombre,
           entidadTipo: torneo.entidad_organizadora.tipo,
         })
+        setGruposEtarios(torneo.grupos_etarios)
         setDisciplinas(disciplinasActuales.map((item) => item.disciplina))
 
-        if (torneo.estado !== 'CREADO') {
+        if (isEditingDisciplinas && torneo.estado !== 'CREADO') {
           setErrors({
             general:
               'Solo se pueden modificar disciplinas mientras el torneo este en estado Creado.',
+          })
+        }
+        if (
+          isEditingTorneo &&
+          torneo.estado !== 'CREADO' &&
+          torneo.estado !== 'INSCRIPCION_ABIERTA'
+        ) {
+          setErrors({
+            general: 'Solo se pueden editar torneos en estado Creado o Inscripcion abierta.',
           })
         }
       } catch (error) {
@@ -117,7 +144,7 @@ export function CrearTorneoPage() {
     return () => {
       cancelled = true
     }
-  }, [torneoId])
+  }, [torneoId, isEditingDisciplinas, isEditingTorneo])
 
   function updateField(field: keyof FormState, value: string) {
     setForm((current) => ({ ...current, [field]: value }))
@@ -132,14 +159,13 @@ export function CrearTorneoPage() {
     if (form.fechaInicio && form.fechaFin && form.fechaFin < form.fechaInicio) {
       nextErrors.fechaFin = 'La fecha de fin debe ser igual o posterior a la de inicio'
     }
-
     if (!isEditingDisciplinas && gruposEtarios.length === 0) {
       nextErrors.gruposEtarios = 'Selecciona al menos una categoría'
     }
     return nextErrors
   }
 
-  function buildPayload(): CrearTorneoPayload {
+  function buildCrearPayload(): CrearTorneoPayload {
     return {
       nombre: form.nombre.trim(),
       descripcion: form.descripcion.trim(),
@@ -153,6 +179,21 @@ export function CrearTorneoPage() {
       entidad_organizadora: {
         nombre: form.entidadNombre.trim(),
         tipo: form.entidadTipo.trim(),
+      },
+      grupos_etarios: gruposEtarios,
+    }
+  }
+
+  function buildActualizarPayload(): ActualizarTorneoPayload {
+    return {
+      nombre: form.nombre.trim(),
+      descripcion: form.descripcion.trim(),
+      fecha_inicio: form.fechaInicio,
+      fecha_fin: form.fechaFin,
+      sede: {
+        nombre: form.sedeNombre.trim(),
+        ciudad: form.sedeCiudad.trim(),
+        pais: form.sedePais.trim(),
       },
       grupos_etarios: gruposEtarios,
     }
@@ -179,13 +220,19 @@ export function CrearTorneoPage() {
 
     setIsSubmitting(true)
     try {
+      if (isEditingTorneo && torneoId) {
+        await actualizarTorneo(torneoId, buildActualizarPayload())
+        navigate(`/organizador/torneo/${torneoId}`)
+        return
+      }
+
       if (isEditingDisciplinas && torneoId) {
         await asignarDisciplinas(torneoId, disciplinas)
         navigate(`/organizador/torneo/${torneoId}`)
         return
       }
 
-      const response = await crearTorneo(buildPayload())
+      const response = await crearTorneo(buildCrearPayload())
       if (disciplinas.length > 0) {
         try {
           await asignarDisciplinas(response.torneo_id, disciplinas)
@@ -203,14 +250,36 @@ export function CrearTorneoPage() {
     }
   }
 
+  const pageTitle = isEditingTorneo
+    ? 'Editar torneo'
+    : isEditingDisciplinas
+      ? 'Editar disciplinas'
+      : 'Nuevo torneo'
+
+  const pageSubtitle = isEditingTorneo
+    ? 'Actualiza el nombre, sede, fechas y categorías del torneo'
+    : isEditingDisciplinas
+      ? 'Mismo formulario de alta reutilizado para ajustar disciplinas mientras el torneo sigue en estado Creado'
+      : 'Alta del torneo y configuracion inicial de disciplinas'
+
+  const submitLabel = isSubmitting
+    ? isEditingTorneo
+      ? 'Guardando...'
+      : isEditingDisciplinas
+        ? 'Guardando...'
+        : 'Creando...'
+    : isEditingTorneo
+      ? 'Guardar cambios'
+      : isEditingDisciplinas
+        ? 'Guardar disciplinas'
+        : 'Crear Torneo'
+
+  const metadataDisabled = isEditingDisciplinas
+
   return (
     <OrganizadorLayout
-      title={isEditingDisciplinas ? 'Editar disciplinas' : 'Nuevo torneo'}
-      subtitle={
-        isEditingDisciplinas
-          ? 'Mismo formulario de alta reutilizado para ajustar disciplinas mientras el torneo sigue en estado Creado'
-          : 'Alta del torneo y configuracion inicial de disciplinas'
-      }
+      title={pageTitle}
+      subtitle={pageSubtitle}
       showTournamentNavigation={false}
       simpleHeader
       actions={
@@ -252,9 +321,9 @@ export function CrearTorneoPage() {
             <input
               value={form.nombre}
               onChange={(event) => updateField('nombre', event.target.value)}
-              className={inputClass(Boolean(errors.nombre))}
+              className={inputClass(Boolean(errors.nombre), metadataDisabled)}
               placeholder="BA 2026"
-              disabled={isEditingDisciplinas}
+              disabled={metadataDisabled}
             />
             {errors.nombre ? <span className="mt-1 block text-sm text-red-300">{errors.nombre}</span> : null}
           </label>
@@ -264,9 +333,9 @@ export function CrearTorneoPage() {
             <input
               value={form.descripcion}
               onChange={(event) => updateField('descripcion', event.target.value)}
-              className={inputClass(Boolean(errors.descripcion))}
+              className={inputClass(Boolean(errors.descripcion), metadataDisabled)}
               placeholder="Torneo nacional indoor"
-              disabled={isEditingDisciplinas}
+              disabled={metadataDisabled}
             />
           </label>
 
@@ -276,9 +345,9 @@ export function CrearTorneoPage() {
               type="date"
               value={form.fechaInicio}
               onChange={(event) => updateField('fechaInicio', event.target.value)}
-              className={inputClass(Boolean(errors.fechaInicio))}
+              className={inputClass(Boolean(errors.fechaInicio), metadataDisabled)}
               required
-              disabled={isEditingDisciplinas}
+              disabled={metadataDisabled}
             />
           </label>
 
@@ -288,9 +357,9 @@ export function CrearTorneoPage() {
               type="date"
               value={form.fechaFin}
               onChange={(event) => updateField('fechaFin', event.target.value)}
-              className={inputClass(Boolean(errors.fechaFin))}
+              className={inputClass(Boolean(errors.fechaFin), metadataDisabled)}
               required
-              disabled={isEditingDisciplinas}
+              disabled={metadataDisabled}
             />
             {errors.fechaFin ? (
               <span className="mt-1 block text-sm text-red-300">{errors.fechaFin}</span>
@@ -304,10 +373,10 @@ export function CrearTorneoPage() {
             <input
               value={form.sedeNombre}
               onChange={(event) => updateField('sedeNombre', event.target.value)}
-              className={inputClass(Boolean(errors.sedeNombre))}
+              className={inputClass(Boolean(errors.sedeNombre), metadataDisabled)}
               placeholder="Club Nautico"
               required
-              disabled={isEditingDisciplinas}
+              disabled={metadataDisabled}
             />
           </label>
 
@@ -316,10 +385,10 @@ export function CrearTorneoPage() {
             <input
               value={form.sedeCiudad}
               onChange={(event) => updateField('sedeCiudad', event.target.value)}
-              className={inputClass(Boolean(errors.sedeCiudad))}
+              className={inputClass(Boolean(errors.sedeCiudad), metadataDisabled)}
               placeholder="Buenos Aires"
               required
-              disabled={isEditingDisciplinas}
+              disabled={metadataDisabled}
             />
           </label>
 
@@ -328,38 +397,40 @@ export function CrearTorneoPage() {
             <input
               value={form.sedePais}
               onChange={(event) => updateField('sedePais', event.target.value)}
-              className={inputClass(Boolean(errors.sedePais))}
+              className={inputClass(Boolean(errors.sedePais), metadataDisabled)}
               required
-              disabled={isEditingDisciplinas}
+              disabled={metadataDisabled}
             />
           </label>
         </div>
 
-        <div className="mt-6 grid gap-5 lg:grid-cols-2">
-          <label className="block text-sm font-semibold text-slate-100">
-            Entidad organizadora
-            <input
-              value={form.entidadNombre}
-              onChange={(event) => updateField('entidadNombre', event.target.value)}
-              className={inputClass(Boolean(errors.entidadNombre))}
-              placeholder="FAAS"
-              required
-              disabled={isEditingDisciplinas}
-            />
-          </label>
+        {!isEditingTorneo ? (
+          <div className="mt-6 grid gap-5 lg:grid-cols-2">
+            <label className="block text-sm font-semibold text-slate-100">
+              Entidad organizadora
+              <input
+                value={form.entidadNombre}
+                onChange={(event) => updateField('entidadNombre', event.target.value)}
+                className={inputClass(Boolean(errors.entidadNombre), metadataDisabled)}
+                placeholder="FAAS"
+                required
+                disabled={metadataDisabled}
+              />
+            </label>
 
-          <label className="block text-sm font-semibold text-slate-100">
-            Tipo de entidad
-            <input
-              value={form.entidadTipo}
-              onChange={(event) => updateField('entidadTipo', event.target.value)}
-              className={inputClass(Boolean(errors.entidadTipo))}
-              placeholder="Federacion"
-              required
-              disabled={isEditingDisciplinas}
-            />
-          </label>
-        </div>
+            <label className="block text-sm font-semibold text-slate-100">
+              Tipo de entidad
+              <input
+                value={form.entidadTipo}
+                onChange={(event) => updateField('entidadTipo', event.target.value)}
+                className={inputClass(Boolean(errors.entidadTipo), metadataDisabled)}
+                placeholder="Federacion"
+                required
+                disabled={metadataDisabled}
+              />
+            </label>
+          </div>
+        ) : null}
 
         <div className="mt-6">
           {!isEditingDisciplinas ? (
@@ -392,14 +463,16 @@ export function CrearTorneoPage() {
             </fieldset>
           ) : null}
 
-          <DisciplinaSelector
-            value={disciplinas}
-            onChange={(nextValue) => {
-              setDisciplinas(nextValue)
-              setErrors((current) => ({ ...current, disciplinas: undefined, general: undefined }))
-            }}
-            error={errors.disciplinas}
-          />
+          {!isEditingTorneo ? (
+            <DisciplinaSelector
+              value={disciplinas}
+              onChange={(nextValue) => {
+                setDisciplinas(nextValue)
+                setErrors((current) => ({ ...current, disciplinas: undefined, general: undefined }))
+              }}
+              error={errors.disciplinas}
+            />
+          ) : null}
         </div>
 
         <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
@@ -419,13 +492,7 @@ export function CrearTorneoPage() {
             }
             className="rounded-full bg-sky-500 px-5 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
           >
-            {isSubmitting
-              ? isEditingDisciplinas
-                ? 'Guardando...'
-                : 'Creando...'
-              : isEditingDisciplinas
-                ? 'Guardar disciplinas'
-                : 'Crear Torneo'}
+            {submitLabel}
           </button>
         </div>
       </form>

--- a/frontend/src/pages/organizador/DetalleTorneoPage.tsx
+++ b/frontend/src/pages/organizador/DetalleTorneoPage.tsx
@@ -145,6 +145,15 @@ function DetalleTorneoContent({ torneoId }: DetalleTorneoContentProps) {
       subtitle="Gestión del torneo activo"
       actions={
         <>
+          {(torneoQuery.data?.estado === 'CREADO' ||
+            torneoQuery.data?.estado === 'INSCRIPCION_ABIERTA') ? (
+            <Link
+              to={`/organizador/torneos/${torneoId}/editar`}
+              className="rounded-full border border-slate-600 bg-slate-800 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-100"
+            >
+              Editar torneo
+            </Link>
+          ) : null}
           {torneoQuery.data?.estado === 'CREADO' ? (
             <Link
               to={`/organizador/torneos/${torneoId}/disciplinas`}

--- a/src/torneo/api/router.py
+++ b/src/torneo/api/router.py
@@ -12,6 +12,10 @@ from pydantic import BaseModel, field_validator, model_validator
 
 from shared.api.dependencies import OrganizadorDep
 from shared.domain.value_objects.disciplina import Disciplina
+from torneo.application.commands.actualizar_torneo import (
+    ActualizarTorneoCommand,
+    ActualizarTorneoHandler,
+)
 from torneo.application.commands.asignar_disciplinas import (
     AsignarDisciplinasCommand,
     AsignarDisciplinasHandler,
@@ -36,7 +40,13 @@ from torneo.application.queries.obtener_torneo import (
     ObtenerTorneoQuery,
 )
 from torneo.domain.aggregates.torneo import Torneo
-from torneo.domain.exceptions import AsignacionNoPermitida, DisciplinaNoEnTorneo, DisciplinaObsoleta
+from torneo.domain.exceptions import (
+    AsignacionNoPermitida,
+    DisciplinaNoEnTorneo,
+    DisciplinaObsoleta,
+    EdicionNoPermitida,
+    TorneoNoEncontrado,
+)
 from torneo.domain.value_objects.grupo_etario import GrupoEtario, ordenar_grupos_etarios
 from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
 
@@ -106,6 +116,35 @@ class CrearTorneoRequest(BaseModel):
 
     @model_validator(mode="after")
     def fechas_coherentes(self) -> CrearTorneoRequest:
+        if self.fecha_fin < self.fecha_inicio:
+            raise ValueError("fecha_fin debe ser mayor o igual a fecha_inicio")
+        return self
+
+    @field_validator("grupos_etarios")
+    @classmethod
+    def grupos_etarios_no_vacio(cls, v: list[GrupoEtario]) -> list[GrupoEtario]:
+        if not v:
+            raise ValueError("Debe seleccionar al menos un grupo etario")
+        return v
+
+
+class ActualizarTorneoRequest(BaseModel):
+    nombre: str
+    descripcion: str
+    fecha_inicio: date
+    fecha_fin: date
+    sede: SedeSchema
+    grupos_etarios: list[GrupoEtario]
+
+    @field_validator("nombre")
+    @classmethod
+    def nombre_no_vacio(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("El nombre no puede estar vacío")
+        return v
+
+    @model_validator(mode="after")
+    def fechas_coherentes(self) -> ActualizarTorneoRequest:
         if self.fecha_fin < self.fecha_inicio:
             raise ValueError("fecha_fin debe ser mayor o igual a fecha_inicio")
         return self
@@ -198,6 +237,31 @@ async def obtener_torneo(torneo_id: UUID) -> TorneoResponse:
     handler = ObtenerTorneoHandler(_repo())
     torneo = await handler.handle(ObtenerTorneoQuery(torneo_id=torneo_id))
     return TorneoResponse.from_torneo(torneo)
+
+
+@router.put("/{torneo_id}", status_code=200)
+async def actualizar_torneo(
+    torneo_id: UUID, body: ActualizarTorneoRequest, _: OrganizadorDep
+) -> JSONResponse:
+    try:
+        await ActualizarTorneoHandler(_repo()).handle(
+            ActualizarTorneoCommand(
+                torneo_id=torneo_id,
+                nombre=body.nombre,
+                descripcion=body.descripcion,
+                fecha_inicio=body.fecha_inicio,
+                fecha_fin=body.fecha_fin,
+                sede_nombre=body.sede.nombre,
+                sede_ciudad=body.sede.ciudad,
+                sede_pais=body.sede.pais,
+                grupos_etarios=frozenset(body.grupos_etarios),
+            )
+        )
+    except TorneoNoEncontrado as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except EdicionNoPermitida as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    return JSONResponse(status_code=200, content={"ok": True})
 
 
 @router.put("/{torneo_id}/abrir-inscripcion", status_code=200)

--- a/src/torneo/application/commands/actualizar_torneo.py
+++ b/src/torneo/application/commands/actualizar_torneo.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from uuid import UUID
+
+from torneo.domain.exceptions import EdicionNoPermitida, TorneoNoEncontrado
+from torneo.domain.ports.torneo_repository_port import TorneoRepositoryPort
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
+from torneo.domain.value_objects.sede import Sede
+
+
+@dataclass(frozen=True)
+class ActualizarTorneoCommand:
+    torneo_id: UUID
+    nombre: str
+    descripcion: str
+    fecha_inicio: date
+    fecha_fin: date
+    sede_nombre: str
+    sede_ciudad: str
+    sede_pais: str
+    grupos_etarios: frozenset[GrupoEtario]
+
+
+class ActualizarTorneoHandler:
+    def __init__(self, repo: TorneoRepositoryPort) -> None:
+        self._repo = repo
+
+    async def handle(self, cmd: ActualizarTorneoCommand) -> None:
+        torneo = await self._repo.find_by_id(cmd.torneo_id)
+        if torneo is None:
+            raise TorneoNoEncontrado(f"Torneo {cmd.torneo_id} no encontrado")
+        torneo.actualizar(
+            nombre=cmd.nombre,
+            descripcion=cmd.descripcion,
+            fecha_inicio=cmd.fecha_inicio,
+            fecha_fin=cmd.fecha_fin,
+            sede=Sede(nombre=cmd.sede_nombre, ciudad=cmd.sede_ciudad, pais=cmd.sede_pais),
+            grupos_etarios=cmd.grupos_etarios,
+        )
+        await self._repo.save(torneo)

--- a/src/torneo/domain/aggregates/torneo.py
+++ b/src/torneo/domain/aggregates/torneo.py
@@ -9,6 +9,7 @@ from torneo.domain.exceptions import (
     AsignacionNoPermitida,
     DisciplinaObsoleta,
     DisciplinaNoEnTorneo,
+    EdicionNoPermitida,
     TorneoCerrado,
     TransicionEstadoInvalida,
 )
@@ -36,6 +37,11 @@ _ESTADOS_ASIGNACION_VALIDOS = {
     EstadoTorneo.CREADO,
     EstadoTorneo.INSCRIPCION_ABIERTA,
     EstadoTorneo.PREPARACION,
+}
+
+_ESTADOS_EDICION_VALIDOS = {
+    EstadoTorneo.CREADO,
+    EstadoTorneo.INSCRIPCION_ABIERTA,
 }
 
 
@@ -85,6 +91,27 @@ class Torneo:
     def cancelar(self) -> None:
         self._validar_cancelacion()
         self.estado = EstadoTorneo.CANCELADO
+
+    def actualizar(
+        self,
+        nombre: str,
+        descripcion: str,
+        fecha_inicio: date,
+        fecha_fin: date,
+        sede: Sede,
+        grupos_etarios: frozenset[GrupoEtario],
+    ) -> None:
+        if self.estado not in _ESTADOS_EDICION_VALIDOS:
+            raise EdicionNoPermitida(f"No se puede editar un torneo en estado {self.estado.value}")
+        self.nombre = nombre
+        self.descripcion = descripcion
+        self.fecha_inicio = fecha_inicio
+        self.fecha_fin = fecha_fin
+        self.sede = sede
+        self.grupos_etarios = grupos_etarios
+        self._validar_nombre()
+        self._validar_fechas()
+        self._validar_grupos_etarios()
 
     def asignar_disciplinas(self, disciplinas: frozenset[Disciplina]) -> None:
         """Configura las disciplinas disponibles.

--- a/src/torneo/domain/exceptions.py
+++ b/src/torneo/domain/exceptions.py
@@ -28,3 +28,7 @@ class AsignacionNoPermitida(Exception):
 
 class DisciplinaObsoleta(Exception):
     pass
+
+
+class EdicionNoPermitida(Exception):
+    pass

--- a/tests/features/US-ADJ-10.1-edicion-torneo.feature
+++ b/tests/features/US-ADJ-10.1-edicion-torneo.feature
@@ -1,0 +1,27 @@
+Feature: Edicion completa del torneo
+
+  Background:
+    Given el sistema tiene una base de datos limpia de torneos
+
+  Scenario: El organizador edita el nombre y sede de un torneo en CREADO
+    Given existe un torneo "Buenos Aires Open 2025" en estado CREADO
+    When el organizador actualiza el torneo con nombre "BA Open 2025 Corregido" y ciudad "Mar del Plata"
+    Then el torneo tiene nombre "BA Open 2025 Corregido"
+    And la sede del torneo tiene ciudad "Mar del Plata"
+
+  Scenario: El organizador edita un torneo en INSCRIPCION_ABIERTA
+    Given existe un torneo "Torneo Inscripcion" en estado INSCRIPCION_ABIERTA
+    When el organizador actualiza el torneo con nombre "Torneo Inscripcion Corregido" y ciudad "Rosario"
+    Then el torneo tiene nombre "Torneo Inscripcion Corregido"
+    And la sede del torneo tiene ciudad "Rosario"
+
+  Scenario: No se puede editar un torneo en EJECUCION
+    Given existe un torneo "Torneo En Ejecucion" en estado EJECUCION
+    When el organizador intenta actualizar el torneo con nombre "Nombre Nuevo"
+    Then la respuesta es 409 con detalle sobre estado invalido
+
+  Scenario: La edicion no afecta las disciplinas del torneo
+    Given existe un torneo "Torneo Con Disciplinas" en estado CREADO con disciplinas STA y DNF
+    When el organizador actualiza el torneo con nombre "Torneo Renombrado" y ciudad "Cordoba"
+    Then el torneo tiene nombre "Torneo Renombrado"
+    And las disciplinas STA y DNF permanecen sin cambios

--- a/tests/features/steps/edicion_torneo_steps.py
+++ b/tests/features/steps/edicion_torneo_steps.py
@@ -1,0 +1,158 @@
+"""Step definitions BDD — US-ADJ-10.1: Edicion completa del torneo."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from identidad.api.dependencies import get_current_user
+from shared.domain.value_objects.disciplina import Disciplina
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.api.router import router
+from torneo.domain.aggregates.torneo import Torneo
+from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
+from torneo.domain.value_objects.sede import Sede
+from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
+
+_torneo_router_mod = sys.modules["torneo.api.router"]
+
+scenarios("../US-ADJ-10.1-edicion-torneo.feature")
+
+
+@pytest.fixture
+def context(tmp_path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    monkeypatch.setenv("TORNEO_DB_PATH", str(tmp_path / "torneo.db"))
+    monkeypatch.setattr(_torneo_router_mod, "_cierre_inscripcion_precondition", None)
+    monkeypatch.setattr(_torneo_router_mod, "_ejecucion_precondition", None)
+    monkeypatch.setattr(_torneo_router_mod, "_ejecucion_post_action", None)
+    return {
+        "repo": SQLiteTorneoRepository(str(tmp_path / "torneo.db")),
+        "torneo_id": None,
+        "response": None,
+    }
+
+
+@pytest.fixture
+def client(context: dict) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "org-1",
+        "email": "org@test.com",
+        "rol": "ORGANIZADOR",
+    }
+    return TestClient(app)
+
+
+def _seed(repo, nombre: str, estado: str, disciplinas: set | None = None) -> str:
+    from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+
+    torneo = Torneo(
+        torneo_id=uuid4(),
+        nombre=nombre,
+        descripcion="desc",
+        fecha_inicio=date(2026, 6, 1),
+        fecha_fin=date(2026, 6, 3),
+        sede=Sede(nombre="Piscina", ciudad="Buenos Aires", pais="AR"),
+        entidad_organizadora=EntidadOrganizadora(nombre="AIDA", tipo="FEDERACION"),
+        grupos_etarios=frozenset({GrupoEtario.SENIOR}),
+    )
+    if estado != "CREADO":
+        torneo.estado = EstadoTorneo(estado)
+    if disciplinas:
+        torneo.asignar_disciplinas(frozenset(disciplinas))
+    asyncio.run(repo.save(torneo))
+    return str(torneo.torneo_id)
+
+
+def _update_payload(nombre: str = "Torneo Editado", ciudad: str = "Cordoba") -> dict:
+    return {
+        "nombre": nombre,
+        "descripcion": "desc editada",
+        "fecha_inicio": "2026-07-01",
+        "fecha_fin": "2026-07-03",
+        "sede": {"nombre": "Club", "ciudad": ciudad, "pais": "AR"},
+        "grupos_etarios": ["SENIOR"],
+    }
+
+
+@given("el sistema tiene una base de datos limpia de torneos")
+def base_limpia(context: dict) -> None:
+    pass
+
+
+@given(parsers.parse('existe un torneo "{nombre}" en estado {estado}'))
+def existe_torneo(client: TestClient, context: dict, nombre: str, estado: str) -> None:
+    context["torneo_id"] = _seed(context["repo"], nombre, estado)
+
+
+@given(parsers.parse('existe un torneo "{nombre}" en estado {estado} con disciplinas STA y DNF'))
+def existe_torneo_con_disciplinas(
+    client: TestClient, context: dict, nombre: str, estado: str
+) -> None:
+    context["torneo_id"] = _seed(context["repo"], nombre, estado, {Disciplina.STA, Disciplina.DNF})
+
+
+@when(parsers.parse('el organizador actualiza el torneo con nombre "{nombre}" y ciudad "{ciudad}"'))
+def actualiza_torneo(client: TestClient, context: dict, nombre: str, ciudad: str) -> None:
+    context["response"] = client.put(
+        f"/torneos/{context['torneo_id']}",
+        json=_update_payload(nombre, ciudad),
+    )
+
+
+@when(parsers.parse('el organizador intenta actualizar el torneo con nombre "{nombre}"'))
+def intenta_actualizar(client: TestClient, context: dict, nombre: str) -> None:
+    context["response"] = client.put(
+        f"/torneos/{context['torneo_id']}",
+        json=_update_payload(nombre),
+    )
+
+
+@when(parsers.parse("el organizador edita el nombre del torneo"))
+def edita_nombre(client: TestClient, context: dict) -> None:
+    context["response"] = client.put(
+        f"/torneos/{context['torneo_id']}",
+        json=_update_payload("Torneo Renombrado", "Cordoba"),
+    )
+
+
+@then(parsers.parse('el torneo tiene nombre "{nombre}"'))
+def torneo_tiene_nombre(context: dict, nombre: str) -> None:
+    torneo_id_uuid = __import__("uuid").UUID(context["torneo_id"])
+    torneo = asyncio.run(context["repo"].find_by_id(torneo_id_uuid))
+    assert torneo is not None
+    assert torneo.nombre == nombre
+
+
+@then(parsers.parse('la sede del torneo tiene ciudad "{ciudad}"'))
+def sede_tiene_ciudad(context: dict, ciudad: str) -> None:
+    torneo_id_uuid = __import__("uuid").UUID(context["torneo_id"])
+    torneo = asyncio.run(context["repo"].find_by_id(torneo_id_uuid))
+    assert torneo is not None
+    assert torneo.sede.ciudad == ciudad
+
+
+@then("la respuesta es 409 con detalle sobre estado invalido")
+def respuesta_409(context: dict) -> None:
+    assert context["response"].status_code == 409
+    assert "estado" in context["response"].json()["detail"].lower()
+
+
+@then("las disciplinas STA y DNF permanecen sin cambios")
+def disciplinas_sin_cambios(context: dict) -> None:
+    torneo_id_uuid = __import__("uuid").UUID(context["torneo_id"])
+    torneo = asyncio.run(context["repo"].find_by_id(torneo_id_uuid))
+    assert torneo is not None
+    disciplinas = {dt.disciplina for dt in torneo.disciplinas_torneo}
+    assert Disciplina.STA in disciplinas
+    assert Disciplina.DNF in disciplinas

--- a/tests/integration/test_actualizar_torneo_api.py
+++ b/tests/integration/test_actualizar_torneo_api.py
@@ -1,0 +1,129 @@
+"""Integración HTTP — PUT /torneos/{id} (US-ADJ-10.1)."""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from identidad.api.dependencies import get_current_user
+from torneo.api.router import router
+from torneo.api.exception_handlers import register_torneo_exception_handlers
+from torneo.domain.aggregates.torneo import Torneo
+from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
+from torneo.domain.value_objects.sede import Sede
+from torneo.infrastructure.repositories.sqlite_torneo_repository import SQLiteTorneoRepository
+
+
+def _organizador() -> dict:
+    return {"sub": "org-1", "email": "org@test.com", "rol": "ORGANIZADOR"}
+
+
+def _seed_torneo(repo: SQLiteTorneoRepository, estado: str = "CREADO") -> Torneo:
+    import asyncio
+    from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+
+    torneo = Torneo(
+        torneo_id=uuid4(),
+        nombre="Torneo Original",
+        descripcion="desc",
+        fecha_inicio=date(2026, 6, 1),
+        fecha_fin=date(2026, 6, 3),
+        sede=Sede(nombre="Piscina", ciudad="Buenos Aires", pais="AR"),
+        entidad_organizadora=EntidadOrganizadora(nombre="AIDA", tipo="FEDERACION"),
+        grupos_etarios=frozenset({GrupoEtario.SENIOR}),
+    )
+    if estado != "CREADO":
+        torneo.estado = EstadoTorneo(estado)
+    asyncio.run(repo.save(torneo))
+    return torneo
+
+
+@pytest.fixture
+def ctx(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    monkeypatch.setenv("TORNEO_DB_PATH", str(tmp_path / "torneo.db"))
+    torneo_router_mod = sys.modules["torneo.api.router"]
+    monkeypatch.setattr(torneo_router_mod, "_cierre_inscripcion_precondition", None)
+    monkeypatch.setattr(torneo_router_mod, "_ejecucion_precondition", None)
+    monkeypatch.setattr(torneo_router_mod, "_ejecucion_post_action", None)
+
+    app = FastAPI()
+    app.include_router(router)
+    register_torneo_exception_handlers(app)
+    app.dependency_overrides[get_current_user] = _organizador
+
+    repo = SQLiteTorneoRepository(str(tmp_path / "torneo.db"))
+    client = TestClient(app)
+    return {"client": client, "repo": repo}
+
+
+def _payload(nombre: str = "Torneo Editado", ciudad: str = "Cordoba") -> dict:
+    return {
+        "nombre": nombre,
+        "descripcion": "desc editada",
+        "fecha_inicio": "2026-07-01",
+        "fecha_fin": "2026-07-03",
+        "sede": {"nombre": "Club", "ciudad": ciudad, "pais": "AR"},
+        "grupos_etarios": ["SENIOR", "JUNIOR"],
+    }
+
+
+def test_put_torneo_en_creado_retorna_200(ctx):
+    torneo = _seed_torneo(ctx["repo"], "CREADO")
+    response = ctx["client"].put(f"/torneos/{torneo.torneo_id}", json=_payload())
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+def test_put_torneo_persiste_cambios(ctx):
+    import asyncio
+
+    torneo = _seed_torneo(ctx["repo"], "CREADO")
+    ctx["client"].put(f"/torneos/{torneo.torneo_id}", json=_payload("Nuevo Nombre", "Rosario"))
+
+    actualizado = asyncio.run(ctx["repo"].find_by_id(torneo.torneo_id))
+    assert actualizado is not None
+    assert actualizado.nombre == "Nuevo Nombre"
+    assert actualizado.sede.ciudad == "Rosario"
+    assert GrupoEtario.JUNIOR in actualizado.grupos_etarios
+
+
+def test_put_torneo_en_inscripcion_abierta_retorna_200(ctx):
+    torneo = _seed_torneo(ctx["repo"], "INSCRIPCION_ABIERTA")
+    response = ctx["client"].put(f"/torneos/{torneo.torneo_id}", json=_payload())
+    assert response.status_code == 200
+
+
+def test_put_torneo_en_ejecucion_retorna_409(ctx):
+    torneo = _seed_torneo(ctx["repo"], "EJECUCION")
+    response = ctx["client"].put(f"/torneos/{torneo.torneo_id}", json=_payload())
+    assert response.status_code == 409
+    assert "estado" in response.json()["detail"].lower()
+
+
+def test_put_torneo_no_encontrado_retorna_404(ctx):
+    response = ctx["client"].put(f"/torneos/{uuid4()}", json=_payload())
+    assert response.status_code == 404
+
+
+def test_put_torneo_no_afecta_disciplinas(ctx):
+    import asyncio
+    from shared.domain.value_objects.disciplina import Disciplina
+
+    torneo = _seed_torneo(ctx["repo"], "CREADO")
+    torneo.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF}))
+    asyncio.run(ctx["repo"].save(torneo))
+
+    ctx["client"].put(f"/torneos/{torneo.torneo_id}", json=_payload())
+
+    actualizado = asyncio.run(ctx["repo"].find_by_id(torneo.torneo_id))
+    assert actualizado is not None
+    disciplinas = {dt.disciplina for dt in actualizado.disciplinas_torneo}
+    assert Disciplina.STA in disciplinas
+    assert Disciplina.DNF in disciplinas

--- a/tests/unit/test_actualizar_torneo.py
+++ b/tests/unit/test_actualizar_torneo.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from torneo.domain.aggregates.torneo import Torneo
+from torneo.domain.exceptions import EdicionNoPermitida, TorneoNoEncontrado
+from torneo.domain.value_objects.entidad_organizadora import EntidadOrganizadora
+from torneo.domain.value_objects.grupo_etario import GrupoEtario
+from torneo.domain.value_objects.sede import Sede
+from torneo.application.commands.actualizar_torneo import (
+    ActualizarTorneoCommand,
+    ActualizarTorneoHandler,
+)
+
+
+def _torneo(estado_str: str = "CREADO") -> Torneo:
+    from torneo.domain.value_objects.estado_torneo import EstadoTorneo
+
+    torneo = Torneo(
+        torneo_id=uuid4(),
+        nombre="Torneo Original",
+        descripcion="Descripcion original",
+        fecha_inicio=date(2026, 6, 1),
+        fecha_fin=date(2026, 6, 3),
+        sede=Sede(nombre="Piscina", ciudad="Buenos Aires", pais="AR"),
+        entidad_organizadora=EntidadOrganizadora(nombre="AIDA", tipo="FEDERACION"),
+        grupos_etarios=frozenset({GrupoEtario.SENIOR}),
+    )
+    if estado_str != "CREADO":
+        torneo.estado = EstadoTorneo(estado_str)
+    return torneo
+
+
+def _cmd(torneo_id, nombre="Torneo Editado", ciudad="Cordoba") -> ActualizarTorneoCommand:
+    return ActualizarTorneoCommand(
+        torneo_id=torneo_id,
+        nombre=nombre,
+        descripcion="Descripcion editada",
+        fecha_inicio=date(2026, 7, 1),
+        fecha_fin=date(2026, 7, 3),
+        sede_nombre="Club",
+        sede_ciudad=ciudad,
+        sede_pais="AR",
+        grupos_etarios=frozenset({GrupoEtario.SENIOR, GrupoEtario.JUNIOR}),
+    )
+
+
+class TestTorneoActualizar:
+    def test_actualizar_en_creado_modifica_campos(self) -> None:
+        torneo = _torneo("CREADO")
+        torneo.actualizar(
+            nombre="Nuevo nombre",
+            descripcion="Nueva desc",
+            fecha_inicio=date(2026, 7, 1),
+            fecha_fin=date(2026, 7, 3),
+            sede=Sede(nombre="Club", ciudad="Rosario", pais="AR"),
+            grupos_etarios=frozenset({GrupoEtario.JUNIOR}),
+        )
+        assert torneo.nombre == "Nuevo nombre"
+        assert torneo.sede.ciudad == "Rosario"
+        assert GrupoEtario.JUNIOR in torneo.grupos_etarios
+
+    def test_actualizar_en_inscripcion_abierta_permitido(self) -> None:
+        torneo = _torneo("INSCRIPCION_ABIERTA")
+        torneo.actualizar(
+            nombre="Editado",
+            descripcion="desc",
+            fecha_inicio=date(2026, 7, 1),
+            fecha_fin=date(2026, 7, 3),
+            sede=Sede(nombre="Club", ciudad="Mendoza", pais="AR"),
+            grupos_etarios=frozenset({GrupoEtario.SENIOR}),
+        )
+        assert torneo.nombre == "Editado"
+
+    def test_actualizar_en_ejecucion_lanza_edicion_no_permitida(self) -> None:
+        torneo = _torneo("EJECUCION")
+        with pytest.raises(EdicionNoPermitida):
+            torneo.actualizar(
+                nombre="X",
+                descripcion="d",
+                fecha_inicio=date(2026, 7, 1),
+                fecha_fin=date(2026, 7, 3),
+                sede=Sede(nombre="C", ciudad="C", pais="AR"),
+                grupos_etarios=frozenset({GrupoEtario.SENIOR}),
+            )
+
+    def test_actualizar_no_toca_disciplinas(self) -> None:
+        from shared.domain.value_objects.disciplina import Disciplina
+
+        torneo = _torneo("CREADO")
+        torneo.asignar_disciplinas(frozenset({Disciplina.STA, Disciplina.DNF}))
+        disciplinas_antes = list(torneo.disciplinas_torneo)
+
+        torneo.actualizar(
+            nombre="Editado",
+            descripcion="d",
+            fecha_inicio=date(2026, 7, 1),
+            fecha_fin=date(2026, 7, 3),
+            sede=Sede(nombre="C", ciudad="C", pais="AR"),
+            grupos_etarios=frozenset({GrupoEtario.SENIOR}),
+        )
+        assert torneo.disciplinas_torneo == disciplinas_antes
+
+
+class TestActualizarTorneoHandler:
+    @pytest.mark.asyncio
+    async def test_handler_actualiza_y_persiste(self) -> None:
+        torneo = _torneo("CREADO")
+        repo = AsyncMock()
+        repo.find_by_id.return_value = torneo
+        handler = ActualizarTorneoHandler(repo)
+
+        await handler.handle(_cmd(torneo.torneo_id))
+
+        repo.save.assert_awaited_once_with(torneo)
+        assert torneo.nombre == "Torneo Editado"
+
+    @pytest.mark.asyncio
+    async def test_handler_lanza_si_no_encontrado(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_id.return_value = None
+        handler = ActualizarTorneoHandler(repo)
+
+        with pytest.raises(TorneoNoEncontrado):
+            await handler.handle(_cmd(uuid4()))
+
+    @pytest.mark.asyncio
+    async def test_handler_lanza_si_estado_invalido(self) -> None:
+        torneo = _torneo("EJECUCION")
+        repo = AsyncMock()
+        repo.find_by_id.return_value = torneo
+        handler = ActualizarTorneoHandler(repo)
+
+        with pytest.raises(EdicionNoPermitida):
+            await handler.handle(_cmd(torneo.torneo_id))


### PR DESCRIPTION
## Summary

- Agrega `PUT /torneos/{id}` para editar nombre, sede, fechas y categorías de torneos en estado `CREADO` o `INSCRIPCION_ABIERTA`
- Nuevo método `Torneo.actualizar()` en dominio con precondición de estado (`EdicionNoPermitida` → 409)
- Modo edición completo en `CrearTorneoPage` via ruta `/organizador/torneos/:id/editar`
- Botón "Editar torneo" en `DetalleTorneoPage` (visible solo si estado permite)

## Hallazgo resuelto

H-02-06 UAT SP6 F-02: el organizador no podía corregir metadatos del torneo sin cancelarlo y recrearlo.

## Test plan

- [x] 7 unit tests (`test_actualizar_torneo.py`) — dominio + handler
- [x] 6 integration tests (`test_actualizar_torneo_api.py`) — HTTP end-to-end
- [x] 4 BDD scenarios (`US-ADJ-10.1-edicion-torneo.feature`) — criterios de aceptación
- [x] 1187 tests en suite completa — 0 regresiones
- [x] Frontend build limpio (TypeScript sin errores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)