### PR TITLE
feat(frontend): Mis Datos Juez y Organizador [US-ADJ-11.9]

### DIFF
--- a/.claude/tracking/US-ADJ-11.9-tracking.json
+++ b/.claude/tracking/US-ADJ-11.9-tracking.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "us_id": "US-ADJ-11.9",
+    "us_title": "Frontend — Mis Datos Juez y Organizador",
+    "us_points": 3,
+    "producto": "frontend",
+    "tracking_version": "1.0"
+  },
+  "timeline": {
+    "started_at": "2026-05-16T21:53:47.678224+00:00",
+    "completed_at": null,
+    "total_elapsed_seconds": 0,
+    "effective_seconds": 0,
+    "paused_seconds": 0
+  },
+  "phases": [],
+  "pauses": [],
+  "summary": {
+    "total_tasks": 0,
+    "completed_tasks": 0,
+    "total_phases": 0,
+    "estimated_total_minutes": 0,
+    "actual_total_minutes": 0,
+    "variance_minutes": 0,
+    "variance_percent": 0.0
+  }
+}

--- a/docs/reports/US-ADJ-11.9-report.md
+++ b/docs/reports/US-ADJ-11.9-report.md
@@ -1,0 +1,38 @@
+# Reporte de Implementación — US-ADJ-11.9
+## Frontend — Mis Datos Juez y Organizador
+
+**Fecha:** 2026-05-16  
+**SP:** SP-ADJ-11  
+**Branch:** `feature/US-ADJ-11.9-mis-datos-juez-organizador`  
+**Track:** informal (vibe coding) — frontend-only
+
+---
+
+## Artefactos Creados / Modificados
+
+| Artefacto | Cambio |
+|-----------|--------|
+| `frontend/src/api/registro.ts` | `JuezDto`, `ActualizarJuezMePayload`, `OrganizadorDto`, `ActualizarOrganizadorMePayload` + 6 funciones API |
+| `frontend/src/pages/juez/JuezMisDatosPage.tsx` | Nueva página — GET/PATCH `/registro/jueces/me` + CTA crear si 404 |
+| `frontend/src/pages/organizador/OrganizadorMisDatosPage.tsx` | Nueva página — GET/PATCH `/registro/organizadores/me` + CTA crear si 404 |
+| `frontend/src/App.tsx` | Rutas `/juez/mis-datos` y `/organizador/mis-datos` con `RequireRole` |
+| `frontend/src/components/organizador/OrganizadorLayout.tsx` | Nav item "Mis Datos" agregado |
+| `frontend/src/pages/juez/DisciplinasPage.tsx` | Enlace "Mis Datos" en acciones del header |
+
+## Invariantes
+
+| ID | Estado |
+|----|--------|
+| INV-11.9-01 | ✅ `numero_licencia`/`federacion` opcionales |
+| INV-11.9-02 | ✅ `nombre_organizacion` opcional |
+| INV-11.9-03 | ✅ 404 → CTA "Crear mi perfil", sin error al usuario |
+| INV-11.9-04 | ✅ `campo.trim() \|\| undefined` en payload PATCH |
+
+## Quality Gates
+
+| Gate | Resultado |
+|------|-----------|
+| TypeScript (`tsc -b`) | ✅ 0 errores |
+| Vite build | ✅ 192 módulos · 2.81s |
+
+*Reporte generado: 2026-05-16 — US-ADJ-11.9 SP-ADJ-11*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { RequireRole } from './components/RequireRole'
 import { DisciplinasPage } from './pages/juez/DisciplinasPage'
 import { GrillaPage } from './pages/juez/GrillaPage'
 import { PerformanceFlowPage } from './pages/juez/PerformanceFlowPage'
+import { JuezMisDatosPage } from './pages/juez/JuezMisDatosPage'
 import { AtletaHomePage } from './pages/atleta/AtletaHomePage'
 import { AtletaTorneosPage } from './pages/atleta/AtletaTorneosPage'
 import { AtletaTorneoDetallePage } from './pages/atleta/AtletaTorneoDetallePage'
@@ -34,6 +35,7 @@ import { AuditoriaCompetenciaPage } from './pages/organizador/AuditoriaCompetenc
 import { AuditoriaPerformancePage } from './pages/organizador/AuditoriaPerformancePage'
 import { ResultadosPage } from './pages/organizador/ResultadosPage'
 import { PodiosPage } from './pages/organizador/PodiosPage'
+import { OrganizadorMisDatosPage } from './pages/organizador/OrganizadorMisDatosPage'
 import { PublicTorneosPage } from './pages/PublicTorneosPage'
 import { PublicTorneoDetallePage } from './pages/PublicTorneoDetallePage'
 import { PublicTorneoResultadosPage } from './pages/PublicTorneoResultadosPage'
@@ -117,6 +119,14 @@ function App() {
           }
         />
         <Route
+          path="/juez/mis-datos"
+          element={
+            <RequireRole role="juez">
+              <JuezMisDatosPage />
+            </RequireRole>
+          }
+        />
+        <Route
           path="/atleta"
           element={
             <RequireRole role="atleta">
@@ -189,6 +199,14 @@ function App() {
           element={
             <RequireRole role="atleta">
               <AtletaMisDatosPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/organizador/mis-datos"
+          element={
+            <RequireRole role="organizador">
+              <OrganizadorMisDatosPage />
             </RequireRole>
           }
         />

--- a/frontend/src/api/registro.ts
+++ b/frontend/src/api/registro.ts
@@ -175,6 +175,28 @@ export async function fetchAtletaMe(): Promise<AtletaDto> {
   return parseResponse<AtletaDto>(response)
 }
 
+export interface JuezDto {
+  juez_id: string
+  email: string
+  numero_licencia: string | null
+  federacion: string | null
+}
+
+export interface ActualizarJuezMePayload {
+  numero_licencia?: string
+  federacion?: string
+}
+
+export interface OrganizadorDto {
+  organizador_id: string
+  email: string
+  nombre_organizacion: string | null
+}
+
+export interface ActualizarOrganizadorMePayload {
+  nombre_organizacion?: string
+}
+
 export interface ActualizarAtletaMePayload {
   nombre?: string
   apellido?: string
@@ -305,4 +327,56 @@ export async function subirConstanciaPago(
     body: formData,
   })
   return parseResponse<{ path: string }>(response)
+}
+
+export async function fetchJuezMe(): Promise<JuezDto | null> {
+  const response = await fetch('/registro/jueces/me', { headers: buildHeaders() })
+  if (response.status === 404) return null
+  return parseResponse<JuezDto>(response)
+}
+
+export async function crearJuezMe(payload: ActualizarJuezMePayload = {}): Promise<JuezDto> {
+  const response = await fetch('/registro/jueces', {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify(payload),
+  })
+  return parseResponse<JuezDto>(response)
+}
+
+export async function actualizarJuezMe(payload: ActualizarJuezMePayload): Promise<JuezDto> {
+  const response = await fetch('/registro/jueces/me', {
+    method: 'PATCH',
+    headers: buildHeaders(),
+    body: JSON.stringify(payload),
+  })
+  return parseResponse<JuezDto>(response)
+}
+
+export async function fetchOrganizadorMe(): Promise<OrganizadorDto | null> {
+  const response = await fetch('/registro/organizadores/me', { headers: buildHeaders() })
+  if (response.status === 404) return null
+  return parseResponse<OrganizadorDto>(response)
+}
+
+export async function crearOrganizadorMe(
+  payload: ActualizarOrganizadorMePayload = {},
+): Promise<OrganizadorDto> {
+  const response = await fetch('/registro/organizadores', {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify(payload),
+  })
+  return parseResponse<OrganizadorDto>(response)
+}
+
+export async function actualizarOrganizadorMe(
+  payload: ActualizarOrganizadorMePayload,
+): Promise<OrganizadorDto> {
+  const response = await fetch('/registro/organizadores/me', {
+    method: 'PATCH',
+    headers: buildHeaders(),
+    body: JSON.stringify(payload),
+  })
+  return parseResponse<OrganizadorDto>(response)
 }

--- a/frontend/src/components/organizador/OrganizadorLayout.tsx
+++ b/frontend/src/components/organizador/OrganizadorLayout.tsx
@@ -28,6 +28,7 @@ interface NavItem {
     | 'jueces'
     | 'torneo'
     | 'audit'
+    | 'mis-datos'
   disabled?: boolean
 }
 
@@ -41,6 +42,7 @@ const NAV_ITEMS: NavItem[] = [
   { key: 'podios', label: 'Podios', to: '/organizador/podios' },
   { key: 'torneo', label: 'Torneo', to: '/organizador/torneo' },
   { key: 'audit', label: 'Audit Log', to: '/organizador/audit-log' },
+  { key: 'mis-datos', label: 'Mis Datos', to: '/organizador/mis-datos' },
 ]
 
 function currentSection(pathname: string): NavItem['key'] {
@@ -52,6 +54,7 @@ function currentSection(pathname: string): NavItem['key'] {
   if (pathname.startsWith('/organizador/podios')) return 'podios'
   if (pathname.startsWith('/organizador/jueces')) return 'jueces'
   if (pathname.startsWith('/organizador/audit-log')) return 'audit'
+  if (pathname.startsWith('/organizador/mis-datos')) return 'mis-datos'
   if (pathname.startsWith('/organizador/torneos/') && pathname.endsWith('/competencias')) {
     return 'audit'
   }

--- a/frontend/src/pages/juez/DisciplinasPage.tsx
+++ b/frontend/src/pages/juez/DisciplinasPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { JuezLayout } from '../../components/juez/JuezLayout'
 import { useDisciplinasJuez } from '../../hooks/useDisciplinasJuez'
 import useAuthStore from '../../stores/useAuthStore'
@@ -16,13 +16,21 @@ export function DisciplinasPage() {
       title="Mis asignaciones"
       subtitle={subtitle}
       actions={
-        <button
-          type="button"
-          onClick={logout}
-          className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-200"
-        >
-          Salir
-        </button>
+        <div className="flex gap-2">
+          <Link
+            to="/juez/mis-datos"
+            className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 hover:text-slate-200"
+          >
+            Mis Datos
+          </Link>
+          <button
+            type="button"
+            onClick={logout}
+            className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-200"
+          >
+            Salir
+          </button>
+        </div>
       }
     >
       {location.state && (location.state as { passwordUpdated?: boolean }).passwordUpdated ? (

--- a/frontend/src/pages/juez/JuezMisDatosPage.tsx
+++ b/frontend/src/pages/juez/JuezMisDatosPage.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+import { JuezLayout } from '../../components/juez/JuezLayout'
+import { actualizarJuezMe, crearJuezMe, fetchJuezMe, ApiError } from '../../api/registro'
+
+interface FormState {
+  numero_licencia: string
+  federacion: string
+}
+
+function inputClass(): string {
+  return 'mt-2 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition placeholder:text-slate-500 focus:border-sky-400'
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) return error.message
+  if (error instanceof Error) return error.message
+  return 'No se pudo completar la operación'
+}
+
+export function JuezMisDatosPage() {
+  const [perfilExiste, setPerfilExiste] = useState<boolean | null>(null)
+  const [form, setForm] = useState<FormState>({ numero_licencia: '', federacion: '' })
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setIsLoading(true)
+      try {
+        const juez = await fetchJuezMe()
+        if (!cancelled) {
+          if (juez) {
+            setPerfilExiste(true)
+            setForm({
+              numero_licencia: juez.numero_licencia ?? '',
+              federacion: juez.federacion ?? '',
+            })
+          } else {
+            setPerfilExiste(false)
+          }
+        }
+      } catch (err) {
+        if (!cancelled) setError(getErrorMessage(err))
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => { cancelled = true }
+  }, [])
+
+  function updateField(field: keyof FormState, value: string) {
+    setForm((current) => ({ ...current, [field]: value }))
+    setError(null)
+    setSuccess(false)
+  }
+
+  async function handleCrear() {
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const juez = await crearJuezMe()
+      setPerfilExiste(true)
+      setForm({ numero_licencia: juez.numero_licencia ?? '', federacion: juez.federacion ?? '' })
+    } catch (err) {
+      setError(getErrorMessage(err))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const updated = await actualizarJuezMe({
+        numero_licencia: form.numero_licencia.trim() || undefined,
+        federacion: form.federacion.trim() || undefined,
+      })
+      setForm({
+        numero_licencia: updated.numero_licencia ?? '',
+        federacion: updated.federacion ?? '',
+      })
+      setSuccess(true)
+    } catch (err) {
+      setError(getErrorMessage(err))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <JuezLayout title="Mis Datos" subtitle="Perfil de juez">
+      {isLoading ? (
+        <div className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5 text-sm text-slate-300">
+          Cargando perfil...
+        </div>
+      ) : perfilExiste === false ? (
+        <div className="rounded-2xl border border-slate-700 bg-slate-900/85 p-5 shadow-lg">
+          <p className="mb-4 text-sm text-slate-400">
+            Todavía no tenés un perfil de juez. Crealo para agregar tu licencia y federación.
+          </p>
+          {error ? (
+            <div className="mb-4 rounded-xl border border-red-500/40 bg-red-950/40 p-3 text-sm text-red-200">
+              {error}
+            </div>
+          ) : null}
+          <button
+            onClick={() => void handleCrear()}
+            disabled={isSubmitting}
+            className="w-full rounded-full bg-sky-500 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
+          >
+            {isSubmitting ? 'Creando...' : 'Crear mi perfil de juez'}
+          </button>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl border border-slate-700 bg-slate-900/85 p-5 shadow-lg"
+        >
+          {success ? (
+            <div className="mb-4 rounded-xl border border-emerald-500/40 bg-emerald-950/40 p-3 text-sm text-emerald-200">
+              Datos actualizados correctamente.
+            </div>
+          ) : null}
+          {error ? (
+            <div className="mb-4 rounded-xl border border-red-500/40 bg-red-950/40 p-3 text-sm text-red-200">
+              {error}
+            </div>
+          ) : null}
+          <div className="grid gap-4">
+            <label className="block text-sm font-semibold text-slate-100">
+              Número de licencia <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
+              <input
+                value={form.numero_licencia}
+                onChange={(e) => updateField('numero_licencia', e.target.value)}
+                className={inputClass()}
+                placeholder="LIC-001"
+              />
+            </label>
+            <label className="block text-sm font-semibold text-slate-100">
+              Federación <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
+              <input
+                value={form.federacion}
+                onChange={(e) => updateField('federacion', e.target.value)}
+                className={inputClass()}
+                placeholder="AIDA, CMAS..."
+              />
+            </label>
+          </div>
+          <div className="mt-5">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full rounded-full bg-sky-500 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
+            >
+              {isSubmitting ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      )}
+    </JuezLayout>
+  )
+}

--- a/frontend/src/pages/organizador/OrganizadorMisDatosPage.tsx
+++ b/frontend/src/pages/organizador/OrganizadorMisDatosPage.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
+import {
+  actualizarOrganizadorMe,
+  crearOrganizadorMe,
+  fetchOrganizadorMe,
+  ApiError,
+} from '../../api/registro'
+
+interface FormState {
+  nombre_organizacion: string
+}
+
+function inputClass(): string {
+  return 'mt-2 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition placeholder:text-slate-500 focus:border-sky-400'
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) return error.message
+  if (error instanceof Error) return error.message
+  return 'No se pudo completar la operación'
+}
+
+export function OrganizadorMisDatosPage() {
+  const [perfilExiste, setPerfilExiste] = useState<boolean | null>(null)
+  const [form, setForm] = useState<FormState>({ nombre_organizacion: '' })
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setIsLoading(true)
+      try {
+        const org = await fetchOrganizadorMe()
+        if (!cancelled) {
+          if (org) {
+            setPerfilExiste(true)
+            setForm({ nombre_organizacion: org.nombre_organizacion ?? '' })
+          } else {
+            setPerfilExiste(false)
+          }
+        }
+      } catch (err) {
+        if (!cancelled) setError(getErrorMessage(err))
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => { cancelled = true }
+  }, [])
+
+  function updateField(field: keyof FormState, value: string) {
+    setForm((current) => ({ ...current, [field]: value }))
+    setError(null)
+    setSuccess(false)
+  }
+
+  async function handleCrear() {
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const org = await crearOrganizadorMe()
+      setPerfilExiste(true)
+      setForm({ nombre_organizacion: org.nombre_organizacion ?? '' })
+    } catch (err) {
+      setError(getErrorMessage(err))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const updated = await actualizarOrganizadorMe({
+        nombre_organizacion: form.nombre_organizacion.trim() || undefined,
+      })
+      setForm({ nombre_organizacion: updated.nombre_organizacion ?? '' })
+      setSuccess(true)
+    } catch (err) {
+      setError(getErrorMessage(err))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <OrganizadorLayout
+      title="Mis Datos"
+      subtitle="Perfil de organizador"
+      showTournamentNavigation={true}
+    >
+      {isLoading ? (
+        <div className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5 text-sm text-slate-300">
+          Cargando perfil...
+        </div>
+      ) : perfilExiste === false ? (
+        <div className="rounded-2xl border border-slate-700 bg-slate-900/85 p-5 shadow-lg max-w-md">
+          <p className="mb-4 text-sm text-slate-400">
+            Todavía no tenés un perfil de organizador. Crealo para agregar el nombre de tu organización.
+          </p>
+          {error ? (
+            <div className="mb-4 rounded-xl border border-red-500/40 bg-red-950/40 p-3 text-sm text-red-200">
+              {error}
+            </div>
+          ) : null}
+          <button
+            onClick={() => void handleCrear()}
+            disabled={isSubmitting}
+            className="w-full rounded-full bg-sky-500 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
+          >
+            {isSubmitting ? 'Creando...' : 'Crear mi perfil de organizador'}
+          </button>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl border border-slate-700 bg-slate-900/85 p-5 shadow-lg max-w-md"
+        >
+          {success ? (
+            <div className="mb-4 rounded-xl border border-emerald-500/40 bg-emerald-950/40 p-3 text-sm text-emerald-200">
+              Datos actualizados correctamente.
+            </div>
+          ) : null}
+          {error ? (
+            <div className="mb-4 rounded-xl border border-red-500/40 bg-red-950/40 p-3 text-sm text-red-200">
+              {error}
+            </div>
+          ) : null}
+          <div className="grid gap-4">
+            <label className="block text-sm font-semibold text-slate-100">
+              Nombre de organización <span className="ml-1 text-xs font-normal text-slate-400">(opcional)</span>
+              <input
+                value={form.nombre_organizacion}
+                onChange={(e) => updateField('nombre_organizacion', e.target.value)}
+                className={inputClass()}
+                placeholder="Club Apnea BA"
+              />
+            </label>
+          </div>
+          <div className="mt-5">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full rounded-full bg-sky-500 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
+            >
+              {isSubmitting ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      )}
+    </OrganizadorLayout>
+  )
+}


### PR DESCRIPTION
## Resumen

Agrega páginas **Mis Datos** para los perfiles de Juez y Organizador. Ambas páginas manejan el ciclo completo: perfil inexistente (404 → CTA crear), creación y edición de datos opcionales.

## Cambios Principales

- `frontend/src/api/registro.ts` — `JuezDto`, `OrganizadorDto` + 6 funciones API (fetch/crear/actualizar para cada rol)
- `frontend/src/pages/juez/JuezMisDatosPage.tsx` — nueva página con campos `numero_licencia` y `federacion` (opcionales)
- `frontend/src/pages/organizador/OrganizadorMisDatosPage.tsx` — nueva página con campo `nombre_organizacion` (opcional)
- `frontend/src/App.tsx` — rutas `/juez/mis-datos` y `/organizador/mis-datos` con `RequireRole`
- `frontend/src/components/organizador/OrganizadorLayout.tsx` — nav item "Mis Datos" agregado
- `frontend/src/pages/juez/DisciplinasPage.tsx` — enlace "Mis Datos" en acciones del header

## Impacto

- Build: ✅ 0 errores TypeScript · 192 módulos · 2.81s
- Archivos: 8 modificados, 4 nuevos

## Checklist

- [x] 404 → CTA "Crear mi perfil" sin error al usuario (INV-11.9-03)
- [x] Campos opcionales: `campo.trim() || undefined` en payload PATCH (INV-11.9-04)
- [x] TypeScript (`tsc -b`) sin errores
- [x] Vite build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)