### PR TITLE
feat(frontend): US-ADJ-12.4 — precarga doc/tel en inscripción y club fallback

### DIFF
--- a/docs/specs/sp-adj-12/US-ADJ-12.4.md
+++ b/docs/specs/sp-adj-12/US-ADJ-12.4.md
@@ -1,0 +1,102 @@
+---
+us_id: US-ADJ-12.4
+rf_ids: []
+type: fix-frontend
+---
+
+# US-ADJ-12.4 — Frontend: portal atleta — precarga y sincronización de datos
+
+| Campo | Valor |
+|-------|-------|
+| **ID** | US-ADJ-12.4 |
+| **Sprint** | SP-ADJ-12 |
+| **Tipo** | fix frontend |
+| **Issue** | #200 |
+| **Prioridad** | Alta |
+| **Área** | `frontend` — `AtletaInscripcionPage.tsx` · `AtletaHomePage.tsx` |
+
+---
+
+## Descripción
+
+Al inscribirse en un torneo, el portal atleta no precarga el documento (DNI) ni el teléfono desde el perfil del atleta ya registrado, forzando al usuario a reingresar datos que ya proporcionó en Mis Datos.
+Adicionalmente, el campo Club en la home del atleta muestra vacío cuando el atleta no tiene club registrado, y los datos de Mis Datos no se sincronizan post-inscripción.
+
+---
+
+## Precondición
+
+- El atleta tiene un perfil en BC Registro (`AtletaDto`) con campos `dni` y `telefono` (pueden ser `null`).
+- El atleta navega al wizard de inscripción.
+
+## Postcondición
+
+- El paso 1 del wizard muestra `documentoNumero` y `telefono` precargados desde el perfil.
+- La home del atleta muestra `'—'` cuando el campo Club está vacío.
+- Al completar la inscripción, el cache de `atleta-mis-datos` se invalida para reflejar datos actualizados.
+
+## Invariantes
+
+- La precarga no bloquea la edición: el usuario puede modificar los valores precargados.
+- Si el perfil no tiene `dni` o `telefono`, los campos quedan vacíos (no hay fallback inventado).
+- La invalidación de `atleta-mis-datos` ocurre solo en el `onSuccess` de la mutation.
+
+---
+
+## Criterios de Aceptación
+
+1. **Precarga documento y teléfono:** Al abrir el wizard, si el atleta tiene `dni` / `telefono` en su perfil, los campos del paso 1 aparecen precargados con esos valores.
+2. **Club con fallback:** En `AtletaHomePage`, el campo Club muestra `'—'` cuando `atleta.club` es falsy.
+3. **Invalidación post-inscripción:** Tras `onSuccess` de la mutation de inscripción, se llama `queryClient.invalidateQueries({ queryKey: ['atleta-mis-datos'] })`.
+
+---
+
+## Implementación
+
+### 1. `AtletaInscripcionPage.tsx`
+
+Agregar valores computados con fallback desde el perfil del atleta:
+
+```tsx
+const documentoNumeroValue = documentoNumero || atleta?.dni || ''
+const telefonoValue = telefono || atleta?.telefono || ''
+```
+
+Usar estas variables en los inputs del paso 1 en lugar de los estados crudos:
+- Input Documento: `value={documentoNumeroValue}`, `onChange` sigue actualizando `setDocumentoNumero`
+- Input Teléfono: `value={telefonoValue}`, `onChange` sigue actualizando `setTelefono`
+
+En `nextStep()` (validación paso 1), usar los valores computados:
+```tsx
+if (!nombreCompletoValue || !fechaNacimientoValue || !documentoNumeroValue || !telefonoValue) {
+```
+
+En `onSuccess` de la mutation, agregar invalidación:
+```tsx
+queryClient.invalidateQueries({ queryKey: ['atleta-mis-datos'] })
+```
+
+Agregar `useQueryClient` al import de `@tanstack/react-query`.
+
+### 2. `AtletaHomePage.tsx`
+
+```tsx
+<dd className="mt-1 font-semibold text-white">{query.data.atleta.club || '—'}</dd>
+```
+
+---
+
+## Tests
+
+Esta US es frontend-only (fix visual + sincronización de cache). No requiere tests unitarios de backend.
+
+**Validación:** `npm run build` sin errores en `frontend/`.
+
+---
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `frontend/src/pages/atleta/AtletaInscripcionPage.tsx` | Precarga doc/tel + invalidación cache post-inscripción |
+| `frontend/src/pages/atleta/AtletaHomePage.tsx` | Club con fallback `'—'` |

--- a/frontend/src/components/shared/RolesSection.tsx
+++ b/frontend/src/components/shared/RolesSection.tsx
@@ -17,7 +17,6 @@ export function RolesSection() {
   const userId = useAuthStore((s) => s.userId)
   const roles = useAuthStore((s) => s.roles)
   const login = useAuthStore((s) => s.login)
-  const token = useAuthStore((s) => s.token)
   const [error, setError] = useState<string | null>(null)
   const queryClient = useQueryClient()
 

--- a/frontend/src/pages/atleta/AtletaHomePage.tsx
+++ b/frontend/src/pages/atleta/AtletaHomePage.tsx
@@ -87,7 +87,7 @@ export function AtletaHomePage() {
               </div>
               <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
                 <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">Club</dt>
-                <dd className="mt-1 font-semibold text-white">{query.data.atleta.club}</dd>
+                <dd className="mt-1 font-semibold text-white">{query.data.atleta.club || '—'}</dd>
               </div>
             </dl>
           </section>

--- a/frontend/src/pages/atleta/AtletaInscripcionPage.tsx
+++ b/frontend/src/pages/atleta/AtletaInscripcionPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { fetchTorneo, listarDisciplinasTorneo } from '../../api/torneo'
@@ -36,6 +36,7 @@ function getInscripcionError(error: unknown): string {
 export function AtletaInscripcionPage() {
   const { torneoId } = useParams<{ torneoId: string }>()
   const atletaId = useAuthStore((state) => state.userId)
+  const queryClient = useQueryClient()
   const email = useAuthStore((state) => state.email)
   const authNombre = useAuthStore((state) => state.nombre)
   const authApellido = useAuthStore((state) => state.apellido)
@@ -143,6 +144,7 @@ export function AtletaInscripcionPage() {
       return { inscripcionId, warnings }
     },
     onSuccess: ({ warnings }) => {
+      queryClient.invalidateQueries({ queryKey: ['atleta-mis-datos'] })
       if (warnings.length > 0) {
         setPostSubmitWarning(
           `La inscripción fue creada, pero quedaron datos pendientes: ${warnings.join('; ')}`,
@@ -158,6 +160,8 @@ export function AtletaInscripcionPage() {
   const fechaNacimientoValue = fechaNacimiento || atleta?.fecha_nacimiento || ''
   const categoriaValue = categoria || atleta?.categoria || ''
   const brevetValue = brevet || atleta?.brevet || ''
+  const documentoNumeroValue = documentoNumero || atleta?.dni || ''
+  const telefonoValue = telefono || atleta?.telefono || ''
 
   function toggleDisciplina(disciplina: string) {
     setDisciplinasSeleccionadas((current) => {
@@ -175,7 +179,7 @@ export function AtletaInscripcionPage() {
 
   function nextStep() {
     if (step === 1) {
-      if (!nombreCompletoValue || !fechaNacimientoValue || !documentoNumero || !telefono) {
+      if (!nombreCompletoValue || !fechaNacimientoValue || !documentoNumeroValue || !telefonoValue) {
         setValidationError('Completá todos los datos personales obligatorios.')
         return
       }
@@ -307,7 +311,7 @@ export function AtletaInscripcionPage() {
                 <label className="block text-sm text-slate-300">
                   Documento *
                   <input
-                    value={documentoNumero}
+                    value={documentoNumeroValue}
                     onChange={(event) => setDocumentoNumero(event.target.value.replace(/\D/g, ''))}
                     inputMode="numeric"
                     className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"
@@ -317,7 +321,7 @@ export function AtletaInscripcionPage() {
               <label className="block text-sm text-slate-300">
                 Teléfono *
                 <input
-                  value={telefono}
+                  value={telefonoValue}
                   onChange={(event) => setTelefono(event.target.value.replace(/\D/g, ''))}
                   inputMode="numeric"
                   className="mt-2 w-full rounded-2xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-slate-100"


### PR DESCRIPTION
## Cambios

- **AtletaInscripcionPage:** precarga `documentoNumero` y `telefono` desde `atleta.dni` / `atleta.telefono` del perfil registrado — el usuario ya no necesita reingresarlos
- **AtletaInscripcionPage:** `onSuccess` invalida cache `atleta-mis-datos` para que Mis Datos refleje datos post-inscripción
- **AtletaHomePage:** campo Club muestra `'—'` cuando está vacío (en lugar de celda en blanco)
- **RolesSection:** elimina variable `token` declarada sin uso (error TS6133 preexistente de US-ADJ-12.3)

## Test plan

- [ ] `npm run build` — sin errores ✅
- [ ] Inscripción con perfil existente (dni/tel): campos paso 1 precargados
- [ ] Inscripción sin perfil o perfil sin dni/tel: campos vacíos (sin valores inventados)
- [ ] Home atleta sin club: muestra `—`
- [ ] Post-inscripción: Mis Datos sincroniza datos actualizados

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)