### PR TITLE
fix(frontend): US-ADJ-12.1 — fixes layout, navegación y filtros [#198 #199 #201 #203]

### DIFF
--- a/frontend/src/api/identidad.ts
+++ b/frontend/src/api/identidad.ts
@@ -17,7 +17,7 @@ export interface UsuarioDto {
   nombre: string
   apellido: string
   email: string
-  rol: RolIdentidad
+  roles: RolIdentidad[]
   activo: boolean
 }
 

--- a/frontend/src/components/juez/JuezLayout.tsx
+++ b/frontend/src/components/juez/JuezLayout.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import useAuthStore from '../../stores/useAuthStore'
 import { HealthCheck } from '../HealthCheck'
 import { SyncStatusBadge } from './SyncStatusBadge'
 
@@ -10,23 +12,48 @@ interface JuezLayoutProps {
 }
 
 export function JuezLayout({ title, subtitle, actions, children }: JuezLayoutProps) {
+  const logout = useAuthStore((s) => s.logout)
+  const { pathname } = useLocation()
+  const enMisDatos = pathname === '/juez/mis-datos'
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <div className="mx-auto flex min-h-screen w-full max-w-sm flex-col px-4 py-6">
         <header className="mb-6 rounded-3xl border border-slate-800 bg-slate-900/80 p-4 shadow-lg shadow-slate-950/40">
-          <div className="flex items-start justify-between gap-4">
-            <div>
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
               <h1 className="text-2xl font-semibold uppercase tracking-[0.18em] text-slate-50">
                 {title}
               </h1>
-              {subtitle ? <p className="mt-2 text-sm text-slate-400">{subtitle}</p> : null}
-              <div className="mt-2 flex flex-wrap items-center gap-2">
-                <HealthCheck compact />
-                <SyncStatusBadge />
-              </div>
+              {subtitle ? <p className="mt-1 text-sm text-slate-400">{subtitle}</p> : null}
             </div>
-            {actions}
+            <div className="mt-1 flex shrink-0 items-center gap-2">
+              <HealthCheck compact />
+              <SyncStatusBadge />
+            </div>
           </div>
+
+          <div className="mt-3 flex gap-2">
+            <Link
+              to="/juez/mis-datos"
+              className={
+                enMisDatos
+                  ? 'flex-1 rounded-full border border-sky-400/50 bg-sky-500/20 px-3 py-2 text-center text-xs font-semibold uppercase tracking-[0.14em] text-sky-300'
+                  : 'flex-1 rounded-full border border-slate-600 bg-slate-800 px-3 py-2 text-center text-xs font-semibold uppercase tracking-[0.14em] text-slate-300 hover:bg-slate-700 hover:text-white'
+              }
+            >
+              Mis Datos
+            </Link>
+            <button
+              type="button"
+              onClick={logout}
+              className="flex-1 rounded-full border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-red-300 hover:bg-red-500/20 hover:text-red-200"
+            >
+              Salir
+            </button>
+          </div>
+
+          {actions ? <div className="mt-2">{actions}</div> : null}
         </header>
         <main className="flex flex-1 flex-col gap-4">{children}</main>
       </div>

--- a/frontend/src/components/organizador/InscriptosPanel.tsx
+++ b/frontend/src/components/organizador/InscriptosPanel.tsx
@@ -110,11 +110,6 @@ export function InscriptosPanel({ torneoId, torneoEstado }: InscriptosPanelProps
             Revisa inscripciones, disciplinas activas y el estado de AP por atleta.
           </p>
         </div>
-        <div className="max-w-sm rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-xs text-slate-300">
-          {editable
-            ? 'La edición de AP está habilitada. El torneo solo puede pasar a preparación cuando no queden pendientes.'
-            : 'El torneo ya no está en inscripción abierta. Los AP se muestran en solo lectura como referencia operativa.'}
-        </div>
       </div>
 
       <div className="rounded-[1.5rem] border border-slate-700 bg-slate-950/70 p-4">

--- a/frontend/src/components/organizador/JuecesPanel.tsx
+++ b/frontend/src/components/organizador/JuecesPanel.tsx
@@ -78,7 +78,7 @@ export function JuecesPanel({ torneoId }: JuecesPanelProps) {
 
   const disciplinas = useMemo(() => disciplinasQuery.data ?? [], [disciplinasQuery.data])
   const jueces = useMemo(
-    () => (juecesQuery.data ?? []).filter((usuario) => usuario.rol === 'JUEZ' && usuario.activo),
+    () => (juecesQuery.data ?? []).filter((usuario) => usuario.roles.includes('JUEZ') && usuario.activo),
     [juecesQuery.data],
   )
   const rows = useMemo<FilaJuezPerformance[]>(() => {

--- a/frontend/src/components/organizador/OrganizadorLayout.tsx
+++ b/frontend/src/components/organizador/OrganizadorLayout.tsx
@@ -94,10 +94,6 @@ export function OrganizadorLayout({
 
   function shouldShowNavItem(item: NavItem): boolean {
     if (item.key === 'torneo') return Boolean(activeTournamentId)
-    if (item.key === 'podios') return Boolean(activeTournamentId) || seccionActiva === 'podios'
-    if (item.key === 'inscriptos') {
-      return Boolean(activeTournamentId) || seccionActiva === 'inscriptos'
-    }
     return true
   }
 

--- a/frontend/src/pages/juez/DisciplinasPage.tsx
+++ b/frontend/src/pages/juez/DisciplinasPage.tsx
@@ -16,7 +16,7 @@ export function DisciplinasPage() {
       title="Mis asignaciones"
       subtitle={subtitle}
       actions={
-        <div className="flex gap-2">
+        <div className="flex shrink-0 flex-col gap-2">
           <Link
             to="/juez/mis-datos"
             className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 hover:text-slate-200"

--- a/frontend/src/pages/juez/DisciplinasPage.tsx
+++ b/frontend/src/pages/juez/DisciplinasPage.tsx
@@ -1,13 +1,11 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { JuezLayout } from '../../components/juez/JuezLayout'
 import { useDisciplinasJuez } from '../../hooks/useDisciplinasJuez'
-import useAuthStore from '../../stores/useAuthStore'
 import useCompetenciaStore from '../../stores/useCompetenciaStore'
 
 export function DisciplinasPage() {
   const location = useLocation()
   const navigate = useNavigate()
-  const logout = useAuthStore((s) => s.logout)
   const seleccionarCompetencia = useCompetenciaStore((s) => s.seleccionarCompetencia)
   const { torneoActivo, disciplinas, subtitle, isLoading, hasError } = useDisciplinasJuez()
 
@@ -15,23 +13,6 @@ export function DisciplinasPage() {
     <JuezLayout
       title="Mis asignaciones"
       subtitle={subtitle}
-      actions={
-        <div className="flex shrink-0 flex-col gap-2">
-          <Link
-            to="/juez/mis-datos"
-            className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 hover:text-slate-200"
-          >
-            Mis Datos
-          </Link>
-          <button
-            type="button"
-            onClick={logout}
-            className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-200"
-          >
-            Salir
-          </button>
-        </div>
-      }
     >
       {location.state && (location.state as { passwordUpdated?: boolean }).passwordUpdated ? (
         <section className="rounded-3xl border border-emerald-500/30 bg-emerald-500/10 p-5 text-sm text-emerald-100">

--- a/frontend/src/pages/organizador/OrganizadorMisDatosPage.tsx
+++ b/frontend/src/pages/organizador/OrganizadorMisDatosPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
 import {
   actualizarOrganizadorMe,
@@ -23,6 +24,8 @@ function getErrorMessage(error: unknown): string {
 }
 
 export function OrganizadorMisDatosPage() {
+  const [searchParams] = useSearchParams()
+  const torneoId = searchParams.get('torneo_id')
   const [perfilExiste, setPerfilExiste] = useState<boolean | null>(null)
   const [form, setForm] = useState<FormState>({ nombre_organizacion: '' })
   const [isLoading, setIsLoading] = useState(true)
@@ -97,6 +100,7 @@ export function OrganizadorMisDatosPage() {
       title="Mis Datos"
       subtitle="Perfil de organizador"
       showTournamentNavigation={true}
+      activeTournamentId={torneoId ?? undefined}
     >
       {isLoading ? (
         <div className="rounded-2xl border border-slate-700 bg-slate-900/70 p-5 text-sm text-slate-300">

--- a/frontend/src/pages/organizador/UsuariosPage.tsx
+++ b/frontend/src/pages/organizador/UsuariosPage.tsx
@@ -61,7 +61,7 @@ function getUsuarioError(error: unknown): string {
 
 function ordenarUsuarios(usuarios: UsuarioDto[]): UsuarioDto[] {
   return [...usuarios].sort((a, b) => {
-    const rolCompare = a.rol.localeCompare(b.rol)
+    const rolCompare = (a.roles[0] ?? '').localeCompare(b.roles[0] ?? '')
     if (rolCompare !== 0) return rolCompare
     return a.email.localeCompare(b.email)
   })
@@ -205,7 +205,7 @@ export function UsuariosPage() {
                       <td className="px-4 py-3 text-stone-900">{usuario.apellido}</td>
                       <td className="px-4 py-3 font-medium text-stone-900">{usuario.email}</td>
                       <td className="px-4 py-3 text-stone-700">
-                        {ROL_LABELS[usuario.rol] ?? usuario.rol}
+                        {usuario.roles.map((r) => ROL_LABELS[r] ?? r).join(', ')}
                       </td>
                       <td className="px-4 py-3">
                         <span


### PR DESCRIPTION
## Resumen

- **#198** `JuezLayout`: Mis Datos y Salir ahora viven permanentemente en el layout (antes solo aparecían en `DisciplinasPage` via `actions`); botones visibles y con colores correctos en todas las páginas del portal juez.
- **#199** `OrganizadorMisDatosPage`: lee `torneo_id` de `useSearchParams` y lo pasa como `activeTournamentId` al layout, preservando la navegación del torneo activo igual que el resto de páginas del organizador.
- **#201** `InscriptosPanel`: eliminado el bloque informativo redundante sobre estado de edición AP.
- **#203** `JuecesPanel`: filtro corregido a `usuario.roles.includes('JUEZ')` para compatibilidad con modelo multi-rol (`roles: string[]`).
- **identidad.ts** `UsuarioDto.rol → roles: RolIdentidad[]`: alineado con respuesta real del backend; `UsuariosPage` y `JuecesPanel` actualizados en consecuencia.

## Issues cerrados

Closes #198, #199, #201, #203

## Test plan

- [ ] Portal juez: Mis Datos y Salir visibles en todas las páginas (DisciplinasPage, GrillaPage, MisDatosPage)
- [ ] Portal organizador: navegar a Mis Datos con torneo activo → nav items no desaparecen
- [ ] Panel Inscriptos: sin bloque informativo de edición AP
- [ ] Panel Jueces: lista solo usuarios con rol JUEZ activo

🤖 Generated with [Claude Code](https://claude.com/claude-code)