### PR TITLE
fix(frontend): SP-ADJ-13 — fixes UI + navegación móvil hamburguesa + seed producción

### DIFF
--- a/frontend/src/components/atleta/AtletaShell.tsx
+++ b/frontend/src/components/atleta/AtletaShell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import useAuthStore from '../../stores/useAuthStore'
 
@@ -35,17 +35,20 @@ export function AtletaShell({
   const location = useLocation()
   const navigate = useNavigate()
   const logout = useAuthStore((state) => state.logout)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
     document.title = 'AtaraxiaDive · Atleta'
     return () => { document.title = 'AtaraxiaDive' }
   }, [])
 
+  useEffect(() => { setMenuOpen(false) }, [location.pathname])
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <div className="mx-auto flex min-h-screen w-full max-w-[430px] flex-col border-x border-slate-800 bg-slate-950">
         <header className="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/95 backdrop-blur">
-          <div className="flex items-start justify-between gap-3 px-4 pt-3 pb-0">
+          <div className="flex items-start justify-between gap-3 px-4 pt-3 pb-3">
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
                 {showBack ? (
@@ -71,6 +74,14 @@ export function AtletaShell({
               {actions ? <div>{actions}</div> : null}
               <button
                 type="button"
+                onClick={() => setMenuOpen((v) => !v)}
+                className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-400 hover:border-slate-500 hover:text-slate-200"
+                aria-label="Menú de navegación"
+              >
+                {menuOpen ? '✕' : '☰'}
+              </button>
+              <button
+                type="button"
                 onClick={logout}
                 className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-400 hover:border-slate-500 hover:text-slate-200"
               >
@@ -79,25 +90,31 @@ export function AtletaShell({
             </div>
           </div>
 
-          <nav className="mt-3 grid grid-cols-5 border-t border-slate-800">
-            {TABS.map((tab) => {
-              const active = isTabActive(location.pathname, tab.to)
-              return (
-                <Link
-                  key={tab.to}
-                  to={tab.to}
-                  className={[
-                    'flex h-10 items-center justify-center text-center text-xs font-semibold transition-colors',
-                    active
-                      ? 'border-b-2 border-sky-400 text-sky-300'
-                      : 'border-b-2 border-transparent text-slate-400',
-                  ].join(' ')}
-                >
-                  {tab.label}
-                </Link>
-              )
-            })}
-          </nav>
+          {/* Menú vertical desplegable */}
+          {menuOpen ? (
+            <nav className="flex flex-col border-t border-slate-800 px-4">
+              {TABS.map((tab) => {
+                const active = isTabActive(location.pathname, tab.to)
+                return (
+                  <Link
+                    key={tab.to}
+                    to={tab.to}
+                    className={[
+                      'flex items-center border-b border-slate-800/60 py-3.5 text-sm font-semibold transition-colors',
+                      active ? 'text-sky-400' : 'text-slate-300 hover:text-white',
+                    ].join(' ')}
+                  >
+                    {active ? (
+                      <span className="mr-3 h-1.5 w-1.5 rounded-full bg-sky-400" />
+                    ) : (
+                      <span className="mr-3 h-1.5 w-1.5 rounded-full bg-transparent" />
+                    )}
+                    {tab.label}
+                  </Link>
+                )
+              })}
+            </nav>
+          ) : null}
         </header>
 
         <main className="flex-1 px-4 py-4">{children}</main>

--- a/frontend/src/components/juez/JuezLayout.tsx
+++ b/frontend/src/components/juez/JuezLayout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import useAuthStore from '../../stores/useAuthStore'
 
@@ -24,11 +24,14 @@ function isTabActive(pathname: string, to: string): boolean {
 export function JuezLayout({ title, subtitle, actions, children }: JuezLayoutProps) {
   const logout = useAuthStore((s) => s.logout)
   const { pathname } = useLocation()
+  const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
     document.title = 'AtaraxiaDive · Juez'
     return () => { document.title = 'AtaraxiaDive' }
   }, [])
+
+  useEffect(() => { setMenuOpen(false) }, [pathname])
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
@@ -51,6 +54,14 @@ export function JuezLayout({ title, subtitle, actions, children }: JuezLayoutPro
               {actions ? <div>{actions}</div> : null}
               <button
                 type="button"
+                onClick={() => setMenuOpen((v) => !v)}
+                className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-400 hover:border-slate-500 hover:text-slate-200"
+                aria-label="Menú de navegación"
+              >
+                {menuOpen ? '✕' : '☰'}
+              </button>
+              <button
+                type="button"
                 onClick={logout}
                 className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-400 hover:border-slate-500 hover:text-slate-200"
               >
@@ -59,25 +70,31 @@ export function JuezLayout({ title, subtitle, actions, children }: JuezLayoutPro
             </div>
           </div>
 
-          <nav className="mt-3 grid grid-cols-2 border-t border-slate-800">
-            {TABS.map((tab) => {
-              const active = isTabActive(pathname, tab.to)
-              return (
-                <Link
-                  key={tab.to}
-                  to={tab.to}
-                  className={[
-                    'flex h-10 items-center justify-center text-center text-xs font-semibold transition-colors',
-                    active
-                      ? 'border-b-2 border-sky-400 text-sky-300'
-                      : 'border-b-2 border-transparent text-slate-400',
-                  ].join(' ')}
-                >
-                  {tab.label}
-                </Link>
-              )
-            })}
-          </nav>
+          {/* Menú vertical desplegable */}
+          {menuOpen ? (
+            <nav className="flex flex-col border-t border-slate-800 px-4">
+              {TABS.map((tab) => {
+                const active = isTabActive(pathname, tab.to)
+                return (
+                  <Link
+                    key={tab.to}
+                    to={tab.to}
+                    className={[
+                      'flex items-center border-b border-slate-800/60 py-3.5 text-sm font-semibold transition-colors',
+                      active ? 'text-sky-400' : 'text-slate-300 hover:text-white',
+                    ].join(' ')}
+                  >
+                    {active ? (
+                      <span className="mr-3 h-1.5 w-1.5 rounded-full bg-sky-400" />
+                    ) : (
+                      <span className="mr-3 h-1.5 w-1.5 rounded-full bg-transparent" />
+                    )}
+                    {tab.label}
+                  </Link>
+                )
+              })}
+            </nav>
+          ) : null}
         </header>
 
         <main className="flex-1 px-4 py-4">{children}</main>

--- a/frontend/src/components/organizador/OrganizadorLayout.tsx
+++ b/frontend/src/components/organizador/OrganizadorLayout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import type { EstadoTorneo } from '../../api/torneo'
 import { Link, useLocation } from 'react-router-dom'
 import useAuthStore from '../../stores/useAuthStore'
@@ -6,7 +6,6 @@ import useAuthStore from '../../stores/useAuthStore'
 interface OrganizadorLayoutProps {
   title: string
   subtitle: string
-
   children: ReactNode
   showTournamentNavigation?: boolean
   simpleHeader?: boolean
@@ -54,22 +53,10 @@ function currentSection(pathname: string): NavItem['key'] {
   if (pathname.startsWith('/organizador/jueces')) return 'jueces'
   if (pathname.startsWith('/organizador/audit-log')) return 'audit'
   if (pathname.startsWith('/organizador/mis-datos')) return 'mis-datos'
-  if (pathname.startsWith('/organizador/torneos/') && pathname.endsWith('/competencias')) {
-    return 'audit'
-  }
-  if (pathname.startsWith('/organizador/competencias/') && pathname.includes('/auditoria')) {
-    return 'audit'
-  }
-  if (pathname.startsWith('/organizador/torneo/')) {
-    return 'torneo'
-  }
-  if (
-    pathname === '/organizador/torneo' ||
-    pathname.startsWith('/organizador/torneos/') ||
-    pathname.startsWith('/organizador/usuarios')
-  ) {
-    return 'inicio'
-  }
+  if (pathname.startsWith('/organizador/torneos/') && pathname.endsWith('/competencias')) return 'audit'
+  if (pathname.startsWith('/organizador/competencias/') && pathname.includes('/auditoria')) return 'audit'
+  if (pathname.startsWith('/organizador/torneo/')) return 'torneo'
+  if (pathname === '/organizador/torneo' || pathname.startsWith('/organizador/torneos/') || pathname.startsWith('/organizador/usuarios')) return 'inicio'
   return 'panel'
 }
 
@@ -84,11 +71,16 @@ export function OrganizadorLayout({
 }: OrganizadorLayoutProps) {
   void activeTournamentState
   const location = useLocation()
+  const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
     document.title = 'AtaraxiaDive · Organizador'
     return () => { document.title = 'AtaraxiaDive' }
   }, [])
+
+  // Cerrar menú al navegar
+  useEffect(() => { setMenuOpen(false) }, [location.pathname])
+
   const logout = useAuthStore((s) => s.logout)
   const seccionActiva = currentSection(location.pathname)
 
@@ -103,6 +95,8 @@ export function OrganizadorLayout({
     if (item.key === 'torneo') return `/organizador/torneo/${activeTournamentId}`
     return `${item.to}?torneo_id=${encodeURIComponent(activeTournamentId)}`
   }
+
+  const navItems = NAV_ITEMS.filter(shouldShowNavItem)
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
@@ -124,6 +118,17 @@ export function OrganizadorLayout({
               {subtitle ? <p className="mt-1 text-sm text-slate-400">{subtitle}</p> : null}
             </div>
             <div className="flex shrink-0 items-start gap-2">
+              {/* Hamburguesa — solo mobile */}
+              {showTournamentNavigation && !simpleHeader ? (
+                <button
+                  type="button"
+                  onClick={() => setMenuOpen((v) => !v)}
+                  className="rounded-full border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-400 hover:border-slate-500 hover:text-slate-200 md:hidden"
+                  aria-label="Menú de navegación"
+                >
+                  {menuOpen ? '✕' : '☰'}
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={logout}
@@ -134,9 +139,10 @@ export function OrganizadorLayout({
             </div>
           </div>
 
+          {/* Nav horizontal — desktop */}
           {showTournamentNavigation && !simpleHeader ? (
-            <nav className="mt-3 flex overflow-x-auto border-t border-slate-800 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-slate-700">
-              {NAV_ITEMS.filter((item) => shouldShowNavItem(item)).map((item) => {
+            <nav className="mt-3 hidden overflow-x-auto border-t border-slate-800 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-slate-700 md:flex">
+              {navItems.map((item) => {
                 const isActive = seccionActiva === item.key
                 return (
                   <Link
@@ -156,6 +162,34 @@ export function OrganizadorLayout({
             </nav>
           ) : null}
         </div>
+
+        {/* Menú vertical desplegable — mobile */}
+        {menuOpen && showTournamentNavigation && !simpleHeader ? (
+          <div className="border-t border-slate-800 bg-slate-950 md:hidden">
+            <nav className="mx-auto max-w-[1100px] flex flex-col px-5">
+              {navItems.map((item) => {
+                const isActive = seccionActiva === item.key
+                return (
+                  <Link
+                    key={item.key}
+                    to={navHref(item)}
+                    className={[
+                      'flex items-center border-b border-slate-800/60 py-3.5 text-sm font-semibold transition-colors',
+                      isActive ? 'text-sky-400' : 'text-slate-300 hover:text-white',
+                    ].join(' ')}
+                  >
+                    {isActive ? (
+                      <span className="mr-3 h-1.5 w-1.5 rounded-full bg-sky-400" />
+                    ) : (
+                      <span className="mr-3 h-1.5 w-1.5 rounded-full bg-transparent" />
+                    )}
+                    {item.label}
+                  </Link>
+                )
+              })}
+            </nav>
+          </div>
+        ) : null}
       </header>
 
       <div className="mx-auto max-w-[1100px] px-5 py-6 lg:px-8">

--- a/frontend/src/pages/organizador/AuditoriaCompetenciaPage.tsx
+++ b/frontend/src/pages/organizador/AuditoriaCompetenciaPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
 import type { GrillaAtletaDto } from '../../api/competencia'
 import { OrganizadorLayout } from '../../components/organizador/OrganizadorLayout'
@@ -46,15 +46,9 @@ function borderClasePorResultado(atleta: GrillaAtletaDto): string {
   return 'border-stone-300/80 bg-white/85'
 }
 
-function truncateHash(value: string) {
-  if (value.length <= 16) return value
-  return `${value.slice(0, 16)}...`
-}
-
 export function AuditoriaCompetenciaPage() {
   const { competenciaId } = useParams()
   const [searchParams] = useSearchParams()
-  const [copyFeedback, setCopyFeedback] = useState<string | null>(null)
   const disciplina = searchParams.get('disciplina') ?? undefined
   const torneoId = searchParams.get('torneo_id') ?? undefined
 
@@ -72,13 +66,6 @@ export function AuditoriaCompetenciaPage() {
       ]),
     )
   }, [ranking])
-
-  async function handleCopyHash() {
-    if (!estado?.hash_sha256) return
-    await navigator.clipboard.writeText(estado.hash_sha256)
-    setCopyFeedback('Copiado')
-    window.setTimeout(() => setCopyFeedback(null), 1600)
-  }
 
   if (!competenciaId || !disciplina) {
     return (
@@ -116,10 +103,6 @@ export function AuditoriaCompetenciaPage() {
           Volver a Audit Log
         </Link>
       </div>
-      <section className="rounded-[2rem] border border-slate-700 bg-slate-900/75 p-5 text-sm text-slate-300">
-        Vista contextual de auditoria por disciplina. La navegacion principal del organizador se mantiene disponible en el shell superior.
-      </section>
-
       {isLoading ? (
         <section className="rounded-[2rem] border border-slate-700 bg-slate-900/70 p-5 text-sm text-slate-300">
           Cargando auditoria de competencia...
@@ -134,43 +117,13 @@ export function AuditoriaCompetenciaPage() {
 
       {!isLoading && !hasError && estado ? (
         <section className="rounded-[2rem] border border-slate-700 bg-slate-900/85 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.24)]">
-          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                Estado de disciplina
-              </p>
-              <h2 className="mt-2 text-2xl font-semibold text-white">
-                {formatEstado(estado.estado)}
-              </h2>
-            </div>
-
-            {estado.estado === 'Finalizada' && estado.hash_sha256 ? (
-              <div className="rounded-[1.5rem] border border-emerald-500/40 bg-emerald-500/10 px-4 py-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-800">
-                  Hash SHA-256
-                </p>
-                <div className="mt-2 flex flex-wrap items-center gap-3">
-                  <code
-                    title={estado.hash_sha256}
-                    className="rounded-full bg-slate-950 px-3 py-2 text-sm text-emerald-200"
-                  >
-                    {truncateHash(estado.hash_sha256)}
-                  </code>
-                  <button
-                    type="button"
-                    onClick={() => void handleCopyHash()}
-                    className="rounded-full bg-emerald-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white"
-                  >
-                    Copiar
-                  </button>
-                  {copyFeedback ? (
-                    <span className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-900">
-                      {copyFeedback}
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-            ) : null}
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+              Estado de disciplina
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">
+              {formatEstado(estado.estado)}
+            </h2>
           </div>
         </section>
       ) : null}

--- a/frontend/src/pages/organizador/ResultadosPage.tsx
+++ b/frontend/src/pages/organizador/ResultadosPage.tsx
@@ -233,7 +233,7 @@ function ResultadosTorneo({ torneoId }: ResultadosTorneoProps) {
             </div>
 
             {disciplinaActiva ? (
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="mt-6 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
                     Ranking por disciplina

--- a/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
+++ b/frontend/src/pages/organizador/TorneoCompetenciasPage.tsx
@@ -115,7 +115,7 @@ function TorneoCompetenciasContent({ torneoId }: TorneoCompetenciasContentProps)
                   </h2>
                   <p className="mt-2 text-sm text-slate-300">
                     {item.competencia
-                      ? `Competencia ${item.competencia.competencia_id}`
+                      ? `Competencia ${item.disciplina}`
                       : 'Competencia pendiente: generar grilla desde la sección Grilla'}
                   </p>
                 </div>

--- a/tests/uat/produccion/seed_produccion_resultados.py
+++ b/tests/uat/produccion/seed_produccion_resultados.py
@@ -1,0 +1,340 @@
+"""
+Seed producción — Resultados progresivos por disciplina
+
+Alimenta la app en https://ataraxiadive.fly.dev con resultados del dataset BA2025.
+Procesa solo los atletas en estado AnunciadaAP (los ya Ejecutados/DNS se saltean).
+
+Uso:
+  uv run python tests/uat/produccion/seed_produccion_resultados.py --disciplina STA
+  uv run python tests/uat/produccion/seed_produccion_resultados.py --disciplina DNF --limite 6
+  uv run python tests/uat/produccion/seed_produccion_resultados.py --disciplina DNF --desde 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import unicodedata
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import httpx
+
+BASE = "https://ataraxiadive.fly.dev"
+TORNEO_ID = "996e9f82-6a3f-4a6a-bd53-2d6414c10a13"
+
+ORG_EMAIL = "org1faas@prueba.uat"
+PASSWORD = "Ataraxia2026?"
+
+JUECES = {
+    1: "juez1apnea@prueba.uat",
+    2: "raul@urquiza.uat",
+}
+
+DISCIPLINA_UNIDAD = {
+    "DBF": "Metros",
+    "DNF": "Metros",
+    "DYN": "Metros",
+    "SPE_2X50": "Segundos",
+    "STA": "Segundos",
+}
+
+RESULTS_PATH = Path("data/datasets/buenos_aires_2025/results.json")
+
+# Overrides por (nombre_normalizado, disciplina) → tarjeta especial
+# card: "Roja" | "DNS"
+# Para Roja: motivo_dq obligatorio, distancia_blackout opcional (solo disciplinas de distancia)
+SCENARIO_OVERRIDES: dict[tuple[str, str], dict] = {
+    # DNF
+    ("NICOLAS STAFFORINI", "DNF"): {
+        "card": "Roja",
+        "motivo_dq": "BKO_SUBACUATICO",
+        "distancia_blackout": "30",
+    },
+    ("MATIAS GONZALEZ COURTOIS", "DNF"): {
+        "card": "Roja",
+        "motivo_dq": "BKO_SUPERFICIE",
+        "distancia_blackout": "40",
+    },
+    # DYN — Tanda 1
+    ("MATIAS GONZALEZ COURTOIS", "DYN"): {
+        "card": "Roja",
+        "motivo_dq": "BKO_SUPERFICIE",
+        "distancia_blackout": "45",
+    },
+    ("MAURO ALMADA", "DYN"): {
+        "card": "BlancaConPenalizaciones",
+        "penalizaciones": [{"tipo": "SIN_CONTACTO_PARED", "deduccion": "3"}],
+    },
+    ("EZEQUIEL CUCHIARELLI", "DYN"): {
+        "card": "Roja",
+        "motivo_dq": "BKO_SUBACUATICO",
+        "distancia_blackout": "10",
+    },
+    # DYN — Tanda 2
+    ("GUADALUPE FARDI", "DYN"): {
+        "card": "BlancaConPenalizaciones",
+        "penalizaciones": [{"tipo": "SIN_CONTACTO_PARED", "deduccion": "3"}],
+    },
+    ("THIAGO STALLDECKER", "DYN"): {
+        "card": "Roja",
+        "motivo_dq": "BKO_SUPERFICIE",
+        "distancia_blackout": "55",
+    },
+    # DYN — Tanda 3
+    ("PABLO SALE", "DYN"): {
+        "card": "BlancaConPenalizaciones",
+        "penalizaciones": [{"tipo": "SIN_CONTACTO_PARED", "deduccion": "3"}],
+    },
+    ("NICOLAS BURGELL", "DYN"): {
+        "card": "Roja",
+        "motivo_dq": "BKO_SUBACUATICO",
+        "distancia_blackout": "70",
+    },
+}
+
+
+def normalize(s: str) -> str:
+    return unicodedata.normalize("NFD", s).encode("ascii", "ignore").decode().upper()
+
+
+def parse_resultado(valor_str: str) -> Decimal:
+    valor_str = valor_str.strip()
+    if ":" in valor_str:
+        partes = valor_str.replace(",", ".").split(":")
+        return Decimal(int(partes[0]) * 60) + Decimal(partes[1])
+    return Decimal(valor_str.replace(",", "."))
+
+
+def cargar_resultados(disciplina: str) -> dict[str, Decimal]:
+    data = json.loads(RESULTS_PATH.read_text())
+    return {
+        normalize(r["name"]): parse_resultado(r["result"])
+        for r in data
+        if r["discipline"] == disciplina and r["result"] is not None
+    }
+
+
+def assert_ok(resp: httpx.Response, context: str) -> dict:
+    if resp.status_code not in (200, 201, 204):
+        print(f"\n✗ ERROR en {context}: {resp.status_code}")
+        print(resp.text[:500])
+        sys.exit(1)
+    return resp.json() if resp.content else {}
+
+
+def login(client: httpx.Client, email: str, rol: str | None = None) -> str:
+    body: dict = {"email": email, "password": PASSWORD}
+    if rol:
+        body["rol_elegido"] = rol
+    resp = client.post("/auth/login", json=body)
+    data = resp.json()
+    if "requires_role_selection" in data:
+        rol_elegido = rol or data["roles"][0]
+        body["rol_elegido"] = rol_elegido
+        resp = client.post("/auth/login", json=body)
+        assert_ok(resp, f"login {email} (rol={rol_elegido})")
+        return resp.json()["access_token"]
+    assert_ok(resp, f"login {email}")
+    return data["access_token"]
+
+
+def procesar_atleta(
+    client: httpx.Client,
+    comp_id: str,
+    disciplina: str,
+    entrada: dict,
+    resultados: dict[str, Decimal],
+    juez_token: str,
+    posicion: int,
+) -> str:
+    """Procesa un atleta en AnunciadaAP. Retorna 'ok' | 'dns' | 'err'."""
+    nombre_prod = entrada.get("nombre_atleta", "")
+    participante_id = entrada.get("atleta_id")
+    andarivel = entrada.get("andarivel", 1)
+    juez_h = {"Authorization": f"Bearer {juez_token}"}
+    unidad = DISCIPLINA_UNIDAD[disciplina]
+    ot_now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    override = SCENARIO_OVERRIDES.get((normalize(nombre_prod), disciplina))
+
+    # Llamar al atleta
+    resp = client.post(
+        f"/competencia/{comp_id}/llamar",
+        json={
+            "participante_id": participante_id,
+            "disciplina": disciplina,
+            "ot_programado": ot_now,
+            "posicion_grilla": posicion,
+            "andarivel": andarivel,
+        },
+        headers=juez_h,
+    )
+    if resp.status_code != 204:
+        print(f"  ✗ {nombre_prod} — llamar error: {resp.status_code} {resp.text[:200]}")
+        return "err"
+
+    # DNS forzado por override o por ausencia en dataset
+    resultado = resultados.get(normalize(nombre_prod))
+    if (override and override["card"] == "DNS") or resultado is None:
+        resp = client.post(
+            f"/competencia/{comp_id}/registrar-dns",
+            json={"participante_id": participante_id, "disciplina": disciplina},
+            headers=juez_h,
+        )
+        if resp.status_code == 204:
+            print(f"  ✓ {nombre_prod:35s} → DNS")
+            return "dns"
+        print(f"  ✗ {nombre_prod} — DNS error: {resp.status_code} {resp.text[:200]}")
+        return "err"
+
+    # Registrar resultado
+    resp = client.post(
+        f"/competencia/{comp_id}/registrar-resultado",
+        json={
+            "participante_id": participante_id,
+            "disciplina": disciplina,
+            "valor_rp": str(resultado),
+            "unidad": unidad,
+        },
+        headers=juez_h,
+    )
+    if resp.status_code != 204:
+        print(f"  ✗ {nombre_prod} — registrar-resultado error: {resp.status_code} {resp.text[:200]}")
+        return "err"
+
+    # Tarjeta
+    if override and override["card"] == "Roja":
+        tarjeta_body: dict = {
+            "participante_id": participante_id,
+            "disciplina": disciplina,
+            "tipo": "Roja",
+            "motivo_dq": override["motivo_dq"],
+        }
+        if "distancia_blackout" in override:
+            tarjeta_body["distancia_blackout"] = override["distancia_blackout"]
+        label = f"Roja ({override['motivo_dq']})"
+    elif override and override["card"] == "BlancaConPenalizaciones":
+        tarjeta_body = {
+            "participante_id": participante_id,
+            "disciplina": disciplina,
+            "tipo": "BlancaConPenalizaciones",
+            "penalizaciones": override["penalizaciones"],
+        }
+        deduccion = sum(float(p["deduccion"]) for p in override["penalizaciones"])
+        label = f"BlancaConPenalizaciones (−{deduccion:.0f}m)"
+    else:
+        tarjeta_body = {
+            "participante_id": participante_id,
+            "disciplina": disciplina,
+            "tipo": "Blanca",
+        }
+        label = "Blanca"
+
+    resp = client.post(
+        f"/competencia/{comp_id}/asignar-tarjeta",
+        json=tarjeta_body,
+        headers=juez_h,
+    )
+    if resp.status_code != 204:
+        print(f"  ✗ {nombre_prod} — asignar-tarjeta error: {resp.status_code} {resp.text[:200]}")
+        return "err"
+
+    print(f"  ✓ {nombre_prod:35s} RP={resultado} {unidad} · {label}")
+    return "ok"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed producción — resultados por disciplina")
+    parser.add_argument("--disciplina", required=True, choices=["STA", "DNF", "DYN", "DBF", "SPE_2X50"])
+    parser.add_argument("--limite", type=int, help="Procesar solo los primeros N pendientes")
+    parser.add_argument("--desde", type=int, default=1, help="Empezar desde el N-ésimo pendiente (1-based)")
+    parser.add_argument("--dry-run", action="store_true", help="Muestra el plan sin llamar a la API")
+    args = parser.parse_args()
+    disciplina = args.disciplina
+
+    print(f"\n=== Seed producción — {disciplina} ===\n")
+    print(f"  Base:   {BASE}")
+    print(f"  Torneo: {TORNEO_ID}\n")
+
+    resultados = cargar_resultados(disciplina)
+
+    with httpx.Client(base_url=BASE, timeout=30) as client:
+        org_token = login(client, ORG_EMAIL)
+        org_h = {"Authorization": f"Bearer {org_token}"}
+
+        resp = client.get("/competencia", params={"torneo_id": TORNEO_ID}, headers=org_h)
+        assert_ok(resp, "competencias")
+        comp = next((c for c in resp.json() if c["disciplina"] == disciplina), None)
+        if not comp:
+            print(f"✗ No se encontró competencia para {disciplina}")
+            sys.exit(1)
+        comp_id = comp["competencia_id"]
+
+        resp = client.get(f"/competencia/{comp_id}/grilla", params={"disciplina": disciplina}, headers=org_h)
+        assert_ok(resp, "grilla")
+        grilla = resp.json()
+
+        pendientes = [e for e in grilla if e.get("estado") == "AnunciadaAP"]
+        ya_procesados = len(grilla) - len(pendientes)
+
+        # Aplicar rango --desde / --limite
+        inicio = args.desde - 1
+        fin = inicio + args.limite if args.limite else len(pendientes)
+        tanda = pendientes[inicio:fin]
+
+        print(f"  Ya procesados:  {ya_procesados}")
+        print(f"  Total pendientes: {len(pendientes)}")
+        print(f"  Esta tanda:     {len(tanda)} (posiciones {inicio+1}–{inicio+len(tanda)})\n")
+
+        if not tanda:
+            print("  Nada que procesar en este rango.")
+            return
+
+        # Mostrar plan
+        print("  Plan:")
+        for i, entrada in enumerate(tanda, start=inicio+1):
+            nombre = entrada.get("nombre_atleta", "")
+            override = SCENARIO_OVERRIDES.get((normalize(nombre), disciplina))
+            resultado = resultados.get(normalize(nombre))
+            if override and override["card"] == "DNS":
+                tarjeta = "DNS (override)"
+            elif resultado is None:
+                tarjeta = "DNS (sin dato)"
+            elif override and override["card"] == "Roja":
+                tarjeta = f"Roja ({override['motivo_dq']})"
+            elif override and override["card"] == "BlancaConPenalizaciones":
+                deduccion = sum(Decimal(p["deduccion"]) for p in override["penalizaciones"])
+                tarjeta = f"BlancaConPenalizaciones −{deduccion}m → {resultado - deduccion} {DISCIPLINA_UNIDAD[disciplina]}"
+            else:
+                tarjeta = f"Blanca — {resultado} {DISCIPLINA_UNIDAD[disciplina]}"
+            print(f"    {i:2d}. {nombre:35s} → {tarjeta}")
+
+        if args.dry_run:
+            print("\n  [DRY RUN — sin llamadas de escritura]")
+            return
+
+        print()
+        juez_tokens = {andarivel: login(client, email, rol="JUEZ") for andarivel, email in JUECES.items()}
+        print(f"  Jueces autenticados: {list(JUECES.values())}\n")
+        print(f"▸ Ejecutando tanda...\n")
+
+        totales: dict[str, int] = {"ok": 0, "dns": 0, "err": 0}
+        for pos, entrada in enumerate(tanda, start=inicio+1):
+            andarivel = entrada.get("andarivel", 1)
+            juez_token = juez_tokens.get(andarivel, juez_tokens[1])
+            r = procesar_atleta(client, comp_id, disciplina, entrada, resultados, juez_token, pos)
+            totales[r] = totales.get(r, 0) + 1
+
+        print(f"\n=== Tanda completada ===")
+        print(f"  Registrados: {totales['ok']}")
+        print(f"  DNS:         {totales['dns']}")
+        print(f"  Errores:     {totales['err']}")
+        if totales["err"] == 0:
+            print(f"\n  ✓ Verificar: {BASE}/portalapnea")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/uat/sp6/seed_ba2025_usuarios.py
+++ b/tests/uat/sp6/seed_ba2025_usuarios.py
@@ -165,7 +165,7 @@ def crear_usuario(client: httpx.Client, email: str, nombre: str, apellido: str, 
         json={
             "email": email,
             "password": PASSWORD,
-            "rol": rol,
+            "roles": [rol],
             "nombre": nombre,
             "apellido": apellido,
         },
@@ -269,25 +269,29 @@ def main() -> None:
             atleta_id = str(uuid.uuid4())
             fecha_nac = FECHA_NAC[atleta["category"]]
 
-            # Auth user
-            crear_usuario(client, email, nombre, apellido, "ATLETA")
+            # Auth user — el registro crea el perfil atleta automáticamente
+            atleta_token = crear_usuario(client, email, nombre, apellido, "ATLETA")
+            atleta_h = {"Authorization": f"Bearer {atleta_token}"}
 
-            # Registro BC
+            # Obtener atleta_id real del perfil auto-creado
+            perfil_resp = assert_ok(
+                client.get("/registro/atletas/me", headers=atleta_h),
+                f"get perfil {nombre_completo}",
+            )
+            atleta_id = perfil_resp["atleta_id"]
+
+            # Completar perfil con datos del dataset
             assert_ok(
-                client.post(
-                    "/registro/atletas",
+                client.patch(
+                    "/registro/atletas/me",
                     json={
-                        "atleta_id": atleta_id,
-                        "nombre": nombre,
-                        "apellido": apellido,
-                        "email": email,
                         "fecha_nacimiento": fecha_nac,
                         "categoria": categoria,
                         "club": atleta["club"],
                     },
-                    headers=admin_h,
+                    headers=atleta_h,
                 ),
-                f"registro atleta {nombre_completo}",
+                f"patch perfil {nombre_completo}",
             )
 
             ids["atletas"][nombre_completo] = {


### PR DESCRIPTION
## Summary

- **#213** `AuditoriaCompetenciaPage`: eliminar cartel placeholder "Vista contextual..." y sección Hash SHA-256
- **#214** `ResultadosPage`: separar título "Ranking por disciplina" de las pestañas con `mt-6`
- **#215** `TorneoCompetenciasPage` (Audit Log): mostrar nombre de disciplina en lugar del UUID de competencia
- **#216** Navegación móvil: menú hamburguesa `☰` en los tres portales que despliega panel vertical con todos los items; se cierra al navegar

## Navegación móvil — detalle

| Portal | Comportamiento |
|--------|---------------|
| Organizador | Hamburguesa en mobile (`md:hidden`); nav horizontal desktop se mantiene |
| Juez | Hamburguesa reemplaza tabs horizontales |
| Atleta | Hamburguesa reemplaza grid-cols-5 comprimido |

Item activo marcado con punto sky `●`. Menú cierra automáticamente al navegar.

## Seeds UAT

- `seed_ba2025_usuarios.py`: adaptado a API multi-rol (`rol` → `roles[]`; `POST /registro/atletas` → `PATCH /registro/atletas/me` para no duplicar perfil auto-creado)
- `tests/uat/produccion/seed_produccion_resultados.py`: nuevo script para alimentar producción progresivamente (`--disciplina`, `--limite`, `--desde`, `--dry-run`; soporta Blanca / Roja BKO / DNS / BlancaConPenalizaciones)

## Test plan

- [ ] Verificar los 4 fixes visuales en portal organizador (Audit Log, Resultados)
- [ ] Abrir menú hamburguesa en mobile en los tres portales — navegar entre secciones
- [ ] Confirmar que nav horizontal desktop de organizador se mantiene intacta
- [ ] Correr `seed_ba2025_usuarios.py` contra servidor local — 31 atletas sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)