### PR TITLE
feat(frontend): RegistroPage multi-rol — checkboxes + secciones Juez/Organizador [US-ADJ-11.6]

### DIFF
--- a/.claude/tracking/US-ADJ-11.6-tracking.json
+++ b/.claude/tracking/US-ADJ-11.6-tracking.json
@@ -1,0 +1,145 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-11.6",
+    "us_title": "Frontend — Registro multi-rol",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-16T19:02:36.153507+00:00",
+    "completed_at": "2026-05-16T19:09:25.728767+00:00",
+    "total_elapsed_seconds": 409,
+    "effective_seconds": 409,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-16T19:03:01.544391+00:00",
+      "completed_at": "2026-05-16T19:03:46.084978+00:00",
+      "elapsed_seconds": 44,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "Generación de Escenarios BDD",
+      "started_at": "2026-05-16T19:03:46.197674+00:00",
+      "completed_at": "2026-05-16T19:04:14.067778+00:00",
+      "elapsed_seconds": 27,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan de Implementación",
+      "started_at": "2026-05-16T19:04:14.307855+00:00",
+      "completed_at": "2026-05-16T19:05:14.810919+00:00",
+      "elapsed_seconds": 60,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-16T19:05:14.903561+00:00",
+      "completed_at": "2026-05-16T19:08:44.911954+00:00",
+      "elapsed_seconds": 210,
+      "status": "completed",
+      "tasks": [
+        {
+          "task_id": "T1",
+          "task_name": "api/identidad.ts — actualizar tipos",
+          "task_type": "implementation",
+          "estimated_minutes": 15.0,
+          "started_at": "2026-05-16T19:05:19.751223+00:00",
+          "completed_at": "2026-05-16T19:05:32.963650+00:00",
+          "elapsed_seconds": 13,
+          "actual_minutes": 0.22,
+          "variance_minutes": -14.78,
+          "file_created": null,
+          "status": "completed"
+        },
+        {
+          "task_id": "T2",
+          "task_name": "RegistroPage.tsx — estado y tipos",
+          "task_type": "implementation",
+          "estimated_minutes": 20.0,
+          "started_at": "2026-05-16T19:05:33.054745+00:00",
+          "completed_at": "2026-05-16T19:06:32.048194+00:00",
+          "elapsed_seconds": 58,
+          "actual_minutes": 0.97,
+          "variance_minutes": -19.03,
+          "file_created": null,
+          "status": "completed"
+        },
+        {
+          "task_id": "T6",
+          "task_name": "npm run build — TypeScript",
+          "task_type": "quality",
+          "estimated_minutes": 5.0,
+          "started_at": "2026-05-16T19:06:35.827749+00:00",
+          "completed_at": "2026-05-16T19:08:42.178761+00:00",
+          "elapsed_seconds": 126,
+          "actual_minutes": 2.1,
+          "variance_minutes": -2.9,
+          "file_created": null,
+          "status": "completed"
+        }
+      ],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-16T19:08:45.005854+00:00",
+      "completed_at": "2026-05-16T19:08:54.623023+00:00",
+      "elapsed_seconds": 9,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-16T19:08:54.711619+00:00",
+      "completed_at": "2026-05-16T19:09:22.180670+00:00",
+      "elapsed_seconds": 27,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-16T19:09:22.267980+00:00",
+      "completed_at": null,
+      "elapsed_seconds": 0,
+      "status": "in_progress",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 3,
+    "completed_tasks": 3,
+    "total_phases": 7,
+    "estimated_total_minutes": 40.0,
+    "actual_total_minutes": 3.28,
+    "variance_minutes": -36.72,
+    "variance_percent": -91.79
+  }
+}

--- a/docs/plans/sp-adj-11/US-ADJ-11.6-plan.md
+++ b/docs/plans/sp-adj-11/US-ADJ-11.6-plan.md
@@ -1,0 +1,79 @@
+# Plan de Implementación — US-ADJ-11.6
+# Frontend — Registro multi-rol
+
+**Fecha:** 2026-05-16  
+**Track:** Informal (vibe coding) — solo `frontend/`  
+**Estimación:** 3 puntos (~90 min)  
+**Branch:** `feature/US-ADJ-11.6-registro-multi-rol`
+
+---
+
+## Artefactos a modificar
+
+| Archivo | Cambio |
+|---------|--------|
+| `frontend/src/api/identidad.ts` | `CrearUsuarioRequest.rol` → `roles: RolGestionUsuario[]`; agregar `CrearUsuarioResponse` con `requires_role_selection?`, `access_token?`, `token_type?` |
+| `frontend/src/pages/RegistroPage.tsx` | Reemplazar `<select>` por checkboxes multi-rol; agregar secciones colapsables Juez/Organizador; manejar `requires_role_selection` en `onSuccess` |
+
+---
+
+## Tareas
+
+### T1 — `api/identidad.ts`: actualizar tipos (~15 min)
+
+1. Cambiar `CrearUsuarioRequest.rol: RolGestionUsuario` → `roles: RolGestionUsuario[]`
+2. Ampliar `CrearUsuarioResponse` para cubrir ambas formas de respuesta del backend:
+   - Flujo directo: `{ usuario_id, access_token, token_type }`
+   - Flujo multi-rol: `{ usuario_id, requires_role_selection: true, roles }`
+
+### T2 — `RegistroPage.tsx`: estado y tipos (~20 min)
+
+1. Reemplazar `FormState` — quitar `rol: RolGestionUsuario`, agregar:
+   - `roles: RolGestionUsuario[]` (checkboxes activos)
+   - `numero_licencia: string`, `federacion: string` (Juez)
+   - `nombre_organizacion: string` (Organizador)
+2. Actualizar `INITIAL_FORM` con los nuevos campos
+3. Actualizar `handleSubmit` — construir payload con `roles` y campos condicionales por rol
+
+### T3 — `RegistroPage.tsx`: selector de roles (~20 min)
+
+1. Reemplazar `<select>` por grupo de checkboxes (ATLETA / JUEZ / ORGANIZADOR)
+2. Handler `toggleRol(rol)` que agrega/quita del array `form.roles`
+3. Mostrar error "Seleccioná al menos un rol" si `roles` está vacío al submit
+4. Botón "Registrarme" deshabilitado si `roles.length === 0`
+
+### T4 — `RegistroPage.tsx`: secciones colapsables (~20 min)
+
+1. Sección Juez: visible si `form.roles.includes('JUEZ')` → campos `numero_licencia` y `federacion` (opcionales)
+2. Sección Organizador: visible si `form.roles.includes('ORGANIZADOR')` → campo `nombre_organizacion` (opcional)
+3. Al desmarcar un rol, ocultar la sección pero NO limpiar los campos (UX no intrusiva)
+
+### T5 — `RegistroPage.tsx`: `onSuccess` multi-rol (~10 min)
+
+1. Si `data.requires_role_selection === true`: redirigir a `/login` con `state: { requiresRoleSelection: true }`
+2. Si `data.access_token`: auto-login y redirect al portal del primer rol de `form.roles`
+3. Mantener el fallback actual a `/login` si el auto-login falla
+
+### T6 — Quality gate: `npm run build` (~5 min)
+
+Compilar TypeScript — sin errores de tipo ni imports rotos.
+
+---
+
+## Criterios de Done
+
+- [ ] `CrearUsuarioRequest` usa `roles: RolGestionUsuario[]`
+- [ ] Checkboxes multi-rol reemplazan el `<select>`
+- [ ] Sección Juez aparece/desaparece según checkbox
+- [ ] Sección Organizador aparece/desaparece según checkbox
+- [ ] Submit deshabilitado / error si `roles` vacío
+- [ ] `requires_role_selection` redirige a `/login` con state
+- [ ] `npm run build` sin errores TypeScript
+
+---
+
+## Notas
+
+- Los campos de rol (numero_licencia, federacion, nombre_organizacion) son **opcionales** — se omiten del payload si están vacíos (enviar `null` o no incluirlos).
+- La lógica de crear perfil en BC Registro post-login queda **fuera de alcance** (US posterior).
+- El redirect post-registro usa el primer rol activo para elegir el portal (o `/atleta` como fallback).

--- a/docs/reports/US-ADJ-11.6-report.md
+++ b/docs/reports/US-ADJ-11.6-report.md
@@ -1,0 +1,63 @@
+# Reporte de Implementación — US-ADJ-11.6
+
+**Historia:** Frontend — Registro multi-rol  
+**Sprint:** SP-ADJ-11  
+**Track:** Informal (vibe coding) — solo `frontend/`  
+**Fecha:** 2026-05-16  
+**Branch:** `feature/US-ADJ-11.6-registro-multi-rol`  
+**Tiempo total:** ~6 min de ejecución de skill (implementación ~3.5 min + build fix ~2 min)
+
+---
+
+## Artefactos generados / modificados
+
+| Artefacto | Tipo | Cambio |
+|-----------|------|--------|
+| `tests/features/US-ADJ-11.6-registro-multi-rol.feature` | Nuevo | Escenarios BDD (6 escenarios) |
+| `docs/plans/sp-adj-11/US-ADJ-11.6-plan.md` | Nuevo | Plan de implementación (6 tareas) |
+| `frontend/src/api/identidad.ts` | Modificado | `CrearUsuarioRequest.rol` → `roles: RolGestionUsuario[]`; `CrearUsuarioResponse` ampliado |
+| `frontend/src/pages/RegistroPage.tsx` | Modificado | `<select>` → checkboxes; secciones colapsables Juez/Organizador; `onSuccess` multi-rol |
+| `frontend/src/pages/organizador/UsuariosPage.tsx` | Modificado | `rol: form.rol` → `roles: [form.rol]` (adaptar al tipo actualizado) |
+| `frontend/src/pages/atleta/AtletaHomePage.tsx` | Modificado | Eliminadas funciones `sortDisciplinasPorOt`/`getOtTimestamp` sin uso (build fix pre-existente) |
+
+---
+
+## Invariantes implementadas
+
+| ID | Invariante | Estado |
+|----|------------|--------|
+| INV-11.6-01 | Al menos un rol seleccionado para habilitar "Registrarme" | ✅ botón `disabled` si `roles.length === 0` + error en submit |
+| INV-11.6-02 | Rol ADMIN no disponible en auto-registro | ✅ no está en la lista de checkboxes; el backend lo enforce |
+| INV-11.6-03 | Secciones de datos por rol son opcionales | ✅ campos no bloquean el envío si están vacíos |
+| INV-11.6-04 | Campos de rol no seleccionado no se envían | ✅ `handleSubmit` construye payload condicionalmente |
+
+---
+
+## Quality Gate
+
+| Gate | Resultado |
+|------|-----------|
+| `npm run build` (TypeScript) | ✅ 190 módulos, 0 errores |
+
+---
+
+## Decisiones técnicas
+
+1. **`onSuccess` tri-path:** (a) `requires_role_selection` → redirect `/login`; (b) `access_token` en respuesta → auto-login directo; (c) fallback a `loginApi` explícito. Cubre todos los casos del backend US-ADJ-11.1.
+
+2. **Redirect post-registro usa `roles[0]`:** cuando hay múltiples roles y el backend retorna token directo, se navega al portal del primer rol del array. Decisión pragmática — el flujo multi-rol completo se termina en US-ADJ-11.7 (selector de rol en login).
+
+3. **Secciones colapsables no limpian al desmarcar:** al desmarcar un rol, el formulario oculta la sección pero conserva los valores. Evita pérdida de datos si el usuario alterna checkboxes.
+
+4. **`UsuariosPage.tsx`:** el formulario de alta del organizador mantiene `<select>` de un solo rol (su UX es correcta — el admin elige un rol por vez). Solo se adapta el `mutate` para enviar `roles: [form.rol]`.
+
+---
+
+## Pendiente (fuera de alcance)
+
+- Crear perfiles Juez/Organizador en BC Registro post-login (US posterior según spec §Notas puntio 2)
+- Selector de rol al iniciar sesión con múltiples roles → US-ADJ-11.7
+
+---
+
+*Generado: 2026-05-16 · /implement-us US-ADJ-11.6*

--- a/frontend/src/api/identidad.ts
+++ b/frontend/src/api/identidad.ts
@@ -26,11 +26,18 @@ export interface CrearUsuarioRequest {
   apellido: string
   email: string
   password: string
-  rol: RolGestionUsuario
+  roles: RolGestionUsuario[]
+  numero_licencia?: string
+  federacion?: string
+  nombre_organizacion?: string
 }
 
 export interface CrearUsuarioResponse {
   usuario_id: string
+  access_token?: string
+  token_type?: string
+  requires_role_selection?: boolean
+  roles?: RolGestionUsuario[]
 }
 
 export interface CambiarPasswordRequest {

--- a/frontend/src/pages/RegistroPage.tsx
+++ b/frontend/src/pages/RegistroPage.tsx
@@ -5,7 +5,6 @@ import { useMutation } from '@tanstack/react-query'
 import {
   ApiError,
   crearUsuario,
-  type CrearUsuarioRequest,
   type RolGestionUsuario,
 } from '../api/identidad'
 import { loginApi } from '../api/auth'
@@ -14,7 +13,17 @@ import { HOME_BY_ROL } from '../utils/auth'
 import type { RolUsuario } from '../types/auth'
 import { PasswordStrengthBar } from '../components/PasswordStrengthBar'
 
-type FormState = CrearUsuarioRequest & { confirmarPassword: string }
+interface FormState {
+  nombre: string
+  apellido: string
+  email: string
+  password: string
+  confirmarPassword: string
+  roles: RolGestionUsuario[]
+  numero_licencia: string
+  federacion: string
+  nombre_organizacion: string
+}
 
 type FormErrors = Partial<Record<keyof FormState | 'general', string>>
 
@@ -24,13 +33,16 @@ const INITIAL_FORM: FormState = {
   email: '',
   password: '',
   confirmarPassword: '',
-  rol: 'ATLETA',
+  roles: ['ATLETA'],
+  numero_licencia: '',
+  federacion: '',
+  nombre_organizacion: '',
 }
 
-const ROLES: Array<{ value: RolGestionUsuario; label: string }> = [
-  { value: 'ATLETA', label: 'Atleta' },
-  { value: 'JUEZ', label: 'Juez' },
-  { value: 'ORGANIZADOR', label: 'Organizador' },
+const ROLES: Array<{ value: RolGestionUsuario; label: string; description: string }> = [
+  { value: 'ATLETA', label: 'Atleta', description: 'Competís en torneos de apnea' },
+  { value: 'JUEZ', label: 'Juez', description: 'Arbitrás competencias' },
+  { value: 'ORGANIZADOR', label: 'Organizador', description: 'Gestionás torneos' },
 ]
 
 function inputClass(hasError: boolean): string {
@@ -62,12 +74,24 @@ export function RegistroPage() {
 
   const mutation = useMutation({
     mutationFn: crearUsuario,
-    onSuccess: async (_data, variables) => {
+    onSuccess: async (data, variables) => {
+      if (data.requires_role_selection) {
+        navigate('/login', { replace: true, state: { requiresRoleSelection: true } })
+        return
+      }
+
+      if (data.access_token) {
+        login(data.access_token)
+        const primerRol = variables.roles[0]?.toLowerCase() as RolUsuario | undefined
+        navigate(HOME_BY_ROL[primerRol ?? 'atleta'] ?? '/atleta', { replace: true })
+        return
+      }
+
       try {
         const tokenData = await loginApi(variables.email, variables.password)
         login(tokenData.access_token)
-        const rolPortal = variables.rol.toLowerCase() as RolUsuario
-        navigate(HOME_BY_ROL[rolPortal] ?? '/atleta', { replace: true })
+        const primerRol = variables.roles[0]?.toLowerCase() as RolUsuario | undefined
+        navigate(HOME_BY_ROL[primerRol ?? 'atleta'] ?? '/atleta', { replace: true })
       } catch {
         navigate('/login', { replace: true, state: { autologinFailed: true } })
       }
@@ -95,6 +119,17 @@ export function RegistroPage() {
     setErrors((current) => ({ ...current, [field]: undefined, general: undefined }))
   }
 
+  function toggleRol(rolValue: RolGestionUsuario) {
+    setForm((current) => {
+      const already = current.roles.includes(rolValue)
+      const next = already
+        ? current.roles.filter((r) => r !== rolValue)
+        : [...current.roles, rolValue]
+      return { ...current, roles: next }
+    })
+    setErrors((current) => ({ ...current, roles: undefined, general: undefined }))
+  }
+
   function validate(): FormErrors {
     const nextErrors: FormErrors = {}
     if (!form.nombre.trim()) nextErrors.nombre = 'El nombre es requerido'
@@ -114,6 +149,9 @@ export function RegistroPage() {
     } else if (form.password !== form.confirmarPassword) {
       nextErrors.confirmarPassword = 'Las contrasenas no coinciden'
     }
+    if (form.roles.length === 0) {
+      nextErrors.roles = 'Seleccioná al menos un rol'
+    }
     return nextErrors
   }
 
@@ -125,14 +163,28 @@ export function RegistroPage() {
       return
     }
 
+    const hasJuez = form.roles.includes('JUEZ')
+    const hasOrganizador = form.roles.includes('ORGANIZADOR')
+
     mutation.mutate({
       nombre: form.nombre.trim(),
       apellido: form.apellido.trim(),
       email: form.email.trim(),
       password: form.password,
-      rol: form.rol,
+      roles: form.roles,
+      ...(hasJuez && form.numero_licencia.trim()
+        ? { numero_licencia: form.numero_licencia.trim() }
+        : {}),
+      ...(hasJuez && form.federacion.trim() ? { federacion: form.federacion.trim() } : {}),
+      ...(hasOrganizador && form.nombre_organizacion.trim()
+        ? { nombre_organizacion: form.nombre_organizacion.trim() }
+        : {}),
     })
   }
+
+  const hasJuez = form.roles.includes('JUEZ')
+  const hasOrganizador = form.roles.includes('ORGANIZADOR')
+  const rolesVacios = form.roles.length === 0
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
@@ -184,7 +236,9 @@ export function RegistroPage() {
                 onChange={(event) => updateField('email', event.target.value)}
                 className={inputClass(Boolean(errors.email))}
               />
-              {errors.email ? <span className="mt-1 block text-sm text-red-300">{errors.email}</span> : null}
+              {errors.email ? (
+                <span className="mt-1 block text-sm text-red-300">{errors.email}</span>
+              ) : null}
             </label>
 
             <label className="text-sm font-medium text-slate-300">
@@ -217,20 +271,92 @@ export function RegistroPage() {
               ) : null}
             </label>
 
-            <label className="text-sm font-medium text-slate-300">
-              Rol
-              <select
-                value={form.rol}
-                onChange={(event) => updateField('rol', event.target.value as RolGestionUsuario)}
-                className={inputClass(false)}
-              >
-                {ROLES.map((rolOption) => (
-                  <option key={rolOption.value} value={rolOption.value}>
-                    {rolOption.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            {/* Selector multi-rol */}
+            <fieldset>
+              <legend className="mb-2 text-sm font-medium text-slate-300">Rol / Roles</legend>
+              <div className="flex flex-col gap-2">
+                {ROLES.map((rolOption) => {
+                  const checked = form.roles.includes(rolOption.value)
+                  return (
+                    <label
+                      key={rolOption.value}
+                      className={[
+                        'flex cursor-pointer items-start gap-3 rounded-2xl border px-4 py-3 transition-colors',
+                        checked
+                          ? 'border-sky-500/60 bg-sky-950/30'
+                          : 'border-slate-700 bg-slate-950 hover:border-slate-600',
+                      ].join(' ')}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleRol(rolOption.value)}
+                        className="mt-0.5 h-4 w-4 rounded accent-sky-500"
+                      />
+                      <div>
+                        <span className="block text-sm font-semibold text-slate-100">
+                          {rolOption.label}
+                        </span>
+                        <span className="block text-xs text-slate-400">{rolOption.description}</span>
+                      </div>
+                    </label>
+                  )
+                })}
+              </div>
+              {errors.roles ? (
+                <span className="mt-1 block text-sm text-red-300">{errors.roles}</span>
+              ) : null}
+            </fieldset>
+
+            {/* Sección Juez */}
+            {hasJuez ? (
+              <div className="rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-4">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-sky-400">
+                  Datos de Juez (opcionales)
+                </p>
+                <div className="flex flex-col gap-3">
+                  <label className="text-sm font-medium text-slate-300">
+                    Número de licencia
+                    <input
+                      type="text"
+                      value={form.numero_licencia}
+                      onChange={(event) => updateField('numero_licencia', event.target.value)}
+                      placeholder="Ej: AIDA-12345"
+                      className={inputClass(false)}
+                    />
+                  </label>
+                  <label className="text-sm font-medium text-slate-300">
+                    Federación
+                    <input
+                      type="text"
+                      value={form.federacion}
+                      onChange={(event) => updateField('federacion', event.target.value)}
+                      placeholder="Ej: AIDA, CMAS"
+                      className={inputClass(false)}
+                    />
+                  </label>
+                </div>
+              </div>
+            ) : null}
+
+            {/* Sección Organizador */}
+            {hasOrganizador ? (
+              <div className="rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-4">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-sky-400">
+                  Datos de Organizador (opcionales)
+                </p>
+                <label className="text-sm font-medium text-slate-300">
+                  Nombre de organización
+                  <input
+                    type="text"
+                    value={form.nombre_organizacion}
+                    onChange={(event) => updateField('nombre_organizacion', event.target.value)}
+                    placeholder="Ej: Club Apnea Buenos Aires"
+                    className={inputClass(false)}
+                  />
+                </label>
+              </div>
+            ) : null}
 
             {errors.general ? (
               <p className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-100">
@@ -240,7 +366,7 @@ export function RegistroPage() {
 
             <button
               type="submit"
-              disabled={mutation.isPending}
+              disabled={mutation.isPending || rolesVacios}
               className="rounded-2xl bg-sky-500 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-slate-950 transition-colors hover:bg-sky-400 disabled:opacity-50"
             >
               {mutation.isPending ? 'Creando cuenta...' : 'Registrarme'}

--- a/frontend/src/pages/atleta/AtletaHomePage.tsx
+++ b/frontend/src/pages/atleta/AtletaHomePage.tsx
@@ -11,36 +11,8 @@ import {
   formatHora,
   getEstadoTorneoLabel,
   loadAtletaPortalSnapshot,
-  type AtletaPortalEntry,
 } from './portalData'
 
-function getOtTimestamp(entry: AtletaPortalEntry): number | null {
-  if (!entry.ot) return null
-  const timestamp = new Date(entry.ot).getTime()
-  return Number.isNaN(timestamp) ? null : timestamp
-}
-
-function sortDisciplinasPorOt(entries: AtletaPortalEntry[], now = new Date()): AtletaPortalEntry[] {
-  const nowTimestamp = now.getTime()
-
-  return [...entries].sort((left, right) => {
-    const leftTimestamp = getOtTimestamp(left)
-    const rightTimestamp = getOtTimestamp(right)
-    const leftFuture = leftTimestamp !== null && leftTimestamp > nowTimestamp
-    const rightFuture = rightTimestamp !== null && rightTimestamp > nowTimestamp
-    const leftPast = leftTimestamp !== null && leftTimestamp <= nowTimestamp
-    const rightPast = rightTimestamp !== null && rightTimestamp <= nowTimestamp
-
-    if (leftFuture && rightFuture) return leftTimestamp - rightTimestamp
-    if (leftFuture) return -1
-    if (rightFuture) return 1
-    if (!leftPast && !rightPast) return 0
-    if (!leftPast) return -1
-    if (!rightPast) return 1
-    if (leftTimestamp !== null && rightTimestamp !== null) return leftTimestamp - rightTimestamp
-    return 0
-  })
-}
 
 export function AtletaHomePage() {
   const atletaId = useAuthStore((state) => state.userId)

--- a/frontend/src/pages/organizador/UsuariosPage.tsx
+++ b/frontend/src/pages/organizador/UsuariosPage.tsx
@@ -141,7 +141,7 @@ export function UsuariosPage() {
       apellido: form.apellido.trim(),
       email: form.email.trim(),
       password: form.password,
-      rol: form.rol,
+      roles: [form.rol],
     })
   }
 

--- a/tests/features/US-ADJ-11.6-registro-multi-rol.feature
+++ b/tests/features/US-ADJ-11.6-registro-multi-rol.feature
@@ -1,0 +1,43 @@
+Feature: Registro multi-rol en RegistroPage
+  As a user registering in AtaraxiaDive
+  I want to select one or more roles (Atleta, Juez, Organizador)
+  So that my account reflects all my activities from the start
+
+  Background:
+    Given the user is on /registro and is not authenticated
+
+  Scenario: Usuario selecciona un solo rol (ATLETA) — flujo actual sin cambios
+    Given the user checks only the ATLETA checkbox
+    And completes nombre, apellido, email, password fields
+    When the user submits the registration form
+    Then the API receives roles=["ATLETA"]
+    And auto-login succeeds and redirects to /atleta
+
+  Scenario: Usuario selecciona múltiples roles — sección Juez visible
+    Given the user checks ATLETA and JUEZ checkboxes
+    Then the Juez data section is visible with fields numero_licencia and federacion
+    When the user submits the registration form
+    Then the API receives roles=["ATLETA", "JUEZ"]
+
+  Scenario: Usuario selecciona múltiples roles — sección Organizador visible
+    Given the user checks ATLETA and ORGANIZADOR checkboxes
+    Then the Organizador data section is visible with field nombre_organizacion
+    When the user submits the registration form
+    Then the API receives roles=["ATLETA", "ORGANIZADOR"]
+
+  Scenario: Respuesta con requires_role_selection
+    Given the user checks ATLETA and ORGANIZADOR checkboxes
+    And completes the registration form
+    When the backend returns requires_role_selection=true
+    Then the frontend redirects to /login with state requiresRoleSelection=true
+
+  Scenario: Intento de envío sin roles seleccionados
+    Given the user unchecks all role checkboxes
+    Then the submit button is disabled
+    And the message "Seleccioná al menos un rol" is visible
+
+  Scenario: Campos de rol no seleccionado no se envían en el payload
+    Given the user checks only ATLETA
+    And the Juez section is hidden
+    When the user submits the registration form
+    Then the payload does not include numero_licencia or federacion


### PR DESCRIPTION
## Resumen

Adapta `RegistroPage` al backend multi-rol de US-ADJ-11.1: reemplaza el `<select>` de rol único por checkboxes múltiples (ATLETA / JUEZ / ORGANIZADOR) con secciones colapsables de datos opcionales por rol. Actualiza `CrearUsuarioRequest.rol → roles[]` y maneja la respuesta `requires_role_selection` del backend.

## Cambios principales

- `api/identidad.ts` — `CrearUsuarioRequest.roles: RolGestionUsuario[]`; `CrearUsuarioResponse` ampliado con `access_token?`, `requires_role_selection?`
- `RegistroPage.tsx` — checkboxes multi-rol, secciones Juez (numero_licencia, federacion) y Organizador (nombre_organizacion), botón deshabilitado si sin roles, `onSuccess` tri-path
- `UsuariosPage.tsx` — adaptado al nuevo tipo (`roles: [form.rol]`)
- `AtletaHomePage.tsx` — eliminadas funciones sin uso que bloqueaban el build

## UAT

| Escenario | Resultado |
|-----------|-----------|
| Estado inicial — ATLETA pre-marcado | ✅ |
| Sin roles → botón deshabilitado (INV-11.6-01) | ✅ |
| ATLETA + JUEZ → sección Juez visible | ✅ |
| Campos Juez vacíos → registro funciona (INV-11.6-03) | ✅ |
| Solo ATLETA → auto-login → `/atleta` | ✅ |
| Email duplicado → error 409 en campo email | ✅ |

## Gaps identificados (fuera de alcance)

- Perfil en BC Registro no se crea al registrarse → US-ADJ-11.10
- Login multi-rol sin token → US-ADJ-11.7

## Impacto

- `npm run build` ✅ — 190 módulos, 0 errores TypeScript
- 8 archivos modificados · ~492 líneas agregadas, 57 eliminadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)