### PR TITLE
feat(identidad): BC Identidad multi-rol — US-ADJ-11.1

### DIFF
--- a/.claude/plans/US-ADJ-11.1-plan.md
+++ b/.claude/plans/US-ADJ-11.1-plan.md
@@ -1,0 +1,86 @@
+# Plan US-ADJ-11.1 — BC Identidad multi-rol
+
+**Branch:** `feature/US-ADJ-11.1-identidad-multi-rol`
+**Estimado total:** 90 min
+
+---
+
+## Tareas
+
+### T1 — Domain: Usuario.roles + excepciones nuevas (10 min)
+- `src/identidad/domain/aggregates/usuario.py`: `rol: Rol` → `roles: list[Rol]`
+- `src/identidad/domain/exceptions.py`: agregar `RolYaAsignado`, `RolNoEncontrado`
+
+### T2 — Port + Infra JWT: generate con rol_activo (10 min)
+- `src/identidad/domain/ports/token_service_port.py`: `generate(usuario, rol_activo: Rol) -> str`
+- `src/identidad/infrastructure/jwt_service.py`: `generate(usuario, rol_activo)` usa `rol_activo.value`
+
+### T3 — Infra Repo: migración DB + serialización JSON (15 min)
+- `src/identidad/infrastructure/repositories/sqlite_usuario_repository.py`:
+  - ADD COLUMN `roles TEXT NOT NULL DEFAULT '["ATLETA"]'`
+  - Migración: UPDATE existentes (`rol` → `roles` JSON)
+  - `save()`: serializa `json.dumps([r.value for r in usuario.roles])`
+  - `find_by_*()`: deserializa `[Rol(r) for r in json.loads(roles_str)]`
+  - `list_by_rol()`: filtro `WHERE roles LIKE '%"ROL"%'`
+  - `_row_to_usuario()`: 8 columnas (agrega `roles`)
+
+### T4 — Application: RegistrarUsuarioHandler (20 min)
+- `src/identidad/application/commands/registrar_usuario.py`:
+  - `RegistrarUsuarioCommand.roles: list[Rol]` (reemplaza `rol: Rol`)
+  - Nuevo `RegistroResult(usuario_id, token_response, roles_disponibles)`
+  - Handler inyecta `token_service: TokenServicePort`
+  - Lógica: si email existe → validar password → agregar roles (o lanzar `RolYaAsignado`)
+  - Respuesta: token si 1 rol, `roles_disponibles` si varios
+
+### T5 — Application: AutenticarUsuarioHandler (10 min)
+- `src/identidad/application/commands/autenticar_usuario.py`:
+  - `AutenticarUsuarioCommand.rol_elegido: Rol | None = None`
+  - Nuevo `RoleSelectionRequired(roles: list[Rol])`
+  - Lógica: 1 rol → token; N roles sin `rol_elegido` → `RoleSelectionRequired`; `rol_elegido` fuera de roles → `CredencialesInvalidas`
+
+### T6 — API Router: schemas + endpoints (15 min)
+- `src/identidad/api/router.py`:
+  - `RegistroRequest.roles: list[Rol]` (reemplaza `rol: Rol`)
+  - `LoginRequest.rol_elegido: Rol | None = None`
+  - `UsuarioResponse.roles: list[Rol]`
+  - `/registro`: inyecta `token_service`; discrimina `RegistroResult` (201 new / 200 add-roles)
+  - `/login`: discrimina `TokenResponse | RoleSelectionRequired`
+  - `listar_usuarios`: serializa `roles` como lista
+
+### T7 — Actualizar tests existentes (10 min)
+- Cambio sistemático `rol=Rol.X` → `roles=[Rol.X]` en constructores `Usuario()`
+- Cambio `RegistrarUsuarioCommand(rol=)` → `roles=[]`
+- `generate(usuario)` → `generate(usuario, rol_activo)` en tests
+- `_make_usuario()` helper actualizado
+- US-3.2.1 BDD steps: `"rol": x` → `"roles": [x]`
+
+---
+
+## Archivos afectados
+
+| Archivo | Tipo de cambio |
+|---------|---------------|
+| `src/identidad/domain/aggregates/usuario.py` | Refactor |
+| `src/identidad/domain/exceptions.py` | Agregar |
+| `src/identidad/domain/ports/token_service_port.py` | Refactor |
+| `src/identidad/infrastructure/jwt_service.py` | Refactor |
+| `src/identidad/infrastructure/repositories/sqlite_usuario_repository.py` | Refactor + migración |
+| `src/identidad/application/commands/registrar_usuario.py` | Refactor |
+| `src/identidad/application/commands/autenticar_usuario.py` | Refactor |
+| `src/identidad/api/router.py` | Refactor |
+| `tests/unit/identidad/domain/test_usuario.py` | Actualizar |
+| `tests/unit/identidad/application/test_handlers.py` | Actualizar + nuevos tests |
+| `tests/unit/identidad/api/test_*.py` (4 archivos) | Actualizar |
+| `tests/integration/identidad/test_sqlite_usuario_repository.py` | Actualizar |
+| `tests/integration/identidad/test_registro_email_handler.py` | Actualizar |
+| `tests/features/steps/identidad_jwt_steps.py` | Actualizar |
+| `tests/features/US-3.2.1-bc-identidad-jwt.feature` | Actualizar |
+| `tests/features/steps/adj_11_1_multi_rol_steps.py` | Nuevo |
+
+---
+
+## Riesgos
+
+- **R4 (confirmado):** Tests existentes de handlers usan `rol=Rol.X` — todos rompen con T1. Resolver en T7.
+- **R1:** Migración DB — `_ensure_column` + UPDATE solo si columna `rol` existe.
+- Columna `rol` se mantiene como legacy (no se elimina) para migración incremental.

--- a/.claude/tracking/US-ADJ-11.1-tracking.json
+++ b/.claude/tracking/US-ADJ-11.1-tracking.json
@@ -1,0 +1,20 @@
+{
+  "us_id": "US-ADJ-11.1",
+  "description": "BC Identidad: aggregate Usuario multi-rol + JWT + login/registro",
+  "branch": "feature/US-ADJ-11.1-identidad-multi-rol",
+  "started_at": "2026-05-16T12:30:00Z",
+  "status": "in_progress",
+  "current_phase": 0,
+  "phases": {
+    "0": {"name": "Validación de Contexto", "started_at": "2026-05-16T12:30:00Z", "status": "in_progress"},
+    "1": {"name": "BDD", "status": "pending"},
+    "2": {"name": "Planning", "status": "pending"},
+    "3": {"name": "Implementation", "status": "pending"},
+    "4": {"name": "Unit Tests", "status": "pending"},
+    "5": {"name": "Integration Tests", "status": "pending"},
+    "6": {"name": "BDD Validation", "status": "pending"},
+    "7": {"name": "Quality Gates", "status": "pending"},
+    "8": {"name": "Documentation", "status": "pending"},
+    "9": {"name": "Final Report", "status": "pending"}
+  }
+}

--- a/src/identidad/api/router.py
+++ b/src/identidad/api/router.py
@@ -20,6 +20,7 @@ from identidad.api.dependencies import (
 from identidad.application.commands.autenticar_usuario import (
     AutenticarUsuarioCommand,
     AutenticarUsuarioHandler,
+    RoleSelectionRequired,
     TokenResponse,
 )
 from identidad.application.commands.cambiar_password import (
@@ -41,10 +42,10 @@ from identidad.application.commands.solicitar_reset_password import (
 from identidad.domain.exceptions import (
     CampoRequerido,
     CredencialesInvalidas,
-    EmailYaRegistrado,
     PasswordActualIncorrecto,
     PasswordDemasiadoCorto,
     RolNoPermitido,
+    RolYaAsignado,
     TokenResetInvalido,
     UsuarioInactivo,
     UsuarioNoEncontrado,
@@ -66,7 +67,7 @@ class RegistroRequest(BaseModel):
     apellido: str
     email: str
     password: str
-    rol: Rol
+    roles: list[Rol]
 
     @field_validator("nombre", "apellido")
     @classmethod
@@ -83,19 +84,18 @@ class RegistroRequest(BaseModel):
             raise ValueError("La contraseña debe tener al menos 8 caracteres")
         return v
 
-
-class RegistroResponse(BaseModel):
-    usuario_id: UUID
+    @field_validator("roles")
+    @classmethod
+    def roles_not_empty(cls, v: list[Rol]) -> list[Rol]:
+        if not v:
+            raise ValueError("Se debe especificar al menos un rol")
+        return v
 
 
 class LoginRequest(BaseModel):
     email: str
     password: str
-
-
-class LoginResponse(BaseModel):
-    access_token: str
-    token_type: str
+    rol_elegido: Rol | None = None
 
 
 class CambiarPasswordRequest(BaseModel):
@@ -126,15 +126,6 @@ class ResetPasswordRequest(BaseModel):
         return v
 
 
-class UsuarioResponse(BaseModel):
-    usuario_id: UUID
-    nombre: str
-    apellido: str
-    email: str
-    rol: Rol
-    activo: bool
-
-
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 
@@ -143,27 +134,51 @@ async def registrar_usuario(
     body: RegistroRequest,
     repo: Annotated[UsuarioRepositoryPort, Depends(get_usuario_repository)],
     password_hasher: Annotated[PasswordHashingPort, Depends(get_password_hasher)],
+    token_service: Annotated[TokenServicePort, Depends(get_token_service)],
     email_sender: Annotated[EmailPort, Depends(get_email_sender)],
 ) -> JSONResponse:
-    handler = RegistrarUsuarioHandler(repo, password_hasher, email_sender)
+    handler = RegistrarUsuarioHandler(repo, password_hasher, token_service, email_sender)
     cmd = RegistrarUsuarioCommand(
         nombre=body.nombre,
         apellido=body.apellido,
         email=body.email,
         password=body.password,
-        rol=body.rol,
+        roles=body.roles,
     )
     try:
-        usuario_id = await handler.handle(cmd)
+        resultado = await handler.handle(cmd)
     except CampoRequerido as exc:
         return JSONResponse(status_code=422, content={"detail": str(exc)})
     except PasswordDemasiadoCorto as exc:
         return JSONResponse(status_code=422, content={"detail": str(exc)})
-    except EmailYaRegistrado as exc:
+    except CredencialesInvalidas:
+        return JSONResponse(status_code=401, content={"detail": "Credenciales inválidas"})
+    except RolYaAsignado as exc:
         return JSONResponse(status_code=409, content={"detail": str(exc)})
     except RolNoPermitido as exc:
         return JSONResponse(status_code=403, content={"detail": str(exc)})
-    return JSONResponse(status_code=201, content={"usuario_id": str(usuario_id)})
+
+    status = 201 if resultado.es_usuario_nuevo else 200
+
+    if resultado.requires_role_selection:
+        return JSONResponse(
+            status_code=status,
+            content={
+                "usuario_id": str(resultado.usuario_id),
+                "requires_role_selection": True,
+                "roles": [r.value for r in resultado.roles_disponibles],
+            },
+        )
+
+    assert resultado.token_response is not None
+    return JSONResponse(
+        status_code=status,
+        content={
+            "usuario_id": str(resultado.usuario_id),
+            "access_token": resultado.token_response.access_token,
+            "token_type": resultado.token_response.token_type,
+        },
+    )
 
 
 @router.post("/login", status_code=200)
@@ -174,16 +189,30 @@ async def autenticar_usuario(
     password_hasher: Annotated[PasswordHashingPort, Depends(get_password_hasher)],
 ) -> JSONResponse:
     handler = AutenticarUsuarioHandler(repo, token_service, password_hasher)
-    cmd = AutenticarUsuarioCommand(email=body.email, password=body.password)
+    cmd = AutenticarUsuarioCommand(
+        email=body.email,
+        password=body.password,
+        rol_elegido=body.rol_elegido,
+    )
     try:
-        token_response: TokenResponse = await handler.handle(cmd)
+        result = await handler.handle(cmd)
     except (CredencialesInvalidas, UsuarioInactivo):
         return JSONResponse(status_code=401, content={"detail": "Credenciales inválidas"})
+
+    if isinstance(result, RoleSelectionRequired):
+        return JSONResponse(
+            status_code=200,
+            content={
+                "requires_role_selection": True,
+                "roles": [r.value for r in result.roles],
+            },
+        )
+
     return JSONResponse(
         status_code=200,
         content={
-            "access_token": token_response.access_token,
-            "token_type": token_response.token_type,
+            "access_token": result.access_token,
+            "token_type": result.token_type,
         },
     )
 
@@ -268,7 +297,7 @@ async def listar_usuarios(
                 "nombre": usuario.nombre,
                 "apellido": usuario.apellido,
                 "email": usuario.email,
-                "rol": usuario.rol.value,
+                "roles": [r.value for r in usuario.roles],
                 "activo": usuario.activo,
             }
             for usuario in usuarios

--- a/src/identidad/application/commands/autenticar_usuario.py
+++ b/src/identidad/application/commands/autenticar_usuario.py
@@ -6,18 +6,25 @@ from identidad.domain.exceptions import CredencialesInvalidas, UsuarioInactivo
 from identidad.domain.ports.password_hashing_port import PasswordHashingPort
 from identidad.domain.ports.token_service_port import TokenServicePort
 from identidad.domain.ports.usuario_repository_port import UsuarioRepositoryPort
+from identidad.domain.value_objects.rol import Rol
 
 
 @dataclass(frozen=True)
 class AutenticarUsuarioCommand:
     email: str
     password: str
+    rol_elegido: Rol | None = None
 
 
 @dataclass(frozen=True)
 class TokenResponse:
     access_token: str
     token_type: str = "bearer"
+
+
+@dataclass(frozen=True)
+class RoleSelectionRequired:
+    roles: list[Rol]
 
 
 class AutenticarUsuarioHandler:
@@ -31,7 +38,7 @@ class AutenticarUsuarioHandler:
         self._token_service = token_service
         self._password_hasher = password_hasher
 
-    async def handle(self, cmd: AutenticarUsuarioCommand) -> TokenResponse:
+    async def handle(self, cmd: AutenticarUsuarioCommand) -> TokenResponse | RoleSelectionRequired:
         usuario = await self._repo.find_by_email(cmd.email)
         if usuario is None:
             raise CredencialesInvalidas()
@@ -42,5 +49,14 @@ class AutenticarUsuarioHandler:
         if not self._password_hasher.verify(cmd.password, usuario.password_hash):
             raise CredencialesInvalidas()
 
-        token = self._token_service.generate(usuario)
-        return TokenResponse(access_token=token)
+        if cmd.rol_elegido is not None:
+            if cmd.rol_elegido not in usuario.roles:
+                raise CredencialesInvalidas()
+            token = self._token_service.generate(usuario, cmd.rol_elegido)
+            return TokenResponse(access_token=token)
+
+        if len(usuario.roles) == 1:
+            token = self._token_service.generate(usuario, usuario.roles[0])
+            return TokenResponse(access_token=token)
+
+        return RoleSelectionRequired(roles=list(usuario.roles))

--- a/src/identidad/application/commands/registrar_usuario.py
+++ b/src/identidad/application/commands/registrar_usuario.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 import logging
 import re
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
 
+from identidad.application.commands.autenticar_usuario import TokenResponse
 from identidad.domain.aggregates.usuario import Usuario
-from identidad.domain.exceptions import EmailYaRegistrado, PasswordDemasiadoCorto, RolNoPermitido
+from identidad.domain.exceptions import (
+    CredencialesInvalidas,
+    PasswordDemasiadoCorto,
+    RolNoPermitido,
+    RolYaAsignado,
+)
 from identidad.domain.ports.password_hashing_port import PasswordHashingPort
+from identidad.domain.ports.token_service_port import TokenServicePort
 from identidad.domain.ports.usuario_repository_port import UsuarioRepositoryPort
 from identidad.domain.value_objects.rol import Rol
 from notificaciones.domain.ports.email_port import EmailPort
@@ -25,7 +32,19 @@ class RegistrarUsuarioCommand:
     apellido: str
     email: str
     password: str  # plain — el handler hashea con bcrypt
-    rol: Rol
+    roles: list[Rol]
+
+
+@dataclass(frozen=True)
+class RegistroResult:
+    usuario_id: UUID
+    es_usuario_nuevo: bool = True
+    token_response: TokenResponse | None = None
+    roles_disponibles: list[Rol] = field(default_factory=list)
+
+    @property
+    def requires_role_selection(self) -> bool:
+        return self.token_response is None
 
 
 class RegistrarUsuarioHandler:
@@ -33,14 +52,15 @@ class RegistrarUsuarioHandler:
         self,
         repo: UsuarioRepositoryPort,
         password_hasher: PasswordHashingPort,
+        token_service: TokenServicePort,
         email_sender: EmailPort | None = None,
     ) -> None:
         self._repo = repo
         self._password_hasher = password_hasher
+        self._token_service = token_service
         self._email_sender = email_sender
 
-    async def handle(self, cmd: RegistrarUsuarioCommand) -> UUID:
-        # INV-ID-02: mínimo 10 caracteres, al menos 1 mayúscula y 1 número
+    async def handle(self, cmd: RegistrarUsuarioCommand) -> RegistroResult:
         if (
             len(cmd.password) < _MIN_PASSWORD_LENGTH
             or not re.search(r"[A-Z]", cmd.password)
@@ -48,24 +68,29 @@ class RegistrarUsuarioHandler:
         ):
             raise PasswordDemasiadoCorto()
 
-        if cmd.rol == Rol.ADMIN:
+        if Rol.ADMIN in cmd.roles:
             raise RolNoPermitido()
 
-        # INV-ID-01: email único
         existente = await self._repo.find_by_email(cmd.email)
         if existente is not None:
-            raise EmailYaRegistrado(cmd.email)
+            # Email ya registrado: validar password y agregar roles nuevos
+            if not self._password_hasher.verify(cmd.password, existente.password_hash):
+                raise CredencialesInvalidas()
+            for rol in cmd.roles:
+                if rol in existente.roles:
+                    raise RolYaAsignado(rol.value)
+                existente.roles.append(rol)
+            await self._repo.save(existente)
+            return self._build_result(existente, es_usuario_nuevo=False)
 
-        # INV-ID-03: hash bcrypt — nunca plain text
         password_hash = self._password_hasher.hash(cmd.password)
-
         usuario = Usuario(
             usuario_id=uuid.uuid4(),
             nombre=cmd.nombre,
             apellido=cmd.apellido,
             email=cmd.email,
             password_hash=password_hash,
-            rol=cmd.rol,
+            roles=list(cmd.roles),
         )
         await self._repo.save(usuario)
 
@@ -88,4 +113,18 @@ class RegistrarUsuarioHandler:
             except Exception:
                 _log.warning("No se pudo enviar email de bienvenida a %s", usuario.email)
 
-        return usuario.usuario_id
+        return self._build_result(usuario, es_usuario_nuevo=True)
+
+    def _build_result(self, usuario: Usuario, *, es_usuario_nuevo: bool) -> RegistroResult:
+        if len(usuario.roles) == 1:
+            token = self._token_service.generate(usuario, usuario.roles[0])
+            return RegistroResult(
+                usuario_id=usuario.usuario_id,
+                es_usuario_nuevo=es_usuario_nuevo,
+                token_response=TokenResponse(access_token=token),
+            )
+        return RegistroResult(
+            usuario_id=usuario.usuario_id,
+            es_usuario_nuevo=es_usuario_nuevo,
+            roles_disponibles=list(usuario.roles),
+        )

--- a/src/identidad/domain/aggregates/usuario.py
+++ b/src/identidad/domain/aggregates/usuario.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from uuid import UUID
 
-from identidad.domain.exceptions import CampoRequerido
+from identidad.domain.exceptions import CampoRequerido, RolesVacios, RolDuplicado
 from identidad.domain.value_objects.rol import Rol
 
 
@@ -14,12 +14,16 @@ class Usuario:
     apellido: str
     email: str
     password_hash: str  # bcrypt — nunca plain text
-    rol: Rol
+    roles: list[Rol]
     activo: bool = field(default=True)
 
     def __post_init__(self) -> None:
         self.nombre = self._validar_requerido(self.nombre, "nombre")
         self.apellido = self._validar_requerido(self.apellido, "apellido")
+        if not self.roles:
+            raise RolesVacios()
+        if len(self.roles) != len(set(self.roles)):
+            raise RolDuplicado()
 
     @staticmethod
     def _validar_requerido(valor: str, campo: str) -> str:

--- a/src/identidad/domain/exceptions.py
+++ b/src/identidad/domain/exceptions.py
@@ -51,3 +51,23 @@ class TokenInvalido(Exception):
 class TokenResetInvalido(Exception):
     def __init__(self) -> None:
         super().__init__("Token de recuperación inválido o expirado")
+
+
+class RolYaAsignado(Exception):
+    def __init__(self, rol: str) -> None:
+        super().__init__(f"El usuario ya posee el rol {rol}")
+
+
+class RolNoEncontrado(Exception):
+    def __init__(self, rol: str) -> None:
+        super().__init__(f"El usuario no posee el rol {rol}")
+
+
+class RolesVacios(Exception):
+    def __init__(self) -> None:
+        super().__init__("El usuario debe tener al menos un rol")
+
+
+class RolDuplicado(Exception):
+    def __init__(self) -> None:
+        super().__init__("El usuario no puede tener el mismo rol más de una vez")

--- a/src/identidad/domain/ports/token_service_port.py
+++ b/src/identidad/domain/ports/token_service_port.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from identidad.domain.aggregates.usuario import Usuario
+
+if TYPE_CHECKING:
+    from identidad.domain.value_objects.rol import Rol
 
 
 class TokenServicePort(ABC):
     """Puerto de generacion y verificacion de tokens de autenticacion."""
 
     @abstractmethod
-    def generate(self, usuario: Usuario) -> str:
-        """Genera un token para el usuario autenticado."""
+    def generate(self, usuario: Usuario, rol_activo: "Rol") -> str:
+        """Genera un token para el usuario autenticado con el rol activo indicado."""
 
     @abstractmethod
     def generate_reset_token(self, email: str) -> str:

--- a/src/identidad/infrastructure/jwt_service.py
+++ b/src/identidad/infrastructure/jwt_service.py
@@ -8,6 +8,7 @@ import jwt
 from identidad.domain.aggregates.usuario import Usuario
 from identidad.domain.exceptions import TokenInvalido
 from identidad.domain.ports.token_service_port import TokenServicePort
+from identidad.domain.value_objects.rol import Rol
 
 _DEFAULT_EXPIRY_HOURS = 24
 _RESET_TOKEN_EXPIRY_HOURS = 1
@@ -25,13 +26,13 @@ class JWTService(TokenServicePort):
         self._expiry_hours = expiry_hours
         self._algorithm = "HS256"
 
-    def generate(self, usuario: Usuario) -> str:
+    def generate(self, usuario: Usuario, rol_activo: Rol) -> str:
         payload = {
             "sub": str(usuario.usuario_id),
             "email": usuario.email,
             "nombre": usuario.nombre,
             "apellido": usuario.apellido,
-            "rol": usuario.rol.value,
+            "rol": rol_activo.value,
             "exp": datetime.now(tz=timezone.utc) + timedelta(hours=self._expiry_hours),
         }
         return jwt.encode(payload, self._secret, algorithm=self._algorithm)

--- a/src/identidad/infrastructure/repositories/sqlite_usuario_repository.py
+++ b/src/identidad/infrastructure/repositories/sqlite_usuario_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from uuid import UUID
 
@@ -16,8 +17,9 @@ CREATE TABLE IF NOT EXISTS usuarios (
     apellido      TEXT NOT NULL DEFAULT '',
     email         TEXT UNIQUE NOT NULL,
     password_hash TEXT NOT NULL,
-    rol           TEXT NOT NULL,
-    activo        INTEGER NOT NULL DEFAULT 1
+    rol           TEXT NOT NULL DEFAULT 'ATLETA',
+    activo        INTEGER NOT NULL DEFAULT 1,
+    roles         TEXT NOT NULL DEFAULT '["ATLETA"]'
 )
 """
 
@@ -30,6 +32,8 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
         await conn.execute(_CREATE_TABLE)
         await _ensure_column(conn, "nombre", "TEXT NOT NULL DEFAULT ''")
         await _ensure_column(conn, "apellido", "TEXT NOT NULL DEFAULT ''")
+        await _ensure_column(conn, "roles", "TEXT NOT NULL DEFAULT '[\"ATLETA\"]'")
+        await _migrate_rol_to_roles(conn)
         await conn.commit()
 
     async def save(self, usuario: Usuario) -> None:
@@ -38,8 +42,8 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await conn.execute(
                 """
                 INSERT OR REPLACE INTO usuarios
-                    (usuario_id, nombre, apellido, email, password_hash, rol, activo)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (usuario_id, nombre, apellido, email, password_hash, rol, activo, roles)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     str(usuario.usuario_id),
@@ -47,8 +51,9 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
                     usuario.apellido,
                     usuario.email,
                     usuario.password_hash,
-                    usuario.rol.value,
+                    usuario.roles[0].value,
                     1 if usuario.activo else 0,
+                    _serialize_roles(usuario.roles),
                 ),
             )
             await conn.commit()
@@ -58,7 +63,7 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await self._ensure_table(conn)
             async with conn.execute(
                 """
-                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, activo, roles
                 FROM usuarios
                 WHERE usuario_id = ?
                 """,
@@ -72,7 +77,7 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await self._ensure_table(conn)
             async with conn.execute(
                 """
-                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, activo, roles
                 FROM usuarios
                 WHERE email = ?
                 """,
@@ -86,12 +91,12 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
             await self._ensure_table(conn)
             async with conn.execute(
                 """
-                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, activo, roles
                 FROM usuarios
-                WHERE rol = ?
+                WHERE roles LIKE ?
                 ORDER BY email
                 """,
-                (rol.value,),
+                (f'%"{rol.value}"%',),
             ) as cursor:
                 rows = await cursor.fetchall()
         return [_row_to_usuario(row) for row in rows]
@@ -100,23 +105,31 @@ class SQLiteUsuarioRepository(UsuarioRepositoryPort):
         async with aiosqlite.connect(self._db_path) as conn:
             await self._ensure_table(conn)
             async with conn.execute("""
-                SELECT usuario_id, nombre, apellido, email, password_hash, rol, activo
+                SELECT usuario_id, nombre, apellido, email, password_hash, activo, roles
                 FROM usuarios
-                ORDER BY rol, email
+                ORDER BY email
                 """) as cursor:
                 rows = await cursor.fetchall()
         return [_row_to_usuario(row) for row in rows]
 
 
+def _serialize_roles(roles: list[Rol]) -> str:
+    return json.dumps([r.value for r in roles])
+
+
+def _deserialize_roles(roles_str: str) -> list[Rol]:
+    return [Rol(r) for r in json.loads(roles_str)]
+
+
 def _row_to_usuario(row: tuple) -> Usuario:  # type: ignore[type-arg]
-    usuario_id, nombre, apellido, email, password_hash, rol, activo = row
+    usuario_id, nombre, apellido, email, password_hash, activo, roles_str = row
     return Usuario(
         usuario_id=UUID(usuario_id),
         nombre=nombre,
         apellido=apellido,
         email=email,
         password_hash=password_hash,
-        rol=Rol(rol),
+        roles=_deserialize_roles(roles_str),
         activo=bool(activo),
     )
 
@@ -127,3 +140,22 @@ async def _ensure_column(conn: aiosqlite.Connection, column: str, definition: st
     if any(row[1] == column for row in rows):
         return
     await conn.execute(f"ALTER TABLE usuarios ADD COLUMN {column} {definition}")
+
+
+async def _migrate_rol_to_roles(conn: aiosqlite.Connection) -> None:
+    """Convierte columna legacy 'rol' a 'roles' JSON para filas sin migrar."""
+    async with conn.execute("PRAGMA table_info(usuarios)") as cursor:
+        cols = {row[1] for row in await cursor.fetchall()}
+    if "rol" not in cols or "roles" not in cols:
+        return
+    # Solo actualiza filas donde roles está en el valor default vacío o mal formado
+    await conn.execute("""
+        UPDATE usuarios
+        SET roles = json_array(rol)
+        WHERE roles = '["ATLETA"]' AND rol != 'ATLETA'
+        """)
+    await conn.execute("""
+        UPDATE usuarios
+        SET roles = json_array(rol)
+        WHERE json_valid(roles) = 0
+        """)

--- a/tests/features/US-3.2.1-bc-identidad-jwt.feature
+++ b/tests/features/US-3.2.1-bc-identidad-jwt.feature
@@ -12,9 +12,9 @@ Feature: US-3.2.1 — BC Identidad JWT
     Then la respuesta es 201
     And la respuesta contiene un campo "usuario_id"
 
-  Scenario: registrar usuario con email duplicado retorna 409
+  Scenario: registrar usuario con email y rol ya existente retorna 409
     Given un usuario registrado con email "existente@test.com"
-    When POST /auth/registro con email "existente@test.com", password "Otralave1A", rol "ATLETA"
+    When POST /auth/registro con email "existente@test.com", password "Password1A", rol "ATLETA"
     Then la respuesta es 409
 
   Scenario: registrar usuario con password menor a 8 caracteres retorna 422

--- a/tests/features/US-ADJ-11.1-identidad-multi-rol.feature
+++ b/tests/features/US-ADJ-11.1-identidad-multi-rol.feature
@@ -1,0 +1,62 @@
+Feature: US-ADJ-11.1 — BC Identidad multi-rol: registro y login
+  Como persona que participa en el mundo del apnea en múltiples roles
+  Quiero poder registrarme con más de un rol en una única cuenta
+  Para no necesitar dos emails distintos cuando soy juez y también compito
+
+  Background:
+    Given el sistema de identidad está inicializado
+
+  Scenario: Registro con un único rol devuelve token directo
+    Given no existe ningún usuario con email "maria@test.com"
+    When se registra con email "maria@test.com" password "Apnea2024!" y roles "ATLETA"
+    Then la respuesta es 201
+    And la respuesta contiene campo "access_token"
+    And el token del registro contiene rol "ATLETA"
+
+  Scenario: Registro con múltiples roles devuelve requires_role_selection
+    Given no existe ningún usuario con email "carlos@test.com"
+    When se registra con email "carlos@test.com" password "Apnea2024!" y roles "JUEZ,ATLETA"
+    Then la respuesta es 201
+    And la respuesta contiene campo "requires_role_selection"
+    And la respuesta no contiene campo "access_token"
+
+  Scenario: Login con usuario de un único rol devuelve token
+    Given existe un usuario con email "ana@test.com" password "Apnea2024!" y roles "ORGANIZADOR"
+    When hace login con email "ana@test.com" password "Apnea2024!" sin rol_elegido
+    Then la respuesta es 200
+    And la respuesta contiene campo "access_token"
+    And el token del login contiene rol "ORGANIZADOR"
+
+  Scenario: Login con múltiples roles sin rol_elegido devuelve requires_role_selection
+    Given existe un usuario con email "pedro@test.com" password "Apnea2024!" y roles "JUEZ,ATLETA"
+    When hace login con email "pedro@test.com" password "Apnea2024!" sin rol_elegido
+    Then la respuesta es 200
+    And la respuesta contiene campo "requires_role_selection"
+    And la respuesta no contiene campo "access_token"
+
+  Scenario: Login con múltiples roles especificando rol_elegido devuelve token
+    Given existe un usuario con email "pedro@test.com" password "Apnea2024!" y roles "JUEZ,ATLETA"
+    When hace login con email "pedro@test.com" password "Apnea2024!" y rol_elegido "ATLETA"
+    Then la respuesta es 200
+    And el token del login contiene rol "ATLETA"
+
+  Scenario: Login con rol_elegido que el usuario no posee retorna 401
+    Given existe un usuario con email "solo@test.com" password "Apnea2024!" y roles "ATLETA"
+    When hace login con email "solo@test.com" password "Apnea2024!" y rol_elegido "JUEZ"
+    Then la respuesta es 401
+
+  Scenario: Registro con email existente agrega roles nuevos y requiere selección
+    Given existe un usuario con email "lucia@test.com" password "Apnea2024!" y roles "ATLETA"
+    When se registra con email "lucia@test.com" password "Apnea2024!" y roles "JUEZ"
+    Then la respuesta es 200
+    And la respuesta contiene campo "requires_role_selection"
+
+  Scenario: Registro con email existente y contraseña incorrecta retorna 401
+    Given existe un usuario con email "lucia@test.com" password "Apnea2024!" y roles "ATLETA"
+    When se registra con email "lucia@test.com" password "WrongPass1!" y roles "JUEZ"
+    Then la respuesta es 401
+
+  Scenario: Registro con email existente y rol ya asignado retorna 409
+    Given existe un usuario con email "lucia@test.com" password "Apnea2024!" y roles "ATLETA"
+    When se registra con email "lucia@test.com" password "Apnea2024!" y roles "ATLETA"
+    Then la respuesta es 409

--- a/tests/features/steps/adj_11_1_multi_rol_steps.py
+++ b/tests/features/steps/adj_11_1_multi_rol_steps.py
@@ -1,0 +1,159 @@
+"""Step definitions BDD — US-ADJ-11.1: BC Identidad multi-rol."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from pytest_bdd import given, parsers, scenarios, then, when
+
+scenarios("../US-ADJ-11.1-identidad-multi-rol.feature")
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def context(tmp_path: Any, monkeypatch: Any) -> dict[str, Any]:
+    db_path = str(tmp_path / "identidad_adj11_test.db")
+    monkeypatch.setenv("IDENTIDAD_DB_PATH", db_path)
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-adj11-32-chars-min!!")
+    return {}
+
+
+@pytest.fixture
+def client(context: dict[str, Any]) -> TestClient:
+    import importlib
+    import app as app_module
+
+    importlib.reload(app_module)
+    from app import app as fastapi_app
+
+    return TestClient(fastapi_app)
+
+
+# ── Background ────────────────────────────────────────────────────────────────
+
+
+@given("el sistema de identidad está inicializado")
+def sistema_inicializado_adj11(context: dict[str, Any]) -> None:
+    pass  # fixtures garantizan DB nueva + JWT secret
+
+
+# ── Given ─────────────────────────────────────────────────────────────────────
+
+
+@given(parsers.parse('no existe ningún usuario con email "{email}"'))
+def no_existe_usuario(context: dict[str, Any], email: str) -> None:
+    context["email"] = email
+
+
+@given(
+    parsers.parse(
+        'existe un usuario con email "{email}" password "{password}" y roles "{roles_str}"'
+    )
+)
+def existe_usuario_con_roles(
+    client: TestClient, context: dict[str, Any], email: str, password: str, roles_str: str
+) -> None:
+    roles = [r.strip() for r in roles_str.split(",")]
+    resp = client.post(
+        "/auth/registro",
+        json={
+            "email": email,
+            "nombre": "Test",
+            "apellido": "User",
+            "password": password,
+            "roles": roles,
+        },
+    )
+    assert resp.status_code in (200, 201), f"Setup falló: {resp.status_code} {resp.text}"
+    context["email"] = email
+    context["password"] = password
+    context["roles_str"] = roles_str
+
+
+# ── When ──────────────────────────────────────────────────────────────────────
+
+
+@when(parsers.parse('se registra con email "{email}" password "{password}" y roles "{roles_str}"'))
+def registrar_con_roles(
+    client: TestClient, context: dict[str, Any], email: str, password: str, roles_str: str
+) -> None:
+    roles = [r.strip() for r in roles_str.split(",")]
+    context["response"] = client.post(
+        "/auth/registro",
+        json={
+            "email": email,
+            "nombre": "Test",
+            "apellido": "User",
+            "password": password,
+            "roles": roles,
+        },
+    )
+
+
+@when(parsers.parse('hace login con email "{email}" password "{password}" sin rol_elegido'))
+def login_sin_rol_elegido(
+    client: TestClient, context: dict[str, Any], email: str, password: str
+) -> None:
+    context["response"] = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+    )
+
+
+@when(parsers.parse('hace login con email "{email}" password "{password}" y rol_elegido "{rol}"'))
+def login_con_rol_elegido(
+    client: TestClient, context: dict[str, Any], email: str, password: str, rol: str
+) -> None:
+    context["response"] = client.post(
+        "/auth/login",
+        json={"email": email, "password": password, "rol_elegido": rol},
+    )
+
+
+# ── Then ──────────────────────────────────────────────────────────────────────
+
+
+@then(parsers.parse("la respuesta es {status_code:d}"))
+def respuesta_status(context: dict[str, Any], status_code: int) -> None:
+    assert (
+        context["response"].status_code == status_code
+    ), f"Esperaba {status_code}, got {context['response'].status_code}: {context['response'].text}"
+
+
+@then(parsers.parse('la respuesta contiene campo "{campo}"'))
+def respuesta_contiene_campo(context: dict[str, Any], campo: str) -> None:
+    body = context["response"].json()
+    assert campo in body, f"Campo '{campo}' no encontrado en: {body}"
+    context[campo] = body[campo]
+
+
+@then(parsers.parse('la respuesta no contiene campo "{campo}"'))
+def respuesta_no_contiene_campo(context: dict[str, Any], campo: str) -> None:
+    body = context["response"].json()
+    assert campo not in body, f"Campo '{campo}' encontrado (no esperado) en: {body}"
+
+
+@then(parsers.parse('el token del registro contiene rol "{rol}"'))
+def token_registro_contiene_rol(context: dict[str, Any], rol: str) -> None:
+    from identidad.infrastructure.jwt_service import JWTService
+
+    svc = JWTService()
+    token = context["response"].json().get("access_token")
+    assert token, "No hay access_token en la respuesta de registro"
+    payload = svc.verify(token)
+    assert payload["rol"] == rol, f"Esperaba rol '{rol}', got '{payload['rol']}'"
+
+
+@then(parsers.parse('el token del login contiene rol "{rol}"'))
+def token_login_contiene_rol(context: dict[str, Any], rol: str) -> None:
+    from identidad.infrastructure.jwt_service import JWTService
+
+    svc = JWTService()
+    token = context["response"].json().get("access_token")
+    assert token, "No hay access_token en la respuesta de login"
+    payload = svc.verify(token)
+    assert payload["rol"] == rol, f"Esperaba rol '{rol}', got '{payload['rol']}'"

--- a/tests/features/steps/identidad_jwt_steps.py
+++ b/tests/features/steps/identidad_jwt_steps.py
@@ -60,7 +60,7 @@ def usuario_ya_registrado(client: TestClient, context: dict[str, Any], email: st
             "nombre": "Test",
             "apellido": "User",
             "password": "Password1A",
-            "rol": "ATLETA",
+            "roles": ["ATLETA"],
         },
     )
     context["email"] = email
@@ -79,7 +79,7 @@ def usuario_registrado_con_rol(
             "nombre": "Test",
             "apellido": "User",
             "password": password,
-            "rol": rol,
+            "roles": [rol],
         },
     )
     assert resp.status_code == 201
@@ -112,7 +112,7 @@ def post_registro(
             "nombre": "Test",
             "apellido": "User",
             "password": password,
-            "rol": rol,
+            "roles": [rol],
         },
     )
 

--- a/tests/integration/identidad/test_registro_email_handler.py
+++ b/tests/integration/identidad/test_registro_email_handler.py
@@ -13,6 +13,7 @@ from identidad.application.commands.registrar_usuario import (
 )
 from identidad.domain.value_objects.rol import Rol
 from identidad.infrastructure.bcrypt_password_hasher import BcryptPasswordHasher
+from identidad.infrastructure.jwt_service import JWTService
 from identidad.infrastructure.repositories.sqlite_usuario_repository import SQLiteUsuarioRepository
 
 
@@ -35,77 +36,89 @@ def db_path(tmp_path) -> str:  # type: ignore[no-untyped-def]
     return str(tmp_path / "identidad_int.db")
 
 
+@pytest.fixture
+def token_service(monkeypatch) -> JWTService:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-integration-32-chars!!")
+    return JWTService()
+
+
 @pytest.mark.asyncio
-async def test_registro_envia_email_de_bienvenida(db_path: str) -> None:
+async def test_registro_envia_email_de_bienvenida(db_path: str, token_service: JWTService) -> None:
     repo = SQLiteUsuarioRepository(db_path=db_path)
     spy = SpyEmailSender()
-    handler = RegistrarUsuarioHandler(repo, BcryptPasswordHasher(), spy)
+    handler = RegistrarUsuarioHandler(repo, BcryptPasswordHasher(), token_service, spy)
 
     cmd = RegistrarUsuarioCommand(
         nombre="Ana",
         apellido="Garcia",
         email="ana@int.com",
         password="Apnea12345",
-        rol=Rol.ATLETA,
+        roles=[Rol.ATLETA],
     )
-    usuario_id = await handler.handle(cmd)
+    resultado = await handler.handle(cmd)
 
-    assert usuario_id is not None
+    assert resultado.usuario_id is not None
     assert spy.calls == ["ana@int.com"]
-    usuario = await repo.find_by_id(usuario_id)
+    usuario = await repo.find_by_id(resultado.usuario_id)
     assert usuario is not None
     assert usuario.email == "ana@int.com"
 
 
 @pytest.mark.asyncio
-async def test_registro_no_falla_si_email_no_disponible(db_path: str) -> None:
+async def test_registro_no_falla_si_email_no_disponible(
+    db_path: str, token_service: JWTService
+) -> None:
     repo = SQLiteUsuarioRepository(db_path=db_path)
-    handler = RegistrarUsuarioHandler(repo, BcryptPasswordHasher(), FailingEmailSender())
+    handler = RegistrarUsuarioHandler(
+        repo, BcryptPasswordHasher(), token_service, FailingEmailSender()
+    )
 
     cmd = RegistrarUsuarioCommand(
         nombre="Luis",
         apellido="Perez",
         email="luis@int.com",
         password="Apnea12345",
-        rol=Rol.JUEZ,
+        roles=[Rol.JUEZ],
     )
-    usuario_id = await handler.handle(cmd)
+    resultado = await handler.handle(cmd)
 
-    assert usuario_id is not None
-    usuario = await repo.find_by_id(usuario_id)
+    assert resultado.usuario_id is not None
+    usuario = await repo.find_by_id(resultado.usuario_id)
     assert usuario is not None
     assert usuario.email == "luis@int.com"
 
 
 @pytest.mark.asyncio
-async def test_registro_y_login_con_mismas_credenciales(db_path: str) -> None:
-    os.environ["IDENTIDAD_JWT_SECRET"] = "test-secret-integration-32-chars!!"
+async def test_registro_y_login_con_mismas_credenciales(
+    db_path: str, token_service: JWTService
+) -> None:
     repo = SQLiteUsuarioRepository(db_path=db_path)
-    handler = RegistrarUsuarioHandler(repo, BcryptPasswordHasher(), SpyEmailSender())
+    handler = RegistrarUsuarioHandler(repo, BcryptPasswordHasher(), token_service, SpyEmailSender())
 
     cmd = RegistrarUsuarioCommand(
         nombre="Marco",
         apellido="Polo",
         email="marco@int.com",
         password="Apnea12345",
-        rol=Rol.ORGANIZADOR,
+        roles=[Rol.ORGANIZADOR],
     )
     await handler.handle(cmd)
 
     usuario = await repo.find_by_email("marco@int.com")
     assert usuario is not None
-    assert usuario.rol == Rol.ORGANIZADOR
+    assert Rol.ORGANIZADOR in usuario.roles
 
     from identidad.application.commands.autenticar_usuario import (
         AutenticarUsuarioCommand,
         AutenticarUsuarioHandler,
+        TokenResponse,
     )
-    from identidad.infrastructure.jwt_service import JWTService
 
-    auth_handler = AutenticarUsuarioHandler(repo, JWTService(), BcryptPasswordHasher())
-    token_resp = await auth_handler.handle(
+    auth_handler = AutenticarUsuarioHandler(repo, token_service, BcryptPasswordHasher())
+    result = await auth_handler.handle(
         AutenticarUsuarioCommand(email="marco@int.com", password="Apnea12345")
     )
-    assert token_resp.access_token
-    payload = JWTService().verify(token_resp.access_token)
+    assert isinstance(result, TokenResponse)
+    assert result.access_token
+    payload = token_service.verify(result.access_token)
     assert payload["rol"] == "ORGANIZADOR"

--- a/tests/integration/identidad/test_sqlite_usuario_repository.py
+++ b/tests/integration/identidad/test_sqlite_usuario_repository.py
@@ -34,7 +34,7 @@ def _usuario(
         apellido=apellido,
         email=email,
         password_hash="$2b$12$fakehash",
-        rol=rol,
+        roles=[rol],
         activo=activo,
     )
 
@@ -49,7 +49,7 @@ async def test_save_y_find_by_id(repo: SQLiteUsuarioRepository) -> None:
     assert resultado.nombre == u.nombre
     assert resultado.apellido == u.apellido
     assert resultado.email == u.email
-    assert resultado.rol == Rol.ORGANIZADOR
+    assert Rol.ORGANIZADOR in resultado.roles
     assert resultado.activo is True
 
 
@@ -84,7 +84,7 @@ async def test_save_upsert_actualiza_registro(repo: SQLiteUsuarioRepository) -> 
         u.apellido,
         u.email,
         u.password_hash,
-        u.rol,
+        u.roles,
         activo=False,
     )
     await repo.save(u_inactivo)
@@ -94,12 +94,30 @@ async def test_save_upsert_actualiza_registro(repo: SQLiteUsuarioRepository) -> 
 
 
 @pytest.mark.asyncio
-async def test_save_persiste_rol_correctamente(repo: SQLiteUsuarioRepository) -> None:
+async def test_save_persiste_roles_correctamente(repo: SQLiteUsuarioRepository) -> None:
     u = _usuario(rol=Rol.ADMIN)
     await repo.save(u)
     resultado = await repo.find_by_id(u.usuario_id)
     assert resultado is not None
-    assert resultado.rol == Rol.ADMIN
+    assert Rol.ADMIN in resultado.roles
+
+
+@pytest.mark.asyncio
+async def test_save_persiste_multi_rol(repo: SQLiteUsuarioRepository) -> None:
+    u = Usuario(
+        usuario_id=uuid.uuid4(),
+        nombre="Pedro",
+        apellido="Lopez",
+        email="pedro@test.com",
+        password_hash="$2b$12$fakehash",
+        roles=[Rol.JUEZ, Rol.ATLETA],
+    )
+    await repo.save(u)
+    resultado = await repo.find_by_id(u.usuario_id)
+    assert resultado is not None
+    assert Rol.JUEZ in resultado.roles
+    assert Rol.ATLETA in resultado.roles
+    assert len(resultado.roles) == 2
 
 
 @pytest.mark.asyncio
@@ -114,7 +132,26 @@ async def test_list_by_rol_filtra_y_ordena_por_email(repo: SQLiteUsuarioReposito
 
 
 @pytest.mark.asyncio
-async def test_list_all_devuelve_todos_ordenados_por_rol_y_email(
+async def test_list_by_rol_incluye_multi_rol(repo: SQLiteUsuarioRepository) -> None:
+    multi = Usuario(
+        usuario_id=uuid.uuid4(),
+        nombre="Pedro",
+        apellido="Lopez",
+        email="pedro@test.com",
+        password_hash="hash",
+        roles=[Rol.JUEZ, Rol.ATLETA],
+    )
+    await repo.save(multi)
+    await repo.save(_usuario(email="solo@test.com", rol=Rol.ATLETA))
+
+    atletas = await repo.list_by_rol(Rol.ATLETA)
+    emails = [u.email for u in atletas]
+    assert "pedro@test.com" in emails
+    assert "solo@test.com" in emails
+
+
+@pytest.mark.asyncio
+async def test_list_all_devuelve_todos_ordenados_por_email(
     repo: SQLiteUsuarioRepository,
 ) -> None:
     await repo.save(_usuario(email="z-juez@test.com", rol=Rol.JUEZ))
@@ -124,11 +161,11 @@ async def test_list_all_devuelve_todos_ordenados_por_rol_y_email(
 
     usuarios = await repo.list_all()
 
-    assert [(usuario.rol, usuario.email) for usuario in usuarios] == [
-        (Rol.ATLETA, "atleta@test.com"),
-        (Rol.JUEZ, "a-juez@test.com"),
-        (Rol.JUEZ, "z-juez@test.com"),
-        (Rol.ORGANIZADOR, "org@test.com"),
+    assert [u.email for u in usuarios] == [
+        "a-juez@test.com",
+        "atleta@test.com",
+        "org@test.com",
+        "z-juez@test.com",
     ]
 
 
@@ -156,3 +193,32 @@ async def test_ensure_table_migra_columnas_nombre_y_apellido() -> None:
     assert resultado is not None
     assert resultado.nombre == "Ana"
     assert resultado.apellido == "Garcia"
+
+
+@pytest.mark.asyncio
+async def test_migracion_rol_a_roles_para_filas_existentes() -> None:
+    """Verifica que filas con columna 'rol' legacy se migran correctamente a 'roles' JSON."""
+    db_path = Path(tempfile.mktemp(suffix=".db"))
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute("""
+            CREATE TABLE usuarios (
+                usuario_id TEXT PRIMARY KEY,
+                nombre TEXT NOT NULL DEFAULT '',
+                apellido TEXT NOT NULL DEFAULT '',
+                email TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                rol TEXT NOT NULL,
+                activo INTEGER NOT NULL DEFAULT 1
+            )
+            """)
+        await conn.execute(
+            "INSERT INTO usuarios VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), "Carlos", "Perez", "carlos@test.com", "hash", "ORGANIZADOR", 1),
+        )
+        await conn.commit()
+
+    repo = SQLiteUsuarioRepository(db_path=str(db_path))
+    resultado = await repo.find_by_email("carlos@test.com")
+
+    assert resultado is not None
+    assert Rol.ORGANIZADOR in resultado.roles

--- a/tests/uat/sp6/seed_atleta_portal.py
+++ b/tests/uat/sp6/seed_atleta_portal.py
@@ -72,7 +72,7 @@ async def crear_admin_directo(email: str, password: str) -> None:
         apellido="UAT",
         email=email,
         password_hash=hasher.hash(password),
-        rol=Rol.ADMIN,
+        roles=[Rol.ADMIN],
     )
     await repo.save(usuario)
     log(f"admin creado: {email}")

--- a/tests/uat/sp6/seed_ba2025_usuarios.py
+++ b/tests/uat/sp6/seed_ba2025_usuarios.py
@@ -203,7 +203,7 @@ async def crear_admin() -> None:
         apellido="BA2025",
         email=admin_email,
         password_hash=hasher.hash(PASSWORD),
-        rol=Rol.ADMIN,
+        roles=[Rol.ADMIN],
     )
     await repo.save(usuario)
     log(f"✓ ADMIN          {admin_email}")

--- a/tests/unit/identidad/api/test_cambiar_password.py
+++ b/tests/unit/identidad/api/test_cambiar_password.py
@@ -23,7 +23,7 @@ class FakeUsuarioRepository:
             apellido="Segura",
             email="juez1@email.com",
             password_hash=password_hasher.hash("Apnea12345"),
-            rol=Rol.JUEZ,
+            roles=[Rol.JUEZ],
         )
 
     async def save(self, usuario: Usuario) -> None:
@@ -40,7 +40,7 @@ class FakeUsuarioRepository:
         return None
 
     async def list_by_rol(self, rol: Rol) -> list[Usuario]:
-        return [self.usuario] if self.usuario.rol == rol else []
+        return [self.usuario] if rol in self.usuario.roles else []
 
     async def list_all(self) -> list[Usuario]:
         return [self.usuario]

--- a/tests/unit/identidad/api/test_listar_usuarios.py
+++ b/tests/unit/identidad/api/test_listar_usuarios.py
@@ -16,20 +16,20 @@ from identidad.domain.value_objects.rol import Rol
 class FakeUsuarioRepository:
     def __init__(self) -> None:
         self.usuarios = [
-            Usuario(uuid4(), "Julia", "Segura", "juez2@ataraxia.com", "$2b$hash", Rol.JUEZ),
-            Usuario(uuid4(), "Olga", "Rios", "org@ataraxia.com", "$2b$hash", Rol.ORGANIZADOR),
-            Usuario(uuid4(), "Juan", "Acuna", "juez1@ataraxia.com", "$2b$hash", Rol.JUEZ),
-            Usuario(uuid4(), "Ana", "Lopez", "atleta@ataraxia.com", "$2b$hash", Rol.ATLETA),
+            Usuario(uuid4(), "Julia", "Segura", "juez2@ataraxia.com", "$2b$hash", [Rol.JUEZ]),
+            Usuario(uuid4(), "Olga", "Rios", "org@ataraxia.com", "$2b$hash", [Rol.ORGANIZADOR]),
+            Usuario(uuid4(), "Juan", "Acuna", "juez1@ataraxia.com", "$2b$hash", [Rol.JUEZ]),
+            Usuario(uuid4(), "Ana", "Lopez", "atleta@ataraxia.com", "$2b$hash", [Rol.ATLETA]),
         ]
 
     async def list_by_rol(self, rol: Rol) -> list[Usuario]:
         return sorted(
-            [usuario for usuario in self.usuarios if usuario.rol == rol],
+            [usuario for usuario in self.usuarios if rol in usuario.roles],
             key=lambda usuario: usuario.email,
         )
 
     async def list_all(self) -> list[Usuario]:
-        return sorted(self.usuarios, key=lambda usuario: (usuario.rol.value, usuario.email))
+        return sorted(self.usuarios, key=lambda usuario: usuario.email)
 
 
 def _mock_user(rol: str) -> dict:  # type: ignore[type-arg]
@@ -51,7 +51,7 @@ def test_listar_usuarios_filtra_rol_juez() -> None:
         "juez1@ataraxia.com",
         "juez2@ataraxia.com",
     ]
-    assert all(usuario["rol"] == "JUEZ" for usuario in data)
+    assert all("JUEZ" in usuario["roles"] for usuario in data)
     assert [usuario["nombre"] for usuario in data] == ["Juan", "Julia"]
 
 
@@ -66,13 +66,12 @@ def test_listar_usuarios_sin_rol_devuelve_todos_ordenados() -> None:
 
     assert response.status_code == 200
     data = response.json()
-    assert [(usuario["rol"], usuario["email"]) for usuario in data] == [
-        ("ATLETA", "atleta@ataraxia.com"),
-        ("JUEZ", "juez1@ataraxia.com"),
-        ("JUEZ", "juez2@ataraxia.com"),
-        ("ORGANIZADOR", "org@ataraxia.com"),
-    ]
-    assert data[0]["apellido"] == "Lopez"
+    emails = [usuario["email"] for usuario in data]
+    assert "atleta@ataraxia.com" in emails
+    assert "juez1@ataraxia.com" in emails
+    assert "juez2@ataraxia.com" in emails
+    assert "org@ataraxia.com" in emails
+    assert data[0]["apellido"] == "Lopez"  # atleta@ataraxia.com viene primero (orden alfabético)
 
 
 def test_listar_usuarios_requiere_organizador() -> None:

--- a/tests/unit/identidad/api/test_registro_usuario.py
+++ b/tests/unit/identidad/api/test_registro_usuario.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from identidad.api.dependencies import get_email_sender, get_password_hasher, get_usuario_repository
+from identidad.api.dependencies import (
+    get_email_sender,
+    get_password_hasher,
+    get_token_service,
+    get_usuario_repository,
+)
 from identidad.api.router import router
 from identidad.domain.aggregates.usuario import Usuario
 from identidad.domain.ports.password_hashing_port import PasswordHashingPort
 from identidad.domain.value_objects.rol import Rol
 from identidad.infrastructure.bcrypt_password_hasher import BcryptPasswordHasher
+from identidad.infrastructure.jwt_service import JWTService
 
 
 class FakeUsuarioRepository:
@@ -36,7 +43,7 @@ class FakeUsuarioRepository:
         return None
 
     async def list_by_rol(self, rol: Rol) -> list[Usuario]:
-        return [usuario for usuario in self.usuarios if usuario.rol == rol]
+        return [usuario for usuario in self.usuarios if rol in usuario.roles]
 
     async def list_all(self) -> list[Usuario]:
         return list(self.usuarios)
@@ -54,18 +61,29 @@ class SpyEmailSender:
 def _app(
     repo: FakeUsuarioRepository,
     password_hasher: PasswordHashingPort,
+    token_service=None,
     email_sender: SpyEmailSender | None = None,
+    monkeypatch=None,
 ) -> TestClient:
     spy = email_sender or SpyEmailSender()
+    if token_service is None:
+        if monkeypatch:
+            monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
+        import os
+
+        os.environ.setdefault("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
+        token_service = JWTService()
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[get_usuario_repository] = lambda: repo
     app.dependency_overrides[get_password_hasher] = lambda: password_hasher
+    app.dependency_overrides[get_token_service] = lambda: token_service
     app.dependency_overrides[get_email_sender] = lambda: spy
     return TestClient(app)
 
 
-def test_registro_exitoso_persiste_nombre_apellido_y_rol() -> None:
+def test_registro_exitoso_persiste_nombre_apellido_y_rol(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
     repo = FakeUsuarioRepository()
     client = _app(repo, BcryptPasswordHasher())
 
@@ -76,7 +94,7 @@ def test_registro_exitoso_persiste_nombre_apellido_y_rol() -> None:
             "apellido": "Garcia",
             "email": "ana@email.com",
             "password": "Apnea12345",
-            "rol": "ATLETA",
+            "roles": ["ATLETA"],
         },
     )
 
@@ -85,38 +103,116 @@ def test_registro_exitoso_persiste_nombre_apellido_y_rol() -> None:
     usuario = repo.usuarios[0]
     assert usuario.nombre == "Ana"
     assert usuario.apellido == "Garcia"
-    assert usuario.rol == Rol.ATLETA
+    assert Rol.ATLETA in usuario.roles
 
 
-def test_registro_rechaza_email_duplicado() -> None:
+def test_registro_un_rol_devuelve_token(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
     repo = FakeUsuarioRepository()
+    client = _app(repo, BcryptPasswordHasher())
+
+    response = client.post(
+        "/auth/registro",
+        json={
+            "nombre": "Ana",
+            "apellido": "Garcia",
+            "email": "ana@email.com",
+            "password": "Apnea12345",
+            "roles": ["ATLETA"],
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert "access_token" in body
+    assert "requires_role_selection" not in body
+
+
+def test_registro_multi_rol_devuelve_role_selection(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
+    repo = FakeUsuarioRepository()
+    client = _app(repo, BcryptPasswordHasher())
+
+    response = client.post(
+        "/auth/registro",
+        json={
+            "nombre": "Pedro",
+            "apellido": "Lopez",
+            "email": "pedro@email.com",
+            "password": "Apnea12345",
+            "roles": ["JUEZ", "ATLETA"],
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body.get("requires_role_selection") is True
+    assert "access_token" not in body
+
+
+def test_registro_email_existente_agrega_rol_devuelve_200(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
+    repo = FakeUsuarioRepository()
+    hasher = BcryptPasswordHasher()
     repo.usuarios.append(
         Usuario(
             usuario_id=uuid4(),
             nombre="Julia",
             apellido="Segura",
             email="juez1@email.com",
-            password_hash="$2b$hash",
-            rol=Rol.JUEZ,
+            password_hash=hasher.hash("Apnea12345"),
+            roles=[Rol.JUEZ],
         )
     )
-    client = _app(repo, BcryptPasswordHasher())
+    client = _app(repo, hasher)
 
     response = client.post(
         "/auth/registro",
         json={
-            "nombre": "Otro",
-            "apellido": "Usuario",
+            "nombre": "Julia",
+            "apellido": "Segura",
             "email": "juez1@email.com",
             "password": "Apnea12345",
-            "rol": "ATLETA",
+            "roles": ["ATLETA"],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json().get("requires_role_selection") is True
+
+
+def test_registro_email_existente_mismo_rol_retorna_409(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
+    repo = FakeUsuarioRepository()
+    hasher = BcryptPasswordHasher()
+    repo.usuarios.append(
+        Usuario(
+            usuario_id=uuid4(),
+            nombre="Julia",
+            apellido="Segura",
+            email="juez1@email.com",
+            password_hash=hasher.hash("Apnea12345"),
+            roles=[Rol.JUEZ],
+        )
+    )
+    client = _app(repo, hasher)
+
+    response = client.post(
+        "/auth/registro",
+        json={
+            "nombre": "Julia",
+            "apellido": "Segura",
+            "email": "juez1@email.com",
+            "password": "Apnea12345",
+            "roles": ["JUEZ"],
         },
     )
 
     assert response.status_code == 409
 
 
-def test_registro_rechaza_password_corta() -> None:
+def test_registro_rechaza_password_corta(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
     repo = FakeUsuarioRepository()
     client = _app(repo, BcryptPasswordHasher())
 
@@ -127,14 +223,15 @@ def test_registro_rechaza_password_corta() -> None:
             "apellido": "Garcia",
             "email": "ana@email.com",
             "password": "corta",
-            "rol": "ATLETA",
+            "roles": ["ATLETA"],
         },
     )
 
     assert response.status_code == 422
 
 
-def test_registro_rechaza_rol_admin() -> None:
+def test_registro_rechaza_rol_admin(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
     repo = FakeUsuarioRepository()
     client = _app(repo, BcryptPasswordHasher())
 
@@ -145,7 +242,7 @@ def test_registro_rechaza_rol_admin() -> None:
             "apellido": "Prohibido",
             "email": "admin@email.com",
             "password": "Apnea12345",
-            "rol": "ADMIN",
+            "roles": ["ADMIN"],
         },
     )
 
@@ -153,10 +250,11 @@ def test_registro_rechaza_rol_admin() -> None:
     assert response.json()["detail"] == "El rol ADMIN no está permitido en el auto-registro"
 
 
-def test_registro_invoca_email_sender_al_crear_usuario() -> None:
+def test_registro_invoca_email_sender_al_crear_usuario(monkeypatch) -> None:
+    monkeypatch.setenv("IDENTIDAD_JWT_SECRET", "test-secret-registro-32chars!!")
     repo = FakeUsuarioRepository()
     spy = SpyEmailSender()
-    client = _app(repo, BcryptPasswordHasher(), spy)
+    client = _app(repo, BcryptPasswordHasher(), email_sender=spy)
 
     response = client.post(
         "/auth/registro",
@@ -165,7 +263,7 @@ def test_registro_invoca_email_sender_al_crear_usuario() -> None:
             "apellido": "Polo",
             "email": "marco@email.com",
             "password": "Apnea12345",
-            "rol": "ATLETA",
+            "roles": ["ATLETA"],
         },
     )
 

--- a/tests/unit/identidad/api/test_reset_password.py
+++ b/tests/unit/identidad/api/test_reset_password.py
@@ -30,7 +30,7 @@ class FakeUsuarioRepository:
             apellido="Segura",
             email="juez1@email.com",
             password_hash=password_hash,
-            rol=Rol.JUEZ,
+            roles=[Rol.JUEZ],
         )
 
     async def save(self, usuario: Usuario) -> None:
@@ -47,7 +47,7 @@ class FakeUsuarioRepository:
         return None
 
     async def list_by_rol(self, rol: Rol) -> list[Usuario]:
-        return [self.usuario] if self.usuario.rol == rol else []
+        return [self.usuario] if rol in self.usuario.roles else []
 
     async def list_all(self) -> list[Usuario]:
         return [self.usuario]
@@ -134,7 +134,7 @@ def test_reset_password_rechaza_token_de_sesion(monkeypatch) -> None:
     response = client.post(
         "/auth/reset-password",
         json={
-            "token": token_service.generate(repo.usuario),
+            "token": token_service.generate(repo.usuario, repo.usuario.roles[0]),
             "password_nueva": "NuevaPass456",
         },
     )

--- a/tests/unit/identidad/application/test_handlers.py
+++ b/tests/unit/identidad/application/test_handlers.py
@@ -12,6 +12,7 @@ import pytest
 from identidad.application.commands.autenticar_usuario import (
     AutenticarUsuarioCommand,
     AutenticarUsuarioHandler,
+    RoleSelectionRequired,
     TokenResponse,
 )
 from identidad.application.commands.cambiar_password import (
@@ -22,6 +23,7 @@ from identidad.application.commands.reset_password import ResetPasswordCommand, 
 from identidad.application.commands.registrar_usuario import (
     RegistrarUsuarioCommand,
     RegistrarUsuarioHandler,
+    RegistroResult,
 )
 from identidad.application.commands.solicitar_reset_password import (
     SolicitarResetPasswordCommand,
@@ -30,10 +32,10 @@ from identidad.application.commands.solicitar_reset_password import (
 from identidad.domain.aggregates.usuario import Usuario
 from identidad.domain.exceptions import (
     CredencialesInvalidas,
-    EmailYaRegistrado,
     PasswordActualIncorrecto,
     PasswordDemasiadoCorto,
     RolNoPermitido,
+    RolYaAsignado,
     TokenResetInvalido,
     UsuarioNoEncontrado,
     UsuarioInactivo,
@@ -75,32 +77,34 @@ def token_service(jwt_service: JWTService) -> TokenServicePort:
 
 @pytest.mark.asyncio
 async def test_registrar_usuario_exitoso(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
     cmd = RegistrarUsuarioCommand(
         nombre="Nuevo",
         apellido="Usuario",
         email="nuevo@test.com",
         password="Seguro1234",
-        rol=Rol.ORGANIZADOR,
+        roles=[Rol.ORGANIZADOR],
     )
-    usuario_id = await handler.handle(cmd)
-    assert usuario_id is not None
+    resultado = await handler.handle(cmd)
+    assert isinstance(resultado, RegistroResult)
+    assert resultado.usuario_id is not None
+    assert resultado.token_response is not None
     mock_repo.save.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_registrar_guarda_hash_no_plain(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
     cmd = RegistrarUsuarioCommand(
         nombre="Ana",
         apellido="Garcia",
         email="t@t.com",
         password="Password10",
-        rol=Rol.ATLETA,
+        roles=[Rol.ATLETA],
     )
     await handler.handle(cmd)
     saved_usuario: Usuario = mock_repo.save.call_args[0][0]
@@ -111,34 +115,103 @@ async def test_registrar_guarda_hash_no_plain(
 
 
 @pytest.mark.asyncio
-async def test_registrar_email_duplicado_lanza_excepcion(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+async def test_registrar_un_rol_devuelve_token(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    existente = Usuario(uuid.uuid4(), "Dup", "Existente", "dup@test.com", "$2b$hash", Rol.JUEZ)
-    mock_repo.find_by_email.return_value = existente
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
     cmd = RegistrarUsuarioCommand(
-        nombre="Dup",
-        apellido="Nuevo",
-        email="dup@test.com",
-        password="Password10",
-        rol=Rol.JUEZ,
+        nombre="Ana", apellido="Garcia", email="t@t.com", password="Password10", roles=[Rol.ATLETA]
     )
-    with pytest.raises(EmailYaRegistrado):
+    resultado = await handler.handle(cmd)
+    assert resultado.token_response is not None
+    assert not resultado.requires_role_selection
+
+
+@pytest.mark.asyncio
+async def test_registrar_multi_rol_devuelve_role_selection(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
+) -> None:
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Pedro",
+        apellido="Lopez",
+        email="p@t.com",
+        password="Password10",
+        roles=[Rol.JUEZ, Rol.ATLETA],
+    )
+    resultado = await handler.handle(cmd)
+    assert resultado.requires_role_selection
+    assert resultado.token_response is None
+    assert set(resultado.roles_disponibles) == {Rol.JUEZ, Rol.ATLETA}
+
+
+@pytest.mark.asyncio
+async def test_registrar_email_existente_agrega_rol_nuevo(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
+) -> None:
+    existente = _make_usuario("lucia@test.com", "Seguro1234", Rol.ATLETA)
+    mock_repo.find_by_email.return_value = existente
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Lucia",
+        apellido="Perez",
+        email="lucia@test.com",
+        password="Seguro1234",
+        roles=[Rol.JUEZ],
+    )
+    resultado = await handler.handle(cmd)
+    assert Rol.JUEZ in existente.roles
+    assert resultado.requires_role_selection
+    mock_repo.save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_registrar_email_existente_password_incorrecta_lanza_excepcion(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
+) -> None:
+    existente = _make_usuario("lucia@test.com", "Seguro1234", Rol.ATLETA)
+    mock_repo.find_by_email.return_value = existente
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Lucia",
+        apellido="Perez",
+        email="lucia@test.com",
+        password="WrongPass1!",
+        roles=[Rol.JUEZ],
+    )
+    with pytest.raises(CredencialesInvalidas):
+        await handler.handle(cmd)
+
+
+@pytest.mark.asyncio
+async def test_registrar_email_existente_rol_duplicado_lanza_excepcion(
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
+) -> None:
+    existente = _make_usuario("lucia@test.com", "Seguro1234", Rol.ATLETA)
+    mock_repo.find_by_email.return_value = existente
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
+    cmd = RegistrarUsuarioCommand(
+        nombre="Lucia",
+        apellido="Perez",
+        email="lucia@test.com",
+        password="Seguro1234",
+        roles=[Rol.ATLETA],
+    )
+    with pytest.raises(RolYaAsignado):
         await handler.handle(cmd)
 
 
 @pytest.mark.asyncio
 async def test_registrar_password_corto_lanza_excepcion(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
     cmd = RegistrarUsuarioCommand(
         nombre="Ana",
         apellido="Garcia",
         email="t@t.com",
         password="corto",
-        rol=Rol.ATLETA,
+        roles=[Rol.ATLETA],
     )
     with pytest.raises(PasswordDemasiadoCorto):
         await handler.handle(cmd)
@@ -146,31 +219,31 @@ async def test_registrar_password_corto_lanza_excepcion(
 
 @pytest.mark.asyncio
 async def test_registrar_password_exactamente_10_es_valido(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
     cmd = RegistrarUsuarioCommand(
         nombre="Ana",
         apellido="Garcia",
         email="t@t.com",
         password="Valida1234",
-        rol=Rol.ATLETA,
+        roles=[Rol.ATLETA],
     )
-    usuario_id = await handler.handle(cmd)
-    assert usuario_id is not None
+    resultado = await handler.handle(cmd)
+    assert resultado.usuario_id is not None
 
 
 @pytest.mark.asyncio
 async def test_registrar_admin_lanza_excepcion(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
     cmd = RegistrarUsuarioCommand(
         nombre="Admin",
         apellido="Prohibido",
         email="admin@test.com",
         password="Valida1234",
-        rol=Rol.ADMIN,
+        roles=[Rol.ADMIN],
     )
     with pytest.raises(RolNoPermitido):
         await handler.handle(cmd)
@@ -268,12 +341,16 @@ class FailingEmailSender:
 
 @pytest.mark.asyncio
 async def test_registrar_usuario_envia_email_de_bienvenida(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
     email_sender = FakeEmailSender()
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, email_sender)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service, email_sender)
     cmd = RegistrarUsuarioCommand(
-        nombre="Ana", apellido="Garcia", email="ana@test.com", password="Seguro1234", rol=Rol.ATLETA
+        nombre="Ana",
+        apellido="Garcia",
+        email="ana@test.com",
+        password="Seguro1234",
+        roles=[Rol.ATLETA],
     )
     await handler.handle(cmd)
     assert len(email_sender.enviados) == 1
@@ -284,35 +361,37 @@ async def test_registrar_usuario_envia_email_de_bienvenida(
 
 @pytest.mark.asyncio
 async def test_registrar_usuario_no_falla_si_email_lanza_excepcion(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, FailingEmailSender())
+    handler = RegistrarUsuarioHandler(
+        mock_repo, password_hasher, token_service, FailingEmailSender()
+    )
     cmd = RegistrarUsuarioCommand(
         nombre="Luis",
         apellido="Perez",
         email="luis@test.com",
         password="Seguro1234",
-        rol=Rol.JUEZ,
+        roles=[Rol.JUEZ],
     )
-    usuario_id = await handler.handle(cmd)
-    assert usuario_id is not None
+    resultado = await handler.handle(cmd)
+    assert resultado.usuario_id is not None
     mock_repo.save.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_registrar_usuario_sin_email_sender_funciona(
-    mock_repo: AsyncMock, password_hasher: PasswordHashingPort
+    mock_repo: AsyncMock, password_hasher: PasswordHashingPort, token_service: TokenServicePort
 ) -> None:
-    handler = RegistrarUsuarioHandler(mock_repo, password_hasher)
+    handler = RegistrarUsuarioHandler(mock_repo, password_hasher, token_service)
     cmd = RegistrarUsuarioCommand(
         nombre="Sin",
         apellido="Email",
         email="sin@test.com",
         password="Seguro1234",
-        rol=Rol.ORGANIZADOR,
+        roles=[Rol.ORGANIZADOR],
     )
-    usuario_id = await handler.handle(cmd)
-    assert usuario_id is not None
+    resultado = await handler.handle(cmd)
+    assert resultado.usuario_id is not None
 
 
 @pytest.mark.asyncio
@@ -377,7 +456,7 @@ async def test_reset_password_rechaza_token_de_sesion(
 ) -> None:
     usuario = _make_usuario("juez@test.com", "clave1234")
     handler = ResetPasswordHandler(mock_repo, token_service, password_hasher)
-    token = token_service.generate(usuario)
+    token = token_service.generate(usuario, usuario.roles[0])
 
     with pytest.raises(TokenResetInvalido):
         await handler.handle(ResetPasswordCommand(token=token, password_nueva="NuevaPass456"))
@@ -398,7 +477,7 @@ async def test_reset_password_rechaza_password_corta(
 
 def _make_usuario(email: str, password: str, rol: Rol = Rol.JUEZ, activo: bool = True) -> Usuario:
     hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
-    return Usuario(uuid.uuid4(), "Test", "Usuario", email, hashed, rol, activo)
+    return Usuario(uuid.uuid4(), "Test", "Usuario", email, hashed, [rol], activo)
 
 
 @pytest.mark.asyncio
@@ -415,6 +494,57 @@ async def test_autenticar_exitoso_retorna_token(
     assert isinstance(result, TokenResponse)
     assert result.token_type == "bearer"
     assert len(result.access_token) > 0
+
+
+@pytest.mark.asyncio
+async def test_autenticar_multi_rol_sin_rol_elegido_devuelve_selection(
+    mock_repo: AsyncMock,
+    token_service: TokenServicePort,
+    password_hasher: PasswordHashingPort,
+) -> None:
+    hashed = bcrypt.hashpw(b"clave1234", bcrypt.gensalt()).decode()
+    u = Usuario(uuid.uuid4(), "Pedro", "Lopez", "pedro@test.com", hashed, [Rol.JUEZ, Rol.ATLETA])
+    mock_repo.find_by_email.return_value = u
+    handler = AutenticarUsuarioHandler(mock_repo, token_service, password_hasher)
+    cmd = AutenticarUsuarioCommand(email="pedro@test.com", password="clave1234")
+    result = await handler.handle(cmd)
+    assert isinstance(result, RoleSelectionRequired)
+    assert set(result.roles) == {Rol.JUEZ, Rol.ATLETA}
+
+
+@pytest.mark.asyncio
+async def test_autenticar_multi_rol_con_rol_elegido_devuelve_token(
+    mock_repo: AsyncMock,
+    token_service: TokenServicePort,
+    password_hasher: PasswordHashingPort,
+) -> None:
+    hashed = bcrypt.hashpw(b"clave1234", bcrypt.gensalt()).decode()
+    u = Usuario(uuid.uuid4(), "Pedro", "Lopez", "pedro@test.com", hashed, [Rol.JUEZ, Rol.ATLETA])
+    mock_repo.find_by_email.return_value = u
+    handler = AutenticarUsuarioHandler(mock_repo, token_service, password_hasher)
+    cmd = AutenticarUsuarioCommand(
+        email="pedro@test.com", password="clave1234", rol_elegido=Rol.ATLETA
+    )
+    result = await handler.handle(cmd)
+    assert isinstance(result, TokenResponse)
+    payload = token_service.verify(result.access_token)
+    assert payload["rol"] == "ATLETA"
+
+
+@pytest.mark.asyncio
+async def test_autenticar_rol_elegido_no_poseido_lanza_credenciales_invalidas(
+    mock_repo: AsyncMock,
+    token_service: TokenServicePort,
+    password_hasher: PasswordHashingPort,
+) -> None:
+    u = _make_usuario("solo@test.com", "clave1234", Rol.ATLETA)
+    mock_repo.find_by_email.return_value = u
+    handler = AutenticarUsuarioHandler(mock_repo, token_service, password_hasher)
+    cmd = AutenticarUsuarioCommand(
+        email="solo@test.com", password="clave1234", rol_elegido=Rol.JUEZ
+    )
+    with pytest.raises(CredencialesInvalidas):
+        await handler.handle(cmd)
 
 
 @pytest.mark.asyncio
@@ -463,7 +593,7 @@ async def test_autenticar_usuario_inactivo_lanza_excepcion(
 
 def test_jwt_generate_y_verify_payload(jwt_service: JWTService) -> None:
     u = _make_usuario("admin@test.com", "pass1234", Rol.ADMIN)
-    token = jwt_service.generate(u)
+    token = jwt_service.generate(u, Rol.ADMIN)
     payload = jwt_service.verify(token)
     assert payload["sub"] == str(u.usuario_id)
     assert payload["email"] == "admin@test.com"

--- a/tests/unit/identidad/domain/test_usuario.py
+++ b/tests/unit/identidad/domain/test_usuario.py
@@ -12,7 +12,9 @@ from identidad.domain.exceptions import (
     CredencialesInvalidas,
     EmailYaRegistrado,
     PasswordDemasiadoCorto,
+    RolDuplicado,
     RolNoPermitido,
+    RolesVacios,
     TokenInvalido,
     UsuarioInactivo,
     UsuarioNoEncontrado,
@@ -44,13 +46,13 @@ def test_usuario_creacion_basica() -> None:
         apellido="Garcia",
         email="test@test.com",
         password_hash="$2b$12$hash",
-        rol=Rol.ORGANIZADOR,
+        roles=[Rol.ORGANIZADOR],
     )
     assert u.usuario_id == uid
     assert u.nombre == "Ana"
     assert u.apellido == "Garcia"
     assert u.email == "test@test.com"
-    assert u.rol == Rol.ORGANIZADOR
+    assert Rol.ORGANIZADOR in u.roles
     assert u.activo is True
 
 
@@ -61,7 +63,7 @@ def test_usuario_inactivo_por_defecto_es_true() -> None:
         apellido="Garcia",
         email="a@b.com",
         password_hash="hash",
-        rol=Rol.ATLETA,
+        roles=[Rol.ATLETA],
     )
     assert u.activo is True
 
@@ -73,10 +75,24 @@ def test_usuario_puede_estar_inactivo() -> None:
         apellido="Garcia",
         email="a@b.com",
         password_hash="hash",
-        rol=Rol.ATLETA,
+        roles=[Rol.ATLETA],
         activo=False,
     )
     assert u.activo is False
+
+
+def test_usuario_multi_rol() -> None:
+    u = Usuario(
+        usuario_id=uuid.uuid4(),
+        nombre="Pedro",
+        apellido="Lopez",
+        email="pedro@b.com",
+        password_hash="hash",
+        roles=[Rol.JUEZ, Rol.ATLETA],
+    )
+    assert Rol.JUEZ in u.roles
+    assert Rol.ATLETA in u.roles
+    assert len(u.roles) == 2
 
 
 def test_usuario_trim_nombre_y_apellido() -> None:
@@ -86,7 +102,7 @@ def test_usuario_trim_nombre_y_apellido() -> None:
         apellido="  Garcia  ",
         email="a@b.com",
         password_hash="hash",
-        rol=Rol.ATLETA,
+        roles=[Rol.ATLETA],
     )
     assert u.nombre == "Ana"
     assert u.apellido == "Garcia"
@@ -103,7 +119,35 @@ def test_usuario_rechaza_nombre_o_apellido_vacios(campo: str, nombre: str, apell
             apellido=apellido,
             email="a@b.com",
             password_hash="hash",
-            rol=Rol.ATLETA,
+            roles=[Rol.ATLETA],
+        )
+
+
+def test_usuario_rechaza_roles_vacios() -> None:
+    from identidad.domain.exceptions import RolesVacios
+
+    with pytest.raises(RolesVacios):
+        Usuario(
+            usuario_id=uuid.uuid4(),
+            nombre="Ana",
+            apellido="Garcia",
+            email="a@b.com",
+            password_hash="hash",
+            roles=[],
+        )
+
+
+def test_usuario_rechaza_rol_duplicado() -> None:
+    from identidad.domain.exceptions import RolDuplicado
+
+    with pytest.raises(RolDuplicado):
+        Usuario(
+            usuario_id=uuid.uuid4(),
+            nombre="Ana",
+            apellido="Garcia",
+            email="a@b.com",
+            password_hash="hash",
+            roles=[Rol.ATLETA, Rol.ATLETA],
         )
 
 


### PR DESCRIPTION
## Summary

- `Usuario.roles: list[Rol]` reemplaza `rol: Rol` en domain, infrastructure y API
- `RegistrarUsuarioHandler` ahora acepta `roles: list[Rol]`; si el email ya existe valida password y agrega roles nuevos (`RolYaAsignado` si duplicado)
- `AutenticarUsuarioHandler` acepta `rol_elegido: Rol | None`; devuelve token si 1 rol, `RoleSelectionRequired` si el usuario tiene múltiples y no eligió
- `SQLiteUsuarioRepository`: columna `roles TEXT` (JSON) con migración automática desde columna `rol` legacy
- Router actualizado: `RegistroRequest.roles`, `LoginRequest.rol_elegido`, respuesta condicional (`access_token` o `requires_role_selection`)

## Test plan

- [x] 79 unit tests pasando (`tests/unit/identidad/`)
- [x] 15 integration tests pasando (`tests/integration/identidad/`)
- [x] 7 BDD escenarios US-3.2.1 pasando (sin regresión)
- [x] 9 BDD escenarios US-ADJ-11.1 pasando
- [x] CodeGuard: 0 errores
- [x] Black: código formateado

## Notas de migración DB

La columna `rol` legacy se mantiene; `_migrate_rol_to_roles()` convierte automáticamente filas existentes al arrancar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)