### PR TITLE
feat(frontend): Mis Datos Atleta — campos dni y telefono [US-ADJ-11.8]

### DIFF
--- a/.claude/tracking/US-ADJ-11.8-tracking.json
+++ b/.claude/tracking/US-ADJ-11.8-tracking.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-11.8",
+    "us_title": "Frontend — Mis Datos Atleta — dni, telefono y campos opcionales",
+    "us_points": 2,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-16T21:43:59.328667+00:00",
+    "completed_at": "2026-05-16T21:47:00.468737+00:00",
+    "total_elapsed_seconds": 181,
+    "effective_seconds": 181,
+    "paused_seconds": 0
+  },
+  "phases": [
+    {
+      "phase_number": 0,
+      "phase_name": "Validación de Contexto",
+      "started_at": "2026-05-16T21:44:02.948025+00:00",
+      "completed_at": "2026-05-16T21:44:25.509603+00:00",
+      "elapsed_seconds": 22,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 1,
+      "phase_name": "BDD",
+      "started_at": "2026-05-16T21:44:30.274180+00:00",
+      "completed_at": "2026-05-16T21:44:47.336248+00:00",
+      "elapsed_seconds": 17,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 2,
+      "phase_name": "Plan",
+      "started_at": "2026-05-16T21:44:47.439895+00:00",
+      "completed_at": "2026-05-16T21:45:02.901913+00:00",
+      "elapsed_seconds": 15,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 3,
+      "phase_name": "Implementación",
+      "started_at": "2026-05-16T21:45:02.992156+00:00",
+      "completed_at": "2026-05-16T21:46:31.132827+00:00",
+      "elapsed_seconds": 88,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 7,
+      "phase_name": "Quality Gates",
+      "started_at": "2026-05-16T21:46:31.213401+00:00",
+      "completed_at": "2026-05-16T21:46:56.195915+00:00",
+      "elapsed_seconds": 24,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 8,
+      "phase_name": "Documentación",
+      "started_at": "2026-05-16T21:46:56.277390+00:00",
+      "completed_at": "2026-05-16T21:47:00.294929+00:00",
+      "elapsed_seconds": 4,
+      "status": "completed",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    },
+    {
+      "phase_number": 9,
+      "phase_name": "Reporte Final",
+      "started_at": "2026-05-16T21:47:00.384755+00:00",
+      "completed_at": null,
+      "elapsed_seconds": 0,
+      "status": "in_progress",
+      "tasks": [],
+      "auto_approved": true,
+      "user_approval_time_seconds": 0
+    }
+  ],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 7,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/reports/US-ADJ-11.8-report.md
+++ b/docs/reports/US-ADJ-11.8-report.md
@@ -1,0 +1,34 @@
+# Reporte de Implementación — US-ADJ-11.8
+## Frontend — Mis Datos Atleta — dni, telefono y campos opcionales
+
+**Fecha:** 2026-05-16  
+**SP:** SP-ADJ-11  
+**Branch:** `feature/US-ADJ-11.8-mis-datos-atleta-dni-telefono`  
+**Tiempo total:** ~15 min (estimado: —) · **Track:** informal (vibe coding)
+
+---
+
+## Artefactos Modificados
+
+| Artefacto | Cambio |
+|-----------|--------|
+| `frontend/src/api/registro.ts` | `AtletaDto`: `dni: string \| null`, `telefono: string \| null`. `ActualizarAtletaMePayload`: `dni?: string`, `telefono?: string` |
+| `frontend/src/pages/atleta/AtletaMisDatosPage.tsx` | `FormState` + estado inicial + `toFormState()` + `handleSubmit` + UI (2 inputs con label "opcional") |
+| `tests/features/US-ADJ-11.8-mis-datos-atleta-dni-telefono.feature` | 4 scenarios BDD documentales |
+
+## Invariantes
+
+| ID | Estado |
+|----|--------|
+| INV-11.8-01 | ✅ Campos no requeridos en el formulario |
+| INV-11.8-02 | ✅ `form.dni.trim() \|\| undefined` — vacío no sobreescribe dato existente |
+| INV-11.8-03 | ✅ Patrón ya existente para `club`/`categoria` — sin cambios |
+
+## Quality Gates
+
+| Gate | Resultado |
+|------|-----------|
+| TypeScript (`tsc -b`) | ✅ 0 errores |
+| Vite build | ✅ 190 módulos · 2.82s |
+
+*Reporte generado: 2026-05-16 — US-ADJ-11.8 SP-ADJ-11*

--- a/frontend/src/api/registro.ts
+++ b/frontend/src/api/registro.ts
@@ -53,6 +53,8 @@ export interface AtletaDto {
   categoria: string
   club: string
   brevet: string | null
+  dni: string | null
+  telefono: string | null
 }
 
 export interface CrearAtletaPayload {
@@ -180,6 +182,8 @@ export interface ActualizarAtletaMePayload {
   club?: string
   fecha_nacimiento?: string
   brevet?: string
+  dni?: string
+  telefono?: string
 }
 
 export async function actualizarAtletaMe(payload: ActualizarAtletaMePayload): Promise<AtletaDto> {

--- a/frontend/src/pages/atleta/AtletaMisDatosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaMisDatosPage.tsx
@@ -24,6 +24,8 @@ interface FormState {
   club: string
   fecha_nacimiento: string
   brevet: string
+  dni: string
+  telefono: string
 }
 
 function inputClass(hasError = false): string {
@@ -47,6 +49,8 @@ function toFormState(atleta: AtletaDto): FormState {
     club: atleta.club ?? '',
     fecha_nacimiento: atleta.fecha_nacimiento ?? '',
     brevet: atleta.brevet ?? '',
+    dni: atleta.dni ?? '',
+    telefono: atleta.telefono ?? '',
   }
 }
 
@@ -58,6 +62,8 @@ export function AtletaMisDatosPage() {
     club: '',
     fecha_nacimiento: '',
     brevet: '',
+    dni: '',
+    telefono: '',
   })
   const [isLoading, setIsLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -105,6 +111,8 @@ export function AtletaMisDatosPage() {
         club: form.club.trim() || undefined,
         fecha_nacimiento: form.fecha_nacimiento || undefined,
         brevet: form.brevet.trim() || undefined,
+        dni: form.dni.trim() || undefined,
+        telefono: form.telefono.trim() || undefined,
       })
       setForm(toFormState(updated))
       setSuccess(true)
@@ -202,6 +210,28 @@ export function AtletaMisDatosPage() {
                 onChange={(e) => updateField('brevet', e.target.value)}
                 className={inputClass()}
                 placeholder="Número de brevet (opcional)"
+              />
+            </label>
+
+            <label className="block text-sm font-semibold text-slate-100">
+              DNI <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
+              <input
+                value={form.dni}
+                onChange={(e) => updateField('dni', e.target.value)}
+                className={inputClass()}
+                placeholder="12345678"
+                inputMode="numeric"
+              />
+            </label>
+
+            <label className="block text-sm font-semibold text-slate-100">
+              Teléfono <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
+              <input
+                value={form.telefono}
+                onChange={(e) => updateField('telefono', e.target.value)}
+                className={inputClass()}
+                placeholder="1123456789"
+                inputMode="tel"
               />
             </label>
           </div>

--- a/frontend/src/pages/atleta/AtletaMisDatosPage.tsx
+++ b/frontend/src/pages/atleta/AtletaMisDatosPage.tsx
@@ -168,6 +168,38 @@ export function AtletaMisDatosPage() {
             </label>
 
             <label className="block text-sm font-semibold text-slate-100">
+              Fecha de nacimiento
+              <input
+                type="date"
+                value={form.fecha_nacimiento}
+                onChange={(e) => updateField('fecha_nacimiento', e.target.value)}
+                className={inputClass()}
+              />
+            </label>
+
+            <label className="block text-sm font-semibold text-slate-100">
+              DNI <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
+              <input
+                value={form.dni}
+                onChange={(e) => updateField('dni', e.target.value)}
+                className={inputClass()}
+                placeholder="12345678"
+                inputMode="numeric"
+              />
+            </label>
+
+            <label className="block text-sm font-semibold text-slate-100">
+              Teléfono <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
+              <input
+                value={form.telefono}
+                onChange={(e) => updateField('telefono', e.target.value)}
+                className={inputClass()}
+                placeholder="1123456789"
+                inputMode="tel"
+              />
+            </label>
+
+            <label className="block text-sm font-semibold text-slate-100">
               Categoría
               <select
                 value={form.categoria}
@@ -194,44 +226,12 @@ export function AtletaMisDatosPage() {
             </label>
 
             <label className="block text-sm font-semibold text-slate-100">
-              Fecha de nacimiento
-              <input
-                type="date"
-                value={form.fecha_nacimiento}
-                onChange={(e) => updateField('fecha_nacimiento', e.target.value)}
-                className={inputClass()}
-              />
-            </label>
-
-            <label className="block text-sm font-semibold text-slate-100">
               Brevet
               <input
                 value={form.brevet}
                 onChange={(e) => updateField('brevet', e.target.value)}
                 className={inputClass()}
                 placeholder="Número de brevet (opcional)"
-              />
-            </label>
-
-            <label className="block text-sm font-semibold text-slate-100">
-              DNI <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
-              <input
-                value={form.dni}
-                onChange={(e) => updateField('dni', e.target.value)}
-                className={inputClass()}
-                placeholder="12345678"
-                inputMode="numeric"
-              />
-            </label>
-
-            <label className="block text-sm font-semibold text-slate-100">
-              Teléfono <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
-              <input
-                value={form.telefono}
-                onChange={(e) => updateField('telefono', e.target.value)}
-                className={inputClass()}
-                placeholder="1123456789"
-                inputMode="tel"
               />
             </label>
           </div>

--- a/tests/features/US-ADJ-11.8-mis-datos-atleta-dni-telefono.feature
+++ b/tests/features/US-ADJ-11.8-mis-datos-atleta-dni-telefono.feature
@@ -1,0 +1,29 @@
+Feature: Mis Datos Atleta — campos dni y telefono
+  Como atleta registrado,
+  quiero poder ingresar y actualizar mi DNI y teléfono en Mis Datos,
+  para completar mi perfil con información de contacto real.
+
+  # INV-11.8-01: dni y telefono son opcionales — el formulario no valida su presencia.
+  # INV-11.8-02: campo vacío → undefined en el payload (no borra el dato existente).
+  # INV-11.8-03: club y categoria ya opcionales — verificar envío como undefined si vacíos.
+
+  Scenario: Atleta carga Mis Datos — ve dni y telefono guardados
+    Given el atleta tiene dni="12345678" y telefono="1234567890" guardados
+    When accede a /atleta/mis-datos
+    Then los campos DNI y Teléfono muestran esos valores
+
+  Scenario: Atleta actualiza su DNI
+    Given el atleta está en /atleta/mis-datos
+    When ingresa "98765432" en el campo DNI y guarda
+    Then el PATCH a /registro/atletas/me incluye dni="98765432"
+    And el formulario refleja el valor actualizado
+
+  Scenario: Atleta deja DNI vacío — no se borra el dato existente
+    Given el atleta tiene dni="12345678" guardado
+    When guarda el formulario sin modificar el campo DNI
+    Then el PATCH no incluye el campo dni en el payload
+
+  Scenario: Atleta con dni null — campo queda vacío sin error
+    Given el atleta no tiene dni registrado
+    When accede a /atleta/mis-datos
+    Then el campo DNI aparece vacío sin error


### PR DESCRIPTION
## Summary

- `AtletaDto` y `ActualizarAtletaMePayload` en `api/registro.ts`: agregar `dni` y `telefono`
- `AtletaMisDatosPage`: `FormState` + `toFormState()` + `handleSubmit` + UI con 2 nuevos inputs con helper "(opcional)"
- Orden de campos ajustado: Nombre → Apellido → Fecha de nacimiento → DNI → Teléfono → Categoría → Club → Brevet
- Campo vacío → `undefined` en el payload (INV-11.8-02: no sobreescribe dato existente)

## Test plan

- [ ] `/atleta/mis-datos` muestra campos DNI y Teléfono con helper "(opcional)"
- [ ] Ingresar DNI y Teléfono y guardar — se persisten correctamente
- [ ] Dejar DNI vacío y guardar — no borra el dato existente en el backend
- [ ] Atleta sin DNI registrado — campo aparece vacío sin error
- [x] `npm run build` — 0 errores TypeScript ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)