### PR TITLE
feat(registro): BC Registro entidad Juez [US-ADJ-11.4]

### DIFF
--- a/.claude/tracking/US-ADJ-11.4-tracking.json
+++ b/.claude/tracking/US-ADJ-11.4-tracking.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-11.4",
+    "us_title": "BC Registro: entidad Juez",
+    "us_points": 3,
+    "producto": "registro",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-16T14:23:14.722694+00:00",
+    "completed_at": null,
+    "total_elapsed_seconds": 0,
+    "effective_seconds": 0,
+    "paused_seconds": 0
+  },
+  "phases": [],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 0,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/plans/sp-adj-11/PLAN-SP-ADJ-11.md
+++ b/docs/plans/sp-adj-11/PLAN-SP-ADJ-11.md
@@ -126,12 +126,13 @@ frontend completo. Las 9 US están ordenadas por capa y dependencia.
 
 ---
 
-### US-ADJ-11.4 — BC Registro: entidad Juez
+### US-ADJ-11.4 — BC Registro: entidad Juez ✅
 
 **Prioridad:** Alta
 **Tipo:** nueva entidad backend
 **Área:** BC `registro` (domain · application · infrastructure · api)
 **Spec:** `docs/specs/sp-adj-11/US-ADJ-11.4.md`
+**Estado:** Implementada — branch `feature/US-ADJ-11.4-juez` — 35 tests pasando
 
 **Cambios:**
 1. `Juez` aggregate: `juez_id: UUID`, `email: str`, `numero_licencia: str | None`, `federacion: str | None`. Método `actualizar()`.

--- a/docs/plans/sp-adj-11/US-ADJ-11.4-plan.md
+++ b/docs/plans/sp-adj-11/US-ADJ-11.4-plan.md
@@ -1,0 +1,100 @@
+# US-ADJ-11.4 — Plan de Implementación: BC Registro entidad Juez
+
+| Campo | Valor |
+|-------|-------|
+| **US** | US-ADJ-11.4 |
+| **Branch** | `feature/US-ADJ-11.4-juez` |
+| **Estimación total** | 45 min |
+| **Story points** | 3 |
+| **Patrón** | Idéntico a Atleta — aggregate + port + repo SQLite + commands + query + endpoints |
+
+---
+
+## Tareas de implementación
+
+### T1 — Domain: aggregate Juez + port + excepciones (15 min)
+
+**Archivos:**
+- `src/registro/domain/aggregates/juez.py` (nuevo)
+- `src/registro/domain/ports/juez_repository_port.py` (nuevo)
+- `src/registro/domain/exceptions.py` (agregar JuezNoEncontrado, JuezYaRegistrado)
+
+**Contratos:**
+```python
+@dataclass
+class Juez:
+    juez_id: UUID
+    email: str
+    numero_licencia: str | None = None
+    federacion: str | None = None
+
+    def __post_init__(self) -> None: ...  # INV-11.4-01/03/04
+    def actualizar(self, numero_licencia=None, federacion=None) -> None: ...  # patch parcial
+```
+
+---
+
+### T2 — Infrastructure: SQLiteJuezRepository (10 min)
+
+**Archivo:** `src/registro/infrastructure/repositories/sqlite_juez_repository.py` (nuevo)
+
+**Tabla:** `jueces(juez_id TEXT PK, email TEXT UNIQUE NOT NULL, numero_licencia TEXT, federacion TEXT)`
+
+**Mismo patrón que** `SQLiteAtletaRepository`: `_ensure_table`, `save` (INSERT OR REPLACE), `find_by_email`, `find_by_id`.
+
+---
+
+### T3 — Application: commands + query (10 min)
+
+**Archivos:**
+- `src/registro/application/commands/registrar_juez.py` (nuevo)
+- `src/registro/application/commands/actualizar_juez.py` (nuevo)
+- `src/registro/application/queries/obtener_juez.py` (nuevo)
+
+**Contratos:**
+```python
+RegistrarJuezCommand(email, numero_licencia=None, federacion=None)  # handler genera juez_id
+ActualizarJuezCommand(email, numero_licencia=None, federacion=None)  # patch parcial
+ObtenerJuezHandler.handle(email) -> Juez  # lanza JuezNoEncontrado
+```
+
+---
+
+### T4 — API: schemas y endpoints en router.py (10 min)
+
+**Archivo:** `src/registro/api/router.py` (modificar)
+
+**Schemas nuevos:**
+```python
+class RegistrarJuezRequest(BaseModel):
+    numero_licencia: str | None = None
+    federacion: str | None = None
+
+class JuezResponse(BaseModel):
+    juez_id: UUID; email: str
+    numero_licencia: str | None; federacion: str | None
+
+class ActualizarJuezMeRequest(BaseModel):
+    numero_licencia: str | None = None
+    federacion: str | None = None
+```
+
+**Endpoints:**
+```
+POST  /registro/jueces        → JuezDep — 201 JuezResponse | 409
+GET   /registro/jueces/me     → JuezDep — 200 JuezResponse | 404
+PATCH /registro/jueces/me     → JuezDep — 200 JuezResponse | 404
+```
+
+---
+
+## Checklist
+
+- [ ] T1: aggregate Juez + port + excepciones
+- [ ] T2: SQLiteJuezRepository
+- [ ] T3: commands + query
+- [ ] T4: router.py schemas + endpoints
+
+---
+
+*Creado: 2026-05-16*

--- a/docs/specs/sp-adj-11/US-ADJ-11.4.md
+++ b/docs/specs/sp-adj-11/US-ADJ-11.4.md
@@ -1,6 +1,6 @@
 # US-ADJ-11.4: BC Registro — entidad Juez
 
-**Estado**: `Especificada`
+**Estado**: `Implementada`
 **Iteracion / Sprint**: SP-ADJ-11
 **Tipo**: nueva entidad backend
 **Agregado principal afectado**: `Juez` (nuevo)

--- a/src/registro/api/router.py
+++ b/src/registro/api/router.py
@@ -27,12 +27,21 @@ from registro.application.commands.actualizar_atleta import (
     ActualizarAtletaCommand,
     ActualizarAtletaHandler,
 )
+from registro.application.commands.actualizar_juez import (
+    ActualizarJuezCommand,
+    ActualizarJuezHandler,
+)
 from registro.application.commands.registrar_atleta import (
     RegistrarAtletaCommand,
     RegistrarAtletaHandler,
 )
+from registro.application.commands.registrar_juez import (
+    RegistrarJuezCommand,
+    RegistrarJuezHandler,
+)
 from registro.application.queries.listar_inscriptos import ListarInscriptosHandler
 from registro.application.queries.obtener_atleta import ObtenerAtletaHandler
+from registro.application.queries.obtener_juez import ObtenerJuezHandler
 from registro.application.queries.verificar_completitud_ap import (
     VerificarCompletitudAPHandler,
 )
@@ -45,6 +54,8 @@ from registro.domain.exceptions import (
     DisciplinaNoDisponible,
     DisciplinaNoInscripta,
     InscripcionNoEncontrada,
+    JuezNoEncontrado,
+    JuezYaRegistrado,
     PlazoCancelacionVencido,
     TorneoNoDisponible,
 )
@@ -57,7 +68,8 @@ from registro.infrastructure.repositories.sqlite_atleta_repository import SQLite
 from registro.infrastructure.repositories.sqlite_inscripcion_repository import (
     SQLiteInscripcionRepository,
 )
-from shared.api.dependencies import AtletaDep, OrganizadorDep
+from registro.infrastructure.repositories.sqlite_juez_repository import SQLiteJuezRepository
+from shared.api.dependencies import AtletaDep, JuezDep, OrganizadorDep
 from shared.domain.value_objects.disciplina import Disciplina
 
 router = APIRouter(prefix="/registro", tags=["registro"])
@@ -119,6 +131,26 @@ class ActualizarAtletaMeRequest(BaseModel):
     telefono: str | None = None
 
 
+# ── Schemas — Juez ───────────────────────────────────────────────────────────
+
+
+class RegistrarJuezRequest(BaseModel):
+    numero_licencia: str | None = None
+    federacion: str | None = None
+
+
+class JuezResponse(BaseModel):
+    juez_id: UUID
+    email: str
+    numero_licencia: str | None
+    federacion: str | None
+
+
+class ActualizarJuezMeRequest(BaseModel):
+    numero_licencia: str | None = None
+    federacion: str | None = None
+
+
 # ── Schemas — Inscripcion ─────────────────────────────────────────────────────
 
 
@@ -166,6 +198,10 @@ class DeclararAPInscripcionRequest(BaseModel):
 
 def _repo() -> SQLiteAtletaRepository:
     return SQLiteAtletaRepository()
+
+
+def _juez_repo() -> SQLiteJuezRepository:
+    return SQLiteJuezRepository()
 
 
 def _inscripcion_repo() -> SQLiteInscripcionRepository:
@@ -601,4 +637,71 @@ async def subir_constancia_pago(
         archivo,
         "constancia_pago",
         "adjuntar_constancia_pago",
+    )
+
+
+# ── Endpoints — Juez ──────────────────────────────────────────────────────────
+
+
+@router.post("/jueces", status_code=201)
+async def registrar_juez(body: RegistrarJuezRequest, current_user: JuezDep) -> JSONResponse:
+    repo = _juez_repo()
+    handler = RegistrarJuezHandler(repo)
+    try:
+        juez_id = await handler.handle(
+            RegistrarJuezCommand(
+                email=current_user["email"],
+                numero_licencia=body.numero_licencia,
+                federacion=body.federacion,
+            )
+        )
+    except JuezYaRegistrado:
+        return JSONResponse(status_code=409, content={"detail": "Perfil de juez ya registrado"})
+    juez = await repo.find_by_id(juez_id)
+    return JSONResponse(
+        status_code=201,
+        content=JuezResponse(
+            juez_id=juez.juez_id,  # type: ignore[union-attr]
+            email=juez.email,  # type: ignore[union-attr]
+            numero_licencia=juez.numero_licencia,  # type: ignore[union-attr]
+            federacion=juez.federacion,  # type: ignore[union-attr]
+        ).model_dump(mode="json"),
+    )
+
+
+@router.get("/jueces/me", status_code=200)
+async def obtener_juez_me(current_user: JuezDep) -> JSONResponse:
+    try:
+        juez = await ObtenerJuezHandler(_juez_repo()).handle(current_user["email"])
+    except JuezNoEncontrado:
+        return JSONResponse(status_code=404, content={"detail": "Juez no encontrado"})
+    return JSONResponse(
+        content=JuezResponse(
+            juez_id=juez.juez_id,
+            email=juez.email,
+            numero_licencia=juez.numero_licencia,
+            federacion=juez.federacion,
+        ).model_dump(mode="json")
+    )
+
+
+@router.patch("/jueces/me", status_code=200)
+async def actualizar_juez_me(body: ActualizarJuezMeRequest, current_user: JuezDep) -> JSONResponse:
+    try:
+        juez = await ActualizarJuezHandler(_juez_repo()).handle(
+            ActualizarJuezCommand(
+                email=current_user["email"],
+                numero_licencia=body.numero_licencia,
+                federacion=body.federacion,
+            )
+        )
+    except JuezNoEncontrado:
+        return JSONResponse(status_code=404, content={"detail": "Juez no encontrado"})
+    return JSONResponse(
+        content=JuezResponse(
+            juez_id=juez.juez_id,
+            email=juez.email,
+            numero_licencia=juez.numero_licencia,
+            federacion=juez.federacion,
+        ).model_dump(mode="json")
     )

--- a/src/registro/application/commands/actualizar_juez.py
+++ b/src/registro/application/commands/actualizar_juez.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from registro.domain.exceptions import JuezNoEncontrado
+from registro.domain.ports.juez_repository_port import JuezRepositoryPort
+
+
+@dataclass(frozen=True)
+class ActualizarJuezCommand:
+    email: str
+    numero_licencia: str | None = field(default=None)
+    federacion: str | None = field(default=None)
+
+
+class ActualizarJuezHandler:
+    def __init__(self, repo: JuezRepositoryPort) -> None:
+        self._repo = repo
+
+    async def handle(self, cmd: ActualizarJuezCommand):  # type: ignore[return]
+        juez = await self._repo.find_by_email(cmd.email)
+        if juez is None:
+            raise JuezNoEncontrado(f"No existe perfil de juez con email {cmd.email}")
+
+        juez.actualizar(
+            numero_licencia=cmd.numero_licencia,
+            federacion=cmd.federacion,
+        )
+        await self._repo.save(juez)
+        return juez

--- a/src/registro/application/commands/registrar_juez.py
+++ b/src/registro/application/commands/registrar_juez.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+from registro.domain.aggregates.juez import Juez
+from registro.domain.exceptions import JuezYaRegistrado
+from registro.domain.ports.juez_repository_port import JuezRepositoryPort
+
+
+@dataclass(frozen=True)
+class RegistrarJuezCommand:
+    email: str
+    numero_licencia: str | None = field(default=None)
+    federacion: str | None = field(default=None)
+
+
+class RegistrarJuezHandler:
+    def __init__(self, repo: JuezRepositoryPort) -> None:
+        self._repo = repo
+
+    async def handle(self, cmd: RegistrarJuezCommand) -> UUID:
+        existing = await self._repo.find_by_email(cmd.email)
+        if existing is not None:
+            raise JuezYaRegistrado(f"Ya existe un perfil de juez con email {cmd.email}")
+
+        juez = Juez(
+            juez_id=uuid4(),
+            email=cmd.email,
+            numero_licencia=cmd.numero_licencia,
+            federacion=cmd.federacion,
+        )
+        await self._repo.save(juez)
+        return juez.juez_id

--- a/src/registro/application/queries/obtener_juez.py
+++ b/src/registro/application/queries/obtener_juez.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from registro.domain.aggregates.juez import Juez
+from registro.domain.exceptions import JuezNoEncontrado
+from registro.domain.ports.juez_repository_port import JuezRepositoryPort
+
+
+class ObtenerJuezHandler:
+    def __init__(self, repo: JuezRepositoryPort) -> None:
+        self._repo = repo
+
+    async def handle(self, email: str) -> Juez:
+        juez = await self._repo.find_by_email(email)
+        if juez is None:
+            raise JuezNoEncontrado(f"No existe perfil de juez con email {email}")
+        return juez

--- a/src/registro/domain/aggregates/juez.py
+++ b/src/registro/domain/aggregates/juez.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from uuid import UUID
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _no_vacio_si_presente(valor: str | None, label: str) -> None:
+    if valor is not None and not valor.strip():
+        raise ValueError(f"{label} no puede ser vacío")
+
+
+@dataclass
+class Juez:
+    juez_id: UUID
+    email: str
+    numero_licencia: str | None = field(default=None)
+    federacion: str | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        if not _EMAIL_RE.match(self.email):
+            raise ValueError("INV-11.4-01: email debe tener formato válido")
+        _no_vacio_si_presente(self.numero_licencia, "INV-11.4-03: numero_licencia")
+        _no_vacio_si_presente(self.federacion, "INV-11.4-04: federacion")
+
+    def actualizar(
+        self,
+        numero_licencia: str | None = None,
+        federacion: str | None = None,
+    ) -> None:
+        if numero_licencia is not None:
+            _no_vacio_si_presente(numero_licencia, "numero_licencia")
+            self.numero_licencia = numero_licencia
+        if federacion is not None:
+            _no_vacio_si_presente(federacion, "federacion")
+            self.federacion = federacion

--- a/src/registro/domain/exceptions.py
+++ b/src/registro/domain/exceptions.py
@@ -36,3 +36,11 @@ class APIncompletoParaPreparacion(Exception):
 
 class APYaDeclarado(Exception):
     pass
+
+
+class JuezNoEncontrado(Exception):
+    pass
+
+
+class JuezYaRegistrado(Exception):
+    pass

--- a/src/registro/domain/ports/juez_repository_port.py
+++ b/src/registro/domain/ports/juez_repository_port.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from uuid import UUID
+
+from registro.domain.aggregates.juez import Juez
+
+
+class JuezRepositoryPort(ABC):
+    @abstractmethod
+    async def save(self, juez: Juez) -> None: ...
+
+    @abstractmethod
+    async def find_by_id(self, juez_id: UUID) -> Juez | None: ...
+
+    @abstractmethod
+    async def find_by_email(self, email: str) -> Juez | None: ...

--- a/src/registro/infrastructure/repositories/sqlite_juez_repository.py
+++ b/src/registro/infrastructure/repositories/sqlite_juez_repository.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+from uuid import UUID
+
+import aiosqlite
+
+from registro.domain.aggregates.juez import Juez
+from registro.domain.ports.juez_repository_port import JuezRepositoryPort
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS jueces (
+    juez_id          TEXT PRIMARY KEY,
+    email            TEXT NOT NULL UNIQUE,
+    numero_licencia  TEXT,
+    federacion       TEXT
+)
+"""
+
+_SELECT_COLS = "juez_id, email, numero_licencia, federacion"
+
+
+class SQLiteJuezRepository(JuezRepositoryPort):
+    def __init__(self, db_path: str | None = None) -> None:
+        self._db_path = db_path or os.getenv("REGISTRO_DB_PATH", "data/registro.db")
+
+    async def _ensure_table(self, conn: aiosqlite.Connection) -> None:
+        await conn.execute(_CREATE_TABLE)
+        await conn.commit()
+
+    async def save(self, juez: Juez) -> None:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._ensure_table(conn)
+            await conn.execute(
+                """
+                INSERT OR REPLACE INTO jueces
+                    (juez_id, email, numero_licencia, federacion)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    str(juez.juez_id),
+                    juez.email,
+                    juez.numero_licencia,
+                    juez.federacion,
+                ),
+            )
+            await conn.commit()
+
+    async def find_by_id(self, juez_id: UUID) -> Juez | None:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._ensure_table(conn)
+            async with conn.execute(
+                f"SELECT {_SELECT_COLS} FROM jueces WHERE juez_id = ?",
+                (str(juez_id),),
+            ) as cursor:
+                row = await cursor.fetchone()
+        return self._row_to_juez(row) if row else None
+
+    async def find_by_email(self, email: str) -> Juez | None:
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._ensure_table(conn)
+            async with conn.execute(
+                f"SELECT {_SELECT_COLS} FROM jueces WHERE email = ?",
+                (email,),
+            ) as cursor:
+                row = await cursor.fetchone()
+        return self._row_to_juez(row) if row else None
+
+    @staticmethod
+    def _row_to_juez(row: tuple) -> Juez:
+        # 0:juez_id 1:email 2:numero_licencia 3:federacion
+        return Juez(
+            juez_id=UUID(row[0]),
+            email=row[1],
+            numero_licencia=row[2],
+            federacion=row[3],
+        )

--- a/tests/features/US-ADJ-11.4-juez.feature
+++ b/tests/features/US-ADJ-11.4-juez.feature
@@ -1,0 +1,46 @@
+Feature: US-ADJ-11.4 — BC Registro: entidad Juez
+  Como usuario con rol JUEZ
+  Quiero poder crear y actualizar mi perfil de juez
+  Para que el organizador tenga mis datos de licencia disponibles
+
+  Background:
+    Given el repositorio de jueces está inicializado
+
+  Scenario: Crear perfil Juez con datos mínimos
+    Given no existe perfil Juez para "juez@test.com"
+    When hace POST /registro/jueces con body vacío como "juez@test.com"
+    Then la respuesta es 201
+    And la respuesta contiene un juez_id generado por el backend
+    And el juez "juez@test.com" tiene numero_licencia null y federacion null
+
+  Scenario: Crear perfil Juez con datos completos
+    Given no existe perfil Juez para "completo@test.com"
+    When hace POST /registro/jueces con numero_licencia "ARG-001" y federacion "AIDA" como "completo@test.com"
+    Then la respuesta es 201
+    And el juez "completo@test.com" tiene numero_licencia "ARG-001" y federacion "AIDA"
+
+  Scenario: Intentar crear perfil Juez duplicado devuelve 409
+    Given existe un perfil Juez para "juez@test.com" sin licencia
+    When hace POST /registro/jueces con body vacío como "juez@test.com"
+    Then la respuesta es 409
+
+  Scenario: Obtener perfil Juez propio
+    Given existe un perfil Juez para "juez@test.com" sin licencia
+    When hace GET /registro/jueces/me como "juez@test.com"
+    Then la respuesta es 200
+    And el cuerpo contiene el email "juez@test.com"
+
+  Scenario: Obtener perfil Juez inexistente devuelve 404
+    Given no existe perfil Juez para "nuevo@test.com"
+    When hace GET /registro/jueces/me como "nuevo@test.com"
+    Then la respuesta es 404
+
+  Scenario: Actualizar numero de licencia
+    Given existe un perfil Juez para "juez@test.com" sin licencia
+    When hace PATCH /registro/jueces/me con numero_licencia "ARG-042" como "juez@test.com"
+    Then la respuesta es 200
+    And el juez "juez@test.com" tiene numero_licencia "ARG-042" y federacion null
+
+  Scenario: Usuario con rol ATLETA no puede crear perfil Juez
+    When hace POST /registro/jueces como ATLETA con email "atleta@test.com"
+    Then la respuesta es 403

--- a/tests/features/steps/juez_steps.py
+++ b/tests/features/steps/juez_steps.py
@@ -1,0 +1,152 @@
+"""Step definitions BDD — US-ADJ-11.4: entidad Juez."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from identidad.api.dependencies import get_current_user
+from registro.api.router import router
+from registro.infrastructure.repositories.sqlite_juez_repository import SQLiteJuezRepository
+
+scenarios("../US-ADJ-11.4-juez.feature")
+
+
+@pytest.fixture
+def ctx(tmp_path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    db_path = str(tmp_path / "registro.db")
+    monkeypatch.setenv("REGISTRO_DB_PATH", db_path)
+    repo = SQLiteJuezRepository(db_path)
+    return {"repo": repo, "response": None, "email_activo": None, "rol_activo": "JUEZ"}
+
+
+@pytest.fixture
+def client(ctx: dict) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+
+    def _current_user():
+        return {
+            "sub": str(uuid4()),
+            "email": ctx["email_activo"] or "juez@test.com",
+            "rol": ctx["rol_activo"],
+        }
+
+    app.dependency_overrides[get_current_user] = _current_user
+    return TestClient(app)
+
+
+# ── Givens ────────────────────────────────────────────────────────────────────
+
+
+@given("el repositorio de jueces está inicializado")
+def repositorio_inicializado(ctx: dict) -> None:
+    pass
+
+
+@given(parsers.parse('no existe perfil Juez para "{email}"'))
+def no_existe_juez(email: str, ctx: dict) -> None:
+    ctx["email_activo"] = email
+
+
+@given(parsers.parse('existe un perfil Juez para "{email}" sin licencia'))
+def existe_juez_sin_licencia(email: str, ctx: dict) -> None:
+    from registro.domain.aggregates.juez import Juez
+
+    juez = Juez(juez_id=uuid4(), email=email)
+    asyncio.run(ctx["repo"].save(juez))
+    ctx["email_activo"] = email
+
+
+# ── Whens ─────────────────────────────────────────────────────────────────────
+
+
+@when(parsers.parse('hace POST /registro/jueces con body vacío como "{email}"'))
+def post_juez_vacio(email: str, ctx: dict, client: TestClient) -> None:
+    ctx["email_activo"] = email
+    ctx["response"] = client.post("/registro/jueces", json={})
+
+
+@when(
+    parsers.parse(
+        'hace POST /registro/jueces con numero_licencia "{licencia}" y federacion "{fed}" '
+        'como "{email}"'
+    )
+)
+def post_juez_completo(licencia: str, fed: str, email: str, ctx: dict, client: TestClient) -> None:
+    ctx["email_activo"] = email
+    ctx["response"] = client.post(
+        "/registro/jueces",
+        json={"numero_licencia": licencia, "federacion": fed},
+    )
+
+
+@when(parsers.parse('hace GET /registro/jueces/me como "{email}"'))
+def get_juez_me(email: str, ctx: dict, client: TestClient) -> None:
+    ctx["email_activo"] = email
+    ctx["response"] = client.get("/registro/jueces/me")
+
+
+@when(
+    parsers.parse('hace PATCH /registro/jueces/me con numero_licencia "{licencia}" como "{email}"')
+)
+def patch_juez_licencia(licencia: str, email: str, ctx: dict, client: TestClient) -> None:
+    ctx["email_activo"] = email
+    ctx["response"] = client.patch("/registro/jueces/me", json={"numero_licencia": licencia})
+
+
+@when(parsers.parse('hace POST /registro/jueces como ATLETA con email "{email}"'))
+def post_juez_como_atleta(email: str, ctx: dict, client: TestClient) -> None:
+    ctx["email_activo"] = email
+    ctx["rol_activo"] = "ATLETA"
+    ctx["response"] = client.post("/registro/jueces", json={})
+
+
+# ── Thens ─────────────────────────────────────────────────────────────────────
+
+
+@then(parsers.parse("la respuesta es {status:d}"))
+def respuesta_status(status: int, ctx: dict) -> None:
+    assert ctx["response"].status_code == status, ctx["response"].text
+
+
+@then("la respuesta contiene un juez_id generado por el backend")
+def respuesta_contiene_juez_id(ctx: dict) -> None:
+    data = ctx["response"].json()
+    assert "juez_id" in data
+    assert data["juez_id"]
+
+
+@then(parsers.parse('el juez "{email}" tiene numero_licencia null y federacion null'))
+def juez_sin_datos(email: str, ctx: dict) -> None:
+    juez = asyncio.run(ctx["repo"].find_by_email(email))
+    assert juez is not None
+    assert juez.numero_licencia is None
+    assert juez.federacion is None
+
+
+@then(parsers.parse('el juez "{email}" tiene numero_licencia "{licencia}" y federacion "{fed}"'))
+def juez_con_datos(email: str, licencia: str, fed: str, ctx: dict) -> None:
+    juez = asyncio.run(ctx["repo"].find_by_email(email))
+    assert juez is not None
+    assert juez.numero_licencia == licencia
+    assert juez.federacion == fed
+
+
+@then(parsers.parse('el juez "{email}" tiene numero_licencia "{licencia}" y federacion null'))
+def juez_con_licencia_sin_federacion(email: str, licencia: str, ctx: dict) -> None:
+    juez = asyncio.run(ctx["repo"].find_by_email(email))
+    assert juez is not None
+    assert juez.numero_licencia == licencia
+    assert juez.federacion is None
+
+
+@then(parsers.parse('el cuerpo contiene el email "{email}"'))
+def cuerpo_contiene_email(email: str, ctx: dict) -> None:
+    data = ctx["response"].json()
+    assert data.get("email") == email

--- a/tests/integration/registro/test_sqlite_juez_repository.py
+++ b/tests/integration/registro/test_sqlite_juez_repository.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from registro.domain.aggregates.juez import Juez
+from registro.infrastructure.repositories.sqlite_juez_repository import SQLiteJuezRepository
+
+
+def _juez(**kwargs) -> Juez:
+    defaults = dict(juez_id=uuid4(), email="juez@example.com")
+    defaults.update(kwargs)
+    return Juez(**defaults)
+
+
+@pytest.fixture
+def repo(tmp_path) -> SQLiteJuezRepository:
+    return SQLiteJuezRepository(db_path=str(tmp_path / "registro.db"))
+
+
+class TestSQLiteJuezRepository:
+    async def test_save_y_find_by_id(self, repo: SQLiteJuezRepository) -> None:
+        juez = _juez()
+        await repo.save(juez)
+        result = await repo.find_by_id(juez.juez_id)
+        assert result is not None
+        assert result.juez_id == juez.juez_id
+        assert result.email == juez.email
+        assert result.numero_licencia is None
+        assert result.federacion is None
+
+    async def test_save_con_todos_los_campos(self, repo: SQLiteJuezRepository) -> None:
+        juez = _juez(numero_licencia="ARG-001", federacion="AIDA")
+        await repo.save(juez)
+        result = await repo.find_by_id(juez.juez_id)
+        assert result is not None
+        assert result.numero_licencia == "ARG-001"
+        assert result.federacion == "AIDA"
+
+    async def test_find_by_email(self, repo: SQLiteJuezRepository) -> None:
+        juez = _juez(email="otro@example.com")
+        await repo.save(juez)
+        result = await repo.find_by_email("otro@example.com")
+        assert result is not None
+        assert result.juez_id == juez.juez_id
+
+    async def test_find_by_id_no_existente(self, repo: SQLiteJuezRepository) -> None:
+        result = await repo.find_by_id(uuid4())
+        assert result is None
+
+    async def test_find_by_email_no_existente(self, repo: SQLiteJuezRepository) -> None:
+        result = await repo.find_by_email("noexiste@example.com")
+        assert result is None
+
+    async def test_upsert_actualiza_datos(self, repo: SQLiteJuezRepository) -> None:
+        juez = _juez()
+        await repo.save(juez)
+        juez.actualizar(numero_licencia="ARG-042", federacion="CMAS")
+        await repo.save(juez)
+        result = await repo.find_by_id(juez.juez_id)
+        assert result is not None
+        assert result.numero_licencia == "ARG-042"
+        assert result.federacion == "CMAS"
+
+    async def test_dos_jueces_en_misma_db(self, repo: SQLiteJuezRepository) -> None:
+        juez1 = _juez(email="juez1@example.com")
+        juez2 = _juez(email="juez2@example.com")
+        await repo.save(juez1)
+        await repo.save(juez2)
+        r1 = await repo.find_by_email("juez1@example.com")
+        r2 = await repo.find_by_email("juez2@example.com")
+        assert r1 is not None and r1.juez_id == juez1.juez_id
+        assert r2 is not None and r2.juez_id == juez2.juez_id

--- a/tests/unit/registro/test_juez.py
+++ b/tests/unit/registro/test_juez.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from registro.domain.aggregates.juez import Juez
+
+
+def _juez(**kwargs) -> Juez:
+    defaults = dict(juez_id=uuid4(), email="juez@test.com")
+    defaults.update(kwargs)
+    return Juez(**defaults)
+
+
+class TestJuezAggregate:
+    def test_crear_juez_minimo(self) -> None:
+        juez = _juez()
+        assert juez.numero_licencia is None
+        assert juez.federacion is None
+
+    def test_crear_juez_completo(self) -> None:
+        juez = _juez(numero_licencia="ARG-001", federacion="AIDA")
+        assert juez.numero_licencia == "ARG-001"
+        assert juez.federacion == "AIDA"
+
+    def test_email_invalido_lanza_error(self) -> None:
+        with pytest.raises(ValueError, match="email"):
+            _juez(email="no-es-email")
+
+    def test_email_vacio_lanza_error(self) -> None:
+        with pytest.raises(ValueError, match="email"):
+            _juez(email="")
+
+    def test_numero_licencia_vacio_lanza_error(self) -> None:
+        with pytest.raises(ValueError, match="numero_licencia"):
+            _juez(numero_licencia="")
+
+    def test_federacion_vacia_lanza_error(self) -> None:
+        with pytest.raises(ValueError, match="federacion"):
+            _juez(federacion="  ")
+
+    def test_actualizar_numero_licencia(self) -> None:
+        juez = _juez()
+        juez.actualizar(numero_licencia="ARG-042")
+        assert juez.numero_licencia == "ARG-042"
+
+    def test_actualizar_federacion(self) -> None:
+        juez = _juez()
+        juez.actualizar(federacion="CMAS")
+        assert juez.federacion == "CMAS"
+
+    def test_actualizar_parcial_no_borra_otros(self) -> None:
+        juez = _juez(numero_licencia="ARG-001", federacion="AIDA")
+        juez.actualizar(numero_licencia="ARG-999")
+        assert juez.federacion == "AIDA"
+
+    def test_actualizar_sin_argumentos_no_cambia_nada(self) -> None:
+        juez = _juez(numero_licencia="ARG-001")
+        juez.actualizar()
+        assert juez.numero_licencia == "ARG-001"
+
+    def test_actualizar_numero_licencia_vacio_lanza_error(self) -> None:
+        juez = _juez()
+        with pytest.raises(ValueError, match="numero_licencia"):
+            juez.actualizar(numero_licencia="")
+
+    def test_actualizar_federacion_vacia_lanza_error(self) -> None:
+        juez = _juez()
+        with pytest.raises(ValueError, match="federacion"):
+            juez.actualizar(federacion="")

--- a/tests/unit/registro/test_juez_handlers.py
+++ b/tests/unit/registro/test_juez_handlers.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from registro.application.commands.actualizar_juez import (
+    ActualizarJuezCommand,
+    ActualizarJuezHandler,
+)
+from registro.application.commands.registrar_juez import (
+    RegistrarJuezCommand,
+    RegistrarJuezHandler,
+)
+from registro.application.queries.obtener_juez import ObtenerJuezHandler
+from registro.domain.aggregates.juez import Juez
+from registro.domain.exceptions import JuezNoEncontrado, JuezYaRegistrado
+
+
+def _juez(**kwargs) -> Juez:
+    defaults = dict(juez_id=uuid4(), email="juez@test.com")
+    defaults.update(kwargs)
+    return Juez(**defaults)
+
+
+class TestRegistrarJuezHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_genera_juez_id(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_email.return_value = None
+        handler = RegistrarJuezHandler(repo)
+
+        juez_id = await handler.handle(RegistrarJuezCommand(email="juez@test.com"))
+
+        assert juez_id is not None
+        repo.save.assert_awaited_once()
+        saved: Juez = repo.save.call_args[0][0]
+        assert saved.juez_id == juez_id
+        assert saved.email == "juez@test.com"
+
+    @pytest.mark.asyncio
+    async def test_email_duplicado_lanza_excepcion(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_email.return_value = _juez()
+        handler = RegistrarJuezHandler(repo)
+
+        with pytest.raises(JuezYaRegistrado):
+            await handler.handle(RegistrarJuezCommand(email="juez@test.com"))
+
+        repo.save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_registra_con_datos_completos(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_email.return_value = None
+        handler = RegistrarJuezHandler(repo)
+
+        await handler.handle(
+            RegistrarJuezCommand(
+                email="juez@test.com",
+                numero_licencia="ARG-001",
+                federacion="AIDA",
+            )
+        )
+
+        saved: Juez = repo.save.call_args[0][0]
+        assert saved.numero_licencia == "ARG-001"
+        assert saved.federacion == "AIDA"
+
+    @pytest.mark.asyncio
+    async def test_registra_sin_datos_opcionales(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_email.return_value = None
+        handler = RegistrarJuezHandler(repo)
+
+        await handler.handle(RegistrarJuezCommand(email="juez@test.com"))
+
+        saved: Juez = repo.save.call_args[0][0]
+        assert saved.numero_licencia is None
+        assert saved.federacion is None
+
+
+class TestActualizarJuezHandler:
+    @pytest.mark.asyncio
+    async def test_actualiza_y_persiste(self) -> None:
+        juez = _juez()
+        repo = AsyncMock()
+        repo.find_by_email.return_value = juez
+
+        result = await ActualizarJuezHandler(repo).handle(
+            ActualizarJuezCommand(email="juez@test.com", numero_licencia="ARG-042")
+        )
+
+        repo.save.assert_awaited_once_with(juez)
+        assert result.numero_licencia == "ARG-042"
+
+    @pytest.mark.asyncio
+    async def test_lanza_si_no_encontrado(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_email.return_value = None
+
+        with pytest.raises(JuezNoEncontrado):
+            await ActualizarJuezHandler(repo).handle(
+                ActualizarJuezCommand(email="noexiste@test.com")
+            )
+
+    @pytest.mark.asyncio
+    async def test_patch_parcial_no_borra_otros(self) -> None:
+        juez = _juez(numero_licencia="ARG-001", federacion="AIDA")
+        repo = AsyncMock()
+        repo.find_by_email.return_value = juez
+
+        await ActualizarJuezHandler(repo).handle(
+            ActualizarJuezCommand(email="juez@test.com", numero_licencia="ARG-999")
+        )
+
+        assert juez.federacion == "AIDA"
+        assert juez.numero_licencia == "ARG-999"
+
+
+class TestObtenerJuezHandler:
+    @pytest.mark.asyncio
+    async def test_retorna_juez_existente(self) -> None:
+        juez = _juez(numero_licencia="ARG-001")
+        repo = AsyncMock()
+        repo.find_by_email.return_value = juez
+
+        result = await ObtenerJuezHandler(repo).handle("juez@test.com")
+
+        assert result.numero_licencia == "ARG-001"
+
+    @pytest.mark.asyncio
+    async def test_lanza_si_no_encontrado(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_email.return_value = None
+
+        with pytest.raises(JuezNoEncontrado):
+            await ObtenerJuezHandler(repo).handle("noexiste@test.com")


### PR DESCRIPTION
## Summary

- `Juez` aggregate: `juez_id` (generado por backend), `email`, `numero_licencia?`, `federacion?`
- `JuezRepositoryPort` + `SQLiteJuezRepository` — tabla `jueces` en la misma `registro.db`
- `RegistrarJuezCommand/Handler`: lanza `JuezYaRegistrado` si email ya existe
- `ActualizarJuezCommand/Handler` + `ObtenerJuezHandler`: semántica PATCH parcial, lanza `JuezNoEncontrado`
- Router: `POST /registro/jueces`, `GET /registro/jueces/me`, `PATCH /registro/jueces/me` — todos protegidos con `JuezDep`

## Test plan

- [x] 21 unit tests — `test_juez.py`, `test_juez_handlers.py`
- [x] 7 integration tests — `test_sqlite_juez_repository.py`
- [x] 7 BDD scenarios — `US-ADJ-11.4-juez.feature`
- [x] CodeGuard: 0 errores (2 advertencias B608 falsos positivos, mismo patrón que Atleta)
- [x] Black: sin cambios pendientes
- [ ] DesignReviewer: ejecuta pre-merge automáticamente

## Parte de

SP-ADJ-11 — Modelo de usuarios con múltiples roles (US-ADJ-11.1 ✅, 11.2 ✅, 11.3 ✅, **11.4** ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)