### PR TITLE
feat(identidad): US-ADJ-12.2 — agregar/quitar rol a usuario existente

### DIFF
--- a/src/identidad/api/router.py
+++ b/src/identidad/api/router.py
@@ -17,12 +17,14 @@ from identidad.api.dependencies import (
     get_token_service,
     get_usuario_repository,
 )
+from identidad.application.commands.agregar_rol import AgregarRolCommand, AgregarRolHandler
 from identidad.application.commands.autenticar_usuario import (
     AutenticarUsuarioCommand,
     AutenticarUsuarioHandler,
     RoleSelectionRequired,
     TokenResponse,
 )
+from identidad.application.commands.quitar_rol import QuitarRolCommand, QuitarRolHandler
 from identidad.application.commands.cambiar_password import (
     CambiarPasswordCommand,
     CambiarPasswordHandler,
@@ -44,8 +46,10 @@ from identidad.domain.exceptions import (
     CredencialesInvalidas,
     PasswordActualIncorrecto,
     PasswordDemasiadoCorto,
+    RolNoEncontrado,
     RolNoPermitido,
     RolYaAsignado,
+    RolesVacios,
     TokenResetInvalido,
     UsuarioInactivo,
     UsuarioNoEncontrado,
@@ -312,4 +316,60 @@ async def listar_usuarios(
             }
             for usuario in usuarios
         ],
+    )
+
+
+class AgregarRolRequest(BaseModel):
+    rol: Rol
+
+
+@router.post("/usuarios/{usuario_id}/roles", status_code=200)
+async def agregar_rol_usuario(
+    usuario_id: UUID,
+    body: AgregarRolRequest,
+    _: OrganizadorDep,
+    repo: Annotated[UsuarioRepositoryPort, Depends(get_usuario_repository)],
+) -> JSONResponse:
+    handler = AgregarRolHandler(repo)
+    try:
+        await handler.handle(AgregarRolCommand(usuario_id=usuario_id, rol=body.rol))
+    except UsuarioNoEncontrado as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except RolYaAsignado as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    usuario = await repo.find_by_id(usuario_id)
+    assert usuario is not None
+    return JSONResponse(
+        status_code=200,
+        content={
+            "usuario_id": str(usuario.usuario_id),
+            "roles": [r.value for r in usuario.roles],
+        },
+    )
+
+
+@router.delete("/usuarios/{usuario_id}/roles/{rol}", status_code=200)
+async def quitar_rol_usuario(
+    usuario_id: UUID,
+    rol: Rol,
+    _: OrganizadorDep,
+    repo: Annotated[UsuarioRepositoryPort, Depends(get_usuario_repository)],
+) -> JSONResponse:
+    handler = QuitarRolHandler(repo)
+    try:
+        await handler.handle(QuitarRolCommand(usuario_id=usuario_id, rol=rol))
+    except UsuarioNoEncontrado as exc:
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    except RolNoEncontrado as exc:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+    except RolesVacios as exc:
+        return JSONResponse(status_code=422, content={"detail": str(exc)})
+    usuario = await repo.find_by_id(usuario_id)
+    assert usuario is not None
+    return JSONResponse(
+        status_code=200,
+        content={
+            "usuario_id": str(usuario.usuario_id),
+            "roles": [r.value for r in usuario.roles],
+        },
     )

--- a/src/identidad/application/commands/agregar_rol.py
+++ b/src/identidad/application/commands/agregar_rol.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from identidad.domain.exceptions import UsuarioNoEncontrado
+from identidad.domain.ports.usuario_repository_port import UsuarioRepositoryPort
+from identidad.domain.value_objects.rol import Rol
+
+
+@dataclass(frozen=True)
+class AgregarRolCommand:
+    usuario_id: UUID
+    rol: Rol
+
+
+class AgregarRolHandler:
+    def __init__(self, repo: UsuarioRepositoryPort) -> None:
+        self._repo = repo
+
+    async def handle(self, cmd: AgregarRolCommand) -> None:
+        usuario = await self._repo.find_by_id(cmd.usuario_id)
+        if usuario is None:
+            raise UsuarioNoEncontrado(str(cmd.usuario_id))
+        usuario.agregar_rol(cmd.rol)
+        await self._repo.save(usuario)

--- a/src/identidad/application/commands/quitar_rol.py
+++ b/src/identidad/application/commands/quitar_rol.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from identidad.domain.exceptions import UsuarioNoEncontrado
+from identidad.domain.ports.usuario_repository_port import UsuarioRepositoryPort
+from identidad.domain.value_objects.rol import Rol
+
+
+@dataclass(frozen=True)
+class QuitarRolCommand:
+    usuario_id: UUID
+    rol: Rol
+
+
+class QuitarRolHandler:
+    def __init__(self, repo: UsuarioRepositoryPort) -> None:
+        self._repo = repo
+
+    async def handle(self, cmd: QuitarRolCommand) -> None:
+        usuario = await self._repo.find_by_id(cmd.usuario_id)
+        if usuario is None:
+            raise UsuarioNoEncontrado(str(cmd.usuario_id))
+        usuario.quitar_rol(cmd.rol)
+        await self._repo.save(usuario)

--- a/src/identidad/domain/aggregates/usuario.py
+++ b/src/identidad/domain/aggregates/usuario.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from uuid import UUID
 
-from identidad.domain.exceptions import CampoRequerido, RolesVacios, RolDuplicado
+from identidad.domain.exceptions import (
+    CampoRequerido,
+    RolNoEncontrado,
+    RolYaAsignado,
+    RolesVacios,
+    RolDuplicado,
+)
 from identidad.domain.value_objects.rol import Rol
 
 
@@ -24,6 +30,18 @@ class Usuario:
             raise RolesVacios()
         if len(self.roles) != len(set(self.roles)):
             raise RolDuplicado()
+
+    def agregar_rol(self, rol: Rol) -> None:
+        if rol in self.roles:
+            raise RolYaAsignado(rol.value)
+        self.roles.append(rol)
+
+    def quitar_rol(self, rol: Rol) -> None:
+        if rol not in self.roles:
+            raise RolNoEncontrado(rol.value)
+        if len(self.roles) == 1:
+            raise RolesVacios()
+        self.roles.remove(rol)
 
     @staticmethod
     def _validar_requerido(valor: str, campo: str) -> str:

--- a/tests/unit/identidad/application/test_handlers.py
+++ b/tests/unit/identidad/application/test_handlers.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock
 import bcrypt
 import pytest
 
+from identidad.application.commands.agregar_rol import AgregarRolCommand, AgregarRolHandler
+from identidad.application.commands.quitar_rol import QuitarRolCommand, QuitarRolHandler
 from identidad.application.commands.autenticar_usuario import (
     AutenticarUsuarioCommand,
     AutenticarUsuarioHandler,
@@ -34,8 +36,10 @@ from identidad.domain.exceptions import (
     CredencialesInvalidas,
     PasswordActualIncorrecto,
     PasswordDemasiadoCorto,
+    RolNoEncontrado,
     RolNoPermitido,
     RolYaAsignado,
+    RolesVacios,
     TokenResetInvalido,
     UsuarioNoEncontrado,
     UsuarioInactivo,
@@ -586,6 +590,93 @@ async def test_autenticar_usuario_inactivo_lanza_excepcion(
     cmd = AutenticarUsuarioCommand(email="juez@test.com", password="clave1234")
     with pytest.raises(UsuarioInactivo):
         await handler.handle(cmd)
+
+
+# ── AgregarRolHandler / QuitarRolHandler ─────────────────────────────────────
+
+
+def _make_usuario_con_roles(roles: list[Rol]) -> Usuario:
+    return Usuario(
+        usuario_id=uuid.uuid4(),
+        nombre="Test",
+        apellido="Usuario",
+        email="test@test.com",
+        password_hash="$2b$12$hash",
+        roles=roles,
+    )
+
+
+@pytest.mark.asyncio
+async def test_agregar_rol_handler_exitoso(mock_repo: AsyncMock) -> None:
+    uid = uuid.uuid4()
+    usuario = _make_usuario_con_roles([Rol.ATLETA])
+    usuario.usuario_id = uid
+    mock_repo.find_by_id = AsyncMock(return_value=usuario)
+    handler = AgregarRolHandler(mock_repo)
+    await handler.handle(AgregarRolCommand(usuario_id=uid, rol=Rol.JUEZ))
+    mock_repo.save.assert_called_once()
+    assert Rol.JUEZ in usuario.roles
+
+
+@pytest.mark.asyncio
+async def test_agregar_rol_handler_usuario_no_encontrado(mock_repo: AsyncMock) -> None:
+    mock_repo.find_by_id = AsyncMock(return_value=None)
+    handler = AgregarRolHandler(mock_repo)
+    with pytest.raises(UsuarioNoEncontrado):
+        await handler.handle(AgregarRolCommand(usuario_id=uuid.uuid4(), rol=Rol.JUEZ))
+
+
+@pytest.mark.asyncio
+async def test_agregar_rol_handler_rol_ya_asignado(mock_repo: AsyncMock) -> None:
+    uid = uuid.uuid4()
+    usuario = _make_usuario_con_roles([Rol.ATLETA])
+    usuario.usuario_id = uid
+    mock_repo.find_by_id = AsyncMock(return_value=usuario)
+    handler = AgregarRolHandler(mock_repo)
+    with pytest.raises(RolYaAsignado):
+        await handler.handle(AgregarRolCommand(usuario_id=uid, rol=Rol.ATLETA))
+
+
+@pytest.mark.asyncio
+async def test_quitar_rol_handler_exitoso(mock_repo: AsyncMock) -> None:
+    uid = uuid.uuid4()
+    usuario = _make_usuario_con_roles([Rol.ATLETA, Rol.JUEZ])
+    usuario.usuario_id = uid
+    mock_repo.find_by_id = AsyncMock(return_value=usuario)
+    handler = QuitarRolHandler(mock_repo)
+    await handler.handle(QuitarRolCommand(usuario_id=uid, rol=Rol.JUEZ))
+    mock_repo.save.assert_called_once()
+    assert Rol.JUEZ not in usuario.roles
+
+
+@pytest.mark.asyncio
+async def test_quitar_rol_handler_usuario_no_encontrado(mock_repo: AsyncMock) -> None:
+    mock_repo.find_by_id = AsyncMock(return_value=None)
+    handler = QuitarRolHandler(mock_repo)
+    with pytest.raises(UsuarioNoEncontrado):
+        await handler.handle(QuitarRolCommand(usuario_id=uuid.uuid4(), rol=Rol.JUEZ))
+
+
+@pytest.mark.asyncio
+async def test_quitar_rol_handler_rol_no_asignado(mock_repo: AsyncMock) -> None:
+    uid = uuid.uuid4()
+    usuario = _make_usuario_con_roles([Rol.ATLETA])
+    usuario.usuario_id = uid
+    mock_repo.find_by_id = AsyncMock(return_value=usuario)
+    handler = QuitarRolHandler(mock_repo)
+    with pytest.raises(RolNoEncontrado):
+        await handler.handle(QuitarRolCommand(usuario_id=uid, rol=Rol.JUEZ))
+
+
+@pytest.mark.asyncio
+async def test_quitar_rol_handler_unico_rol(mock_repo: AsyncMock) -> None:
+    uid = uuid.uuid4()
+    usuario = _make_usuario_con_roles([Rol.ATLETA])
+    usuario.usuario_id = uid
+    mock_repo.find_by_id = AsyncMock(return_value=usuario)
+    handler = QuitarRolHandler(mock_repo)
+    with pytest.raises(RolesVacios):
+        await handler.handle(QuitarRolCommand(usuario_id=uid, rol=Rol.ATLETA))
 
 
 # ── JWTService ────────────────────────────────────────────────────────────────

--- a/tests/unit/identidad/domain/test_usuario.py
+++ b/tests/unit/identidad/domain/test_usuario.py
@@ -13,7 +13,9 @@ from identidad.domain.exceptions import (
     EmailYaRegistrado,
     PasswordDemasiadoCorto,
     RolDuplicado,
+    RolNoEncontrado,
     RolNoPermitido,
+    RolYaAsignado,
     RolesVacios,
     TokenInvalido,
     UsuarioInactivo,
@@ -149,6 +151,52 @@ def test_usuario_rechaza_rol_duplicado() -> None:
             password_hash="hash",
             roles=[Rol.ATLETA, Rol.ATLETA],
         )
+
+
+# ── agregar_rol / quitar_rol ──────────────────────────────────────────────────
+
+
+def _usuario_base(roles: list[Rol]) -> Usuario:
+    return Usuario(
+        usuario_id=uuid.uuid4(),
+        nombre="Ana",
+        apellido="Garcia",
+        email="a@b.com",
+        password_hash="hash",
+        roles=roles,
+    )
+
+
+def test_agregar_rol_nuevo() -> None:
+    u = _usuario_base([Rol.ATLETA])
+    u.agregar_rol(Rol.JUEZ)
+    assert Rol.JUEZ in u.roles
+    assert len(u.roles) == 2
+
+
+def test_agregar_rol_ya_asignado_lanza_excepcion() -> None:
+    u = _usuario_base([Rol.ATLETA])
+    with pytest.raises(RolYaAsignado):
+        u.agregar_rol(Rol.ATLETA)
+
+
+def test_quitar_rol_existente() -> None:
+    u = _usuario_base([Rol.ATLETA, Rol.JUEZ])
+    u.quitar_rol(Rol.JUEZ)
+    assert Rol.JUEZ not in u.roles
+    assert len(u.roles) == 1
+
+
+def test_quitar_rol_no_asignado_lanza_excepcion() -> None:
+    u = _usuario_base([Rol.ATLETA])
+    with pytest.raises(RolNoEncontrado):
+        u.quitar_rol(Rol.ORGANIZADOR)
+
+
+def test_quitar_unico_rol_lanza_roles_vacios() -> None:
+    u = _usuario_base([Rol.ATLETA])
+    with pytest.raises(RolesVacios):
+        u.quitar_rol(Rol.ATLETA)
 
 
 # ── Exceptions ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Resumen

Backend del feature de gestión de roles (#204).

- **Domain:** `Usuario.agregar_rol()` / `quitar_rol()` con invariantes: `RolYaAsignado`, `RolNoEncontrado`, `RolesVacios`
- **Application:** `AgregarRolCommand` + `AgregarRolHandler` · `QuitarRolCommand` + `QuitarRolHandler`
- **API:** `POST /auth/usuarios/{usuario_id}/roles` · `DELETE /auth/usuarios/{usuario_id}/roles/{rol}` — requieren rol ORGANIZADOR

## Issues

Closes #204 (backend — frontend en US-ADJ-12.3)

## Test plan

- [x] 91 tests unitarios identidad — todos ✅
- [ ] `POST /auth/usuarios/{id}/roles` agrega rol correctamente
- [ ] `DELETE /auth/usuarios/{id}/roles/{rol}` quita rol correctamente
- [ ] 404 si usuario no existe
- [ ] 409 si rol ya asignado (POST) / no asignado (DELETE)
- [ ] 422 si queda sin roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)